### PR TITLE
Hoist endf_channel_radius_fm() out of hot energy loops

### DIFF
--- a/crates/nereids-physics/src/reich_moore.rs
+++ b/crates/nereids-physics/src/reich_moore.rs
@@ -658,10 +658,12 @@ fn precompute_range_data<'a>(
                 } else {
                     0.0
                 };
-                // Channel radius for precompute: when APL > 0, use it; otherwise
-                // use the constant scattering_radius. The ap_table (NRO=1) case
-                // is handled inside penetrability_at_resonance, which evaluates
-                // the table at E_r for each resonance.
+                // Channel radius for precompute: when a penetrability radius
+                // override is available (APL > 0 or NAPS=0), use that
+                // precomputed radius; otherwise fall back to the constant
+                // scattering_radius. The ap_table (NRO=1) case is handled
+                // inside penetrability_at_resonance, which evaluates the
+                // table at E_r for each resonance.
                 let channel_radius = if pen_radius_override > 0.0 {
                     pen_radius_override
                 } else {


### PR DESCRIPTION
## Summary
- Precompute NAPS=0 channel radius formula (`cbrt` + arithmetic) at range-precompute time, store as `pen_radius_override` in `PrecomputedSlbwLGroupData` and `PrecomputedRmLGroupData`
- At evaluation time, the 3-way branch (APL / NAPS=0 / scattering radius) reduces to a 2-way check against the precomputed override
- Eliminates per-energy `cbrt()` calls in the hot vectorized cross-section path

Closes #353

## Test plan
- [x] All 557 Rust tests pass (including NAPS=0 tests from PR #351)
- [x] Clippy clean
- [x] No behavioral change — pure performance optimization

🤖 Generated with [Claude Code](https://claude.com/claude-code)