### PR TITLE
Add parameter constraints (fixed/free) to fitting pipeline

### DIFF
--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -104,8 +104,8 @@ pub enum FitConfigError {
     /// constraints.densities length must match resonance_data length.
     ConstraintCountMismatch { constraints: usize, isotopes: usize },
     /// Fixed density value must be finite and non-negative.
-    NonFiniteFixedDensity { index: usize, value: f64 },
-    /// Fixed temperature must be finite and non-negative.
+    InvalidFixedDensity { index: usize, value: f64 },
+    /// Fixed temperature must be finite and within physical bounds [1, 5000] K.
     InvalidFixedTemperature(f64),
     /// Temperature must be finite.
     NonFiniteTemperature(f64),
@@ -138,13 +138,13 @@ impl fmt::Display for FitConfigError {
                 f,
                 "constraints.densities length ({constraints}) must match resonance_data length ({isotopes})"
             ),
-            Self::NonFiniteFixedDensity { index, value } => write!(
+            Self::InvalidFixedDensity { index, value } => write!(
                 f,
                 "fixed density at index {index} must be finite and non-negative, got {value}"
             ),
             Self::InvalidFixedTemperature(v) => write!(
                 f,
-                "fixed temperature must be finite and non-negative, got {v}"
+                "fixed temperature must be finite and within [1, 5000] K, got {v}"
             ),
             Self::NonFiniteTemperature(v) => {
                 write!(f, "temperature must be finite, got {v}")
@@ -405,14 +405,14 @@ impl FitConfig {
             if let ParameterRole::Fixed(v) = role
                 && (!v.is_finite() || *v < 0.0)
             {
-                return Err(FitConfigError::NonFiniteFixedDensity {
+                return Err(FitConfigError::InvalidFixedDensity {
                     index: i,
                     value: *v,
                 });
             }
         }
         if let ParameterRole::Fixed(v) = constraints.temperature
-            && (!v.is_finite() || v < 0.0)
+            && (!v.is_finite() || !(1.0..=5000.0).contains(&v))
         {
             return Err(FitConfigError::InvalidFixedTemperature(v));
         }
@@ -1745,7 +1745,7 @@ mod tests {
                 temperature: ParameterRole::Free,
             })
             .unwrap_err();
-        assert!(matches!(err, FitConfigError::NonFiniteFixedDensity { .. }));
+        assert!(matches!(err, FitConfigError::InvalidFixedDensity { .. }));
     }
 
     #[test]
@@ -1768,7 +1768,7 @@ mod tests {
                 temperature: ParameterRole::Free,
             })
             .unwrap_err();
-        assert!(matches!(err, FitConfigError::NonFiniteFixedDensity { .. }));
+        assert!(matches!(err, FitConfigError::InvalidFixedDensity { .. }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Introduce `ParameterRole` enum (`Free` / `Fixed(f64)`) and `ParameterConstraints` struct in `FitConfig`
- Users can fix individual isotope densities or temperature during fitting, enabling workflows like:
  - Fix known matrix, fit traces only
  - Fix temperature, fit densities first, then refine temperature
  - Lock well-known natural densities
- Uncertainty mapping correctly expands free-param-only LM uncertainties back to all-param positions (0.0 for fixed params)
- Works with both LM and Poisson KL solvers
- 9 new tests (566 total, up from 557)

## Test plan

- [x] `test_constraints_all_free_unchanged` — default constraints match no-constraints behavior
- [x] `test_constraints_fix_one_density` — fixed isotope exact, free isotope recovered (LM)
- [x] `test_constraints_fix_temperature` — fixed temperature exact, density recovered
- [x] `test_constraints_fix_all_but_one` — single free param converges
- [x] `test_constraints_fixed_values_in_output` — both fixed at correct indices
- [x] `test_constraints_poisson_fix_one_density` — Poisson solver with fixed param
- [x] `test_constraints_count_mismatch` — validation: wrong density count
- [x] `test_constraints_non_finite_fixed_density` — validation: NaN rejected
- [x] `test_constraints_invalid_fixed_temperature` — validation: negative T rejected
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --exclude nereids-python` — 566 passed

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)