### PR TITLE
feat: Python bindings for NeXus histogram and event loading

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 nereids-core = { workspace = true }
 nereids-endf = { workspace = true }
 nereids-physics = { workspace = true }
-nereids-io = { workspace = true }
+nereids-io = { workspace = true, features = ["hdf5"] }
 nereids-fitting = { workspace = true }
 nereids-pipeline = { workspace = true }
 pyo3 = { workspace = true }

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -9,6 +9,50 @@ from numpy.typing import NDArray
 # Classes
 # ---------------------------------------------------------------------------
 
+class NexusMetadata:
+    """Metadata from probing a NeXus/HDF5 file."""
+
+    @property
+    def has_histogram(self) -> bool: ...
+    @property
+    def has_events(self) -> bool: ...
+    @property
+    def histogram_shape(self) -> tuple[int, int, int, int] | None: ...
+    @property
+    def n_events(self) -> int | None: ...
+    @property
+    def flight_path_m(self) -> float | None: ...
+    @property
+    def tof_offset_ns(self) -> float | None: ...
+
+class NexusData:
+    """Result of loading NeXus histogram or event data."""
+
+    @property
+    def counts(self) -> NDArray[np.float64]:
+        """3D counts array (n_tof, height, width)."""
+        ...
+    @property
+    def tof_edges_us(self) -> NDArray[np.float64]:
+        """TOF bin edges in microseconds (length = n_tof + 1)."""
+        ...
+    @property
+    def flight_path_m(self) -> float | None: ...
+    @property
+    def dead_pixels(self) -> NDArray[np.bool_] | None:
+        """Dead pixel mask (height, width). True = dead."""
+        ...
+    @property
+    def n_rotation_angles(self) -> int: ...
+    @property
+    def event_total(self) -> int | None:
+        """Total events before filtering (event data only)."""
+        ...
+    @property
+    def event_kept(self) -> int | None:
+        """Events kept after filtering (event data only)."""
+        ...
+
 class ResonanceData:
     """ENDF resonance data for an isotope."""
 
@@ -435,6 +479,33 @@ def load_tiff_folder(
     pattern: str | None = None,
 ) -> NDArray[np.float64]:
     """Load a folder of single-frame TIFFs into a 3D numpy array."""
+    ...
+
+def probe_nexus(path: str) -> NexusMetadata:
+    """Probe a NeXus/HDF5 file for available data without loading it."""
+    ...
+
+def load_nexus_histogram(path: str) -> NexusData:
+    """Load pre-histogrammed counts from a NeXus/HDF5 file.
+
+    Reads ``/entry/histogram/counts``, sums over rotation angles,
+    and returns a ``NexusData`` with shape ``(n_tof, height, width)``.
+    """
+    ...
+
+def load_nexus_events(
+    path: str,
+    n_bins: int,
+    tof_min_us: float,
+    tof_max_us: float,
+    height: int,
+    width: int,
+) -> NexusData:
+    """Load event data from a NeXus/HDF5 file, histogramming into TOF bins.
+
+    Reads ``/entry/neutrons/event_time_offset``, ``/x``, ``/y`` and bins
+    events into a linear TOF grid.
+    """
     ...
 
 def normalize(

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -2196,10 +2196,21 @@ impl PyNexusData {
 ///
 /// Returns:
 ///     NexusMetadata with has_histogram, has_events, n_events, etc.
+/// Map nereids_io::IoError to appropriate Python exception.
+fn map_io_error(e: nereids_io::error::IoError) -> pyo3::PyErr {
+    use nereids_io::error::IoError;
+    match e {
+        IoError::FileNotFound(..) => pyo3::exceptions::PyFileNotFoundError::new_err(format!("{e}")),
+        IoError::InvalidParameter(..) | IoError::ShapeMismatch(..) => {
+            pyo3::exceptions::PyValueError::new_err(format!("{e}"))
+        }
+        _ => pyo3::exceptions::PyIOError::new_err(format!("{e}")),
+    }
+}
+
 #[pyfunction]
 fn probe_nexus(path: &str) -> PyResult<PyNexusMetadata> {
-    let meta = nereids_io::nexus::probe_nexus(std::path::Path::new(path))
-        .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{e}")))?;
+    let meta = nereids_io::nexus::probe_nexus(std::path::Path::new(path)).map_err(map_io_error)?;
     Ok(PyNexusMetadata { inner: meta })
 }
 
@@ -2216,7 +2227,7 @@ fn probe_nexus(path: &str) -> PyResult<PyNexusMetadata> {
 #[pyfunction]
 fn load_nexus_histogram(py: Python<'_>, path: &str) -> PyResult<PyNexusData> {
     let data = nereids_io::nexus::load_nexus_histogram(std::path::Path::new(path))
-        .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{e}")))?;
+        .map_err(map_io_error)?;
     Ok(nexus_data_to_py(py, data))
 }
 
@@ -2254,7 +2265,7 @@ fn load_nexus_events(
         width,
     };
     let data = nereids_io::nexus::load_nexus_events(std::path::Path::new(path), &params)
-        .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{e}")))?;
+        .map_err(map_io_error)?;
     Ok(nexus_data_to_py(py, data))
 }
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -2064,6 +2064,220 @@ fn py_calibrate_energy(
     })
 }
 
+// ── NeXus I/O Bindings ──────────────────────────────────────────────────
+
+/// Result of probing a NeXus file for available data.
+#[pyclass(name = "NexusMetadata")]
+struct PyNexusMetadata {
+    inner: nereids_io::nexus::NexusMetadata,
+}
+
+#[pymethods]
+impl PyNexusMetadata {
+    /// Whether the file contains a pre-histogrammed dataset.
+    #[getter]
+    fn has_histogram(&self) -> bool {
+        self.inner.has_histogram
+    }
+
+    /// Whether the file contains event data.
+    #[getter]
+    fn has_events(&self) -> bool {
+        self.inner.has_events
+    }
+
+    /// Shape of the histogram dataset as (rotation, y, x, tof), if present.
+    #[getter]
+    fn histogram_shape(&self) -> Option<[usize; 4]> {
+        self.inner.histogram_shape
+    }
+
+    /// Number of neutron events, if present.
+    #[getter]
+    fn n_events(&self) -> Option<usize> {
+        self.inner.n_events
+    }
+
+    /// Flight path in metres from file metadata, if present.
+    #[getter]
+    fn flight_path_m(&self) -> Option<f64> {
+        self.inner.flight_path_m
+    }
+
+    /// TOF offset in nanoseconds, if present.
+    #[getter]
+    fn tof_offset_ns(&self) -> Option<f64> {
+        self.inner.tof_offset_ns
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "NexusMetadata(histogram={}, events={}, n_events={:?}, flight_path={:?})",
+            self.inner.has_histogram,
+            self.inner.has_events,
+            self.inner.n_events,
+            self.inner.flight_path_m,
+        )
+    }
+}
+
+/// Result of loading NeXus histogram or event data.
+#[pyclass(name = "NexusData")]
+struct PyNexusData {
+    counts: Py<PyArray3<f64>>,
+    tof_edges_us: Py<PyArray1<f64>>,
+    flight_path_m: Option<f64>,
+    dead_pixels: Option<Py<PyArray2<bool>>>,
+    n_rotation_angles: usize,
+    event_total: Option<usize>,
+    event_kept: Option<usize>,
+}
+
+#[pymethods]
+impl PyNexusData {
+    /// 3D counts array with shape (n_tof, height, width).
+    #[getter]
+    fn counts<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray3<f64>> {
+        self.counts.bind(py).clone()
+    }
+
+    /// TOF bin edges in microseconds (length = n_tof + 1).
+    #[getter]
+    fn tof_edges_us<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        self.tof_edges_us.bind(py).clone()
+    }
+
+    /// Flight path in metres from file metadata, if present.
+    #[getter]
+    fn flight_path_m(&self) -> Option<f64> {
+        self.flight_path_m
+    }
+
+    /// Dead pixel mask (height, width), if present.  True = dead.
+    #[getter]
+    fn dead_pixels<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyArray2<bool>>> {
+        self.dead_pixels.as_ref().map(|m| m.bind(py).clone())
+    }
+
+    /// Number of rotation angles summed (1 for single-angle data).
+    #[getter]
+    fn n_rotation_angles(&self) -> usize {
+        self.n_rotation_angles
+    }
+
+    /// Total events before filtering (event data only).
+    #[getter]
+    fn event_total(&self) -> Option<usize> {
+        self.event_total
+    }
+
+    /// Events kept after filtering (event data only).
+    #[getter]
+    fn event_kept(&self) -> Option<usize> {
+        self.event_kept
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> String {
+        let shape = self.counts.bind(py).shape();
+        format!(
+            "NexusData(shape=({}, {}, {}), tof_bins={}, flight_path={:?})",
+            shape[0], shape[1], shape[2], shape[0], self.flight_path_m,
+        )
+    }
+}
+
+/// Probe a NeXus/HDF5 file for available data without loading it.
+///
+/// Returns metadata about what the file contains (histogram, events,
+/// flight path, etc.) without reading the full dataset.
+///
+/// Args:
+///     path: Path to the NeXus/HDF5 file.
+///
+/// Returns:
+///     NexusMetadata with has_histogram, has_events, n_events, etc.
+#[pyfunction]
+fn probe_nexus(path: &str) -> PyResult<PyNexusMetadata> {
+    let meta = nereids_io::nexus::probe_nexus(std::path::Path::new(path))
+        .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{e}")))?;
+    Ok(PyNexusMetadata { inner: meta })
+}
+
+/// Load pre-histogrammed counts from a NeXus/HDF5 file.
+///
+/// Reads `/entry/histogram/counts` (4D: rotation × y × x × tof),
+/// sums over rotation angles, and transposes to (tof, y, x).
+///
+/// Args:
+///     path: Path to the NeXus/HDF5 file.
+///
+/// Returns:
+///     NexusData with counts, tof_edges_us, flight_path_m, dead_pixels.
+#[pyfunction]
+fn load_nexus_histogram(py: Python<'_>, path: &str) -> PyResult<PyNexusData> {
+    let data = nereids_io::nexus::load_nexus_histogram(std::path::Path::new(path))
+        .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{e}")))?;
+    Ok(nexus_data_to_py(py, data))
+}
+
+/// Load event data from a NeXus/HDF5 file, histogramming into TOF bins.
+///
+/// Reads `/entry/neutrons/event_time_offset`, `/x`, `/y` and bins
+/// events into a linear TOF grid with the specified parameters.
+///
+/// Args:
+///     path: Path to the NeXus/HDF5 file.
+///     n_bins: Number of TOF bins.
+///     tof_min_us: Minimum TOF in microseconds.
+///     tof_max_us: Maximum TOF in microseconds.
+///     height: Detector height in pixels.
+///     width: Detector width in pixels.
+///
+/// Returns:
+///     NexusData with counts, tof_edges_us, flight_path_m, and event stats.
+#[pyfunction]
+#[pyo3(signature = (path, n_bins, tof_min_us, tof_max_us, height, width))]
+fn load_nexus_events(
+    py: Python<'_>,
+    path: &str,
+    n_bins: usize,
+    tof_min_us: f64,
+    tof_max_us: f64,
+    height: usize,
+    width: usize,
+) -> PyResult<PyNexusData> {
+    let params = nereids_io::nexus::EventBinningParams {
+        n_bins,
+        tof_min_us,
+        tof_max_us,
+        height,
+        width,
+    };
+    let data = nereids_io::nexus::load_nexus_events(std::path::Path::new(path), &params)
+        .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{e}")))?;
+    Ok(nexus_data_to_py(py, data))
+}
+
+/// Convert Rust NexusHistogramData to Python PyNexusData.
+fn nexus_data_to_py(py: Python<'_>, data: nereids_io::nexus::NexusHistogramData) -> PyNexusData {
+    let (event_total, event_kept) = data
+        .event_stats
+        .as_ref()
+        .map(|s| (Some(s.total), Some(s.kept)))
+        .unwrap_or((None, None));
+    PyNexusData {
+        counts: PyArray3::from_owned_array(py, data.counts).unbind(),
+        tof_edges_us: PyArray1::from_vec(py, data.tof_edges_us).unbind(),
+        flight_path_m: data.flight_path_m,
+        dead_pixels: data
+            .dead_pixels
+            .map(|dp| PyArray2::from_owned_array(py, dp).unbind()),
+        n_rotation_angles: data.n_rotation_angles,
+        event_total,
+        event_kept,
+    }
+}
+
 /// NEREIDS Python module.
 #[pymodule]
 fn nereids(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -2086,6 +2300,11 @@ fn nereids(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_apply_resolution, m)?)?;
     m.add_function(wrap_pyfunction!(load_tiff_stack, m)?)?;
     m.add_function(wrap_pyfunction!(load_tiff_folder, m)?)?;
+    m.add_class::<PyNexusMetadata>()?;
+    m.add_class::<PyNexusData>()?;
+    m.add_function(wrap_pyfunction!(probe_nexus, m)?)?;
+    m.add_function(wrap_pyfunction!(load_nexus_histogram, m)?)?;
+    m.add_function(wrap_pyfunction!(load_nexus_events, m)?)?;
     m.add_function(wrap_pyfunction!(normalize, m)?)?;
     m.add_function(wrap_pyfunction!(tof_to_energy_centers, m)?)?;
     m.add_function(wrap_pyfunction!(py_element_symbol, m)?)?;

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -864,6 +864,7 @@ class TestNexusIO:
         meta = nereids.probe_nexus(path)
         assert meta.has_events is True
         assert meta.n_events == 1000
+        assert meta.flight_path_m == pytest.approx(25.0)
 
     def test_load_nexus_histogram(self, tmp_path):
         path = str(tmp_path / "hist.h5")
@@ -899,6 +900,7 @@ class TestNexusIO:
         assert data.event_kept is not None
         assert data.event_kept > 0
         assert data.event_kept <= 5000
+        assert data.flight_path_m == pytest.approx(25.0)
 
     def test_load_nexus_histogram_bad_path(self):
         with pytest.raises(IOError):

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -821,8 +821,8 @@ def _create_synthetic_nexus_histogram(path, n_tof=10, height=4, width=4):
         # TOF edges in nanoseconds (n_tof + 1) — dataset name matches VENUS schema
         tof_ns = np.linspace(1e4, 5e4, n_tof + 1)
         hist.create_dataset("time_of_flight", data=tof_ns)
-        # Flight path
-        entry.attrs["L1"] = 25.0
+        # Flight path — attribute name matches VENUS schema expected by Rust reader
+        entry.attrs["flight_path_m"] = 25.0
 
 
 def _create_synthetic_nexus_events(path, n_events=1000, height=4, width=4):
@@ -841,8 +841,8 @@ def _create_synthetic_nexus_events(path, n_events=1000, height=4, width=4):
         y = rng.uniform(0, height - 1, size=n_events)
         neutrons.create_dataset("x", data=x)
         neutrons.create_dataset("y", data=y)
-        # Flight path
-        entry.attrs["L1"] = 25.0
+        # Flight path — attribute name matches VENUS schema
+        entry.attrs["flight_path_m"] = 25.0
 
 
 @pytest.mark.skipif(not HAS_H5PY, reason="h5py not installed")
@@ -856,6 +856,7 @@ class TestNexusIO:
         assert isinstance(meta, nereids.NexusMetadata)
         assert meta.has_histogram is True
         assert meta.has_events is False
+        assert meta.flight_path_m == pytest.approx(25.0)
 
     def test_probe_nexus_events(self, tmp_path):
         path = str(tmp_path / "events.h5")
@@ -875,6 +876,8 @@ class TestNexusIO:
         assert data.n_rotation_angles == 1
         # Counts should be non-negative
         assert np.all(data.counts >= 0)
+        # Flight path from metadata
+        assert data.flight_path_m == pytest.approx(25.0)
 
     def test_load_nexus_events(self, tmp_path):
         path = str(tmp_path / "events.h5")

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -795,6 +795,128 @@ class TestTraceDetectability:
 
 
 # ===========================================================================
+# NeXus I/O Tests
 # ===========================================================================
+
+try:
+    import h5py
+
+    HAS_H5PY = True
+except ImportError:
+    HAS_H5PY = False
+
+
+def _create_synthetic_nexus_histogram(path, n_tof=10, height=4, width=4):
+    """Create a minimal VENUS-schema NeXus file with histogram data."""
+    import h5py
+
+    with h5py.File(path, "w") as f:
+        entry = f.create_group("entry")
+        hist = entry.create_group("histogram")
+        # Shape: (1 rotation, height, width, n_tof) — u64
+        counts = np.random.default_rng(42).integers(
+            0, 100, size=(1, height, width, n_tof), dtype=np.uint64
+        )
+        hist.create_dataset("counts", data=counts)
+        # TOF edges in nanoseconds (n_tof + 1) — dataset name matches VENUS schema
+        tof_ns = np.linspace(1e4, 5e4, n_tof + 1)
+        hist.create_dataset("time_of_flight", data=tof_ns)
+        # Flight path
+        entry.attrs["L1"] = 25.0
+
+
+def _create_synthetic_nexus_events(path, n_events=1000, height=4, width=4):
+    """Create a minimal VENUS-schema NeXus file with event data."""
+    import h5py
+
+    rng = np.random.default_rng(43)
+    with h5py.File(path, "w") as f:
+        entry = f.create_group("entry")
+        neutrons = entry.create_group("neutrons")
+        # Event time offsets in nanoseconds (u64)
+        tof_ns = rng.integers(10_000, 50_000, size=n_events, dtype=np.uint64)
+        neutrons.create_dataset("event_time_offset", data=tof_ns)
+        # Pixel coordinates (f64)
+        x = rng.uniform(0, width - 1, size=n_events)
+        y = rng.uniform(0, height - 1, size=n_events)
+        neutrons.create_dataset("x", data=x)
+        neutrons.create_dataset("y", data=y)
+        # Flight path
+        entry.attrs["L1"] = 25.0
+
+
+@pytest.mark.skipif(not HAS_H5PY, reason="h5py not installed")
+class TestNexusIO:
+    """Tests for NeXus loading Python bindings."""
+
+    def test_probe_nexus_histogram(self, tmp_path):
+        path = str(tmp_path / "hist.h5")
+        _create_synthetic_nexus_histogram(path)
+        meta = nereids.probe_nexus(path)
+        assert isinstance(meta, nereids.NexusMetadata)
+        assert meta.has_histogram is True
+        assert meta.has_events is False
+
+    def test_probe_nexus_events(self, tmp_path):
+        path = str(tmp_path / "events.h5")
+        _create_synthetic_nexus_events(path)
+        meta = nereids.probe_nexus(path)
+        assert meta.has_events is True
+        assert meta.n_events == 1000
+
+    def test_load_nexus_histogram(self, tmp_path):
+        path = str(tmp_path / "hist.h5")
+        _create_synthetic_nexus_histogram(path, n_tof=10, height=4, width=4)
+        data = nereids.load_nexus_histogram(path)
+        assert isinstance(data, nereids.NexusData)
+        # Shape should be (n_tof, height, width)
+        assert data.counts.shape == (10, 4, 4)
+        assert data.tof_edges_us.shape == (11,)
+        assert data.n_rotation_angles == 1
+        # Counts should be non-negative
+        assert np.all(data.counts >= 0)
+
+    def test_load_nexus_events(self, tmp_path):
+        path = str(tmp_path / "events.h5")
+        _create_synthetic_nexus_events(path, n_events=5000, height=4, width=4)
+        data = nereids.load_nexus_events(
+            path,
+            n_bins=20,
+            tof_min_us=10.0,
+            tof_max_us=50.0,
+            height=4,
+            width=4,
+        )
+        assert isinstance(data, nereids.NexusData)
+        assert data.counts.shape == (20, 4, 4)
+        assert data.tof_edges_us.shape == (21,)
+        # Event stats should be populated
+        assert data.event_total is not None
+        assert data.event_total == 5000
+        assert data.event_kept is not None
+        assert data.event_kept > 0
+        assert data.event_kept <= 5000
+
+    def test_load_nexus_histogram_bad_path(self):
+        with pytest.raises(IOError):
+            nereids.load_nexus_histogram("/nonexistent/file.h5")
+
+    def test_probe_nexus_bad_path(self):
+        with pytest.raises(IOError):
+            nereids.probe_nexus("/nonexistent/file.h5")
+
+    def test_nexus_histogram_to_fitting_workflow(self, tmp_path):
+        """End-to-end: load histogram → normalize → fit."""
+        path = str(tmp_path / "hist.h5")
+        n_tof, h, w = 50, 2, 2
+        _create_synthetic_nexus_histogram(path, n_tof=n_tof, height=h, width=w)
+        data = nereids.load_nexus_histogram(path)
+        assert data.counts.shape == (n_tof, h, w)
+        # Verify the loaded data can be used in from_counts
+        sample = data.counts
+        ob = np.full_like(sample, 100.0)  # synthetic OB
+        input_data = nereids.from_counts(sample, ob)
+        assert input_data is not None  # successfully created InputData
+
 
 


### PR DESCRIPTION
## Summary

Closes the remaining restoration blocker: Python users can now load raw VENUS NeXus data directly without external preprocessing or the GUI.

### New Python API

| Function | Description |
|----------|-------------|
| `probe_nexus(path)` → `NexusMetadata` | Lightweight probe — has_histogram, has_events, n_events, flight_path_m |
| `load_nexus_histogram(path)` → `NexusData` | Load pre-histogrammed counts from `/entry/histogram/counts` |
| `load_nexus_events(path, n_bins, tof_min_us, tof_max_us, height, width)` → `NexusData` | Histogram events from `/entry/neutrons/` into linear TOF bins |

### New types

- **`NexusMetadata`**: has_histogram, has_events, histogram_shape, n_events, flight_path_m, tof_offset_ns
- **`NexusData`**: counts (3D ndarray), tof_edges_us, flight_path_m, dead_pixels, n_rotation_angles, event_total, event_kept

### Example workflow (Python-only, no GUI needed)

```python
import nereids

# Load raw VENUS histogram
data = nereids.load_nexus_histogram("sample.nxs.h5")
ob = nereids.load_nexus_histogram("open_beam.nxs.h5")

# Normalize
t, sigma = nereids.normalize(data.counts, ob.counts, pc_sample=1.0, pc_ob=1.0)

# Or use counts directly with KL solver
input_data = nereids.from_counts(data.counts, ob.counts)
result = nereids.spatial_map_typed(input_data, energies, isotopes=[rd])
```

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings` clean
- [x] 606 Rust tests pass, 0 failures
- [x] 70 Python tests pass (7 new NeXus tests, require h5py)
- [x] Tests create synthetic VENUS-schema NeXus files and verify shape/metadata contracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)