### PR TITLE
Fix Poisson KL fitting in Python binding

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -838,10 +838,11 @@ fn fit_spectrum(
                 // Transmission-space formulation: flux = 1.0 everywhere since
                 // Y = T, not Y = Φ·T + B.  The analytical gradient formulas
                 // reduce correctly with Φ=1 (matches pipeline.rs).
+                let n_e = e_owned.len();
                 let density_indices: Arc<Vec<usize>> = Arc::new((0..n_isotopes).collect());
-                let xs_arc = Arc::new(xs.clone());
+                let xs_arc = Arc::new(xs);
                 let precomputed = PrecomputedTransmissionModel {
-                    cross_sections: xs_arc,
+                    cross_sections: Arc::clone(&xs_arc),
                     density_indices: Arc::clone(&density_indices),
                 };
 
@@ -862,7 +863,7 @@ fn fit_spectrum(
                 let full_model;
                 let t_model: &dyn FitModel = if fit_temperature {
                     full_model = TransmissionFitModel::new(
-                        e_owned.clone(),
+                        e_owned,
                         res_data,
                         temperature_k,
                         instrument.map(Arc::new),
@@ -876,7 +877,7 @@ fn fit_spectrum(
                     &precomputed
                 };
 
-                let flux = vec![1.0f64; e_owned.len()];
+                let flux = vec![1.0f64; n_e];
 
                 let poisson_config = PoissonConfig {
                     max_iter,
@@ -887,7 +888,7 @@ fn fit_spectrum(
                     t_model,
                     &y_obs,
                     &flux,
-                    &xs,
+                    &*xs_arc,
                     &density_indices,
                     &mut params,
                     &poisson_config,

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -571,7 +571,7 @@ class TestFitSpectrumPoisson:
         """Poisson fitter with synthetic transmission data."""
         energies = np.linspace(1.0, 30.0, 300)
         true_density = 0.002
-        flux = 10000.0  # high counts for easy fitting
+        open_beam_counts = 10000.0  # high counts for easy fitting
 
         # Build clean transmission
         t_clean = np.asarray(
@@ -580,9 +580,9 @@ class TestFitSpectrumPoisson:
 
         # Simulate Poisson counts, then convert to transmission + uncertainty
         rng = np.random.default_rng(123)
-        sample_counts = rng.poisson(flux * t_clean).astype(float)
-        measured_t = sample_counts / flux
-        sigma = np.sqrt(np.maximum(sample_counts, 1.0)) / flux
+        sample_counts = rng.poisson(open_beam_counts * t_clean).astype(float)
+        measured_t = sample_counts / open_beam_counts
+        sigma = np.sqrt(np.maximum(sample_counts, 1.0)) / open_beam_counts
 
         result = nereids.fit_spectrum(
             measured_t,


### PR DESCRIPTION
## Summary

- **Fixed** `fit_spectrum(fitter='poisson')` which used sigma (uncertainty) as flux and wrapped the model in `CountsModel`, causing density to converge near-zero and temperature to hit bounds
- **Corrected** to transmission-space formulation (`flux=1.0`, pass model directly to `poisson_fit_analytic`), matching the canonical Rust pipeline implementation
- **Updated** Poisson tests to pass transmission+uncertainty instead of counts+open_beam

## Root Cause

Two bugs in the Python binding's inline Poisson path (`bindings/python/src/lib.rs`):
1. `flux_owned = s.to_vec()` used sigma (~0.005) as flux instead of 1.0
2. `CountsModel` wrapper made model return `sigma * T(σ,n)` instead of `T(σ,n)`

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --exclude nereids-python` — clean
- [x] `cargo test --workspace --exclude nereids-python` — 557 pass
- [x] `pixi run build && pixi run test-python` — 104 pass
- [x] Synthetic validation: Poisson+temperature with single-resonance data converges to 0.0% error on both density and temperature
- [x] Phase A review: 0 P1s, 3 P2s fixed (allocation optimization, test clarity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)