### PR TITLE
Optimize resolution broadening O(N²) → O(N×W)

### DIFF
--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -128,9 +128,8 @@ pub fn resolution_broaden(
         let j_hi = energies.partition_point(|&ej| ej <= e_high);
         for j in j_lo..j_hi {
             let arg = (energies[j] - e) / w;
-            if arg * arg > 100.0 {
-                continue;
-            }
+            // No need for arg*arg > 100 guard: partition_point already bounds
+            // j to [e - 5w, e + 5w], so |arg| <= 5 and arg*arg <= 25.
             let g = (-arg * arg).exp();
 
             // Trapezoidal width
@@ -180,11 +179,8 @@ pub fn resolution_broaden_transmission(
     transmission: &[f64],
     params: &ResolutionParams,
 ) -> Vec<f64> {
-    debug_assert!(
-        energies.windows(2).all(|w| w[0] <= w[1]),
-        "energies must be sorted ascending for partition_point"
-    );
     // The convolution kernel is the same; only the interpretation differs.
+    // Note: resolution_broaden already asserts that energies are sorted.
     resolution_broaden(energies, transmission, params)
 }
 
@@ -414,6 +410,10 @@ impl TabulatedResolution {
     /// Interpolate kernel at an arbitrary energy using log-space linear interpolation
     /// between the two nearest reference energies.
     fn interpolated_kernel(&self, energy: f64) -> (Vec<f64>, Vec<f64>) {
+        debug_assert!(
+            self.ref_energies.windows(2).all(|w| w[0] <= w[1]),
+            "ref_energies must be sorted ascending for partition_point"
+        );
         let n_ref = self.ref_energies.len();
 
         // Clamp to nearest reference if outside range


### PR DESCRIPTION
## Summary
- Replace linear inner-loop scan with `partition_point` binary search bounds in `resolution_broaden` and `resolution_broaden_transmission`
- Replace linear bracket search in `interpolated_kernel` with binary search
- Add `debug_assert!` for sorted energy precondition required by `partition_point`

Part of #79 (Tier 1 performance). Closes #83.

## Test plan
- [x] All 262 workspace tests pass
- [x] `cargo clippy` zero warnings
- [x] Multi-AI review: 0 P1s, P2s addressed (kernel pre-cache removed, sorted assertion added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)