### PR TITLE
Wrap large arrays in Arc to avoid deep clones during async save

### DIFF
--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -594,7 +594,7 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
     let Some((x_values, x_label)) = design::build_spectrum_x_axis(&design::SpectrumXAxisParams {
         axis: state.analyze_spectrum_axis,
         energies: state.energies.as_deref(),
-        spectrum_values: state.spectrum_values.as_deref(),
+        spectrum_values: state.spectrum_values.as_ref().map(|v| v.as_slice()),
         spectrum_unit: state.spectrum_unit,
         spectrum_kind: state.spectrum_kind,
         flight_path_m: state.beamline.flight_path_m,

--- a/apps/gui/src/guided/bin.rs
+++ b/apps/gui/src/guided/bin.rs
@@ -4,6 +4,8 @@
 //! Normalize). The user sets bin parameters and triggers histogramming
 //! of the raw HDF5 event data loaded in the previous step.
 
+use std::sync::Arc;
+
 use crate::state::{AppState, ProvenanceEventKind};
 use crate::theme::ThemeColors;
 use crate::widgets::design;
@@ -117,7 +119,7 @@ fn histogram_events(state: &mut AppState) {
                 shape[0], shape[1], shape[2]
             );
 
-            state.spectrum_values = Some(data.tof_edges_us.clone());
+            state.spectrum_values = Some(Arc::new(data.tof_edges_us.clone()));
             state.spectrum_unit = nereids_io::spectrum::SpectrumUnit::TofMicroseconds;
             state.spectrum_kind = nereids_io::spectrum::SpectrumValueKind::BinEdges;
 
@@ -146,7 +148,7 @@ fn histogram_events(state: &mut AppState) {
                     shape[0], shape[1], shape[2]
                 ),
             );
-            state.sample_data = Some(data.counts);
+            state.sample_data = Some(Arc::new(data.counts));
         }
         Err(e) => {
             state.status_message = format!("Event histogramming failed: {e}");

--- a/apps/gui/src/guided/load.rs
+++ b/apps/gui/src/guided/load.rs
@@ -3,6 +3,8 @@
 //! Prototype: `.content-area` → cards with drop zones, auto-load,
 //! format hints, and a Continue button with data guard.
 
+use std::sync::Arc;
+
 use crate::state::{AppState, InputMode, ProvenanceEventKind};
 use crate::theme::ThemeColors;
 use crate::widgets::design;
@@ -546,7 +548,7 @@ fn load_hdf5_histogram(state: &mut AppState) {
                 shape[0], shape[1], shape[2]
             );
 
-            state.spectrum_values = Some(data.tof_edges_us.clone());
+            state.spectrum_values = Some(Arc::new(data.tof_edges_us.clone()));
             state.spectrum_unit = nereids_io::spectrum::SpectrumUnit::TofMicroseconds;
 
             let n_frames = data.counts.shape()[0];
@@ -583,7 +585,7 @@ fn load_hdf5_histogram(state: &mut AppState) {
                     shape[0], shape[1], shape[2]
                 ),
             );
-            state.sample_data = Some(data.counts);
+            state.sample_data = Some(Arc::new(data.counts));
         }
         Err(e) => {
             state.status_message = format!("HDF5 load failed: {e}");
@@ -609,7 +611,7 @@ fn load_all_data(state: &mut AppState) {
                         path.display()
                     ),
                 );
-                state.sample_data = Some(data);
+                state.sample_data = Some(Arc::new(data));
                 state.status_message = "Sample loaded".into();
             }
             Err(e) => {
@@ -626,7 +628,7 @@ fn load_all_data(state: &mut AppState) {
     {
         match nereids_io::tiff_stack::load_tiff_auto(path) {
             Ok(data) => {
-                state.open_beam_data = Some(data);
+                state.open_beam_data = Some(Arc::new(data));
                 state.status_message = "Sample and open beam loaded".into();
             }
             Err(e) => {
@@ -695,7 +697,7 @@ fn load_all_data(state: &mut AppState) {
                     return;
                 }
 
-                state.spectrum_values = Some(values);
+                state.spectrum_values = Some(Arc::new(values));
                 state.status_message = "All data loaded".into();
             }
             Err(e) => {

--- a/apps/gui/src/guided/normalize.rs
+++ b/apps/gui/src/guided/normalize.rs
@@ -303,7 +303,7 @@ fn preview_spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
     let Some((x_values, x_label)) = design::build_spectrum_x_axis(&design::SpectrumXAxisParams {
         axis: state.normalize_spectrum_axis,
         energies: state.energies.as_deref(),
-        spectrum_values: state.spectrum_values.as_deref(),
+        spectrum_values: state.spectrum_values.as_ref().map(|v| v.as_slice()),
         spectrum_unit: state.spectrum_unit,
         spectrum_kind: state.spectrum_kind,
         flight_path_m: state.beamline.flight_path_m,
@@ -466,7 +466,7 @@ pub(crate) fn prepare_transmission(state: &mut AppState) {
     state.spatial_result = None;
 
     let sample = match state.sample_data {
-        Some(ref d) => d.clone(),
+        Some(ref d) => (**d).clone(),
         None => return,
     };
 
@@ -550,7 +550,7 @@ fn compute_energies(state: &AppState, n_tof: usize) -> Result<Vec<f64>, String> 
                 if values.iter().any(|&v| v <= 0.0) {
                     return Err("Energy bin centers must be positive".into());
                 }
-                values.clone()
+                values.to_vec()
             }
         };
 

--- a/apps/gui/src/guided/rebin.rs
+++ b/apps/gui/src/guided/rebin.rs
@@ -4,6 +4,8 @@
 //! - **Transmission data** (TransmissionTiff): average adjacent bins
 //!   (assumes uniform I₀ — this is an approximation).
 
+use std::sync::Arc;
+
 use crate::state::{AppState, InputMode};
 use crate::theme::ThemeColors;
 use crate::widgets::design;
@@ -167,13 +169,13 @@ pub(crate) fn apply_rebin(state: &mut AppState, is_transmission: bool) {
         } else {
             nereids_io::rebin::rebin_counts(data, factor)
         };
-        state.sample_data = Some(rebinned);
+        state.sample_data = Some(Arc::new(rebinned));
     }
 
     // Rebin open_beam_data (always counts)
     if let Some(ref data) = state.open_beam_data {
         let rebinned = nereids_io::rebin::rebin_counts(data, factor);
-        state.open_beam_data = Some(rebinned);
+        state.open_beam_data = Some(Arc::new(rebinned));
     }
 
     // Rebin spectrum axis
@@ -183,7 +185,7 @@ pub(crate) fn apply_rebin(state: &mut AppState, is_transmission: bool) {
         } else {
             nereids_io::rebin::rebin_centers(vals, factor)
         };
-        state.spectrum_values = Some(new_vals);
+        state.spectrum_values = Some(Arc::new(new_vals));
     }
 
     // Update preview image (sum along TOF axis of new data)

--- a/apps/gui/src/project.rs
+++ b/apps/gui/src/project.rs
@@ -321,9 +321,9 @@ pub fn save_modal(ctx: &egui::Context, state: &mut AppState) {
     let can_embed = state.sample_data.is_some();
     let (raw_bytes, compressed_bytes) = if can_embed {
         nereids_io::project::estimate_embedded_size(
-            state.sample_data.as_ref(),
-            state.open_beam_data.as_ref(),
-            state.spectrum_values.as_deref(),
+            state.sample_data.as_deref(),
+            state.open_beam_data.as_deref(),
+            state.spectrum_values.as_ref().map(|v| v.as_slice()),
         )
     } else {
         (0, 0)
@@ -503,9 +503,9 @@ fn execute_save(state: &mut AppState, path: &Path, mode: SaveDataMode) {
     let handle = std::thread::spawn(move || {
         let result = if let Some((ref sample, ref open_beam, ref spectrum)) = embedded_data {
             let emb = EmbeddedData {
-                sample: sample.as_ref(),
-                open_beam: open_beam.as_ref(),
-                spectrum: spectrum.as_deref(),
+                sample: sample.as_deref(),
+                open_beam: open_beam.as_deref(),
+                spectrum: spectrum.as_ref().map(|v| v.as_slice()),
             };
             nereids_io::project::save_project_with_data(&path, &snap, Some(&emb))
         } else {
@@ -788,13 +788,13 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
     // 14b. Restore embedded data if present
     if snap.data_mode == "embedded" {
         if let Some(data) = snap.sample_data {
-            state.sample_data = Some(data);
+            state.sample_data = Some(Arc::new(data));
         }
         if let Some(data) = snap.open_beam_data {
-            state.open_beam_data = Some(data);
+            state.open_beam_data = Some(Arc::new(data));
         }
         if let Some(data) = snap.spectrum_values {
-            state.spectrum_values = Some(data);
+            state.spectrum_values = Some(Arc::new(data));
         }
         state.last_save_mode = SaveDataMode::Embedded;
     } else {

--- a/apps/gui/src/state.rs
+++ b/apps/gui/src/state.rs
@@ -570,14 +570,14 @@ pub struct AppState {
     pub input_mode: InputMode,
     pub sample_path: Option<PathBuf>,
     pub open_beam_path: Option<PathBuf>,
-    pub sample_data: Option<Array3<f64>>,
-    pub open_beam_data: Option<Array3<f64>>,
+    pub sample_data: Option<Arc<Array3<f64>>>,
+    pub open_beam_data: Option<Arc<Array3<f64>>>,
     pub normalized: Option<Arc<NormalizedData>>,
     pub dead_pixels: Option<Array2<bool>>,
 
     // -- Spectrum file --
     pub spectrum_path: Option<PathBuf>,
-    pub spectrum_values: Option<Vec<f64>>,
+    pub spectrum_values: Option<Arc<Vec<f64>>>,
     pub spectrum_unit: SpectrumUnit,
     pub spectrum_kind: SpectrumValueKind,
 

--- a/apps/gui/src/studio/mod.rs
+++ b/apps/gui/src/studio/mod.rs
@@ -317,7 +317,7 @@ fn analysis_spectrum_column(ui: &mut egui::Ui, state: &mut AppState) {
     let Some((x_values, x_label)) = design::build_spectrum_x_axis(&design::SpectrumXAxisParams {
         axis: state.analyze_spectrum_axis,
         energies: state.energies.as_deref(),
-        spectrum_values: state.spectrum_values.as_deref(),
+        spectrum_values: state.spectrum_values.as_ref().map(|v| v.as_slice()),
         spectrum_unit: state.spectrum_unit,
         spectrum_kind: state.spectrum_kind,
         flight_path_m: state.beamline.flight_path_m,


### PR DESCRIPTION
## Summary

- Wraps `sample_data`, `open_beam_data`, and `spectrum_values` in `Arc` at the `AppState` level
- The async save path (`execute_save`) now does `Arc::clone()` (O(1) refcount increment) instead of deep-copying ~2 GB of data on the GUI thread
- Follows the existing `precomputed_base_xs: Option<Arc<Vec<Vec<f64>>>>` pattern from `FitConfig`
- 8 files changed, ~45 transparent read sites unchanged via Arc auto-deref

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --exclude nereids-python` — all 557 tests pass
- [ ] Manual: load large dataset in GUI, save in embedded mode, verify no UI freeze

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)