### PR TITLE
Fix: Arc-wrap resonance data, release GIL in load_endf/load_endf_file

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1010,14 +1010,6 @@ fn load_endf(
 ///     ResonanceData parsed from the file.
 #[pyfunction]
 fn load_endf_file(py: Python<'_>, path: &str) -> PyResult<PyResonanceData> {
-    // Validate path existence while we still hold the GIL (cheap check).
-    if !std::path::Path::new(path).exists() {
-        return Err(pyo3::exceptions::PyIOError::new_err(format!(
-            "Cannot read '{}': No such file or directory",
-            path
-        )));
-    }
-
     // Release the GIL for the file I/O and ENDF parsing.
     // Tag errors: false = I/O, true = parse.
     let owned_path = path.to_owned();


### PR DESCRIPTION
## Summary
- **#159**: Change `PyResonanceData.inner` and `PyTabulatedResolution.inner` to `Arc<T>`, making `.clone()` in `py.detach()` closures O(1). Uses `Arc::unwrap_or_clone` for zero-cost move when refcount is 1.
- **#160**: Release GIL in `load_endf` (network I/O) and `load_endf_file` (file I/O + parsing) with `py.detach()`. Preserve `ValueError`/`RuntimeError` distinction via `(bool, String)` error tagging.
- `py_apply_resolution` now takes resolution by value for `Arc::unwrap_or_clone`.

Closes #159, closes #160

## Test plan
- [x] 280 Rust tests pass
- [x] `pixi run build` succeeds
- [x] `pixi run test-python` — 79 Python tests pass
- [x] Phase A review: 0 P1s after fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)