### PR TITLE
Fix tech debt P2s from PRs #135-#136

### DIFF
--- a/crates/nereids-core/src/constants.rs
+++ b/crates/nereids-core/src/constants.rs
@@ -66,7 +66,7 @@ pub const DIVISION_FLOOR: f64 = 1e-50;
 /// Generic tiny positive floor used as a near-zero tolerance across physics
 /// calculations (e.g., cross-sections in barns, energies in eV, widths,
 /// dimensionless parameters). Values below this are treated as negligible.
-pub const CROSS_SECTION_FLOOR: f64 = 1e-60;
+pub const NEAR_ZERO_FLOOR: f64 = 1e-60;
 
 /// Floor for pivot detection and division safety in numerical linear algebra
 /// (LM solver, Gaussian elimination). Values below this indicate a

--- a/crates/nereids-fitting/src/poisson.rs
+++ b/crates/nereids-fitting/src/poisson.rs
@@ -236,9 +236,8 @@ fn project(params: &mut ParameterSet) {
 ///
 /// # Failure contract
 ///
-/// On `None` return (line search exhausted), `params` is left in the state
-/// of the last trial step, NOT restored to `old_free`. The caller MUST
-/// restore `params` via `params.set_free_values(old_free)` after receiving `None`.
+/// On `None` return (line search exhausted), `params` is restored to
+/// `old_free` before returning. Callers need not restore manually.
 // All 9 arguments are genuinely needed: this is an extraction of inline code
 // shared between two callers that differ only in search_dir vs. grad.
 #[allow(clippy::too_many_arguments)]
@@ -290,6 +289,7 @@ fn backtracking_line_search(
         // Backtrack
         alpha *= config.backtrack;
     }
+    params.set_free_values(old_free);
     None
 }
 
@@ -378,8 +378,8 @@ pub fn poisson_fit(
         ) {
             Some(new_nll) => nll = new_nll,
             None => {
-                params.set_free_values(&old_free);
                 // Can't improve from this point; stop without claiming convergence.
+                // (params already restored by backtracking_line_search)
                 break;
             }
         }
@@ -759,7 +759,7 @@ pub fn poisson_fit_analytic(
         ) {
             Some(new_nll) => nll = new_nll,
             None => {
-                params.set_free_values(&old_free);
+                // (params already restored by backtracking_line_search)
                 break;
             }
         }

--- a/crates/nereids-physics/src/coulomb.rs
+++ b/crates/nereids-physics/src/coulomb.rs
@@ -13,7 +13,7 @@
 //! When η = 0, F_0 = sin ρ, G_0 = cos ρ, reproducing hard-sphere
 //! (Blatt-Weisskopf) penetrabilities from `penetrability.rs`.
 
-use nereids_core::constants::{self, CROSS_SECTION_FLOOR};
+use nereids_core::constants::{self, NEAR_ZERO_FLOOR};
 
 /// Sommerfeld parameter η for a Coulomb channel.
 ///
@@ -356,7 +356,7 @@ pub fn coulomb_penetrability(l: u32, eta: f64, rho: f64) -> f64 {
         Some((fl, gl, _, _)) => rho / (fl * fl + gl * gl),
         None => {
             // Coulomb wave functions failed (ρ too small).
-            if eta.abs() < CROSS_SECTION_FLOOR {
+            if eta.abs() < NEAR_ZERO_FLOOR {
                 // Neutral channel (η ≈ 0): fall back to the non-Coulomb
                 // (hard-sphere) penetrability, which is exact when η = 0.
                 crate::penetrability::penetrability(l, rho)

--- a/crates/nereids-physics/src/doppler.rs
+++ b/crates/nereids-physics/src/doppler.rs
@@ -27,7 +27,7 @@
 //! The SAMMY Doppler width at energy E is:
 //!   Δ_D(E) = √(4·k_B·T·E / AWR)
 
-use nereids_core::constants::{self, CROSS_SECTION_FLOOR, DIVISION_FLOOR};
+use nereids_core::constants::{self, DIVISION_FLOOR, NEAR_ZERO_FLOOR};
 
 /// Doppler broadening parameters.
 #[derive(Debug, Clone, Copy)]
@@ -85,7 +85,7 @@ pub fn doppler_broaden(
     }
 
     let u = params.u();
-    if u < CROSS_SECTION_FLOOR {
+    if u < NEAR_ZERO_FLOOR {
         return cross_sections.to_vec();
     }
 
@@ -188,7 +188,7 @@ pub fn doppler_broaden(
     let ext_sigma: Vec<f64> = (0..n_ext)
         .map(|j| {
             let w = ext_v[j];
-            if w.abs() < CROSS_SECTION_FLOOR {
+            if w.abs() < NEAR_ZERO_FLOOR {
                 // At v=0, cross-section is the extrapolated value
                 if !energies.is_empty() {
                     interpolate_cross_section(energies, cross_sections, 0.0)
@@ -206,7 +206,7 @@ pub fn doppler_broaden(
     for i in 0..n {
         let v = velocities[i];
         let e = energies[i];
-        if v < CROSS_SECTION_FLOOR || e < CROSS_SECTION_FLOOR {
+        if v < NEAR_ZERO_FLOOR || e < NEAR_ZERO_FLOOR {
             broadened[i] = cross_sections[i];
             continue;
         }
@@ -290,7 +290,7 @@ fn interpolate_cross_section(energies: &[f64], cross_sections: &[f64], energy: f
         if energy <= 0.0 {
             return cross_sections[0];
         }
-        if energies[0] > CROSS_SECTION_FLOOR {
+        if energies[0] > NEAR_ZERO_FLOOR {
             return cross_sections[0] * (energies[0] / energy).sqrt();
         }
         return cross_sections[0];
@@ -299,7 +299,7 @@ fn interpolate_cross_section(energies: &[f64], cross_sections: &[f64], energy: f
     if energy >= energies[energies.len() - 1] {
         // Extrapolate using 1/v law
         let last = energies.len() - 1;
-        if energy > CROSS_SECTION_FLOOR {
+        if energy > NEAR_ZERO_FLOOR {
             return cross_sections[last] * (energies[last] / energy).sqrt();
         }
         return cross_sections[last];
@@ -325,7 +325,7 @@ fn interpolate_cross_section(energies: &[f64], cross_sections: &[f64], energy: f
     // Guard against duplicate energy grid points: if e0 == e1 (or nearly so),
     // no interpolation is needed — use the value at that point directly.
     // Use a combined relative+absolute threshold that works across the full
-    // energy range (meV to MeV): |de| < |e0|·ε_mach + CROSS_SECTION_FLOOR.
+    // energy range (meV to MeV): |de| < |e0|·ε_mach + NEAR_ZERO_FLOOR.
     // The relative part handles large energies where f64::EPSILON alone would
     // miss near-duplicates; the absolute part handles energies near zero.
     // This is consistent with resolution.rs interp_spectrum.
@@ -334,7 +334,7 @@ fn interpolate_cross_section(energies: &[f64], cross_sections: &[f64], energy: f
     let s0 = cross_sections[idx];
     let s1 = cross_sections[idx + 1];
     let de = e1 - e0;
-    if de.abs() < e0.abs() * f64::EPSILON + CROSS_SECTION_FLOOR {
+    if de.abs() < e0.abs() * f64::EPSILON + NEAR_ZERO_FLOOR {
         return s0;
     }
     let t = (energy - e0) / de;
@@ -682,14 +682,14 @@ mod tests {
             "Near-duplicate query should return finite result, got {result2}"
         );
 
-        // Exercise the `de.abs() < |e0|*EPS + CROSS_SECTION_FLOOR` threshold
+        // Exercise the `de.abs() < |e0|*EPS + NEAR_ZERO_FLOOR` threshold
         // with near-zero adjacent energies where de is essentially zero.
         // With e0 = 1e-50, the relative term |e0|*EPS ≈ 2e-66 is smaller
-        // than CROSS_SECTION_FLOOR (1e-60), so the absolute floor dominates.
+        // than NEAR_ZERO_FLOOR (1e-60), so the absolute floor dominates.
         let tiny_energies = vec![1e-50, 1e-50 + 1e-105, 1.0];
         let tiny_xs = vec![100.0, 200.0, 300.0];
         // Query between the two near-zero points: de ≈ 1e-105 which is
-        // far below the absolute threshold CROSS_SECTION_FLOOR (1e-60),
+        // far below the absolute threshold NEAR_ZERO_FLOOR (1e-60),
         // and the relative term (|1e-50| * EPS ≈ 2e-66) is even smaller,
         // so the absolute floor is the binding constraint.
         let result3 = interpolate_cross_section(&tiny_energies, &tiny_xs, 1e-50 + 5e-106);

--- a/crates/nereids-physics/src/penetrability.rs
+++ b/crates/nereids-physics/src/penetrability.rs
@@ -15,7 +15,7 @@
 //! The penetrability P_l(ρ), shift factor S_l(ρ), and hard-sphere phase
 //! shift φ_l(ρ) depend on orbital angular momentum l.
 
-use nereids_core::constants::CROSS_SECTION_FLOOR;
+use nereids_core::constants::NEAR_ZERO_FLOOR;
 
 /// Penetrability factor P_l(ρ) for orbital angular momentum l.
 ///
@@ -167,7 +167,7 @@ pub fn shift_factor_closed(l: u32, kappa: f64) -> f64 {
 /// upward recursion from the l=0 seed values:
 ///   f_0(iκ) = i·sinh(κ),  g_0(iκ) = cosh(κ)
 fn shift_factor_closed_general(l: u32, kappa: f64) -> f64 {
-    if kappa < CROSS_SECTION_FLOOR {
+    if kappa < NEAR_ZERO_FLOOR {
         return 0.0;
     }
 
@@ -191,7 +191,7 @@ fn shift_factor_closed_general(l: u32, kappa: f64) -> f64 {
 
     // f² + g² (complex square, not modulus squared); result is real
     let denom = f.0 * f.0 - f.1 * f.1 + g.0 * g.0 - g.1 * g.1;
-    if denom.abs() < CROSS_SECTION_FLOOR {
+    if denom.abs() < NEAR_ZERO_FLOOR {
         return 0.0;
     }
     numerator / denom
@@ -324,7 +324,7 @@ fn phase_shift_general(l: u32, rho: f64) -> f64 {
 ///
 /// j_l and n_l are spherical Bessel functions of the first and second kind.
 fn bessel_fg(l: u32, rho: f64) -> (f64, f64) {
-    if rho.abs() < CROSS_SECTION_FLOOR {
+    if rho.abs() < NEAR_ZERO_FLOOR {
         return if l == 0 {
             (0.0, -1.0)
         } else {

--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -28,7 +28,7 @@
 //! where R(E, E') = exp(-(E-E')²/W²) / (W·√π) is a Gaussian kernel
 //! with energy-dependent width W(E).
 
-use nereids_core::constants::{CROSS_SECTION_FLOOR, DIVISION_FLOOR};
+use nereids_core::constants::{DIVISION_FLOOR, NEAR_ZERO_FLOOR};
 use std::fmt;
 
 /// TOF conversion factor: t[μs] = TOF_FACTOR × L[m] / √(E[eV]).
@@ -107,7 +107,7 @@ pub fn resolution_broaden(
         let e = energies[i];
         let w = params.gaussian_width(e);
 
-        if w < CROSS_SECTION_FLOOR {
+        if w < NEAR_ZERO_FLOOR {
             broadened[i] = cross_sections[i];
             continue;
         }
@@ -489,7 +489,7 @@ fn interp_spectrum(energies: &[f64], spectrum: &[f64], e: f64) -> Option<f64> {
     // single-point grid where lo==hi), the denominator is zero.  Return the
     // value at the lower bracket to avoid NaN.
     let span = energies[hi] - energies[lo];
-    if span.abs() < CROSS_SECTION_FLOOR {
+    if span.abs() < NEAR_ZERO_FLOOR {
         return Some(spectrum[lo]);
     }
     let frac = (e - energies[lo]) / span;

--- a/crates/nereids-physics/src/rmatrix_limited.rs
+++ b/crates/nereids-physics/src/rmatrix_limited.rs
@@ -58,7 +58,7 @@
 
 use num_complex::Complex64;
 
-use nereids_core::constants::{CROSS_SECTION_FLOOR, LOG_FLOOR, PIVOT_FLOOR, QUANTUM_NUMBER_EPS};
+use nereids_core::constants::{LOG_FLOOR, NEAR_ZERO_FLOOR, PIVOT_FLOOR, QUANTUM_NUMBER_EPS};
 use nereids_endf::resonance::{ParticlePair, RmlData, SpinGroup};
 
 use crate::{channel, coulomb, penetrability};
@@ -425,8 +425,8 @@ fn spin_group_cross_sections(
                     // whether |L_c| is actually near zero.
                     //
                     // Reference: SAMMY rml/mrml07.f — PH = 1/(S−B+iP).
-                    let inv_l = if l_c[c].norm_sqr() < CROSS_SECTION_FLOOR {
-                        // |L_c|² < CROSS_SECTION_FLOOR: use finite-but-large sentinel so the diagonal
+                    let inv_l = if l_c[c].norm_sqr() < NEAR_ZERO_FLOOR {
+                        // |L_c|² < NEAR_ZERO_FLOOR: use finite-but-large sentinel so the diagonal
                         // dominates and the channel decouples without overflow in inversion.
                         Complex64::new(1e30, 0.0)
                     } else {
@@ -451,7 +451,7 @@ fn spin_group_cross_sections(
             // level matrix; an imaginary perturbation would break unitarity.
             //
             // Use a *relative* epsilon: ε = |diag| × QUANTUM_NUMBER_EPS, with a floor of
-            // CROSS_SECTION_FLOOR for zero diagonals.  A fixed absolute epsilon
+            // NEAR_ZERO_FLOOR for zero diagonals.  A fixed absolute epsilon
             // could be comparable to or larger than the diagonal value itself
             // for high-L channels with very small penetrabilities (where
             // 1/L_c ~ 1/P_c can be enormous, but R_cc' is also large, making
@@ -471,8 +471,8 @@ fn spin_group_cross_sections(
             for (i, row) in y_reg.iter_mut().enumerate().take(nch) {
                 let diag_norm = row[i].norm();
                 // Relative regularization (QUANTUM_NUMBER_EPS × diagonal) with an
-                // absolute floor of CROSS_SECTION_FLOOR for near-zero diagonals.
-                let eps = (diag_norm * QUANTUM_NUMBER_EPS).max(CROSS_SECTION_FLOOR);
+                // absolute floor of NEAR_ZERO_FLOOR for near-zero diagonals.
+                let eps = (diag_norm * QUANTUM_NUMBER_EPS).max(NEAR_ZERO_FLOOR);
                 row[i] += Complex64::new(eps, 0.0);
             }
             match invert_complex_matrix(&y_reg, nch) {


### PR DESCRIPTION
## Summary
- **Rename `CROSS_SECTION_FLOOR` → `NEAR_ZERO_FLOOR`**: the constant (1e-60) was used for Sommerfeld parameters, Bessel denominators, energy spans, etc. — not just cross-sections. Value preserved exactly. 27 occurrences across 7 files.
- **Make `backtracking_line_search` self-restoring**: on `None` return, params are now restored inside the function before returning. Removes redundant caller-side restores from both `poisson_fit` and `poisson_fit_analytic`.
- Items 3-4 from #137 are non-issues: NCH check is already a hard error (`return Err(...)` at `parser.rs:625-639`); `{e}` Display formatting is correct for GUI dialogs (`{e:#}` would show ugly Debug output).

Closes #137

## Test plan
- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --exclude nereids-python -- -D warnings` — zero warnings
- [x] `cargo test --workspace --exclude nereids-python` — 261 tests pass
- [x] `grep -r "CROSS_SECTION_FLOOR" crates/` — zero remaining references

🤖 Generated with [Claude Code](https://claude.com/claude-code)