### PR TITLE
Docs: document MLBW to SLBW dispatch limitation

### DIFF
--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -223,6 +223,9 @@ def cross_sections(
     """Compute cross-sections at given energies for an isotope.
 
     Returns a dict with keys 'total', 'elastic', 'capture', 'fission'.
+
+    Note: MLBW (Multi-Level Breit-Wigner) ranges use SLBW approximation
+    (resonance-resonance interference is ignored).
     """
     ...
 

--- a/crates/nereids-physics/src/reich_moore.rs
+++ b/crates/nereids-physics/src/reich_moore.rs
@@ -312,6 +312,11 @@ pub struct CrossSections {
 /// `[e_low, e_high)` so the boundary point is counted exactly once
 /// (ENDF-6 §2 convention).
 ///
+/// # Limitations
+/// MLBW (Multi-Level Breit-Wigner, LRF=2) ranges are evaluated using SLBW
+/// formulas as an approximation, ignoring resonance-resonance interference.
+/// Results may be inaccurate for closely spaced or overlapping resonances.
+///
 /// # Arguments
 /// * `data` — Parsed resonance parameters from ENDF.
 /// * `energy_ev` — Neutron energy in eV (lab frame).
@@ -403,6 +408,11 @@ pub fn cross_sections_at_energy(data: &ResonanceData, energy_ev: f64) -> CrossSe
 ///
 /// Issue #87: the precompute is hoisted above the energy loop so that
 /// `precompute_jgroups_*` runs O(ranges) times total, not O(ranges × energies).
+///
+/// # Limitations
+/// MLBW (Multi-Level Breit-Wigner, LRF=2) ranges are evaluated using SLBW
+/// formulas as an approximation, ignoring resonance-resonance interference.
+/// Results may be inaccurate for closely spaced or overlapping resonances.
 ///
 /// # Arguments
 /// * `data` — Parsed resonance parameters from ENDF.

--- a/crates/nereids-physics/src/slbw.rs
+++ b/crates/nereids-physics/src/slbw.rs
@@ -9,6 +9,10 @@
 //! For isolated, well-separated resonances, SLBW and Reich-Moore should
 //! give nearly identical results.
 //!
+//! This module also handles MLBW (Multi-Level Breit-Wigner) ranges, which are
+//! evaluated using the SLBW formulas as an approximation (see `reich_moore`
+//! module for details).
+//!
 //! ## SAMMY Reference
 //! - `mlb/mmlb4.f90` Abpart_Mlb subroutine
 //! - SAMMY manual Section 2.1.1


### PR DESCRIPTION
## Summary
- Add `# Limitations` section to `cross_sections_at_energy()` and `cross_sections_on_grid()` docstrings
- Note in `slbw.rs` module docstring about MLBW dispatch
- Update Python type stub docstring for `cross_sections()`
- Documentation-only change, no logic modifications

Closes #174

## Test plan
- [ ] `cargo doc` builds without warnings
- [ ] All tests pass (no logic changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)