### PR TITLE
Add Homebrew cask formula and auto-update job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -321,7 +321,7 @@ jobs:
           for i in $(seq 1 30); do
             rm -f nereids.dmg
             if curl -fSL --retry 3 --retry-delay 5 "$DMG_URL" -o nereids.dmg 2>/dev/null; then
-              if ! head -c 15 nereids.dmg | grep -q '<!DOCTYPE\|<html'; then
+              if ! head -c 15 nereids.dmg | LC_ALL=C grep -aE -q '<!DOCTYPE|<html'; then
                 echo "DMG downloaded successfully"
                 DOWNLOADED=true
                 break

--- a/homebrew/nereids.rb
+++ b/homebrew/nereids.rb
@@ -1,6 +1,8 @@
+# Template only — the canonical cask lives at ornlneutronimaging/homebrew-nereids.
+# CI (publish.yml update-homebrew job) substitutes version + sha256 in the tap repo.
 cask "nereids" do
   version "0.1.0"
-  sha256 "PLACEHOLDER_SHA256"
+  sha256 :no_check
 
   url "https://github.com/ornlneutronimaging/NEREIDS/releases/download/v#{version}/nereids-#{version}-macos-arm64.dmg"
   name "NEREIDS"


### PR DESCRIPTION
## Summary

- Create `homebrew/nereids.rb` cask template (ARM64, Big Sur+, quarantine xattr removal for unsigned app)
- Add `update-homebrew` job to `publish.yml`: runs after `github-release`, downloads DMG, computes SHA256, updates `ornlneutronimaging/homebrew-nereids` tap via `sed` + git push
- Skips pre-release tags (rc/alpha/beta) — only stable releases update the tap
- Polls DMG availability up to 5 minutes (30 × 10s) with HTML error page detection

**Prerequisites (manual)**:
- Create `ornlneutronimaging/homebrew-nereids` repo with `Casks/nereids.rb`
- Add `HOMEBREW_TAP_TOKEN` secret (PAT with `repo` scope)

**User install flow**: `brew tap ornlneutronimaging/nereids && brew install --cask nereids`

Closes #299

## Test plan

- [x] YAML syntax validated (matches existing job patterns)
- [x] Cask formula matches rustpix template structure
- [ ] Workflow dry_run dispatch after merge to verify job structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)