### PR TITLE
fix(#430): refuse silent multi-angle collapse in NeXus histogram loader

### DIFF
--- a/apps/gui/src/guided/load.rs
+++ b/apps/gui/src/guided/load.rs
@@ -410,9 +410,14 @@ fn hdf5_ob_picker(ui: &mut egui::Ui, state: &mut AppState) {
                 // Issue #430: the loader refuses multi-angle files by
                 // default to prevent silent sum-over-angles.  The GUI
                 // makes the explicit opt-in to preserve existing
-                // single-volume analysis behaviour, and surfaces the
-                // angle count in the status banner below so the user
-                // knows projections were combined.
+                // single-volume analysis behaviour on OB input.
+                //
+                // NOTE: this branch does not currently surface the
+                // rotation-angle count to the user via the status
+                // banner — we discard `data.n_rotation_angles` when
+                // mapping to `(counts, tof_edges)`.  The sample-load
+                // path below *does* surface it; parity is tracked as
+                // a follow-up UX issue (#462).
                 nereids_io::nexus::load_nexus_histogram_with_mode(
                     &path,
                     nereids_io::nexus::MultiAngleMode::Sum,

--- a/apps/gui/src/guided/load.rs
+++ b/apps/gui/src/guided/load.rs
@@ -407,7 +407,17 @@ fn hdf5_ob_picker(ui: &mut egui::Ui, state: &mut AppState) {
                 nereids_io::nexus::load_nexus_events(&path, &params)
                     .map(|d| (d.counts, d.tof_edges_us))
             } else {
-                nereids_io::nexus::load_nexus_histogram(&path).map(|d| (d.counts, d.tof_edges_us))
+                // Issue #430: the loader refuses multi-angle files by
+                // default to prevent silent sum-over-angles.  The GUI
+                // makes the explicit opt-in to preserve existing
+                // single-volume analysis behaviour, and surfaces the
+                // angle count in the status banner below so the user
+                // knows projections were combined.
+                nereids_io::nexus::load_nexus_histogram_with_mode(
+                    &path,
+                    nereids_io::nexus::MultiAngleMode::Sum,
+                )
+                .map(|d| (d.counts, d.tof_edges_us))
             };
             match ob_result {
                 Ok((ob_counts, ob_tof_edges)) => {
@@ -656,13 +666,23 @@ fn load_hdf5_histogram(state: &mut AppState) {
 
     state.invalidate_results();
 
-    match nereids_io::nexus::load_nexus_histogram(&path) {
+    // Issue #430: explicit opt-in to the legacy sum-over-angles
+    // behaviour on the sample-data load.  The status banner below
+    // tells the user how many angles were combined.
+    match nereids_io::nexus::load_nexus_histogram_with_mode(
+        &path,
+        nereids_io::nexus::MultiAngleMode::Sum,
+    ) {
         Ok(data) => {
             let shape = data.counts.shape();
             state.preview_image = Some(data.counts.sum_axis(ndarray::Axis(0)));
             // D-5: Report rotation angle count when angles were collapsed.
             let angle_note = if data.n_rotation_angles > 1 {
-                format!(" ({} rotation angles summed)", data.n_rotation_angles)
+                format!(
+                    " ({} rotation angles summed — multi-angle analysis not yet supported, \
+                     see #430)",
+                    data.n_rotation_angles
+                )
             } else {
                 String::new()
             };

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -539,11 +539,26 @@ def probe_nexus(path: str) -> NexusMetadata:
     """Probe a NeXus/HDF5 file for available data without loading it."""
     ...
 
-def load_nexus_histogram(path: str) -> NexusData:
+def load_nexus_histogram(
+    path: str,
+    multi_angle_mode: str = "error",
+    angle_index: int = 0,
+) -> NexusData:
     """Load pre-histogrammed counts from a NeXus/HDF5 file.
 
-    Reads ``/entry/histogram/counts``, sums over rotation angles,
-    and returns a ``NexusData`` with shape ``(n_tof, height, width)``.
+    Reads ``/entry/histogram/counts`` (4D: ``rot × y × x × tof``) and
+    returns a ``NexusData`` with shape ``(n_tof, height, width)``.
+
+    **Issue #430**: by default this function refuses multi-angle files
+    (``n_rot > 1``).  Silently summing over rotation angles at load
+    time destroys projection-resolved information; callers must
+    choose explicitly via ``multi_angle_mode``:
+
+    - ``"error"`` (default): reject multi-angle files with a clear
+      ``ValueError``.
+    - ``"sum"``: sum over all rotation angles into a single
+      ``(tof, y, x)`` volume (legacy behaviour, now opt-in).
+    - ``"select"``: extract a single projection at ``angle_index``.
     """
     ...
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -2306,17 +2306,48 @@ fn probe_nexus(path: &str) -> PyResult<PyNexusMetadata> {
 
 /// Load pre-histogrammed counts from a NeXus/HDF5 file.
 ///
-/// Reads `/entry/histogram/counts` (4D: rotation × y × x × tof),
-/// sums over rotation angles, and transposes to (tof, y, x).
+/// Reads `/entry/histogram/counts` (4D: rotation × y × x × tof) and
+/// transposes the caller-selected single-angle slice to
+/// `(tof, y, x)`.
+///
+/// **Issue #430**: by default this function refuses multi-angle files
+/// (more than one rotation angle) because silently summing them
+/// destroys projection-resolved information on import.  Callers with
+/// a multi-angle file must choose a policy via `multi_angle_mode`.
 ///
 /// Args:
 ///     path: Path to the NeXus/HDF5 file.
+///     multi_angle_mode: one of:
+///         - ``"error"`` (default): reject multi-angle files with a clear error.
+///         - ``"sum"``: sum over all rotation angles into one volume
+///           (legacy behaviour, now opt-in).
+///         - ``"select"``: extract a single rotation angle by
+///           ``angle_index`` (default 0).
+///     angle_index: index of the rotation angle to extract when
+///         ``multi_angle_mode="select"``.  Ignored otherwise.
 ///
 /// Returns:
 ///     NexusData with counts, tof_edges_us, flight_path_m, dead_pixels.
 #[pyfunction]
-fn load_nexus_histogram(py: Python<'_>, path: &str) -> PyResult<PyNexusData> {
-    let data = nereids_io::nexus::load_nexus_histogram(std::path::Path::new(path))
+#[pyo3(signature = (path, multi_angle_mode="error", angle_index=0))]
+fn load_nexus_histogram(
+    py: Python<'_>,
+    path: &str,
+    multi_angle_mode: &str,
+    angle_index: usize,
+) -> PyResult<PyNexusData> {
+    use nereids_io::nexus::MultiAngleMode;
+    let mode = match multi_angle_mode {
+        "error" => MultiAngleMode::Error,
+        "sum" => MultiAngleMode::Sum,
+        "select" => MultiAngleMode::SelectAngle(angle_index),
+        other => {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "multi_angle_mode must be 'error', 'sum', or 'select', got {other:?}"
+            )));
+        }
+    };
+    let data = nereids_io::nexus::load_nexus_histogram_with_mode(std::path::Path::new(path), mode)
         .map_err(map_io_error)?;
     Ok(nexus_data_to_py(py, data))
 }

--- a/crates/nereids-io/src/nexus.rs
+++ b/crates/nereids-io/src/nexus.rs
@@ -1,10 +1,23 @@
 //! NeXus/HDF5 reading for rustpix-processed neutron imaging data.
 //!
 //! Supports two data modalities from rustpix output files:
-//! - **Histogram**: 4D counts array `(rot_angle, y, x, tof)` summed over
-//!   rotation angles and transposed to NEREIDS convention `(tof, y, x)`.
+//! - **Histogram**: 4D counts array `(rot_angle, y, x, tof)`.  The loader
+//!   requires the caller to choose how multi-angle files are handled via
+//!   [`MultiAngleMode`] (error, sum, or select-angle) and transposes the
+//!   chosen 3D slice to NEREIDS convention `(tof, y, x)`.
 //! - **Events**: per-neutron `(event_time_offset, x, y)` histogrammed into
 //!   a `(tof, y, x)` grid with user-specified binning parameters.
+//!
+//! ## Multi-angle handling (issue #430)
+//!
+//! Earlier revisions of this module silently summed multi-angle
+//! histograms into a single `(tof, y, x)` volume at load time — an
+//! irreversible data loss in the import path.  The default now is to
+//! **refuse** multi-angle files via [`MultiAngleMode::Error`]; callers
+//! who genuinely want the legacy sum-over-angles behaviour opt in
+//! explicitly with [`MultiAngleMode::Sum`], and callers who want to
+//! work with a single projection from a multi-angle acquisition
+//! choose [`MultiAngleMode::SelectAngle`].
 //!
 //! ## HDF5 Schema (rustpix convention)
 //!
@@ -138,12 +151,60 @@ pub fn probe_nexus(path: &Path) -> Result<NexusMetadata, IoError> {
     })
 }
 
-/// Load histogram data from a NeXus file.
+/// Policy for handling multi-angle NeXus histogram files.
 ///
-/// Reads `/entry/histogram/counts` (u64 4D), sums over the rotation angle
-/// axis (axis 0), converts to f64, and transposes to NEREIDS convention
-/// `(tof, y, x)`. TOF values are converted from nanoseconds to microseconds.
+/// Issue #430: the loader must refuse to silently collapse the
+/// rotation-angle dimension.  Callers choose explicitly which
+/// projection (or combination of projections) they want.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum MultiAngleMode {
+    /// Reject files with more than one rotation angle with a clear
+    /// [`IoError::InvalidParameter`].  Single-angle files (`n_rot == 1`)
+    /// load normally.  This is the default — it prevents silent data
+    /// loss for callers that aren't multi-angle-aware.
+    #[default]
+    Error,
+    /// Sum across all rotation angles into a single `(tof, y, x)`
+    /// volume.  This is the legacy auto-sum behaviour, preserved as an
+    /// **explicit opt-in** so that callers can't invoke it by
+    /// accident.  Multi-angle analysis information is irreversibly
+    /// lost on this path.
+    Sum,
+    /// Extract a single rotation angle by index.  Returns an error if
+    /// the index is out of range.
+    SelectAngle(usize),
+}
+
+/// Load histogram data from a NeXus file, refusing multi-angle inputs.
+///
+/// Reads `/entry/histogram/counts` (u64 4D), converts to f64, and
+/// transposes the chosen single-angle slice to NEREIDS convention
+/// `(tof, y, x)`.  TOF values are converted from nanoseconds to
+/// microseconds.
+///
+/// If the file has more than one rotation angle (`n_rot > 1`), the
+/// call returns [`IoError::InvalidParameter`] pointing at
+/// [`load_nexus_histogram_with_mode`] — silent sum-over-angles
+/// was the pre-#430 behaviour and has been removed because it lost
+/// projection-resolved information without the caller's knowledge.
+///
+/// Single-angle files (`n_rot == 1`) load normally and reach the same
+/// output as before #430.
 pub fn load_nexus_histogram(path: &Path) -> Result<NexusHistogramData, IoError> {
+    load_nexus_histogram_with_mode(path, MultiAngleMode::Error)
+}
+
+/// Load histogram data from a NeXus file with an explicit multi-angle
+/// handling policy.  See [`MultiAngleMode`] for the options.
+///
+/// This is the explicit-opt-in variant behind
+/// [`load_nexus_histogram`].  Use it when you know the file may have
+/// multiple rotation angles and you have made a deliberate choice
+/// about how to combine them.
+pub fn load_nexus_histogram_with_mode(
+    path: &Path,
+    mode: MultiAngleMode,
+) -> Result<NexusHistogramData, IoError> {
     let file = hdf5::File::open(path).map_err(|e| {
         IoError::FileNotFound(
             path.display().to_string(),
@@ -176,20 +237,36 @@ pub fn load_nexus_histogram(path: &Path) -> Result<NexusHistogramData, IoError> 
         .read()
         .map_err(|e| IoError::InvalidParameter(format!("Failed to read histogram counts: {e}")))?;
 
-    // D-5: Sum over rotation angle axis (axis 0): [rot, y, x, tof] → [y, x, tof]
-    // When n_rot > 1, this silently collapses multi-angle acquisitions.
-    // Log a warning so the user knows angles were combined.
+    // Collapse the rotation-angle axis according to the caller's policy
+    // (issue #430).  For single-angle files all three modes are
+    // equivalent — they just take the only slice that exists.
     let n_rot = shape[0];
-    if n_rot > 1 {
-        eprintln!(
-            "Warning: NeXus histogram has {n_rot} rotation angles — summing into a single \
-             volume. Multi-angle analysis is not yet supported."
-        );
-    }
-    let summed = counts_u64.sum_axis(ndarray::Axis(0));
+    let combined_yxtof = match mode {
+        MultiAngleMode::Error => {
+            if n_rot > 1 {
+                return Err(IoError::InvalidParameter(format!(
+                    "NeXus histogram has {n_rot} rotation angles — refusing to silently \
+                     combine them (issue #430).  Call load_nexus_histogram_with_mode with \
+                     MultiAngleMode::Sum to preserve the legacy sum-over-angles behaviour, \
+                     or MultiAngleMode::SelectAngle(i) to extract a single projection."
+                )));
+            }
+            counts_u64.sum_axis(ndarray::Axis(0))
+        }
+        MultiAngleMode::Sum => counts_u64.sum_axis(ndarray::Axis(0)),
+        MultiAngleMode::SelectAngle(idx) => {
+            if idx >= n_rot {
+                return Err(IoError::InvalidParameter(format!(
+                    "MultiAngleMode::SelectAngle({idx}) out of range: file has {n_rot} \
+                     rotation angle(s), valid indices are 0..{n_rot}"
+                )));
+            }
+            counts_u64.index_axis(ndarray::Axis(0), idx).to_owned()
+        }
+    };
 
     // Convert to f64 and transpose [y, x, tof] → NEREIDS convention [tof, y, x]
-    let counts_f64: Array3<f64> = summed
+    let counts_f64: Array3<f64> = combined_yxtof
         .mapv(|v| v as f64)
         .permuted_axes([2, 0, 1])
         .as_standard_layout()
@@ -605,40 +682,120 @@ mod tests {
     }
 
     #[test]
-    fn test_load_nexus_histogram() {
+    fn test_load_nexus_histogram_single_angle() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.h5");
 
-        // 2 rot angles, 2x3 spatial, 2 TOF bins
-        // Each element set to known value for verification
-        let mut counts = vec![0u64; 2 * 2 * 3 * 2];
-        // counts[rot, y, x, tof] — linearized in row-major order
-        // Set some values: rot=0, y=0, x=0, tof=0 → index 0
-        counts[0] = 10;
-        // rot=1, y=0, x=0, tof=0 → index 1*2*3*2 = 12
-        counts[12] = 5;
+        // 1 rot angle, 2x3 spatial, 2 TOF bins
+        let mut counts = vec![0u64; 2 * 3 * 2];
+        counts[0] = 15; // rot=0, y=0, x=0, tof=0
 
         let tof_ns = vec![1000.0, 2000.0, 3000.0]; // 3 edges for 2 bins
-        create_test_histogram(&path, &counts, [2, 2, 3, 2], &tof_ns, Some(25.0));
+        create_test_histogram(&path, &counts, [1, 2, 3, 2], &tof_ns, Some(25.0));
 
         let data = load_nexus_histogram(&path).unwrap();
 
-        // Shape should be (n_tof=2, n_y=2, n_x=3) after summing rot and transposing
+        // Shape should be (n_tof=2, n_y=2, n_x=3) after transposing
         assert_eq!(data.counts.shape(), &[2, 2, 3]);
-
-        // Summed over rot: counts[tof=0, y=0, x=0] = 10 + 5 = 15
+        // Single angle: value is preserved exactly
         assert_eq!(data.counts[[0, 0, 0]], 15.0);
 
         // TOF edges converted ns → µs
         assert_eq!(data.tof_edges_us.len(), 3);
-        assert!((data.tof_edges_us[0] - 1.0).abs() < 1e-10); // 1000 ns → 1 µs
+        assert!((data.tof_edges_us[0] - 1.0).abs() < 1e-10);
         assert!((data.tof_edges_us[1] - 2.0).abs() < 1e-10);
         assert!((data.tof_edges_us[2] - 3.0).abs() < 1e-10);
-
         assert_eq!(data.flight_path_m, Some(25.0));
+        assert_eq!(data.n_rotation_angles, 1);
+    }
 
-        // D-5: rotation angle count is carried through
+    /// Issue #430: default `load_nexus_histogram` must refuse multi-angle
+    /// files rather than silently collapse the rotation dimension.
+    #[test]
+    fn test_load_nexus_histogram_multi_angle_errors_by_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("multi_angle.h5");
+
+        let counts = vec![1u64; 2 * 2 * 3 * 2];
+        let tof_ns = vec![1000.0, 2000.0, 3000.0];
+        create_test_histogram(&path, &counts, [2, 2, 3, 2], &tof_ns, Some(25.0));
+
+        let err = load_nexus_histogram(&path)
+            .expect_err("multi-angle file must be rejected by the default loader");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("2 rotation angles") && msg.contains("#430"),
+            "error message should name the angle count and reference #430, got: {msg}"
+        );
+        assert!(
+            msg.contains("MultiAngleMode::Sum") && msg.contains("MultiAngleMode::SelectAngle"),
+            "error message should point at the explicit-opt-in APIs, got: {msg}"
+        );
+    }
+
+    /// Issue #430: `MultiAngleMode::Sum` is the explicit opt-in for the
+    /// legacy auto-sum behaviour.  Recovers the pre-#430 output exactly.
+    #[test]
+    fn test_load_nexus_histogram_multi_angle_sum_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("multi_angle_sum.h5");
+
+        let mut counts = vec![0u64; 2 * 2 * 3 * 2];
+        counts[0] = 10; // rot=0, y=0, x=0, tof=0
+        counts[12] = 5; // rot=1, y=0, x=0, tof=0
+        let tof_ns = vec![1000.0, 2000.0, 3000.0];
+        create_test_histogram(&path, &counts, [2, 2, 3, 2], &tof_ns, Some(25.0));
+
+        let data = load_nexus_histogram_with_mode(&path, MultiAngleMode::Sum).unwrap();
+        assert_eq!(data.counts.shape(), &[2, 2, 3]);
+        // Summed: 10 + 5 = 15
+        assert_eq!(data.counts[[0, 0, 0]], 15.0);
         assert_eq!(data.n_rotation_angles, 2);
+    }
+
+    /// Issue #430: `MultiAngleMode::SelectAngle(i)` extracts a single
+    /// projection by index, leaving the other angles' data unread.
+    #[test]
+    fn test_load_nexus_histogram_multi_angle_select_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("multi_angle_select.h5");
+
+        let mut counts = vec![0u64; 3 * 2 * 3 * 2];
+        counts[0] = 100; // rot=0, y=0, x=0, tof=0
+        counts[12] = 200; // rot=1, y=0, x=0, tof=0
+        counts[24] = 300; // rot=2, y=0, x=0, tof=0
+        let tof_ns = vec![1000.0, 2000.0, 3000.0];
+        create_test_histogram(&path, &counts, [3, 2, 3, 2], &tof_ns, Some(25.0));
+
+        // Select angle 1 — should see 200, not 100 / 300 / 600.
+        let data = load_nexus_histogram_with_mode(&path, MultiAngleMode::SelectAngle(1)).unwrap();
+        assert_eq!(data.counts[[0, 0, 0]], 200.0);
+        assert_eq!(data.n_rotation_angles, 3);
+
+        // Out-of-range index → error.
+        let err = load_nexus_histogram_with_mode(&path, MultiAngleMode::SelectAngle(3))
+            .expect_err("out-of-range angle index must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("SelectAngle(3)") && msg.contains("3 rotation angle"),
+            "error should name the bad index and the actual count, got: {msg}"
+        );
+    }
+
+    /// `MultiAngleMode::Error` on a single-angle file is a no-op:
+    /// `n_rot == 1` is the trivial non-collapsing case.
+    #[test]
+    fn test_load_nexus_histogram_error_mode_allows_single_angle() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("single_error.h5");
+        let counts = vec![7u64; 2 * 3 * 2];
+        let tof_ns = vec![1000.0, 2000.0, 3000.0];
+        create_test_histogram(&path, &counts, [1, 2, 3, 2], &tof_ns, None);
+
+        let data = load_nexus_histogram_with_mode(&path, MultiAngleMode::Error).unwrap();
+        assert_eq!(data.n_rotation_angles, 1);
+        // Value preserved (not doubled or summed — single angle)
+        assert_eq!(data.counts[[0, 0, 0]], 7.0);
     }
 
     #[test]

--- a/crates/nereids-io/src/nexus.rs
+++ b/crates/nereids-io/src/nexus.rs
@@ -233,6 +233,41 @@ pub fn load_nexus_histogram_with_mode(
         )));
     }
 
+    // Validate the rotation-angle policy BEFORE reading the full 4D
+    // counts dataset (Codex review on PR-B): the check is purely
+    // metadata-driven and the rejection paths should be cheap.  Reading
+    // the full u64 cube just to error out is wasteful on production
+    // multi-angle NeXus files (easily multi-GB), and historically
+    // caused OOM-before-error on the default "refuse" code path.
+    let n_rot = shape[0];
+    if n_rot == 0 {
+        // Degenerate file with a zero-sized rotation-angle axis.
+        // Reject rather than produce an all-zero output (which would
+        // look like a valid-but-empty measurement).
+        return Err(IoError::InvalidParameter(
+            "NeXus histogram has zero rotation angles; /entry/histogram/counts axis 0 must \
+             be >= 1"
+                .into(),
+        ));
+    }
+    match mode {
+        MultiAngleMode::Error if n_rot > 1 => {
+            return Err(IoError::InvalidParameter(format!(
+                "NeXus histogram has {n_rot} rotation angles — refusing to silently \
+                 combine them (issue #430).  Call load_nexus_histogram_with_mode with \
+                 MultiAngleMode::Sum to preserve the legacy sum-over-angles behaviour, \
+                 or MultiAngleMode::SelectAngle(i) to extract a single projection."
+            )));
+        }
+        MultiAngleMode::SelectAngle(idx) if idx >= n_rot => {
+            return Err(IoError::InvalidParameter(format!(
+                "MultiAngleMode::SelectAngle({idx}) out of range: file has {n_rot} \
+                 rotation angle(s), valid indices are 0..{n_rot}"
+            )));
+        }
+        _ => {}
+    }
+
     let counts_u64: ndarray::Array4<u64> = counts_ds
         .read()
         .map_err(|e| IoError::InvalidParameter(format!("Failed to read histogram counts: {e}")))?;
@@ -240,29 +275,11 @@ pub fn load_nexus_histogram_with_mode(
     // Collapse the rotation-angle axis according to the caller's policy
     // (issue #430).  For single-angle files all three modes are
     // equivalent — they just take the only slice that exists.
-    let n_rot = shape[0];
+    // (Validation above already ruled out every rejection case, so
+    // `Error` here is guaranteed to have n_rot == 1.)
     let combined_yxtof = match mode {
-        MultiAngleMode::Error => {
-            if n_rot > 1 {
-                return Err(IoError::InvalidParameter(format!(
-                    "NeXus histogram has {n_rot} rotation angles — refusing to silently \
-                     combine them (issue #430).  Call load_nexus_histogram_with_mode with \
-                     MultiAngleMode::Sum to preserve the legacy sum-over-angles behaviour, \
-                     or MultiAngleMode::SelectAngle(i) to extract a single projection."
-                )));
-            }
-            counts_u64.sum_axis(ndarray::Axis(0))
-        }
-        MultiAngleMode::Sum => counts_u64.sum_axis(ndarray::Axis(0)),
-        MultiAngleMode::SelectAngle(idx) => {
-            if idx >= n_rot {
-                return Err(IoError::InvalidParameter(format!(
-                    "MultiAngleMode::SelectAngle({idx}) out of range: file has {n_rot} \
-                     rotation angle(s), valid indices are 0..{n_rot}"
-                )));
-            }
-            counts_u64.index_axis(ndarray::Axis(0), idx).to_owned()
-        }
+        MultiAngleMode::Error | MultiAngleMode::Sum => counts_u64.sum_axis(ndarray::Axis(0)),
+        MultiAngleMode::SelectAngle(idx) => counts_u64.index_axis(ndarray::Axis(0), idx).to_owned(),
     };
 
     // Convert to f64 and transpose [y, x, tof] → NEREIDS convention [tof, y, x]
@@ -783,19 +800,81 @@ mod tests {
     }
 
     /// `MultiAngleMode::Error` on a single-angle file is a no-op:
-    /// `n_rot == 1` is the trivial non-collapsing case.
+    /// `n_rot == 1` is the trivial non-collapsing case.  All three
+    /// modes must produce identical output here.
     #[test]
-    fn test_load_nexus_histogram_error_mode_allows_single_angle() {
+    fn test_load_nexus_histogram_single_angle_mode_parity() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("single_error.h5");
+        let path = dir.path().join("single_parity.h5");
         let counts = vec![7u64; 2 * 3 * 2];
         let tof_ns = vec![1000.0, 2000.0, 3000.0];
         create_test_histogram(&path, &counts, [1, 2, 3, 2], &tof_ns, None);
 
-        let data = load_nexus_histogram_with_mode(&path, MultiAngleMode::Error).unwrap();
-        assert_eq!(data.n_rotation_angles, 1);
-        // Value preserved (not doubled or summed — single angle)
-        assert_eq!(data.counts[[0, 0, 0]], 7.0);
+        let d_err = load_nexus_histogram_with_mode(&path, MultiAngleMode::Error).unwrap();
+        let d_sum = load_nexus_histogram_with_mode(&path, MultiAngleMode::Sum).unwrap();
+        let d_sel = load_nexus_histogram_with_mode(&path, MultiAngleMode::SelectAngle(0)).unwrap();
+        // All three modes produce the same output on a single-angle file.
+        assert_eq!(d_err.counts, d_sum.counts);
+        assert_eq!(d_err.counts, d_sel.counts);
+        // Value preserved (not doubled — single angle).
+        assert_eq!(d_err.counts[[0, 0, 0]], 7.0);
+        assert_eq!(d_err.n_rotation_angles, 1);
+    }
+
+    /// A zero-angle file (degenerate, `shape[0] == 0`) must be
+    /// rejected on every mode — otherwise `Sum` would produce an
+    /// all-zero output indistinguishable from a valid but dark
+    /// measurement, and `Error` would silently accept the degenerate
+    /// file.
+    #[test]
+    fn test_load_nexus_histogram_zero_angles_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("zero_angles.h5");
+        let counts: Vec<u64> = Vec::new();
+        let tof_ns = vec![1000.0, 2000.0, 3000.0];
+        create_test_histogram(&path, &counts, [0, 2, 3, 2], &tof_ns, None);
+
+        for mode in [
+            MultiAngleMode::Error,
+            MultiAngleMode::Sum,
+            MultiAngleMode::SelectAngle(0),
+        ] {
+            let err = load_nexus_histogram_with_mode(&path, mode).unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("zero rotation angles"),
+                "mode {mode:?} zero-angle rejection should name the axis, got: {msg}"
+            );
+        }
+    }
+
+    /// Codex review: `MultiAngleMode::Error` must reject multi-angle
+    /// files BEFORE reading the full 4D counts dataset.  On a real
+    /// multi-angle file this dataset can be multi-GB; wasting a read
+    /// to then error out is prohibitive.  This test uses metadata
+    /// (shape is 4D, n_rot > 1) from a tiny synthetic fixture to
+    /// assert the error is returned — the underlying file is
+    /// small here, but the code-path assertion is that rejection
+    /// happens via the shape check alone.  (We can't assert "no
+    /// read happened" directly without hooking HDF5, but the
+    /// structural guarantee is preserved by the order of
+    /// statements in `load_nexus_histogram_with_mode`.)
+    #[test]
+    fn test_multi_angle_rejection_happens_before_counts_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("big_shape.h5");
+        // Small synthetic file, but with shape[0]=4 so we exercise the
+        // rejection path.
+        let counts = vec![1u64; 4 * 2 * 3 * 2];
+        let tof_ns = vec![1000.0, 2000.0, 3000.0];
+        create_test_histogram(&path, &counts, [4, 2, 3, 2], &tof_ns, None);
+
+        let err = load_nexus_histogram_with_mode(&path, MultiAngleMode::Error).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("4 rotation angles") && msg.contains("#430"),
+            "error message should name angle count + reference the issue, got: {msg}"
+        );
     }
 
     #[test]

--- a/crates/nereids-io/src/nexus.rs
+++ b/crates/nereids-io/src/nexus.rs
@@ -36,7 +36,7 @@
 
 use std::path::Path;
 
-use ndarray::Array3;
+use ndarray::{Array3, s};
 
 use crate::error::IoError;
 
@@ -262,24 +262,51 @@ pub fn load_nexus_histogram_with_mode(
         MultiAngleMode::SelectAngle(idx) if idx >= n_rot => {
             return Err(IoError::InvalidParameter(format!(
                 "MultiAngleMode::SelectAngle({idx}) out of range: file has {n_rot} \
-                 rotation angle(s), valid indices are 0..{n_rot}"
+                 rotation angle(s); valid indices are 0..{n_rot} (exclusive, i.e. \
+                 last valid index is {last})",
+                last = n_rot - 1
             )));
         }
         _ => {}
     }
 
-    let counts_u64: ndarray::Array4<u64> = counts_ds
-        .read()
-        .map_err(|e| IoError::InvalidParameter(format!("Failed to read histogram counts: {e}")))?;
-
-    // Collapse the rotation-angle axis according to the caller's policy
-    // (issue #430).  For single-angle files all three modes are
-    // equivalent — they just take the only slice that exists.
-    // (Validation above already ruled out every rejection case, so
-    // `Error` here is guaranteed to have n_rot == 1.)
-    let combined_yxtof = match mode {
-        MultiAngleMode::Error | MultiAngleMode::Sum => counts_u64.sum_axis(ndarray::Axis(0)),
-        MultiAngleMode::SelectAngle(idx) => counts_u64.index_axis(ndarray::Axis(0), idx).to_owned(),
+    // Read only the rotation-angle slice(s) the caller actually needs
+    // (Copilot review on PR-B).  Reading the full 4D cube when the
+    // caller wants one projection is wasteful on production
+    // multi-angle files (multi-GB per acquisition).
+    //
+    // - `Error` is guaranteed to have `n_rot == 1` (validated above),
+    //   so we hyperslab-read the single projection.
+    // - `Sum` on a single-angle file is identity with `Error`.
+    // - `Sum` on a multi-angle file needs every angle; the full read
+    //   is unavoidable and the legacy opt-in carries its memory cost.
+    // - `SelectAngle(idx)` hyperslab-reads only the selected
+    //   projection — the other angles' bytes never enter memory.
+    //
+    // All paths produce a `[y, x, tof]` 3D `u64` array ready for the
+    // f64 conversion + transpose below.
+    let combined_yxtof: ndarray::Array3<u64> = match mode {
+        MultiAngleMode::Error | MultiAngleMode::Sum if n_rot == 1 => {
+            counts_ds.read_slice(s![0, .., .., ..]).map_err(|e| {
+                IoError::InvalidParameter(format!("Failed to read single-angle slice: {e}"))
+            })?
+        }
+        MultiAngleMode::Sum => {
+            let full: ndarray::Array4<u64> = counts_ds.read().map_err(|e| {
+                IoError::InvalidParameter(format!("Failed to read histogram counts: {e}"))
+            })?;
+            full.sum_axis(ndarray::Axis(0))
+        }
+        MultiAngleMode::SelectAngle(idx) => {
+            counts_ds.read_slice(s![idx, .., .., ..]).map_err(|e| {
+                IoError::InvalidParameter(format!("Failed to read selected-angle slice: {e}"))
+            })?
+        }
+        MultiAngleMode::Error => {
+            // Unreachable: n_rot > 1 was rejected above, n_rot == 1 is
+            // matched by the first arm, n_rot == 0 was rejected earlier.
+            unreachable!("Error mode reached with n_rot = {n_rot}")
+        }
     };
 
     // Convert to f64 and transpose [y, x, tof] → NEREIDS convention [tof, y, x]

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -1027,6 +1027,29 @@ def _create_synthetic_nexus_histogram(path, n_tof=10, height=4, width=4):
         entry.attrs["flight_path_m"] = 25.0
 
 
+def _create_synthetic_nexus_histogram_multi_angle(
+    path, n_rot=3, n_tof=10, height=4, width=4, seed=42
+):
+    """Create a NeXus histogram file with more than one rotation angle.
+
+    Used to exercise issue #430: the default loader must refuse these
+    files, and explicit multi-angle policies (``sum`` / ``select``)
+    must produce predictable output.
+    """
+    import h5py
+
+    with h5py.File(path, "w") as f:
+        entry = f.create_group("entry")
+        hist = entry.create_group("histogram")
+        counts = np.random.default_rng(seed).integers(
+            0, 100, size=(n_rot, height, width, n_tof), dtype=np.uint64
+        )
+        hist.create_dataset("counts", data=counts)
+        tof_ns = np.linspace(1e4, 5e4, n_tof + 1)
+        hist.create_dataset("time_of_flight", data=tof_ns)
+        entry.attrs["flight_path_m"] = 25.0
+
+
 def _create_synthetic_nexus_events(path, n_events=1000, height=4, width=4):
     """Create a minimal VENUS-schema NeXus file with event data."""
     import h5py
@@ -1111,6 +1134,61 @@ class TestNexusIO:
     def test_probe_nexus_bad_path(self):
         with pytest.raises(IOError):
             nereids.probe_nexus("/nonexistent/file.h5")
+
+    def test_load_nexus_histogram_rejects_multi_angle_by_default(self, tmp_path):
+        """Issue #430: default `load_nexus_histogram(path)` must refuse
+        multi-angle files — silent sum-over-angles is a data-loss bug
+        the loader used to hide."""
+        path = str(tmp_path / "multi_angle.h5")
+        _create_synthetic_nexus_histogram_multi_angle(path, n_rot=3)
+        with pytest.raises(ValueError, match="3 rotation angles"):
+            nereids.load_nexus_histogram(path)
+
+    def test_load_nexus_histogram_multi_angle_sum_mode(self, tmp_path):
+        """Issue #430: opt-in `multi_angle_mode='sum'` recovers the
+        legacy auto-sum behaviour."""
+        path = str(tmp_path / "multi_angle_sum.h5")
+        _create_synthetic_nexus_histogram_multi_angle(
+            path, n_rot=3, n_tof=5, height=2, width=2
+        )
+        data = nereids.load_nexus_histogram(path, multi_angle_mode="sum")
+        # Summed into single volume, per-angle info is lost.
+        assert data.counts.shape == (5, 2, 2)
+        assert data.n_rotation_angles == 3
+        # Sum across angles must not exceed 3 × max(single-angle) = 3 × 99.
+        assert np.all(data.counts <= 3 * 99)
+
+    def test_load_nexus_histogram_multi_angle_select_mode(self, tmp_path):
+        """Issue #430: `multi_angle_mode='select'` extracts a single
+        projection by `angle_index`."""
+        path = str(tmp_path / "multi_angle_select.h5")
+        _create_synthetic_nexus_histogram_multi_angle(
+            path, n_rot=3, n_tof=5, height=2, width=2
+        )
+        data0 = nereids.load_nexus_histogram(
+            path, multi_angle_mode="select", angle_index=0
+        )
+        data1 = nereids.load_nexus_histogram(
+            path, multi_angle_mode="select", angle_index=1
+        )
+        assert data0.counts.shape == (5, 2, 2)
+        assert data1.counts.shape == (5, 2, 2)
+        # Different angles yield different counts for random-seeded data.
+        assert not np.array_equal(data0.counts, data1.counts)
+
+        # Out-of-range angle index → ValueError
+        with pytest.raises(ValueError, match="SelectAngle.*out of range"):
+            nereids.load_nexus_histogram(
+                path, multi_angle_mode="select", angle_index=99
+            )
+
+    def test_load_nexus_histogram_unknown_mode_rejected(self, tmp_path):
+        """Invalid `multi_angle_mode` string must error with a clear
+        message listing the allowed values."""
+        path = str(tmp_path / "mode_str.h5")
+        _create_synthetic_nexus_histogram(path, n_tof=5, height=2, width=2)
+        with pytest.raises(ValueError, match="multi_angle_mode.*error.*sum.*select"):
+            nereids.load_nexus_histogram(path, multi_angle_mode="average")
 
     def test_nexus_histogram_to_fitting_workflow(self, tmp_path):
         """End-to-end: load histogram → normalize → fit."""


### PR DESCRIPTION
Closes #430 (priority: high, bug, robustness).

## Summary
\`load_nexus_histogram()\` previously summed over the rotation-angle axis unconditionally when \`n_rot > 1\`, destroying projection-resolved information on import.  The fix replaces the silent collapse with an explicit policy:

- **Default (\`MultiAngleMode::Error\`)**: reject multi-angle files with a clear error pointing at the explicit-opt-in APIs.
- **\`MultiAngleMode::Sum\`**: legacy auto-sum, now an explicit opt-in.
- **\`MultiAngleMode::SelectAngle(usize)\`**: extract a single projection by index.

The rejection path is cheap — validates against \`counts_ds.shape()\` metadata without reading the full 4D cube (Codex review catch).

All in-tree callers of \`load_nexus_histogram\` were updated: GUI (both sample and OB branches) switches to the explicit \`MultiAngleMode::Sum\` and extends the status banner to mention #430 when angles were combined.  Python binding exposes \`multi_angle_mode\` + \`angle_index\` kwargs with the same three-way choice.

## Commits
1. \`d14f1b4\` fix(#430): refuse silent multi-angle collapse in NeXus histogram loader
2. \`1ce8bf2\` fix(#430): review-round — cheap rejection + zero-angle guard + parity tests

## Test plan
- [ ] \`cargo fmt --all\` — clean
- [ ] \`cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings\` — clean
- [ ] \`cargo test --workspace --exclude nereids-python\` — 654 passed (was 648; +6 new nexus tests)
- [ ] \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps --exclude nereids-python\` — clean
- [ ] \`pixi run build\` — clean
- [ ] \`pixi run test-python\` — 81 passed, 1 skipped (was 77; +4 new tests)
- [ ] Self-audit round: 0 P1, 6 P2s (3 fixed inline, 1 non-issue on re-read, 2 deferred — GUI OB UX filed as #462, Python \`angle_index\` ignored on non-select mode is doc-only)
- [ ] Codex review round: 1 P2 (cheap rejection path) — fixed inline

## Items deferred / filed
- **#462** filed: GUI OB load doesn't surface rotation-angle count in status banner (UX-only, OB data itself is correct)
- Python binding silently accepts \`angle_index\` when \`multi_angle_mode != \"select\"\` — minor, could warn but would clutter; current behaviour is documented

## Related
- Earlier cleanup PR #461 (#458 correctness sprint) landed related nearby.  This PR is independent and touches different files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)