### PR TITLE
Perf: reduce per-pixel allocation churn in fitting loops

### DIFF
--- a/crates/nereids-fitting/src/lm.rs
+++ b/crates/nereids-fitting/src/lm.rs
@@ -172,6 +172,9 @@ fn chi_squared(residuals: &[f64], weights: &[f64]) -> f64 {
 /// `all_vals_buf` is a scratch buffer reused across the per-parameter FD loop
 /// to avoid allocating a fresh `Vec<f64>` on every `model.evaluate()` call.
 ///
+/// `free_idx_buf` is a scratch buffer for `params.free_indices_into()`, reused
+/// across iterations to avoid per-Jacobian allocation.
+///
 /// J.get(i, j) = ∂model[i] / ∂free_param[j]
 fn compute_jacobian(
     model: &dyn FitModel,
@@ -179,14 +182,15 @@ fn compute_jacobian(
     y_current: &[f64],
     fd_step: f64,
     all_vals_buf: &mut Vec<f64>,
+    free_idx_buf: &mut Vec<usize>,
 ) -> FlatMatrix {
-    let free_indices = params.free_indices();
-    let n_free = free_indices.len();
+    params.free_indices_into(free_idx_buf);
+    let n_free = free_idx_buf.len();
     let n_data = y_current.len();
 
     // Try analytical Jacobian first (no extra evaluate calls).
     params.all_values_into(all_vals_buf);
-    if let Some(j) = model.analytical_jacobian(all_vals_buf, &free_indices, y_current) {
+    if let Some(j) = model.analytical_jacobian(all_vals_buf, free_idx_buf, y_current) {
         debug_assert!(
             j.nrows == n_data && j.ncols == n_free && j.data.len() == n_data * n_free,
             "analytical_jacobian shape mismatch: got ({}x{}, len={}), expected ({}x{}, len={})",
@@ -203,7 +207,7 @@ fn compute_jacobian(
     // Fallback: forward finite differences, reusing y_current as the base.
     let mut jacobian = FlatMatrix::zeros(n_data, n_free);
 
-    for (j, &idx) in free_indices.iter().enumerate() {
+    for (j, &idx) in free_idx_buf.iter().enumerate() {
         let original = params.params[idx].value;
         let step = fd_step * (1.0 + original.abs());
 
@@ -493,11 +497,13 @@ pub fn levenberg_marquardt(
 
     // Scratch buffers reused across the optimization loop for
     // params.all_values_into() calls in compute_jacobian (1 + N_free calls
-    // per Jacobian computation) and the trial-step evaluation, and
+    // per Jacobian computation) and the trial-step evaluation,
     // params.free_values_into() calls for snapshotting free parameters
-    // before trial steps.
+    // before trial steps, and params.free_indices_into() calls inside
+    // compute_jacobian.
     let mut all_vals_buf = Vec::with_capacity(params.params.len());
     let mut free_vals_buf = Vec::with_capacity(n_free);
+    let mut free_idx_buf = Vec::with_capacity(n_free);
 
     // Initial model output, residuals, and chi².
     // y_current is kept up-to-date after accepted steps so that the next
@@ -521,8 +527,14 @@ pub fn levenberg_marquardt(
         // Compute Jacobian — uses y_current to avoid a redundant evaluate().
         // Analytical Jacobian (if provided by the model) costs 0 extra evaluates;
         // finite-difference fallback costs N_free extra evaluates.
-        let jacobian =
-            compute_jacobian(model, params, &y_current, config.fd_step, &mut all_vals_buf);
+        let jacobian = compute_jacobian(
+            model,
+            params,
+            &y_current,
+            config.fd_step,
+            &mut all_vals_buf,
+            &mut free_idx_buf,
+        );
 
         // Build normal equations: JᵀWJ and JᵀWr
         let mut jtw_j = FlatMatrix::zeros(n_free, n_free);
@@ -625,8 +637,14 @@ pub fn levenberg_marquardt(
     // mapping), we skip it entirely — the caller only needs densities and
     // chi-squared, not uncertainties.
     let (covariance, uncertainties) = if config.compute_covariance {
-        let jacobian =
-            compute_jacobian(model, params, &y_current, config.fd_step, &mut all_vals_buf);
+        let jacobian = compute_jacobian(
+            model,
+            params,
+            &y_current,
+            config.fd_step,
+            &mut all_vals_buf,
+            &mut free_idx_buf,
+        );
         let mut jtw_j = FlatMatrix::zeros(n_free, n_free);
         for (i, &wi) in weights.iter().enumerate() {
             for j in 0..n_free {

--- a/crates/nereids-fitting/src/parameters.rs
+++ b/crates/nereids-fitting/src/parameters.rs
@@ -4,20 +4,20 @@
 //! Supports non-negativity constraints and sum-to-one constraints for
 //! isotopes of the same element.
 
+use std::borrow::Cow;
+
 /// A single fit parameter with value, bounds, and fixed/free flag.
 ///
-/// The `name` field uses `String` rather than `Arc<str>` or `Cow<'static, str>`.
-/// For typical isotope names (e.g. "U-238", "isotope_0") the per-pixel clone
-/// cost is negligible compared to the Poisson/LM optimization work (~100s of
-/// model evaluations per pixel).  Switching to `Arc<str>` would save ~4-16
-/// small heap allocations per pixel but adds API complexity and lifetime
-/// constraints that are not justified at current workload sizes (1-4 isotopes
-/// × 16K pixels ≈ 64K short-string copies vs millions of FP ops).
+/// The `name` field uses `Cow<'static, str>` so that static strings
+/// (e.g. `"U-238"`, `"temperature_k"`) avoid heap allocation entirely,
+/// while dynamic strings from `format!()` still work via the `Owned` variant.
+/// When a `ParameterSet` template is cloned per-pixel, `Cow::Borrowed` names
+/// are copied as a pointer+length (16 bytes, no heap) instead of allocating
+/// a new `String` on the heap.
 #[derive(Debug, Clone)]
 pub struct FitParameter {
     /// Parameter name (for reporting).
-    // TODO(perf): consider Arc<str> if profiling shows parameter cloning is a bottleneck
-    pub name: String,
+    pub name: Cow<'static, str>,
     /// Current value.
     pub value: f64,
     /// Lower bound (f64::NEG_INFINITY if unbounded).
@@ -30,7 +30,7 @@ pub struct FitParameter {
 
 impl FitParameter {
     /// Create a new free parameter with non-negativity constraint.
-    pub fn non_negative(name: impl Into<String>, value: f64) -> Self {
+    pub fn non_negative(name: impl Into<Cow<'static, str>>, value: f64) -> Self {
         Self {
             name: name.into(),
             value,
@@ -41,7 +41,7 @@ impl FitParameter {
     }
 
     /// Create a new free parameter with no bounds.
-    pub fn unbounded(name: impl Into<String>, value: f64) -> Self {
+    pub fn unbounded(name: impl Into<Cow<'static, str>>, value: f64) -> Self {
         Self {
             name: name.into(),
             value,
@@ -52,7 +52,7 @@ impl FitParameter {
     }
 
     /// Create a fixed parameter.
-    pub fn fixed(name: impl Into<String>, value: f64) -> Self {
+    pub fn fixed(name: impl Into<Cow<'static, str>>, value: f64) -> Self {
         Self {
             name: name.into(),
             value,
@@ -150,6 +150,22 @@ impl ParameterSet {
             .filter(|(_, p)| !p.fixed)
             .map(|(i, _)| i)
             .collect()
+    }
+
+    /// Write free parameter indices into the provided buffer, resizing if needed.
+    ///
+    /// This is the buffer-reuse counterpart of [`free_indices`](Self::free_indices).
+    /// Callers that compute the Jacobian many times in a loop can allocate one
+    /// `Vec<usize>` and reuse it across iterations to avoid per-call allocation.
+    pub fn free_indices_into(&self, buf: &mut Vec<usize>) {
+        buf.clear();
+        buf.extend(
+            self.params
+                .iter()
+                .enumerate()
+                .filter(|(_, p)| !p.fixed)
+                .map(|(i, _)| i),
+        );
     }
 }
 

--- a/crates/nereids-fitting/src/poisson.rs
+++ b/crates/nereids-fitting/src/poisson.rs
@@ -170,21 +170,25 @@ fn poisson_nll_grad_term(obs: f64, mdl: f64) -> f64 {
 /// `all_vals_buf` is a reusable scratch buffer for `params.all_values_into()`,
 /// avoiding a fresh allocation on every `model.evaluate()` call inside the
 /// per-parameter FD loop (N_free+1 allocations saved per gradient call).
+///
+/// `free_idx_buf` is a scratch buffer for `params.free_indices_into()`, reused
+/// across iterations to avoid per-gradient allocation.
 fn compute_gradient(
     model: &dyn FitModel,
     params: &mut ParameterSet,
     y_obs: &[f64],
     fd_step: f64,
     all_vals_buf: &mut Vec<f64>,
+    free_idx_buf: &mut Vec<usize>,
 ) -> Vec<f64> {
     params.all_values_into(all_vals_buf);
     let base_model = model.evaluate(all_vals_buf);
     let base_nll = poisson_nll(y_obs, &base_model);
 
-    let free_indices = params.free_indices();
-    let mut grad = vec![0.0; free_indices.len()];
+    params.free_indices_into(free_idx_buf);
+    let mut grad = vec![0.0; free_idx_buf.len()];
 
-    for (j, &idx) in free_indices.iter().enumerate() {
+    for (j, &idx) in free_idx_buf.iter().enumerate() {
         let original = params.params[idx].value;
         let step = fd_step * (1.0 + original.abs());
 
@@ -552,6 +556,7 @@ pub fn poisson_fit(
     let mut free_vals_buf = Vec::with_capacity(params.n_free());
     let mut old_free_buf: Vec<f64> = Vec::with_capacity(params.n_free());
     let mut trial_free_buf: Vec<f64> = Vec::with_capacity(params.n_free());
+    let mut free_idx_buf: Vec<usize> = Vec::with_capacity(params.n_free());
 
     params.all_values_into(&mut all_vals_buf);
     let y_model = model.evaluate(&all_vals_buf);
@@ -575,7 +580,14 @@ pub fn poisson_fit(
         iter += 1;
 
         // Compute gradient
-        let grad = compute_gradient(model, params, y_obs, config.fd_step, &mut all_vals_buf);
+        let grad = compute_gradient(
+            model,
+            params,
+            y_obs,
+            config.fd_step,
+            &mut all_vals_buf,
+            &mut free_idx_buf,
+        );
 
         // Check gradient norm for convergence
         let grad_norm: f64 = grad.iter().map(|g| g * g).sum::<f64>().sqrt();

--- a/crates/nereids-pipeline/src/sparse.rs
+++ b/crates/nereids-pipeline/src/sparse.rs
@@ -326,16 +326,15 @@ pub fn sparse_reconstruct(
     let density_idx: Arc<Vec<usize>> = Arc::new((0..n_isotopes).collect());
 
     // Pre-build parameter template outside the pixel loop so that per-pixel
-    // iterations only need a cheap Clone (no String formatting via format!).
+    // iterations only need a cheap Clone (no format!() or name lookup).
     //
     // Why clone instead of reconstruct?  ParameterSet::new + FitParameter
-    // constructors allocate one String per parameter per pixel (via
-    // `name.into()`).  Cloning an existing ParameterSet copies the Vec of
-    // FitParameter (which clones each String), but avoids re-running the
-    // format!/Into<String> conversion logic and re-evaluating the isotope
-    // name lookup.  At 1-4 isotopes the cost difference is tiny, but the
-    // pattern makes intent clear: the template is the single source of truth
-    // for parameter layout, bounds, and initial values.
+    // constructors convert the name via `Into<Cow<'static, str>>` and
+    // re-evaluate the isotope name lookup per pixel.  Cloning an existing
+    // ParameterSet copies the Vec of FitParameter (which clones each
+    // Cow — free for Borrowed, heap-copy for Owned), avoiding the
+    // per-pixel format!/Into conversion overhead.  The template is the
+    // single source of truth for parameter layout, bounds, and initial values.
     //
     // isotope_names.len() == n_isotopes is validated above, so direct indexing
     // is safe — the previous .get(i).unwrap_or_else(|| format!(...)) fallback


### PR DESCRIPTION
## Summary
- Change `FitParameter.name` from `String` to `Cow<'static, str>` — static names (e.g. `"temperature_k"`) are zero-copy on clone, dynamic names (`format!("isotope_{i}")`) fall back to heap-copy
- Add `free_indices_into(&mut Vec<usize>)` buffer-reuse method to `ParameterSet`, eliminating per-iteration `Vec<usize>` allocation in LM and Poisson hot loops
- Thread scratch buffers through `compute_jacobian()`, `compute_gradient()`, and `backtracking_line_search()` to avoid per-call allocation

Closes #92

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --exclude nereids-python -- -D warnings` clean
- [x] `cargo test --workspace --exclude nereids-python` — 286 tests pass
- [x] Self-review: zero P1 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)