### PR TITLE
perf(energy-scale): density-column plan cache in TZERO Jacobian (29% B.3, 22% KL+periso+TZERO)

### DIFF
--- a/crates/nereids-fitting/src/transmission_model.rs
+++ b/crates/nereids-fitting/src/transmission_model.rs
@@ -1144,9 +1144,16 @@ impl FitModel for EnergyScaleTransmissionModel {
             .iter()
             .filter(|&&fp_idx| fp_idx != self.t0_index && fp_idx != self.l_scale_index)
             .count();
+        // Only tabulated resolution has a meaningful plan; Gaussian
+        // would burn an O(n) sorted-grid validation only to return
+        // `None`, so we short-circuit here and stay byte-identical to
+        // the pre-cache Gaussian hot path (Copilot #1).
         let density_plan = if n_density_cols >= 2
             && let Some(inst) = &self.instrument
-        {
+            && matches!(
+                inst.resolution,
+                nereids_physics::resolution::ResolutionFunction::Tabulated(_)
+            ) {
             resolution::build_resolution_plan(&e_corr, &inst.resolution)
                 .ok()
                 .flatten()

--- a/crates/nereids-fitting/src/transmission_model.rs
+++ b/crates/nereids-fitting/src/transmission_model.rs
@@ -1123,6 +1123,37 @@ impl FitModel for EnergyScaleTransmissionModel {
         }
         let t_unresolved: Vec<f64> = neg_opt.iter().map(|&d| d.exp()).collect();
 
+        // Density-column plan cache: when the Jacobian has ≥ 2 density
+        // columns sharing the current (t0, l_scale) grid, build one
+        // broadening plan here and reuse it across every density-col
+        // `apply_resolution_with_plan`.  FD columns (t0, l_scale) go
+        // through `self.evaluate(p_plus/minus)` → `apply_resolution`
+        // unchanged — they each work at a DIFFERENT (t0, l_scale) so
+        // a single-grid plan would miss every time.
+        //
+        // Hit-rate analysis (see PR body):
+        //   - N_density = 1 (A.1 / B.1 / KL+grouped+TZERO): 1 hit, plan
+        //     build ≈ broaden cost → net-neutral.  Guard `>= 2` makes
+        //     this path a no-op: `density_plan` stays None, and
+        //     `apply_resolution_with_plan(None, …)` forwards to the
+        //     original `apply_resolution`, bit-exact.
+        //   - N_density = 6 (B.3, KL+per-iso+TZERO): 6 hits → ~45%
+        //     speedup on density-col broadening + ~30–40% wall on
+        //     the Jacobian call.
+        let n_density_cols = free_param_indices
+            .iter()
+            .filter(|&&fp_idx| fp_idx != self.t0_index && fp_idx != self.l_scale_index)
+            .count();
+        let density_plan = if n_density_cols >= 2
+            && let Some(inst) = &self.instrument
+        {
+            resolution::build_resolution_plan(&e_corr, &inst.resolution)
+                .ok()
+                .flatten()
+        } else {
+            None
+        };
+
         for (col, &fp_idx) in free_param_indices.iter().enumerate() {
             if fp_idx == self.t0_index || fp_idx == self.l_scale_index {
                 // Finite difference for energy-scale parameters
@@ -1156,17 +1187,24 @@ impl FitModel for EnergyScaleTransmissionModel {
                 let inner_deriv: Vec<f64> =
                     (0..n_e).map(|i| -sigma_sum[i] * t_unresolved[i]).collect();
 
-                // Apply resolution to derivative if enabled.  The
-                // non-plan path matches `evaluate_at` above; see its
-                // comment for why the (t0, l_scale)-keyed plan cache
-                // is not wired here.
+                // Apply resolution to derivative if enabled.
+                //
+                // When `density_plan` is Some (N_density ≥ 2) we
+                // hit the hoisted broadening plan built above.  When
+                // None (N_density ≤ 1 or Gaussian resolution),
+                // `apply_resolution_with_plan(None, …)` transparently
+                // forwards to `apply_resolution` — bit-exact with
+                // pre-cache main.
                 if let Some(inst) = &self.instrument {
-                    let resolved_deriv =
-                        match resolution::apply_resolution(&e_corr, &inner_deriv, &inst.resolution)
-                        {
-                            Ok(v) => v,
-                            Err(_) => return None,
-                        };
+                    let resolved_deriv = match resolution::apply_resolution_with_plan(
+                        density_plan.as_ref(),
+                        &e_corr,
+                        &inner_deriv,
+                        &inst.resolution,
+                    ) {
+                        Ok(v) => v,
+                        Err(_) => return None,
+                    };
                     for (i, &val) in resolved_deriv.iter().enumerate() {
                         *jacobian.get_mut(i, col) = val;
                     }

--- a/scripts/perf/baseline_dump.py
+++ b/scripts/perf/baseline_dump.py
@@ -315,9 +315,9 @@ def run_b3() -> dict:
 def run_kl_periso_tzero() -> dict:
     """KL+per-iso+TZERO on 4x4 VENUS Hf crop — added in this PR to
     verify the solver-agnostic nature of the
-    `EnergyScaleTransmissionModel` plan cache.  Not in #459's
-    benchmark set but enabled by `test_spatial_map_typed_allows_
-    counts_kl_with_energy_scale`.
+    `EnergyScaleTransmissionModel` plan cache. Not in #459's
+    benchmark set but enabled by
+    `test_spatial_map_typed_allows_counts_kl_with_energy_scale`.
     """
     return _run_periso_tzero(
         solver="kl",

--- a/scripts/perf/baseline_dump.py
+++ b/scripts/perf/baseline_dump.py
@@ -223,8 +223,117 @@ def run_b1() -> dict:
     }
 
 
+def _run_periso_tzero(solver: str, crop_size: int, label: str, max_iter: int) -> dict:
+    """Shared runner for per-isotope spatial fits with TZERO (B.3 / KL+periso+TZERO).
+
+    Uses a `crop_size × crop_size` pixel window centred on (255, 255).
+    4x4 default keeps the fixture under ~20 s for LM and under ~5 s for
+    KL on the current branch.
+    """
+    with h5py.File(H5, "r") as f:
+        E_full = f["Hf/120min/transmission/spectrum/energy_eV"][:]
+        S3d_raw = f["Hf/120min/counts/sample"][:][::-1, :, :]
+        O3d_raw = f["Hf/open_beam/counts"][:][::-1, :, :]
+        Q_s = float(f["Hf/120min/proton_charges/sample_values_uC"][:].sum())
+        Q_ob = float(f["Hf/120min/proton_charges/ob_values_uC"][0])
+    y0 = 255 - crop_size // 2
+    x0 = 255 - crop_size // 2
+    y1 = y0 + crop_size
+    x1 = x0 + crop_size
+    mask = (E_full >= ENERGY_MIN) & (E_full <= ENERGY_MAX)
+    E = np.ascontiguousarray(E_full[mask])
+    S3d = np.ascontiguousarray(S3d_raw[mask][:, y0:y1, x0:x1]).astype(np.float64)
+    O3d = np.ascontiguousarray(O3d_raw[mask][:, y0:y1, x0:x1]).astype(np.float64)
+    c = Q_s / Q_ob
+
+    hf_group = nereids.IsotopeGroup.natural(72)
+    hf_group.load_endf()
+    resonance_data_list = list(hf_group.resonance_data)
+    members = hf_group.members
+    initial_densities = [1.6e-4 * ratio for _, ratio in members]
+
+    res = nereids.load_resolution(str(RES_FILE), FLIGHT_PATH_M)
+    dead_pixels = np.zeros((S3d.shape[1], S3d.shape[2]), dtype=bool)
+
+    if solver == "lm":
+        T3d = S3d / np.maximum(c * O3d, 1.0)
+        sig3d = T3d * np.sqrt(
+            1.0 / np.maximum(S3d, 1.0) + 1.0 / np.maximum(O3d, 1.0)
+        )
+        input_data = nereids.from_transmission(T3d, sig3d)
+    else:
+        input_data = nereids.from_counts(S3d, O3d)
+
+    kwargs = dict(
+        data=input_data,
+        energies=E,
+        isotopes=resonance_data_list,
+        solver=solver,
+        temperature_k=TEMP_K,
+        initial_densities=initial_densities,
+        max_iter=max_iter,
+        background=True,
+        fit_energy_scale=True,
+        t0_init_us=0.5,
+        l_scale_init=1.005,
+        energy_scale_flight_path_m=FLIGHT_PATH_M,
+        resolution=res,
+        dead_pixels=dead_pixels,
+    )
+    if solver == "kl":
+        kwargs["c"] = c
+
+    t0 = time.time()
+    r = nereids.spatial_map_typed(**kwargs)
+    wall = time.time() - t0
+    # Capture all 6 per-isotope density maps so any per-iso regression
+    # surfaces in the diff (not just the summed or primary isotope).
+    density_hex: list[list[str]] = []
+    for m in r.density_maps:
+        density_hex.append(_array_hex(np.asarray(m)))
+    conv = np.asarray(r.converged_map)
+    return {
+        "name": label,
+        "wall_s": wall,
+        "n_pixels": int(conv.size),
+        "converged_count": int(conv.sum()),
+        "density_per_iso_hex": density_hex,
+        "converged_hex": _array_hex(conv.astype(np.float64)),
+    }
+
+
+def run_b3() -> dict:
+    """B.3: spatial LM+per-iso+TZERO on 4x4 VENUS Hf crop."""
+    return _run_periso_tzero(
+        solver="lm",
+        crop_size=4,
+        label="B3_spatial_LM_periso_background_tzero_4x4",
+        max_iter=200,
+    )
+
+
+def run_kl_periso_tzero() -> dict:
+    """KL+per-iso+TZERO on 4x4 VENUS Hf crop — added in this PR to
+    verify the solver-agnostic nature of the
+    `EnergyScaleTransmissionModel` plan cache.  Not in #459's
+    benchmark set but enabled by `test_spatial_map_typed_allows_
+    counts_kl_with_energy_scale`.
+    """
+    return _run_periso_tzero(
+        solver="kl",
+        crop_size=4,
+        label="KL_spatial_periso_background_tzero_4x4",
+        max_iter=200,
+    )
+
+
 def dump_baseline(out: Path, include_b1: bool) -> None:
-    data = {"a1": run_a1(), "b2": run_b2()}
+    data = {
+        "a1": run_a1(),
+        "b2": run_b2(),
+        "b3": run_b3(),
+        "kl_periso_tzero": run_kl_periso_tzero(),
+    }
     if include_b1:
         data["b1"] = run_b1()
     out.write_text(json.dumps(data, indent=2) + "\n")
@@ -254,6 +363,13 @@ def _diff(label: str, base: dict, cur: dict) -> list[str]:
             if len(bv) != len(cv):
                 diffs.append(f"{label}.{key}: length {len(bv)} vs {len(cv)}")
                 continue
+            if bv and isinstance(bv[0], list):
+                # Nested list-of-lists (e.g. density_per_iso_hex): diff each
+                # sub-list recursively so per-isotope mismatches surface
+                # with their isotope + pixel indices.
+                for i, (sub_b, sub_c) in enumerate(zip(bv, cv)):
+                    diffs.extend(_diff(f"{label}.{key}[{i}]", {"v": sub_b}, {"v": sub_c}))
+                continue
             mismatches = [i for i, (b, c) in enumerate(zip(bv, cv)) if b != c]
             if mismatches:
                 diffs.append(
@@ -275,7 +391,12 @@ def verify_baseline(path: Path, include_b1: bool) -> int:
     # stays as an explicit opt-in for the dump phase; on verify we
     # honour whatever the JSON actually holds.
     effective_include_b1 = include_b1 or ("b1" in base)
-    cur = {"a1": run_a1(), "b2": run_b2()}
+    cur = {
+        "a1": run_a1(),
+        "b2": run_b2(),
+        "b3": run_b3(),
+        "kl_periso_tzero": run_kl_periso_tzero(),
+    }
     if effective_include_b1:
         cur["b1"] = run_b1()
     diffs: list[str] = []

--- a/scripts/perf/profile_b2_kl_grouped.py
+++ b/scripts/perf/profile_b2_kl_grouped.py
@@ -75,26 +75,34 @@ def main() -> None:
 
     Path("/tmp/b2_ready").write_text("ready\n")
 
+    # Post-PR #468 the 4x4 B.2 fit runs in ~0.2 s, which is shorter
+    # than the `/usr/bin/sample` startup handshake.  Repeat the fit
+    # enough times to cover a full 5–6 s sampling window so the
+    # profile isn't empty.  The per-run bit-exactness is preserved
+    # (same inputs every call).
+    N_REPEATS = 25
     t0 = time.time()
-    r = nereids.spatial_map_typed(
-        data=input_data,
-        energies=E_cal,
-        solver="kl",
-        c=c,
-        temperature_k=TEMP_K,
-        groups=[hf_group],
-        initial_densities=[INIT_DENSITY],
-        max_iter=MAX_ITER,
-        background=True,
-        resolution=res,
-        dead_pixels=dead_pixels,
-    )
+    for _ in range(N_REPEATS):
+        r = nereids.spatial_map_typed(
+            data=input_data,
+            energies=E_cal,
+            solver="kl",
+            c=c,
+            temperature_k=TEMP_K,
+            groups=[hf_group],
+            initial_densities=[INIT_DENSITY],
+            max_iter=MAX_ITER,
+            background=True,
+            resolution=res,
+            dead_pixels=dead_pixels,
+        )
     wall = time.time() - t0
     n_px = (CROP_Y1 - CROP_Y0) * (CROP_X1 - CROP_X0)
     conv = np.asarray(r.converged_map)
     dens = np.asarray(r.density_maps[0])
     print(
-        f"B.2 KL 4x4: wall={wall:.2f}s n_px={n_px} converged={int(conv.sum())}/{n_px} "
+        f"B.2 KL 4x4 (x{N_REPEATS}): wall={wall:.2f}s per-call={wall/N_REPEATS:.3f}s "
+        f"n_px={n_px} converged={int(conv.sum())}/{n_px} "
         f"median_density={np.nanmedian(dens):.4e}"
     )
 

--- a/scripts/perf/profile_b3_lm_periso_tzero.py
+++ b/scripts/perf/profile_b3_lm_periso_tzero.py
@@ -1,0 +1,116 @@
+"""Profile driver: spatial B.3 LM+per-iso+TZERO on a 4x4 crop.
+
+Baseline (from #459): per-pixel LM+per-iso+TZERO on 64x64 is
+15 584 s / 64^2 ≈ 3.8 s / pixel at 20.6 % convergence.  Non-
+converged pixels run the full max-iter budget.  4×4 crop at
+max_iter=200 is typically 40–60 s wall, which is a solid sample
+window.
+
+Signals readiness via /tmp/b3_ready (consumed by run_sample_b3.sh).
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import h5py
+import numpy as np
+import nereids
+
+ROOT = Path(__file__).resolve().parents[2]
+H5 = ROOT / ".research/spatial-regularization/data/counts/resonance_data_2cm.h5"
+RES_FILE = ROOT / "_fts_bl10_0p5meV_1keV_25pts.txt"
+
+TEMP_K = 293.6
+FLIGHT_PATH_M = 25.0
+ENERGY_MIN, ENERGY_MAX = 7.0, 200.0
+T0_INIT_US = 0.5
+L_SCALE_INIT = 1.005
+INIT_DENSITY = 1.6e-4
+MAX_ITER = 200
+CROP_Y0, CROP_Y1 = 254, 258
+CROP_X0, CROP_X1 = 254, 258
+
+
+def main() -> None:
+    with h5py.File(H5, "r") as f:
+        E_full = f["Hf/120min/transmission/spectrum/energy_eV"][:]
+        S3d_raw = f["Hf/120min/counts/sample"][:][::-1, :, :]
+        O3d_raw = f["Hf/open_beam/counts"][:][::-1, :, :]
+        Q_s = float(f["Hf/120min/proton_charges/sample_values_uC"][:].sum())
+        Q_ob = float(f["Hf/120min/proton_charges/ob_values_uC"][0])
+    mask = (E_full >= ENERGY_MIN) & (E_full <= ENERGY_MAX)
+    E = np.ascontiguousarray(E_full[mask])
+    S3d = np.ascontiguousarray(
+        S3d_raw[mask][:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
+    ).astype(np.float64)
+    O3d = np.ascontiguousarray(
+        O3d_raw[mask][:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
+    ).astype(np.float64)
+    c = Q_s / Q_ob
+
+    T3d = S3d / np.maximum(c * O3d, 1.0)
+    sig3d = T3d * np.sqrt(
+        1.0 / np.maximum(S3d, 1.0) + 1.0 / np.maximum(O3d, 1.0)
+    )
+
+    # Per-iso: 6 natural-abundance Hf isotopes as separate fit params.
+    hf_group = nereids.IsotopeGroup.natural(72)
+    hf_group.load_endf()
+    members = hf_group.members  # list[((z, a), ratio)]
+    resonance_data_list = list(hf_group.resonance_data)  # 6 ResonanceData
+    initial_densities = [INIT_DENSITY * ratio for _, ratio in members]
+
+    res = nereids.load_resolution(str(RES_FILE), FLIGHT_PATH_M)
+    dead_pixels = np.zeros((S3d.shape[1], S3d.shape[2]), dtype=bool)
+    input_data = nereids.from_transmission(T3d, sig3d)
+
+    # Warm
+    _ = nereids.spatial_map_typed(
+        data=input_data,
+        energies=E,
+        isotopes=resonance_data_list,
+        solver="lm",
+        temperature_k=TEMP_K,
+        initial_densities=initial_densities,
+        max_iter=2,
+        background=True,
+        fit_energy_scale=True,
+        t0_init_us=T0_INIT_US,
+        l_scale_init=L_SCALE_INIT,
+        energy_scale_flight_path_m=FLIGHT_PATH_M,
+        resolution=res,
+        dead_pixels=dead_pixels,
+    )
+
+    Path("/tmp/b3_ready").write_text("ready\n")
+
+    t0 = time.time()
+    r = nereids.spatial_map_typed(
+        data=input_data,
+        energies=E,
+        isotopes=resonance_data_list,
+        solver="lm",
+        temperature_k=TEMP_K,
+        initial_densities=initial_densities,
+        max_iter=MAX_ITER,
+        background=True,
+        fit_energy_scale=True,
+        t0_init_us=T0_INIT_US,
+        l_scale_init=L_SCALE_INIT,
+        energy_scale_flight_path_m=FLIGHT_PATH_M,
+        resolution=res,
+        dead_pixels=dead_pixels,
+    )
+    wall = time.time() - t0
+    n_px = (CROP_Y1 - CROP_Y0) * (CROP_X1 - CROP_X0)
+    conv = np.asarray(r.converged_map)
+    print(
+        f"B.3 LM+per-iso+TZERO 4x4: wall={wall:.2f}s n_px={n_px} "
+        f"converged={int(conv.sum())}/{n_px} max_iter={MAX_ITER}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/perf/run_sample_b3.sh
+++ b/scripts/perf/run_sample_b3.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+PY_BIN=$(pixi info --json 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['environments_info'][0]['prefix'])")/bin/python
+
+rm -f /tmp/b3_ready
+"$PY_BIN" scripts/perf/profile_b3_lm_periso_tzero.py &
+PID=$!
+
+for _ in $(seq 1 1200); do
+    if [ -f /tmp/b3_ready ]; then break; fi
+    sleep 0.05
+done
+sleep 0.2
+
+# B.3 4×4 LM+per-iso+TZERO at max_iter=200 typically runs 40-80 s.
+# Sample for 30 s at 1 ms intervals for a solid profile window.
+/usr/bin/sample "$PID" 30 1 -file /tmp/b3.sample.txt -fullPaths >/dev/null 2>&1 || true
+
+wait "$PID" 2>/dev/null || true
+
+echo "profile: /tmp/b3.sample.txt ($(wc -l </tmp/b3.sample.txt) lines)"

--- a/scripts/perf/run_sample_b3.sh
+++ b/scripts/perf/run_sample_b3.sh
@@ -20,4 +20,11 @@ sleep 0.2
 
 wait "$PID" 2>/dev/null || true
 
-echo "profile: /tmp/b3.sample.txt ($(wc -l </tmp/b3.sample.txt) lines)"
+# `set -e` would abort if /tmp/b3.sample.txt never got created (sample
+# missing on non-macOS, permission denied, target exited early) — give
+# a helpful message instead.  Copilot #2.
+if [ -f /tmp/b3.sample.txt ]; then
+    echo "profile: /tmp/b3.sample.txt ($(wc -l </tmp/b3.sample.txt) lines)"
+else
+    echo "profile: /tmp/b3.sample.txt was not created (sampling may be unavailable, permission denied, or the target exited before sample could attach)"
+fi


### PR DESCRIPTION
## Summary

Hoists the resolution broadening plan once per `analytical_jacobian` call in `EnergyScaleTransmissionModel` when there are ≥ 2 density parameters to amortize across. Density columns share the cached plan via `apply_resolution_with_plan`; FD (t0 / L_scale) columns keep the existing non-plan path since they each work at a different `(t0, l_scale)` and would always miss.

Extends PR #468 (which covered the fixed-grid models) to the TZERO path for per-isotope / multi-density workloads, for **both LM and KL solvers** — `FitModel::analytical_jacobian` is shared by both (verified via [joint_poisson.rs:158, :196](https://github.com/ornlneutronimaging/NEREIDS/blob/main/crates/nereids-fitting/src/joint_poisson.rs#L158)).

Tracks #459 §B3 remaining work for the TZERO / per-iso path.

## Measured impact (VENUS Hf 120 min real data, bit-exact vs main)

| Workload | N_density | Baseline | Post | Speedup |
|---|---|---|---|---|
| A.1 aggregated LM+grouped+TZERO | 1 | 1.29 s | 1.20 s | noise (guard → no plan) |
| B.2 spatial KL+grouped | 1 | 0.22 s | 0.21 s | unchanged (different code path) |
| **B.3 spatial LM+per-iso+TZERO 4×4** | **6** | **16.77 s** | **11.87 s** | **29%** |
| **KL+per-iso+TZERO 4×4** | **6** | **4.18 s** | **3.24 s** | **22%** |

Both target workloads clear the 20% gate-or-kill threshold set in the plan. A.1 / B.2 stay within run-to-run noise.

## Scope

**One file touched** in production code: [`transmission_model.rs`](crates/nereids-fitting/src/transmission_model.rs), `EnergyScaleTransmissionModel::analytical_jacobian` — ~15 lines added (plan build + call-site swap). No public-API change, no trait change, no pipeline edit, no Python binding edit.

Instrumentation additions:
- [`scripts/perf/profile_b3_lm_periso_tzero.py`](scripts/perf/profile_b3_lm_periso_tzero.py) — 4×4 profiling driver.
- [`scripts/perf/run_sample_b3.sh`](scripts/perf/run_sample_b3.sh) — `/usr/bin/sample` wrapper.
- [`scripts/perf/baseline_dump.py`](scripts/perf/baseline_dump.py) — added `run_b3` + `run_kl_periso_tzero`, plus per-isotope density-map diffing (nested list-of-lists handled in `_diff`).
- [`scripts/perf/profile_b2_kl_grouped.py`](scripts/perf/profile_b2_kl_grouped.py) — extended with an x25 repeat loop so post-PR #468's 0.21 s per-call wall doesn't outrun `sample`'s startup handshake.

## Correctness

- `apply_resolution_with_plan(Some(plan), e_corr, ..)` is bit-exact to `apply_resolution(e_corr, ..)` by PR #468's regression tests (`test_apply_resolution_with_plan_tabulated_matches_non_plan_path` + `_rejects_same_length_different_grid`). **No new correctness surface introduced.**
- `n_density >= 2` guard keeps A.1 / B.1 / KL+grouped+TZERO paths byte-identical to pre-change main (no plan is built).
- Gaussian resolution → `build_resolution_plan` returns `Ok(None)` → `apply_resolution_with_plan(None, …)` forwards to `apply_resolution` → unchanged path.
- FD columns untouched — their `self.evaluate(p±h)` calls still go through `evaluate_at` → `apply_resolution`, so t0/L_scale FD derivatives are byte-identical.
- Real-VENUS bit-exact verified on A.1 + B.2 + B.3 + KL+per-iso+TZERO via `scripts/perf/baseline_dump.py --verify`.

## Hot-path re-profile that drove this PR

Post-#468 `/usr/bin/sample` on A.1 showed `broaden_presorted` at **89% of active self-time** — the plan never fires on the TZERO path. B.2 (which now uses the plan) had `ResolutionPlan::apply` at 57% wall time, dominant but already optimal. The next mechanical win was wiring the plan into the TZERO Jacobian — which this PR does, scoped to the N_density ≥ 2 regime where the hit-rate math pencils out.

## Gates

- `cargo fmt --all` clean
- `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings` clean
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --exclude nereids-python` clean
- `cargo test --workspace --exclude nereids-python` — 674 passing
- `pixi run test-python` — 82 passing, 1 skipped
- Real-VENUS bit-exact on 4 workloads

## Test plan

- [ ] CI passes (ubuntu Python + cross-platform Rust + doc build)
- [ ] Copilot review
- [ ] Post-merge bit-exact re-verify on main via `baseline_dump.py --verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)