### PR TITLE
fix(#458): spatial NaN-on-failure + config guards + binding validation (P1 sprint)

### DIFF
--- a/apps/gui/src/project.rs
+++ b/apps/gui/src/project.rs
@@ -1052,6 +1052,10 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
             // D-11/D-21: Now persisted; None for old project files.
             anorm_map: snap.anorm_map,
             background_maps: snap.background_maps,
+            // TZERO maps are not yet persisted in project files — None on
+            // restore.  Re-running spatial_map_typed regenerates them.
+            t0_us_map: None,
+            l_scale_map: None,
             n_converged: snap.n_converged.unwrap_or(0),
             n_total: snap.n_total.unwrap_or(0),
             n_failed: snap.n_failed.unwrap_or(0),

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -296,6 +296,18 @@ class SpatialResult:
         """Per-pixel background parameter maps [BackA, BackB, BackC] (None when background=False)."""
         ...
 
+    @property
+    def t0_us_map(self) -> NDArray[np.float64] | None:
+        """Per-pixel SAMMY TZERO offset t0 (µs) map.
+        ``None`` when the run did not use ``fit_energy_scale=True``."""
+        ...
+
+    @property
+    def l_scale_map(self) -> NDArray[np.float64] | None:
+        """Per-pixel SAMMY TZERO flight-path scale factor map.
+        ``None`` when the run did not use ``fit_energy_scale=True``."""
+        ...
+
 class IsotopeGroup:
     """A group of isotopes sharing one fitted density parameter.
 
@@ -747,6 +759,10 @@ def spatial_map_typed(
     alpha_2_init: float = 1.0,
     c: float = 1.0,
     enable_polish: bool | None = None,
+    fit_energy_scale: bool = False,
+    t0_init_us: float = 0.0,
+    l_scale_init: float = 1.0,
+    energy_scale_flight_path_m: float = 25.0,
     resolution: TabulatedResolution | None = None,
     flight_path_m: float | None = None,
     delta_t_us: float | None = None,
@@ -776,9 +792,19 @@ def spatial_map_typed(
             (default) = the dispatcher auto-disables polish when
             ``n_pixels > 1`` (memo 38 §6 — polish costs ~1000 s per pixel
             on realistic data).  ``True`` forces polish on, ``False`` off.
+        fit_energy_scale: Fit per-pixel SAMMY TZERO calibration
+            (t0 and L_scale).  Required for real VENUS data to match SAMMY
+            chi-squared performance — without it, sharp resonances are
+            offset in TOF and per-pixel chi-squared explodes.
+        t0_init_us: Initial TOF offset in microseconds (default 0.0).
+        l_scale_init: Initial flight-path scale factor (default 1.0).
+        energy_scale_flight_path_m: Nominal flight path (m) for the
+            energy-scale model (default 25.0).
 
     Always returns SpatialResult.  For counts-KL runs,
     ``SpatialResult.deviance_per_dof_map`` is populated as the primary GOF.
+    When ``fit_energy_scale=True``, per-pixel ``t0_us_map`` and
+    ``l_scale_map`` are populated on the returned SpatialResult.
     """
     ...
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -2901,6 +2901,51 @@ fn py_spatial_map_typed<'py>(
         ));
     }
 
+    // ── Issue #458 V1-V3: input validation at the binding boundary ──
+
+    // V1: proton-charge ratio `c` is used by the counts-KL dispatch to
+    // relate sample to open-beam flux.  Non-positive or non-finite
+    // values produce garbage fits deep in `joint_poisson_fit`; reject
+    // here with a clear message instead of letting a PyRuntimeError
+    // bubble up from the solver.
+    if !c.is_finite() || c <= 0.0 {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "c (proton-charge ratio Q_s/Q_ob) must be positive and finite, got {c}",
+        )));
+    }
+
+    // V2: `initial_densities`, when supplied, must all be finite and
+    // non-negative.  NaN/Inf propagates through the solver and
+    // produces meaningless output; negative densities are non-physical
+    // (and LM's analytical Jacobian for exp(-n·σ) assumes n ≥ 0).
+    if let Some(ref init_d) = initial_densities {
+        for (i, &d) in init_d.iter().enumerate() {
+            if !d.is_finite() || d < 0.0 {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "initial_densities[{i}] must be finite and non-negative, got {d}",
+                )));
+            }
+        }
+    }
+
+    // V3: shape validation against the input data cube.
+    let data_shape = data.data_a.shape();
+    let (data_n_e, data_h, data_w) = (data_shape[0], data_shape[1], data_shape[2]);
+    let n_e_supplied = energies.as_slice()?.len();
+    if n_e_supplied != data_n_e {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "energies length ({n_e_supplied}) != data spectral axis length ({data_n_e})",
+        )));
+    }
+    if let Some(ref dp) = dead_pixels {
+        let dp_shape = dp.as_array().shape().to_vec();
+        if dp_shape != [data_h, data_w] {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "dead_pixels shape {dp_shape:?} != data spatial dims ({data_h}, {data_w})",
+            )));
+        }
+    }
+
     let energies_vec = energies.as_slice()?.to_vec();
 
     // Build resolution
@@ -2949,7 +2994,13 @@ fn py_spatial_map_typed<'py>(
     };
 
     // Solver — resolve "auto" eagerly so max_iter is always propagated.
-    let solver_config = parse_solver_config(solver, data.kind == "counts", max_iter)?;
+    // Issue #458 B4: `data.kind` is one of `"counts"`, `"counts_with_nuisance"`,
+    // or the transmission string produced by `from_transmission()`.  Both
+    // counts variants should route `solver="auto"` to the counts-KL
+    // (joint-Poisson) dispatch — `data.kind == "counts"` alone misses
+    // `counts_with_nuisance`, which silently fell through to LM before.
+    let is_counts = data.kind == "counts" || data.kind == "counts_with_nuisance";
+    let solver_config = parse_solver_config(solver, is_counts, max_iter)?;
     config = config.with_solver(solver_config);
 
     // Temperature fitting
@@ -3157,6 +3208,33 @@ fn py_fit_counts_spectrum_typed<'py>(
         )));
     }
     require_non_empty_energy_grid(e_slice)?;
+
+    // Issue #458 V1: reject non-positive / non-finite `c` (Q_s / Q_ob).
+    if !c.is_finite() || c <= 0.0 {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "c (proton-charge ratio Q_s/Q_ob) must be positive and finite, got {c}",
+        )));
+    }
+    // Issue #458 V2: reject non-finite / negative initial densities —
+    // both in `initial_densities` kwarg and in `isotopes: list[(rd, d)]`.
+    if let Some(ref init_d) = initial_densities {
+        for (i, &d) in init_d.iter().enumerate() {
+            if !d.is_finite() || d < 0.0 {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "initial_densities[{i}] must be finite and non-negative, got {d}",
+                )));
+            }
+        }
+    }
+    if let Some(ref iso) = isotopes {
+        for (i, (_, d)) in iso.iter().enumerate() {
+            if !d.is_finite() || *d < 0.0 {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "isotopes[{i}] initial density must be finite and non-negative, got {d}",
+                )));
+            }
+        }
+    }
 
     let detector_background_vec = if let Some(bg) = detector_background {
         let bg_slice = bg.as_slice()?;
@@ -3641,6 +3719,27 @@ fn py_fit_spectrum_typed<'py>(
         )));
     }
     require_non_empty_energy_grid(e_slice)?;
+
+    // Issue #458 V2: reject non-finite / negative initial densities.
+    if let Some(ref init_d) = initial_densities {
+        for (i, &d) in init_d.iter().enumerate() {
+            if !d.is_finite() || d < 0.0 {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "initial_densities[{i}] must be finite and non-negative, got {d}",
+                )));
+            }
+        }
+    }
+    // Also validate embedded densities passed through `isotopes: list[(ResonanceData, float)]`.
+    if let Some(ref iso) = isotopes {
+        for (i, (_, d)) in iso.iter().enumerate() {
+            if !d.is_finite() || *d < 0.0 {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "isotopes[{i}] initial density must be finite and non-negative, got {d}",
+                )));
+            }
+        }
+    }
 
     let energies_vec = e_slice.to_vec();
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -2904,11 +2904,16 @@ fn py_spatial_map_typed<'py>(
     // ── Issue #458 V1-V3: input validation at the binding boundary ──
 
     // V1: proton-charge ratio `c` is used by the counts-KL dispatch to
-    // relate sample to open-beam flux.  Non-positive or non-finite
-    // values produce garbage fits deep in `joint_poisson_fit`; reject
-    // here with a clear message instead of letting a PyRuntimeError
+    // relate sample to open-beam flux.  It is ignored on the
+    // transmission path, so we only validate it when the input is a
+    // counts variant — otherwise a user passing (say) `c=0.0` with
+    // transmission data would see a misleading error about a value
+    // that was never consulted.  Non-positive or non-finite values
+    // produce garbage fits deep in `joint_poisson_fit`; reject here
+    // with a clear message instead of letting a PyRuntimeError
     // bubble up from the solver.
-    if !c.is_finite() || c <= 0.0 {
+    let is_counts_input = data.kind == "counts" || data.kind == "counts_with_nuisance";
+    if is_counts_input && (!c.is_finite() || c <= 0.0) {
         return Err(pyo3::exceptions::PyValueError::new_err(format!(
             "c (proton-charge ratio Q_s/Q_ob) must be positive and finite, got {c}",
         )));
@@ -2999,8 +3004,8 @@ fn py_spatial_map_typed<'py>(
     // counts variants should route `solver="auto"` to the counts-KL
     // (joint-Poisson) dispatch — `data.kind == "counts"` alone misses
     // `counts_with_nuisance`, which silently fell through to LM before.
-    let is_counts = data.kind == "counts" || data.kind == "counts_with_nuisance";
-    let solver_config = parse_solver_config(solver, is_counts, max_iter)?;
+    // (`is_counts_input` computed earlier for V1 validation.)
+    let solver_config = parse_solver_config(solver, is_counts_input, max_iter)?;
     config = config.with_solver(solver_config);
 
     // Temperature fitting

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -621,6 +621,10 @@ struct PySpatialResult {
     anorm_map: Option<Py<PyArray2<f64>>>,
     /// Per-pixel background parameter maps (None when background=False).
     background_maps: Option<[Py<PyArray2<f64>>; 3]>,
+    /// Per-pixel fitted TZERO t0 (µs) map (None when fit_energy_scale=False).
+    t0_us_map: Option<Py<PyArray2<f64>>>,
+    /// Per-pixel fitted TZERO L_scale map (None when fit_energy_scale=False).
+    l_scale_map: Option<Py<PyArray2<f64>>>,
 }
 
 #[pymethods]
@@ -724,6 +728,20 @@ impl PySpatialResult {
         self.background_maps
             .as_ref()
             .map(|maps| maps.iter().map(|m| m.bind(py).clone()).collect())
+    }
+
+    /// Per-pixel SAMMY TZERO offset t0 (µs) map.
+    /// `None` when the run did not fit energy scale.
+    #[getter]
+    fn t0_us_map<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyArray2<f64>>> {
+        self.t0_us_map.as_ref().map(|m| m.bind(py).clone())
+    }
+
+    /// Per-pixel SAMMY TZERO flight-path scale factor map.
+    /// `None` when the run did not fit energy scale.
+    #[getter]
+    fn l_scale_map<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyArray2<f64>>> {
+        self.l_scale_map.as_ref().map(|m| m.bind(py).clone())
     }
 
     fn __repr__(&self) -> String {
@@ -2742,6 +2760,14 @@ fn spatial_result_to_py(
         .deviance_per_dof_map
         .as_ref()
         .map(|m| PyArray2::from_array(py, m).into());
+    let t0_us_map = result
+        .t0_us_map
+        .as_ref()
+        .map(|m| PyArray2::from_array(py, m).into());
+    let l_scale_map = result
+        .l_scale_map
+        .as_ref()
+        .map(|m| PyArray2::from_array(py, m).into());
 
     PySpatialResult {
         density_maps,
@@ -2758,6 +2784,8 @@ fn spatial_result_to_py(
         temperature_uncertainty_map,
         anorm_map,
         background_maps,
+        t0_us_map,
+        l_scale_map,
     }
 }
 
@@ -2793,6 +2821,12 @@ fn spatial_result_to_py(
 ///         `from_counts_with_nuisance()`.
 ///     alpha_1_init: Initial value for `alpha_1` (default 1.0).
 ///     alpha_2_init: Initial value for `alpha_2` (default 1.0).
+///     fit_energy_scale: Fit per-pixel SAMMY TZERO calibration (t0, L_scale).
+///         Required for real VENUS counts data to match SAMMY chi2 performance.
+///     t0_init_us: Initial TOF offset in microseconds (default 0.0).
+///     l_scale_init: Initial flight-path scale factor (default 1.0).
+///     energy_scale_flight_path_m: Nominal flight path (m) for the
+///         energy-scale model. Must match the grid used to compute `energies`.
 ///     resolution: Optional resolution function.
 ///     groups: list of IsotopeGroup objects (mutually exclusive with isotopes).
 ///
@@ -2814,6 +2848,10 @@ fn spatial_result_to_py(
     alpha_2_init = 1.0,
     c = 1.0,
     enable_polish = None,
+    fit_energy_scale = false,
+    t0_init_us = 0.0,
+    l_scale_init = 1.0,
+    energy_scale_flight_path_m = 25.0,
     resolution = None,
     flight_path_m = None,
     delta_t_us = None,
@@ -2839,6 +2877,10 @@ fn py_spatial_map_typed<'py>(
     alpha_2_init: f64,
     c: f64,
     enable_polish: Option<bool>,
+    fit_energy_scale: bool,
+    t0_init_us: f64,
+    l_scale_init: f64,
+    energy_scale_flight_path_m: f64,
     resolution: Option<PyTabulatedResolution>,
     flight_path_m: Option<f64>,
     delta_t_us: Option<f64>,
@@ -2948,6 +2990,14 @@ fn py_spatial_map_typed<'py>(
     // when n_pixels > 1 inside spatial_map_typed.
     if let Some(v) = enable_polish {
         config = config.with_counts_enable_polish(Some(v));
+    }
+
+    // Energy-scale calibration (SAMMY TZERO equivalent).  Required for
+    // real VENUS data — without it, sharp resonances are offset ~0.5 us
+    // in TOF and per-pixel chi2 explodes (see memo on NEREIDS↔SAMMY
+    // parity for VENUS Hf 120min).
+    if fit_energy_scale {
+        config = config.with_energy_scale(t0_init_us, l_scale_init, energy_scale_flight_path_m);
     }
 
     // Build InputData3D from the PyInputData

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -2653,6 +2653,41 @@ fn parse_solver_config(
     }
 }
 
+/// Validate the SAMMY TZERO kwargs before they reach
+/// `UnifiedFitConfig::with_energy_scale`.  Shared across
+/// `py_spatial_map_typed`, `py_fit_spectrum_typed`, and
+/// `py_fit_counts_spectrum_typed`.
+///
+/// Issue #458 (Copilot review on PR #461): without these checks, NaN /
+/// Inf / non-positive values flowed into
+/// `EnergyScaleTransmissionModel::corrected_energies`, which divides
+/// by TOF values derived from `flight_path_m`.  Garbage inputs yielded
+/// NaN grids and confusing `PyRuntimeError`s from the solver rather
+/// than an actionable `PyValueError` at the binding boundary.
+fn validate_energy_scale_params(
+    t0_init_us: f64,
+    l_scale_init: f64,
+    energy_scale_flight_path_m: f64,
+) -> PyResult<()> {
+    if !t0_init_us.is_finite() {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "t0_init_us must be finite when fit_energy_scale=True, got {t0_init_us}"
+        )));
+    }
+    if !l_scale_init.is_finite() {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "l_scale_init must be finite when fit_energy_scale=True, got {l_scale_init}"
+        )));
+    }
+    if !energy_scale_flight_path_m.is_finite() || energy_scale_flight_path_m <= 0.0 {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "energy_scale_flight_path_m must be finite and positive when \
+             fit_energy_scale=True, got {energy_scale_flight_path_m}"
+        )));
+    }
+    Ok(())
+}
+
 /// Build `UnifiedFitConfig` from groups, returning the config and the number of
 /// density parameters (one per group) for initial_densities default.
 fn build_config_from_groups(
@@ -3053,6 +3088,7 @@ fn py_spatial_map_typed<'py>(
     // in TOF and per-pixel chi2 explodes (see memo on NEREIDS↔SAMMY
     // parity for VENUS Hf 120min).
     if fit_energy_scale {
+        validate_energy_scale_params(t0_init_us, l_scale_init, energy_scale_flight_path_m)?;
         config = config.with_energy_scale(t0_init_us, l_scale_init, energy_scale_flight_path_m);
     }
 
@@ -3316,6 +3352,7 @@ fn py_fit_counts_spectrum_typed<'py>(
         config = config.with_transmission_background(bg);
     }
     if fit_energy_scale {
+        validate_energy_scale_params(t0_init_us, l_scale_init, energy_scale_flight_path_m)?;
         config = config.with_energy_scale(t0_init_us, l_scale_init, energy_scale_flight_path_m);
     }
     // Attach CountsBackgroundConfig whenever any of its fields deviates from
@@ -3814,6 +3851,7 @@ fn py_fit_spectrum_typed<'py>(
 
     // Energy-scale calibration (SAMMY TZERO equivalent)
     if fit_energy_scale {
+        validate_energy_scale_params(t0_init_us, l_scale_init, energy_scale_flight_path_m)?;
         config = config.with_energy_scale(t0_init_us, l_scale_init, energy_scale_flight_path_m);
     }
 

--- a/crates/nereids-fitting/src/transmission_model.rs
+++ b/crates/nereids-fitting/src/transmission_model.rs
@@ -8,6 +8,7 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::Arc;
 
+use nereids_core::constants::{EV_TO_JOULES, NEUTRON_MASS_KG};
 use nereids_endf::resonance::ResonanceData;
 use nereids_physics::resolution;
 use nereids_physics::transmission::{self, InstrumentParams, SampleParams};
@@ -918,9 +919,12 @@ impl EnergyScaleTransmissionModel {
         l_scale_index: usize,
         instrument: Option<Arc<transmission::InstrumentParams>>,
     ) -> Self {
-        // TOF_FACTOR = sqrt(m_n / (2 * eV)) * 1e6 [μs·√eV/m]
-        // m_n = 1.6749e-27 kg, eV = 1.602e-19 J
-        let tof_factor = (0.5 * 1.6749e-27 / 1.602e-19_f64).sqrt() * 1.0e6;
+        // TOF_FACTOR = sqrt(m_n / (2 · eV)) · 1e6 [μs·√eV/m].
+        // Use the CODATA 2018 values from nereids-core::constants so that
+        // this model, calibration.rs, and core::tof_to_energy all agree to
+        // machine precision (previously the inline approximations differed
+        // by ~5e-5 relative, enough to visibly shift sharp resonances).
+        let tof_factor = (0.5 * NEUTRON_MASS_KG / EV_TO_JOULES).sqrt() * 1.0e6;
         Self {
             cross_sections,
             density_indices,

--- a/crates/nereids-pipeline/src/calibration.rs
+++ b/crates/nereids-pipeline/src/calibration.rs
@@ -13,15 +13,20 @@
 //! resonance positions shift in the energy domain, causing catastrophic
 //! chi² degradation (e.g. 436 → 2.7 for a 0.3% L correction on VENUS).
 
+use nereids_core::constants::{EV_TO_JOULES, NEUTRON_MASS_KG};
 use nereids_endf::resonance::ResonanceData;
 use nereids_physics::transmission::{self, InstrumentParams, SampleParams};
 
 use crate::error::PipelineError;
 
-/// Neutron mass constant: C = m_n / (2 · eV) = 5.2276e-9 eV·s²/m²
+/// Neutron mass constant: C = m_n / (2 · eV) ≈ 5.2276e-9 eV·s²/m².
 ///
 /// E [eV] = C · (L [m] / t [s])²
-const NEUTRON_MASS_CONSTANT: f64 = 0.5 * 1.6749e-27 / 1.602e-19;
+///
+/// Uses the CODATA 2018 values from `nereids_core::constants` so that
+/// this calibration path, `EnergyScaleTransmissionModel`, and
+/// `core::tof_to_energy` all agree to machine precision.
+const NEUTRON_MASS_CONSTANT: f64 = 0.5 * NEUTRON_MASS_KG / EV_TO_JOULES;
 
 /// Result of energy calibration.
 #[derive(Debug, Clone)]

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -556,6 +556,11 @@ impl UnifiedFitConfig {
     pub fn counts_enable_polish(&self) -> Option<bool> {
         self.counts_enable_polish
     }
+    /// Whether SAMMY TZERO energy-scale calibration is enabled
+    /// (see [`Self::with_energy_scale`]).
+    pub fn fit_energy_scale(&self) -> bool {
+        self.fit_energy_scale
+    }
     pub fn precomputed_cross_sections(&self) -> Option<&Arc<Vec<Vec<f64>>>> {
         self.precomputed_cross_sections.as_ref()
     }

--- a/crates/nereids-pipeline/src/spatial.rs
+++ b/crates/nereids-pipeline/src/spatial.rs
@@ -51,6 +51,13 @@ pub struct SpatialResult {
     /// Transmission LM uses `[BackA, BackB, BackC]`.
     /// Counts KL background uses `[b0, b1, alpha_2]`.
     pub background_maps: Option<[Array2<f64>; 3]>,
+    /// Per-pixel fitted SAMMY TZERO offset (µs) map.
+    /// `Some` when `config.fit_energy_scale` is true; `None` otherwise.
+    /// Entries are NaN where the per-pixel fit hard-failed.
+    pub t0_us_map: Option<Array2<f64>>,
+    /// Per-pixel fitted SAMMY TZERO flight-path scale factor.
+    /// `Some` when `config.fit_energy_scale` is true; `None` otherwise.
+    pub l_scale_map: Option<Array2<f64>>,
     /// Number of pixels that converged.
     pub n_converged: usize,
     /// Total number of pixels fitted.
@@ -281,6 +288,16 @@ pub fn spatial_map_typed(
                     Array2::from_elem((height, width), f64::NAN),
                     Array2::from_elem((height, width), f64::NAN),
                 ])
+            } else {
+                None
+            },
+            t0_us_map: if config.fit_energy_scale() {
+                Some(Array2::from_elem((height, width), f64::NAN))
+            } else {
+                None
+            },
+            l_scale_map: if config.fit_energy_scale() {
+                Some(Array2::from_elem((height, width), f64::NAN))
             } else {
                 None
             },
@@ -579,6 +596,16 @@ pub fn spatial_map_typed(
     } else {
         None
     };
+    let mut t0_us_map: Option<Array2<f64>> = if config.fit_energy_scale() {
+        Some(Array2::from_elem((height, width), f64::NAN))
+    } else {
+        None
+    };
+    let mut l_scale_map: Option<Array2<f64>> = if config.fit_energy_scale() {
+        Some(Array2::from_elem((height, width), f64::NAN))
+    } else {
+        None
+    };
     let mut n_converged = 0;
     let mut temperature_map: Option<Array2<f64>> = if config.fit_temperature() {
         Some(Array2::from_elem((height, width), f64::NAN))
@@ -619,6 +646,12 @@ pub fn spatial_map_typed(
             bg_maps[1][[*y, *x]] = result.background[1];
             bg_maps[2][[*y, *x]] = result.background[2];
         }
+        if let (Some(map), Some(v)) = (&mut t0_us_map, result.t0_us) {
+            map[[*y, *x]] = v;
+        }
+        if let (Some(map), Some(v)) = (&mut l_scale_map, result.l_scale) {
+            map[[*y, *x]] = v;
+        }
         if result.converged {
             n_converged += 1;
         }
@@ -635,6 +668,8 @@ pub fn spatial_map_typed(
         isotope_labels,
         anorm_map,
         background_maps,
+        t0_us_map,
+        l_scale_map,
         n_converged,
         n_total: pixel_coords.len(),
         n_failed: failed_count.load(Ordering::Relaxed),
@@ -1434,5 +1469,93 @@ mod tests {
         };
         let r = spatial_map_typed(&input, &config, None, None, None).unwrap();
         assert!(r.deviance_per_dof_map.is_none());
+    }
+
+    /// `fit_energy_scale=True` on the spatial path routes per-pixel TZERO
+    /// calibration through the same config used by single-spectrum fits,
+    /// populates `t0_us_map` and `l_scale_map`, and leaves them `None`
+    /// when the flag is off.  Regression against the prior gap where
+    /// the Python binding accepted `fit_energy_scale` for single
+    /// spectra but not for spatial, forcing callers to pre-calibrate.
+    #[test]
+    fn test_spatial_map_typed_fit_energy_scale_populates_maps() {
+        let rd = u238_single_resonance();
+        let energies: Vec<f64> = (0..101).map(|i| 1.0 + (i as f64) * 0.1).collect();
+        let (t_3d, u_3d) = synthetic_4x4_transmission(&rd, 0.001, &energies);
+        let data = InputData3D::Transmission {
+            transmission: t_3d.view(),
+            uncertainty: u_3d.view(),
+        };
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![rd],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.0005],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig::default()))
+        .with_energy_scale(0.0, 1.0, 25.0);
+
+        let result = spatial_map_typed(&data, &config, None, None, None).unwrap();
+        let t0_map = result
+            .t0_us_map
+            .as_ref()
+            .expect("t0_us_map must be Some when fit_energy_scale=true");
+        let l_map = result
+            .l_scale_map
+            .as_ref()
+            .expect("l_scale_map must be Some when fit_energy_scale=true");
+        assert_eq!(t0_map.shape(), [4, 4]);
+        assert_eq!(l_map.shape(), [4, 4]);
+        // Synthetic data was generated on the nominal grid (no offset),
+        // so at least one converged pixel should recover t0 ≈ 0 and
+        // L_scale ≈ 1 with finite numeric values.
+        let mut n_finite = 0;
+        for y in 0..4 {
+            for x in 0..4 {
+                if t0_map[[y, x]].is_finite() && l_map[[y, x]].is_finite() {
+                    n_finite += 1;
+                }
+            }
+        }
+        // Wiring check: at least one pixel's TZERO params round-tripped
+        // from the per-pixel SpectrumFitResult into the spatial map.
+        // Physical recovery of exact t0=0 / L=1 is not asserted here
+        // because LM with noise-free data on the nominal grid can stall
+        // at the initial values (zero gradient) without propagating
+        // them through the uncertainty pass; parameter-value checks
+        // belong in dedicated fitting-level tests (transmission_model.rs).
+        assert!(
+            n_finite > 0,
+            "at least one pixel should populate t0_us_map and l_scale_map (finite)"
+        );
+    }
+
+    /// Without `fit_energy_scale`, the TZERO maps are `None` — gate check.
+    #[test]
+    fn test_spatial_map_typed_no_energy_scale_no_maps() {
+        let rd = u238_single_resonance();
+        let energies: Vec<f64> = (0..51).map(|i| 1.0 + (i as f64) * 0.2).collect();
+        let (t_3d, u_3d) = synthetic_4x4_transmission(&rd, 0.001, &energies);
+        let data = InputData3D::Transmission {
+            transmission: t_3d.view(),
+            uncertainty: u_3d.view(),
+        };
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![rd],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.0005],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig::default()));
+
+        let result = spatial_map_typed(&data, &config, None, None, None).unwrap();
+        assert!(result.t0_us_map.is_none());
+        assert!(result.l_scale_map.is_none());
     }
 }

--- a/crates/nereids-pipeline/src/spatial.rs
+++ b/crates/nereids-pipeline/src/spatial.rs
@@ -16,26 +16,43 @@ use crate::error::PipelineError;
 use crate::pipeline::SpectrumFitResult;
 
 /// Result of spatial mapping over a 2D image.
+///
+/// **NaN-on-failure contract (issue #458 B1/B2):**
+/// every per-pixel parameter map
+/// (`density_maps`, `uncertainty_maps`, `chi_squared_map`,
+/// `deviance_per_dof_map`, `temperature_map`,
+/// `temperature_uncertainty_map`, `anorm_map`, `background_maps`,
+/// `t0_us_map`, `l_scale_map`) contains `NaN` at every pixel where
+/// `converged_map` is `false`.  The only map written unconditionally
+/// is `converged_map` itself — it is how callers discover that a
+/// pixel failed.  Callers rendering numeric values should gate on
+/// `converged_map` (or check `value.is_finite()`) to avoid displaying
+/// the placeholder `NaN`.
 #[derive(Debug)]
 pub struct SpatialResult {
     /// Fitted areal density maps, one per isotope.
     /// Each Array2 has shape (height, width).
+    /// NaN at pixels where `converged_map` is `false`.
     pub density_maps: Vec<Array2<f64>>,
     /// Uncertainty maps, one per isotope.
+    /// NaN at pixels where `converged_map` is `false`.
     pub uncertainty_maps: Vec<Array2<f64>>,
     /// Reduced chi-squared map.  For the counts-KL dispatch (joint-Poisson
     /// deviance per memo 35 §P1.2) this is back-compat-mirrored to
     /// `D/(n−k)`; the semantically-correct per-pixel value is also
     /// exposed as [`Self::deviance_per_dof_map`].
+    /// NaN at pixels where `converged_map` is `false`.
     pub chi_squared_map: Array2<f64>,
     /// Per-pixel conditional binomial deviance `D/(n−k)` map.  `Some` when
     /// the effective per-pixel solver is the counts-KL dispatch
     /// (joint-Poisson); `None` for LM-only runs and transmission+PoissonKL
     /// where Pearson χ²/dof is the GOF.
+    /// NaN at pixels where `converged_map` is `false`.
     pub deviance_per_dof_map: Option<Array2<f64>>,
     /// Convergence map (true = converged).
     pub converged_map: Array2<bool>,
     /// Fitted temperature map (K). `Some` when `config.fit_temperature()` is true.
+    /// NaN at pixels where `converged_map` is `false`.
     pub temperature_map: Option<Array2<f64>>,
     /// Per-pixel temperature uncertainty map (K, 1-sigma).
     /// `Some` when `config.fit_temperature()` is true.
@@ -46,10 +63,12 @@ pub struct SpatialResult {
     /// user modifies the isotope list after fitting.
     pub isotope_labels: Vec<String>,
     /// Per-pixel normalization / signal-scale map (when background fitting is enabled).
+    /// NaN at pixels where `converged_map` is `false`.
     pub anorm_map: Option<Array2<f64>>,
     /// Per-pixel background parameter maps.
     /// Transmission LM uses `[BackA, BackB, BackC]`.
     /// Counts KL background uses `[b0, b1, alpha_2]`.
+    /// NaN at pixels where `converged_map` is `false`.
     pub background_maps: Option<[Array2<f64>; 3]>,
     /// Per-pixel fitted SAMMY TZERO offset (µs) map.
     /// `Some` when `config.fit_energy_scale` is true; `None` otherwise.
@@ -247,6 +266,23 @@ pub fn spatial_map_typed(
              build the corrected energy grid and pass it to spatial_map_typed with \
              fit_energy_scale=false. For counts data, solver='kl' (or 'auto') is robust \
              with per-pixel TZERO fitting."
+                .into(),
+        ));
+    }
+
+    // Issue #458 (Codex review): `fit_energy_scale` + `fit_temperature`
+    // is not a supported combination — `EnergyScaleTransmissionModel`
+    // and the temperature-fitting path are mutually exclusive at the
+    // single-spectrum fitter (`pipeline.rs:830, 976, 1183`).  Without
+    // this spatial-layer guard, every per-pixel call would error and
+    // `spatial_map_typed` would report `n_failed == n_total` with an
+    // all-NaN map — a silently-failed map is worse than a clear error.
+    if config.fit_energy_scale() && config.fit_temperature() {
+        return Err(PipelineError::InvalidParameter(
+            "spatial_map_typed: fit_energy_scale=true and fit_temperature=true cannot \
+             both be set — EnergyScaleTransmissionModel does not support temperature \
+             fitting. Choose one: either calibrate TZERO with a fixed temperature, or \
+             fit temperature on the nominal energy grid."
                 .into(),
         ));
     }
@@ -1741,6 +1777,43 @@ mod tests {
         let result = spatial_map_typed(&data, &config, None, None, None)
             .expect("KL + counts + fit_energy_scale must be allowed");
         assert!(result.t0_us_map.is_some());
+    }
+
+    /// `fit_energy_scale + fit_temperature` must be rejected at
+    /// spatial entry (Codex review follow-up to #458).  The
+    /// single-spectrum fitter errors on this combination, but without
+    /// a spatial-layer guard every pixel would error and
+    /// `spatial_map_typed` would silently return `n_failed == n_total`
+    /// with an all-NaN map instead of a clear error.
+    #[test]
+    fn test_spatial_map_typed_rejects_energy_scale_with_temperature() {
+        let rd = u238_single_resonance();
+        let energies: Vec<f64> = (0..51).map(|i| 1.0 + (i as f64) * 0.2).collect();
+        let (t_3d, u_3d) = synthetic_4x4_transmission(&rd, 0.001, &energies);
+        let data = InputData3D::Transmission {
+            transmission: t_3d.view(),
+            uncertainty: u_3d.view(),
+        };
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![rd],
+            vec!["U-238".into()],
+            300.0,
+            None,
+            vec![0.0005],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig::default()))
+        .with_fit_temperature(true)
+        .with_energy_scale(0.0, 1.0, 25.0);
+
+        let err = spatial_map_typed(&data, &config, None, None, None)
+            .expect_err("fit_energy_scale + fit_temperature must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("fit_energy_scale") && msg.contains("fit_temperature"),
+            "error message should name both culprits, got: {msg}"
+        );
     }
 
     /// `(Transmission + LM + fit_energy_scale=true)` is allowed —

--- a/crates/nereids-pipeline/src/spatial.rs
+++ b/crates/nereids-pipeline/src/spatial.rs
@@ -72,10 +72,11 @@ pub struct SpatialResult {
     pub background_maps: Option<[Array2<f64>; 3]>,
     /// Per-pixel fitted SAMMY TZERO offset (µs) map.
     /// `Some` when `config.fit_energy_scale` is true; `None` otherwise.
-    /// Entries are NaN where the per-pixel fit hard-failed.
+    /// NaN at pixels where `converged_map` is `false`.
     pub t0_us_map: Option<Array2<f64>>,
     /// Per-pixel fitted SAMMY TZERO flight-path scale factor.
     /// `Some` when `config.fit_energy_scale` is true; `None` otherwise.
+    /// NaN at pixels where `converged_map` is `false`.
     pub l_scale_map: Option<Array2<f64>>,
     /// Number of pixels that converged.
     pub n_converged: usize,
@@ -318,9 +319,15 @@ pub fn spatial_map_typed(
         return Err(PipelineError::Cancelled);
     }
     if pixel_coords.is_empty() {
+        // All pixels filtered out (typically by `dead_pixels` mask).  Per
+        // the NaN-on-failure contract (issue #458 B1 + Copilot review),
+        // every parameter map must be NaN at every pixel — including
+        // density, which was previously initialised with zeros here.
+        // `converged_map` is all `false`, which is the caller's signal
+        // that no fits ran.
         return Ok(SpatialResult {
             density_maps: (0..n_maps)
-                .map(|_| Array2::zeros((height, width)))
+                .map(|_| Array2::from_elem((height, width), f64::NAN))
                 .collect(),
             uncertainty_maps: (0..n_maps)
                 .map(|_| Array2::from_elem((height, width), f64::NAN))

--- a/crates/nereids-pipeline/src/spatial.rs
+++ b/crates/nereids-pipeline/src/spatial.rs
@@ -221,6 +221,36 @@ pub fn spatial_map_typed(
         )));
     }
 
+    // Reject known-broken configurations at entry.
+    //
+    // Issue #458 B3: per-pixel LM with `fit_energy_scale=True` on
+    // counts data is numerically ill-conditioned.  On real VENUS Hf
+    // 120 min, only ~8 % of pixels converged; `t0` drifts to the
+    // ±10 µs bounds while `density` absorbs the compensating shift
+    // (4-order-of-magnitude errors).  Reject upfront with a pointer
+    // to the global-calibration workaround.
+    //
+    // Note: the LM-on-transmission path with `fit_energy_scale=True`
+    // has the same structural issue, but is left unblocked here —
+    // per-pixel transmission has higher SNR per bin (pre-normalised
+    // by open-beam) and this combination is sometimes useful for
+    // calibration crosschecks.  The config still produces NaN maps
+    // for failed pixels thanks to B1 gating.
+    if input.is_counts()
+        && matches!(config.solver(), SolverConfig::LevenbergMarquardt(_))
+        && config.fit_energy_scale()
+    {
+        return Err(PipelineError::InvalidParameter(
+            "spatial_map_typed: solver='lm' + fit_energy_scale=true on counts input is \
+             numerically unstable per-pixel (issue #458 B3). Recommended workaround: fit \
+             TZERO once on the aggregated spectrum via fit_counts_spectrum_typed, then \
+             build the corrected energy grid and pass it to spatial_map_typed with \
+             fit_energy_scale=false. For counts data, solver='kl' (or 'auto') is robust \
+             with per-pixel TZERO fitting."
+                .into(),
+        ));
+    }
+
     // Collect live pixel coordinates
     let mut pixel_coords: Vec<(usize, usize)> = Vec::new();
     for y in 0..height {
@@ -618,7 +648,39 @@ pub fn spatial_map_typed(
         None
     };
 
+    // Aggregate per-pixel fit results into 2-D maps.
+    //
+    // **Only the `converged_map` entry is written unconditionally.**
+    // All other per-pixel parameter writes are gated on
+    // `result.converged`, so un-converged pixels keep their initial
+    // `NaN` value from the allocation above.
+    //
+    // Rationale (issue #458 B1/B2): the LM solver's
+    // `LAMBDA_BREAKOUT` and stagnation paths restore `params` to the
+    // last-accepted trial step and return `converged = false`.  That
+    // "last accepted" state can be arbitrarily far from optimal if
+    // LM walked astray before getting stuck — e.g., on real VENUS
+    // per-pixel counts with TZERO enabled, LM pins `t0` at the
+    // ±10 µs bound and lets `density` absorb the drift, producing
+    // densities 4 orders of magnitude off.  Writing those garbage
+    // values into the density/t0/L/background maps masked an 8 %
+    // convergence rate as "map of mostly-sensible numbers with a
+    // few outliers" rather than "map of NaN holes with a few fits".
+    //
+    // NaN-on-failure is also the convention asserted by
+    // `test_spatial_map_failed_pixels_remain_nan`; this block makes
+    // it hold for *every* non-converged pixel, not only the hard
+    // failure path.
     for ((y, x), result) in &results {
+        // Always record the convergence flag — this is how callers
+        // discover that a pixel failed.
+        converged_map[[*y, *x]] = result.converged;
+        if !result.converged {
+            continue;
+        }
+
+        n_converged += 1;
+
         for i in 0..n_maps {
             density_maps[i][[*y, *x]] = result.densities[i];
             if let Some(ref unc) = result.uncertainties {
@@ -629,7 +691,6 @@ pub fn spatial_map_typed(
         if let (Some(dpd), Some(v)) = (&mut deviance_per_dof_map, result.deviance_per_dof) {
             dpd[[*y, *x]] = v;
         }
-        converged_map[[*y, *x]] = result.converged;
         if let (Some(t_map), Some(t)) = (&mut temperature_map, result.temperature_k) {
             t_map[[*y, *x]] = t;
         }
@@ -651,9 +712,6 @@ pub fn spatial_map_typed(
         }
         if let (Some(map), Some(v)) = (&mut l_scale_map, result.l_scale) {
             map[[*y, *x]] = v;
-        }
-        if result.converged {
-            n_converged += 1;
         }
     }
 
@@ -1200,17 +1258,25 @@ mod tests {
         );
     }
 
-    /// Unconverged pixels remain NaN, not zero-filled.
+    /// Unconverged pixels remain NaN across **every** output map
+    /// (density, uncertainty, chi², t0, l_scale, temperature, anorm,
+    /// background) — not just uncertainty.  Issue #458 B1/B2:
+    /// previously, failed LM fits that restored to their last-accepted
+    /// trial step wrote those drifted parameter values into the maps
+    /// with `converged=false`, producing a "4096 pixels with sensible
+    /// densities, 92 % of which are converged=false" result that
+    /// masked catastrophic fit failure.
     #[test]
     fn test_spatial_unconverged_pixels_are_nan() {
         let rd = u238_single_resonance();
         let energies: Vec<f64> = (0..101).map(|i| 1.0 + (i as f64) * 0.1).collect();
-        // Create data where pixel (0,0) is dead (all zeros)
-        let (mut t_3d, mut u_3d) = synthetic_4x4_transmission(&rd, 0.001, &energies);
-        for e in 0..energies.len() {
-            t_3d[[e, 0, 0]] = 0.0;
-            u_3d[[e, 0, 0]] = f64::INFINITY;
-        }
+        // Pick a deliberately wrong initial density (100× true) and cap
+        // LM at one iteration so the fit MUST return with
+        // `converged=false` and `params = last_walked_step` ≠ initial.
+        // This mimics the real-world pattern the bug produced: a fit
+        // that walked partway toward the optimum, then ran out of
+        // iterations.
+        let (t_3d, u_3d) = synthetic_4x4_transmission(&rd, 0.001, &energies);
         let data = InputData3D::Transmission {
             transmission: t_3d.view(),
             uncertainty: u_3d.view(),
@@ -1221,19 +1287,68 @@ mod tests {
             vec!["U-238".into()],
             0.0,
             None,
-            vec![0.0005],
+            vec![0.1], // 100× true — LM can't reach optimum in 1 iter.
         )
         .unwrap()
-        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig::default()));
+        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig {
+            max_iter: 1,
+            ..Default::default()
+        }))
+        .with_transmission_background(crate::pipeline::BackgroundConfig::default());
 
         let result = spatial_map_typed(&data, &config, None, None, None).unwrap();
-        // Pixel (0,0) should not converge and uncertainty should remain NaN.
-        if !result.converged_map[[0, 0]] {
-            let u = result.uncertainty_maps[0][[0, 0]];
+
+        // At least one pixel must fail to converge under this setup —
+        // the point of the test is to verify NaN-on-failure for the
+        // aggregation path, so we locate an unconverged pixel and
+        // check every map at that pixel.
+        let unconverged_pixel = (0..4)
+            .flat_map(|y| (0..4).map(move |x| (y, x)))
+            .find(|(y, x)| !result.converged_map[[*y, *x]]);
+        let (uy, ux) = match unconverged_pixel {
+            Some(p) => p,
+            None => panic!(
+                "every pixel converged in max_iter=1 + 100×-off initial density setup — \
+                 test is no longer exercising the un-converged aggregation path; \
+                 tighten the setup (larger offset or fewer iterations)"
+            ),
+        };
+
+        // Every output map must be NaN at that pixel.
+        for (i, m) in result.density_maps.iter().enumerate() {
+            let v = m[[uy, ux]];
             assert!(
-                u.is_nan(),
-                "unconverged pixel uncertainty should be NaN, got {u}"
+                v.is_nan(),
+                "density_maps[{i}] at unconverged pixel ({uy},{ux}) must be NaN, got {v}"
             );
+        }
+        for (i, m) in result.uncertainty_maps.iter().enumerate() {
+            let v = m[[uy, ux]];
+            assert!(
+                v.is_nan(),
+                "uncertainty_maps[{i}] at unconverged pixel ({uy},{ux}) must be NaN, got {v}"
+            );
+        }
+        let chi2 = result.chi_squared_map[[uy, ux]];
+        assert!(
+            chi2.is_nan(),
+            "chi_squared_map at unconverged pixel ({uy},{ux}) must be NaN, got {chi2}"
+        );
+        if let Some(ref a_map) = result.anorm_map {
+            let v = a_map[[uy, ux]];
+            assert!(
+                v.is_nan(),
+                "anorm_map at unconverged pixel ({uy},{ux}) must be NaN, got {v}"
+            );
+        }
+        if let Some(ref bg) = result.background_maps {
+            for (i, m) in bg.iter().enumerate() {
+                let v = m[[uy, ux]];
+                assert!(
+                    v.is_nan(),
+                    "background_maps[{i}] at unconverged pixel ({uy},{ux}) must be NaN, got {v}"
+                );
+            }
         }
     }
 
@@ -1509,28 +1624,31 @@ mod tests {
             .expect("l_scale_map must be Some when fit_energy_scale=true");
         assert_eq!(t0_map.shape(), [4, 4]);
         assert_eq!(l_map.shape(), [4, 4]);
-        // Synthetic data was generated on the nominal grid (no offset),
-        // so at least one converged pixel should recover t0 ≈ 0 and
-        // L_scale ≈ 1 with finite numeric values.
-        let mut n_finite = 0;
+        // Post-#458 B1 semantics:
+        //   * Converged pixel  → finite t0 / L_scale in the maps
+        //   * Un-converged pixel → NaN in the maps (the LM last-walked
+        //     value is NOT leaked)
+        // Parameter-value correctness (t0 ≈ 0, L ≈ 1 on noise-free
+        // nominal-grid data) is tested at the fitting layer, not here;
+        // this test only exercises wiring + aggregation gating.
         for y in 0..4 {
             for x in 0..4 {
-                if t0_map[[y, x]].is_finite() && l_map[[y, x]].is_finite() {
-                    n_finite += 1;
+                let converged = result.converged_map[[y, x]];
+                let t0 = t0_map[[y, x]];
+                let ls = l_map[[y, x]];
+                if converged {
+                    assert!(
+                        t0.is_finite() && ls.is_finite(),
+                        "converged pixel ({y},{x}) must have finite t0/L, got t0={t0}, L={ls}"
+                    );
+                } else {
+                    assert!(
+                        t0.is_nan() && ls.is_nan(),
+                        "un-converged pixel ({y},{x}) must have NaN t0/L (B1 gating), got t0={t0}, L={ls}"
+                    );
                 }
             }
         }
-        // Wiring check: at least one pixel's TZERO params round-tripped
-        // from the per-pixel SpectrumFitResult into the spatial map.
-        // Physical recovery of exact t0=0 / L=1 is not asserted here
-        // because LM with noise-free data on the nominal grid can stall
-        // at the initial values (zero gradient) without propagating
-        // them through the uncertainty pass; parameter-value checks
-        // belong in dedicated fitting-level tests (transmission_model.rs).
-        assert!(
-            n_finite > 0,
-            "at least one pixel should populate t0_us_map and l_scale_map (finite)"
-        );
     }
 
     /// Without `fit_energy_scale`, the TZERO maps are `None` — gate check.
@@ -1557,5 +1675,102 @@ mod tests {
         let result = spatial_map_typed(&data, &config, None, None, None).unwrap();
         assert!(result.t0_us_map.is_none());
         assert!(result.l_scale_map.is_none());
+    }
+
+    /// `(Counts + LM + fit_energy_scale=true)` must be rejected at
+    /// `spatial_map_typed` entry (issue #458 B3).  The combination
+    /// passed silently before and produced 92 % non-convergence with
+    /// garbage parameter values on real VENUS data.
+    #[test]
+    fn test_spatial_map_typed_rejects_counts_lm_with_energy_scale() {
+        let rd = u238_single_resonance();
+        let energies: Vec<f64> = (0..51).map(|i| 1.0 + (i as f64) * 0.2).collect();
+        let (sample, ob) = synthetic_4x4_counts(&rd, 0.001, &energies, 1000.0);
+        let data = InputData3D::Counts {
+            sample_counts: sample.view(),
+            open_beam_counts: ob.view(),
+        };
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![rd],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.0005],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig::default()))
+        .with_energy_scale(0.0, 1.0, 25.0);
+
+        let err = spatial_map_typed(&data, &config, None, None, None)
+            .expect_err("LM + counts + fit_energy_scale must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("fit_energy_scale") && msg.contains("lm"),
+            "error message should name both culprits, got: {msg}"
+        );
+        assert!(
+            msg.contains("#458"),
+            "error message should reference the tracking issue, got: {msg}"
+        );
+    }
+
+    /// `(Counts + KL + fit_energy_scale=true)` is allowed — KL is
+    /// robust per-pixel even with energy-scale on real data.
+    #[test]
+    fn test_spatial_map_typed_allows_counts_kl_with_energy_scale() {
+        let rd = u238_single_resonance();
+        let energies: Vec<f64> = (0..51).map(|i| 1.0 + (i as f64) * 0.2).collect();
+        let (sample, ob) = synthetic_4x4_counts(&rd, 0.001, &energies, 1000.0);
+        let data = InputData3D::Counts {
+            sample_counts: sample.view(),
+            open_beam_counts: ob.view(),
+        };
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![rd],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.0005],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::PoissonKL(PoissonConfig::default()))
+        .with_energy_scale(0.0, 1.0, 25.0);
+
+        let result = spatial_map_typed(&data, &config, None, None, None)
+            .expect("KL + counts + fit_energy_scale must be allowed");
+        assert!(result.t0_us_map.is_some());
+    }
+
+    /// `(Transmission + LM + fit_energy_scale=true)` is allowed —
+    /// per-pixel transmission has higher SNR per bin than raw counts
+    /// and this combination is sometimes useful for calibration
+    /// crosschecks.  NaN-on-failure gating (B1) still protects
+    /// downstream consumers.
+    #[test]
+    fn test_spatial_map_typed_allows_transmission_lm_with_energy_scale() {
+        let rd = u238_single_resonance();
+        let energies: Vec<f64> = (0..51).map(|i| 1.0 + (i as f64) * 0.2).collect();
+        let (t_3d, u_3d) = synthetic_4x4_transmission(&rd, 0.001, &energies);
+        let data = InputData3D::Transmission {
+            transmission: t_3d.view(),
+            uncertainty: u_3d.view(),
+        };
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![rd],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.0005],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig::default()))
+        .with_energy_scale(0.0, 1.0, 25.0);
+
+        let result = spatial_map_typed(&data, &config, None, None, None)
+            .expect("LM + transmission + fit_energy_scale must be allowed");
+        assert!(result.t0_us_map.is_some());
     }
 }

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -662,6 +662,83 @@ class TestSpatialMapCounts:
                 max_iter=5,
             )
 
+    def test_spatial_rejects_bad_tzero_params(self, u238_data):
+        """Issue #458 (Copilot review on PR #461): when `fit_energy_scale=True`,
+        the TZERO kwargs `t0_init_us`, `l_scale_init`, and
+        `energy_scale_flight_path_m` must be validated at the binding
+        boundary.  Non-finite or non-positive values (for flight path)
+        produced opaque PyRuntimeError from the solver rather than a clear
+        PyValueError.
+        """
+        energies = np.linspace(1.0, 10.0, 20)
+        n_e = len(energies)
+        t = np.full((n_e, 2, 2), 0.5)
+        u = np.full((n_e, 2, 2), 0.01)
+        data = nereids.from_transmission(t, u)
+
+        # t0_init_us non-finite
+        for bad_t0 in (float("nan"), float("inf"), float("-inf")):
+            with pytest.raises(ValueError, match="t0_init_us must be finite"):
+                nereids.spatial_map_typed(
+                    data, energies, [u238_data],
+                    solver="lm",
+                    fit_energy_scale=True,
+                    t0_init_us=bad_t0,
+                    max_iter=5,
+                )
+
+        # l_scale_init non-finite
+        for bad_l in (float("nan"), float("inf")):
+            with pytest.raises(ValueError, match="l_scale_init must be finite"):
+                nereids.spatial_map_typed(
+                    data, energies, [u238_data],
+                    solver="lm",
+                    fit_energy_scale=True,
+                    l_scale_init=bad_l,
+                    max_iter=5,
+                )
+
+        # flight_path_m non-positive or non-finite
+        for bad_fp in (0.0, -1.0, float("nan"), float("inf")):
+            with pytest.raises(ValueError, match="energy_scale_flight_path_m"):
+                nereids.spatial_map_typed(
+                    data, energies, [u238_data],
+                    solver="lm",
+                    fit_energy_scale=True,
+                    energy_scale_flight_path_m=bad_fp,
+                    max_iter=5,
+                )
+
+    def test_spatial_all_dead_pixels_returns_nan_density(self, u238_data):
+        """Issue #458 (Copilot review on PR #461): when every pixel is
+        masked dead, the early-return path must honour the NaN-on-failure
+        contract — density_maps must be NaN, not zeros.
+        """
+        energies = np.linspace(1.0, 10.0, 20)
+        n_e = len(energies)
+        h, w = 3, 3
+        t = np.full((n_e, h, w), 0.5)
+        u = np.full((n_e, h, w), 0.01)
+        data = nereids.from_transmission(t, u)
+        all_dead = np.ones((h, w), dtype=bool)
+
+        result = nereids.spatial_map_typed(
+            data, energies, [u238_data],
+            solver="lm",
+            dead_pixels=all_dead,
+            max_iter=5,
+        )
+        # converged_map is the signal that no fits ran.
+        assert result.n_converged == 0
+        assert result.n_total == 0
+        # density_map must be all NaN (not zero-filled).
+        density = np.asarray(result.density_maps[0])
+        assert density.shape == (h, w)
+        assert np.all(np.isnan(density)), (
+            "all-dead-pixels early-return must honour NaN-on-failure contract; "
+            "got density map with non-NaN entries"
+        )
+
     def test_counts_with_nuisance_auto_dispatches_to_kl(self, u238_data):
         """Regression for issue #458 B4.
 

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -599,6 +599,24 @@ class TestSpatialMapCounts:
                     data, energies, [u238_data], c=bad_c, max_iter=5
                 )
 
+    def test_spatial_c_validation_scoped_to_counts(self, u238_data):
+        """Issue #458 V1 (Codex follow-up): `c` is only consumed on counts
+        inputs.  A transmission caller who passes `c=0.0` should NOT be
+        rejected — the value is ignored on their path.  Rejecting it would
+        produce a misleading error that doesn't apply to their input type.
+        """
+        energies = np.linspace(1.0, 10.0, 20)
+        n_e = len(energies)
+        t = np.full((n_e, 2, 2), 0.5)
+        u = np.full((n_e, 2, 2), 0.01)
+        data = nereids.from_transmission(t, u)
+
+        # Should not raise — `c=0.0` is ignored on the transmission path.
+        result = nereids.spatial_map_typed(
+            data, energies, [u238_data], c=0.0, solver="lm", max_iter=5
+        )
+        assert result is not None  # call succeeded
+
     def test_spatial_rejects_bad_initial_densities(self, u238_data):
         """Issue #458 V2: spatial_map_typed must reject NaN / negative
         initial densities at the binding boundary."""

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -583,6 +583,113 @@ class TestSpatialMapCounts:
         # Density recovery: Poisson is noisier, so use wider tolerance
         np.testing.assert_allclose(dmap, true_density, rtol=0.5)
 
+    def test_spatial_rejects_non_positive_c(self, u238_data):
+        """Issue #458 V1: spatial_map_typed must reject c <= 0 or NaN at the
+        binding boundary with a clear PyValueError, not let it crash deep in
+        the solver as an opaque PyRuntimeError."""
+        energies = np.linspace(1.0, 10.0, 20)
+        n_e = len(energies)
+        sample = np.full((n_e, 2, 2), 100.0)
+        ob = np.full((n_e, 2, 2), 200.0)
+        data = nereids.from_counts(sample, ob)
+
+        for bad_c in (0.0, -1.0, float("nan"), float("inf")):
+            with pytest.raises(ValueError, match="c.*positive and finite"):
+                nereids.spatial_map_typed(
+                    data, energies, [u238_data], c=bad_c, max_iter=5
+                )
+
+    def test_spatial_rejects_bad_initial_densities(self, u238_data):
+        """Issue #458 V2: spatial_map_typed must reject NaN / negative
+        initial densities at the binding boundary."""
+        energies = np.linspace(1.0, 10.0, 20)
+        n_e = len(energies)
+        sample = np.full((n_e, 2, 2), 100.0)
+        ob = np.full((n_e, 2, 2), 200.0)
+        data = nereids.from_counts(sample, ob)
+
+        for bad in ([float("nan")], [-0.001], [0.001, float("inf")]):
+            with pytest.raises(ValueError, match="initial_densities.*finite and non-negative"):
+                nereids.spatial_map_typed(
+                    data,
+                    energies,
+                    [u238_data] if len(bad) == 1 else [u238_data, u238_data],
+                    initial_densities=bad,
+                    max_iter=5,
+                )
+
+    def test_spatial_rejects_shape_mismatches(self, u238_data):
+        """Issue #458 V3: spatial_map_typed must reject energies and
+        dead_pixels shape mismatches upfront with a clear PyValueError,
+        rather than letting them panic deep in the Rust pipeline."""
+        energies = np.linspace(1.0, 10.0, 20)
+        n_e = len(energies)
+        sample = np.full((n_e, 3, 4), 100.0)
+        ob = np.full((n_e, 3, 4), 200.0)
+        data = nereids.from_counts(sample, ob)
+
+        # energies length mismatch
+        short_energies = energies[:10]
+        with pytest.raises(ValueError, match="energies length.*data spectral axis length"):
+            nereids.spatial_map_typed(data, short_energies, [u238_data], max_iter=5)
+
+        # dead_pixels shape mismatch
+        wrong_mask = np.zeros((5, 5), dtype=bool)
+        with pytest.raises(ValueError, match="dead_pixels shape.*data spatial dims"):
+            nereids.spatial_map_typed(
+                data,
+                energies,
+                [u238_data],
+                dead_pixels=wrong_mask,
+                max_iter=5,
+            )
+
+    def test_counts_with_nuisance_auto_dispatches_to_kl(self, u238_data):
+        """Regression for issue #458 B4.
+
+        `spatial_map_typed(solver="auto")` with a `from_counts_with_nuisance`
+        input must dispatch to the counts-KL (joint-Poisson) path — previously
+        the ``data.kind == "counts"`` check in the Python binding missed the
+        `"counts_with_nuisance"` variant and silently fell through to LM.
+
+        Proxy observable: the counts-KL dispatch populates
+        `deviance_per_dof_map`; LM on counts does not.  If we see
+        `deviance_per_dof_map is not None`, the auto-dispatch is correct.
+        """
+        energies = np.linspace(1.0, 30.0, 80)
+        true_density = 0.002
+        flux = 4000.0
+        n_e = len(energies)
+        ny, nx = 2, 2
+
+        t_1d = np.asarray(
+            nereids.forward_model(energies, [(u238_data, true_density)])
+        )
+
+        rng = np.random.default_rng(1234)
+        flux_3d = np.full((n_e, ny, nx), flux)
+        # Explicit nuisance spectra: flux and zero detector background.
+        background_3d = np.zeros((n_e, ny, nx))
+        sample_3d = np.zeros((n_e, ny, nx))
+        for y in range(ny):
+            for x in range(nx):
+                sample_3d[:, y, x] = rng.poisson(flux * t_1d).astype(float)
+
+        data = nereids.from_counts_with_nuisance(sample_3d, flux_3d, background_3d)
+        result = nereids.spatial_map_typed(
+            data,
+            energies,
+            [u238_data],
+            solver="auto",
+            max_iter=50,
+        )
+        # Definitive signal that we routed through the counts-KL dispatch:
+        assert result.deviance_per_dof_map is not None, (
+            "from_counts_with_nuisance + solver='auto' should dispatch to "
+            "counts-KL (joint-Poisson), which populates deviance_per_dof_map. "
+            "None means the binding mis-dispatched to LM (issue #458 B4)."
+        )
+
 
 # ===========================================================================
 # Normalization


### PR DESCRIPTION
Closes #458 — P1 items B1, B2, B3, B4, V1, V2, V3.

## Summary
- **Spatial NaN-on-failure contract** (B1 + B2): every per-pixel output map in `SpatialResult` is now NaN at pixels where `converged_map` is `false`.  Previously, LM fits that hit `LAMBDA_BREAKOUT` or iteration-limit stagnation leaked their last-walked-step density / t0 / L / background values into the maps, producing "92% non-converged but sensible-looking densities" on real VENUS data.
- **Guard known-broken configs** at `spatial_map_typed` entry: reject `(Counts + LM + fit_energy_scale=True)` (B3) and `(fit_energy_scale + fit_temperature)` (Codex review).
- **Python binding input validation** (V1, V2, V3): reject non-positive `c`, non-finite/negative `initial_densities` (both kwarg form and `isotopes=[(rd, d)]` tuple form), and `energies`/`dead_pixels` shape mismatches at the binding boundary with clear `PyValueError`s instead of opaque `PyRuntimeError`s bubbling up from the Rust solver.
- **`spatial_map_typed(solver='auto')` auto-dispatch fix** (B4): `from_counts_with_nuisance` inputs now correctly route to the counts-KL (joint-Poisson) dispatch; previously the `data.kind == \"counts\"` check missed the `\"counts_with_nuisance\"` variant and silently fell through to LM.

Also re-lands two orphan commits from PR #450 that missed the squash-merge:
- feat: expose `fit_energy_scale` on `spatial_map_typed` (Python binding + `SpatialResult.t0_us_map` / `l_scale_map` fields + Rust tests)
- fix: consolidate TOF constants to CODATA 2018 across `transmission_model.rs` and `calibration.rs`

## Commits
1. \`8b9003e\` feat: expose fit_energy_scale on spatial_map_typed (Python + SpatialResult TZERO maps)  *[re-land]*
2. \`6e1ed66\` fix: consolidate TOF constants to CODATA 2018 (nereids-core parity)  *[re-land]*
3. \`4d365e8\` fix(#458): spatial NaN-on-failure gating + reject counts+LM+TZERO  *[B1, B2, B3]*
4. \`2f6f9de\` fix(#458): Python binding validation + counts_with_nuisance auto-dispatch  *[B4, V1, V2, V3]*
5. \`3480629\` refactor(#458): self-audit + Codex review findings — 3 P2 fixes  *[doc contract, c-scoping, fit_energy_scale+fit_temperature guard]*

## Test plan
- [ ] \`cargo fmt --all\` — clean
- [ ] \`cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings\` — clean
- [ ] \`cargo test --workspace --exclude nereids-python\` — 648 passed (previously 642; +6 new regression tests)
- [ ] \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps --exclude nereids-python\` — clean
- [ ] \`pixi run build\` — clean (release build)
- [ ] \`pixi run test-python\` — 75 passed, 1 skipped (previously 70; +5 new regression tests)
- [ ] Issue #458 P1 items B1-B4 and V1-V3 covered with regression tests at the level of each fix (spatial aggregation, LM behavior via the aggregation gate, config rejection, Python binding validation).
- [ ] Self-audit round found 0 P1s, 3 P2s (all fixed inline except one GUI-UX P2 filed as #460).
- [ ] Codex review round found 0 P1s, 1 P2 (fit_energy_scale+fit_temperature guard — fixed inline).

## Items deferred from #458
- P2 numerical-stability items (N1, N2) — covered by separate perf issue #459.
- P2 constant-drift items (C1-C5) — covered by #459 Tier D.
- P2 GUI NaN rendering — filed as #460.
- P3 doc/stub drift items — minor, can be batched with future cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)