### PR TITLE
Studio polish: sync buttons, residuals dock, isotopes context (#274, #275, #276)

### DIFF
--- a/apps/gui/src/guided/detectability.rs
+++ b/apps/gui/src/guided/detectability.rs
@@ -680,7 +680,11 @@ pub(crate) fn copy_config_to_detect_matrix(state: &mut AppState) {
             initial_density: e.initial_density,
             resonance_data: e.resonance_data.clone(),
             enabled: e.enabled,
-            endf_status: e.endf_status,
+            endf_status: if e.resonance_data.is_some() {
+                EndfStatus::Loaded
+            } else {
+                EndfStatus::Pending
+            },
         })
         .collect();
     state.detect_endf_library = state.endf_library;

--- a/apps/gui/src/guided/forward_model.rs
+++ b/apps/gui/src/guided/forward_model.rs
@@ -24,11 +24,14 @@ pub fn forward_model_step(ui: &mut egui::Ui, state: &mut AppState) {
         design::teleport_pill(ui, "Analyze →", GuidedStep::Analyze, state);
         ui.separator();
         // Sync buttons (disabled during active ENDF fetches to prevent index corruption)
-        ui.add_enabled_ui(!state.is_fetching_fm_endf, |ui| {
-            if ui.button("Copy from Config").clicked() {
-                copy_config_to_fm(state);
-            }
-        });
+        ui.add_enabled_ui(
+            !state.is_fetching_fm_endf && !state.is_fetching_endf,
+            |ui| {
+                if ui.button("Copy from Config").clicked() {
+                    copy_config_to_fm(state);
+                }
+            },
+        );
         ui.add_enabled_ui(!state.is_fetching_endf, |ui| {
             if ui.button("Push to Config").clicked() {
                 push_fm_to_config(state);
@@ -463,7 +466,11 @@ pub(crate) fn copy_config_to_fm(state: &mut AppState) {
             initial_density: e.initial_density,
             resonance_data: e.resonance_data.clone(),
             enabled: e.enabled,
-            endf_status: e.endf_status,
+            endf_status: if e.resonance_data.is_some() {
+                EndfStatus::Loaded
+            } else {
+                EndfStatus::Pending
+            },
         })
         .collect();
     state.fm_endf_library = state.endf_library;

--- a/apps/gui/src/studio/mod.rs
+++ b/apps/gui/src/studio/mod.rs
@@ -764,8 +764,9 @@ fn dock_residuals(ui: &mut egui::Ui, state: &AppState) {
 
     let overlay_temp = result.temperature_k.unwrap_or(state.temperature_k);
 
-    // Build instrument params matching what the fit used, so residuals
-    // correctly reflect resolution broadening.
+    // Build instrument params from the current resolution settings so residuals
+    // reflect the currently configured resolution broadening (which may differ
+    // from what was used during the fit if settings were changed without re-running).
     let instrument = if state.resolution_enabled {
         use nereids_physics::resolution::{ResolutionFunction, ResolutionParams};
         use nereids_physics::transmission::InstrumentParams;
@@ -773,19 +774,38 @@ fn dock_residuals(ui: &mut egui::Ui, state: &AppState) {
             crate::state::ResolutionMode::Gaussian {
                 delta_t_us,
                 delta_l_m,
-            } => ResolutionParams::new(state.beamline.flight_path_m, *delta_t_us, *delta_l_m)
-                .ok()
-                .map(|p| {
-                    std::sync::Arc::new(InstrumentParams {
+            } => {
+                match ResolutionParams::new(state.beamline.flight_path_m, *delta_t_us, *delta_l_m) {
+                    Ok(p) => Some(std::sync::Arc::new(InstrumentParams {
                         resolution: ResolutionFunction::Gaussian(p),
-                    })
-                }),
+                    })),
+                    Err(_) => {
+                        ui.label(
+                            egui::RichText::new(
+                                "Invalid resolution settings — check configuration.",
+                            )
+                            .small()
+                            .color(colors.fg3),
+                        );
+                        return;
+                    }
+                }
+            }
             crate::state::ResolutionMode::Tabulated {
                 data: Some(tab), ..
             } => Some(std::sync::Arc::new(InstrumentParams {
                 resolution: ResolutionFunction::Tabulated(std::sync::Arc::clone(tab)),
             })),
-            _ => None,
+            crate::state::ResolutionMode::Tabulated { data: None, .. } => {
+                ui.label(
+                    egui::RichText::new(
+                        "Resolution file not loaded — load it in configuration first.",
+                    )
+                    .small()
+                    .color(colors.fg3),
+                );
+                return;
+            }
         }
     } else {
         None


### PR DESCRIPTION
## Summary

Closes out the remaining Studio refactor UI issues from epic #264.

- **#274 — FM/Detect sync buttons**: Extract `copy_config_to_fm` / `push_fm_to_config` into reusable `pub(crate)` functions (deduplicating ~50 lines of inline logic in Guided FM step). Wire both into Studio FM tab. Add `copy_config_to_detect_matrix` for Studio Detectability tab.
- **#275 — Residuals dock**: Replace placeholder with actual residual analysis — computes measured−fitted residual at the selected pixel, shows RMS/max|r|/points/χ²_r stat row + residual vs energy plot. Empty states for no fit, unconverged fit, or missing data.
- **#276 — Isotopes dock context**: Add "Read-only reference — edit densities in the sidebar Isotopes card" label above the grid. Keeps the read-only table for when the sidebar is collapsed.

## Test plan

- [ ] Studio FM tab: "Copy from Config" and "Push to Config" buttons appear and work correctly
- [ ] Studio Detectability tab: "Copy matrix from Config" button populates matrix list from main config
- [ ] Sync buttons disabled during ENDF fetches (prevents index corruption)
- [ ] Guided FM step: sync buttons still work (now using extracted functions)
- [ ] Residuals dock: shows residual plot + stats when a converged pixel fit exists
- [ ] Residuals dock: shows appropriate message when no pixel selected / fit unconverged / no data
- [ ] Isotopes dock: shows context label above the grid
- [ ] `cargo clippy` clean, `cargo test` passes (405 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)