### PR TITLE
fix(#486): default KL polish off (~100× wall win on single-spectrum)

### DIFF
--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -906,6 +906,7 @@ def fit_counts_spectrum_typed(
     delta_l_m: float | None = None,
     groups: list[IsotopeGroup] | None = None,
     initial_densities: list[float] | None = None,
+    enable_polish: bool | None = None,
 ) -> FitResult:
     """Fit a single raw-count spectrum (sample + open-beam counts).
 
@@ -959,6 +960,15 @@ def fit_counts_spectrum_typed(
         resolution: Optional resolution function.
         groups: List of IsotopeGroup objects (mutually exclusive with isotopes).
         initial_densities: Initial density guesses when using groups.
+        enable_polish: Override the Nelder-Mead polish flag for the
+            counts-KL solver.  ``None`` (default) falls through to the
+            library default — currently ``False`` (#486) because the
+            polish ``fatol = 1e-10`` is sub-ULP on real counts data
+            where ``D`` saturates at ``10⁴``-``10⁵`` and burns
+            ``max_iter = 5000`` for ≤ 0.35 Fisher σ parameter
+            movement.  Pass ``True`` to opt in for synthetic / clean
+            (``D ≈ 1``) regimes where the absolute tolerance is
+            physically meaningful; ``False`` to force off explicitly.
     """
     ...
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -3212,6 +3212,7 @@ fn py_spatial_map_typed<'py>(
     delta_l_m = None,
     groups = None,
     initial_densities = None,
+    enable_polish = None,
 ))]
 fn py_fit_counts_spectrum_typed<'py>(
     py: Python<'py>,
@@ -3244,6 +3245,7 @@ fn py_fit_counts_spectrum_typed<'py>(
     delta_l_m: Option<f64>,
     groups: Option<Vec<PyIsotopeGroup>>,
     initial_densities: Option<Vec<f64>>,
+    enable_polish: Option<bool>,
 ) -> PyResult<PyFitResult> {
     use nereids_pipeline::pipeline::{
         CountsBackgroundConfig, InputData, UnifiedFitConfig, fit_spectrum_typed,
@@ -3419,6 +3421,15 @@ fn py_fit_counts_spectrum_typed<'py>(
             open_beam_counts: ob_slice.to_vec(),
         }
     };
+
+    // #486: counts-KL polish override.  Default `None` falls through to
+    // the Rust `JointPoissonFitConfig::default().enable_polish` (now
+    // `false`).  Pass `enable_polish=True` to opt back in for clean /
+    // synthetic fits where the polish tolerances are physically
+    // meaningful (see the field doc on `JointPoissonFitConfig::enable_polish`).
+    if let Some(v) = enable_polish {
+        config = config.with_counts_enable_polish(Some(v));
+    }
 
     let result = py.detach(move || fit_spectrum_typed(&input, &config).map_err(|e| e.to_string()));
     let result = result.map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e))?;

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -3179,6 +3179,16 @@ fn py_spatial_map_typed<'py>(
 ///     resolution: Optional resolution function.
 ///     groups: list of IsotopeGroup objects (mutually exclusive with isotopes).
 ///     initial_densities: Initial density guesses when using groups (default 0.001 each).
+///     enable_polish: Override the Nelder-Mead polish phase on the
+///         counts-KL solver (default ``None`` → use the library default,
+///         which is ``False`` as of #486 because polish's absolute
+///         ``fatol = 1e-10`` is sub-f64-ULP on real-data deviance scales
+///         where ``D ≈ 10⁴``–``10⁵``, so polish hits ``max_iter = 5000``
+///         every fit at 70-260× wall cost for ≤ 0.35 Fisher σ parameter
+///         shift).  Pass ``True`` to opt in for clean / synthetic fits
+///         where ``D → 0`` is achievable and the polish tolerances are
+///         physically meaningful.  See ``JointPoissonFitConfig``
+///         ``enable_polish`` field doc for details.
 ///
 /// Returns:
 ///     FitResult with densities, uncertainties, chi2, etc.

--- a/crates/nereids-fitting/src/joint_poisson.rs
+++ b/crates/nereids-fitting/src/joint_poisson.rs
@@ -452,14 +452,38 @@ pub struct JointPoissonFitConfig {
     pub tol_param: f64,
     /// Finite-difference step for gradient fallback.
     pub fd_step: f64,
-    /// Enable Nelder-Mead polish after stage 1 (memo 35 §P2.1).
+    /// Enable Nelder-Mead polish after stage 1.
     ///
-    /// Default `true`.  Set to `false` only when the caller has external
-    /// evidence that the stage-1 minimum is global for the current regime
-    /// (e.g., a no-background fit with a known convex likelihood).
+    /// Default `false` as of #486.  The polish tolerances
+    /// (`xatol = 1e-9, fatol = 1e-10`) were originally matched to the
+    /// EG5 synthetic benchmark (memo 35 §P2.1) where D stays O(1), so
+    /// `fatol` is physically meaningful.  On real-data regimes where
+    /// D saturates at 10⁴–10⁵ (un-modelled upstream physics —
+    /// memo 35 §P3/§P4), `fatol / D` drops below f64 ULP and polish
+    /// cannot self-terminate — it burns its full `max_iter = 5000`
+    /// every fit at 70–260× wall cost, and the three-scenario
+    /// ablation on real VENUS Hf 120-min data (issue #486) showed
+    /// the resulting parameter shift is ≤ 0.35 Fisher σ on every
+    /// parameter in every scenario — i.e. below the solver's own
+    /// reported uncertainty floor.
+    ///
+    /// The polish mechanism itself is sound (self-terminates cleanly
+    /// on synthetic D≈1 data per ablation S3); only the absolute
+    /// tolerance defaults are mis-calibrated for real counts data.
+    /// A future scale-aware rescale (`fatol_rel` vs `D_stage1`) can
+    /// re-enable polish as a useful opt-in refinement.
+    ///
+    /// Set this to `true` (via `with_counts_enable_polish(Some(true))`
+    /// at the pipeline level) when you specifically want the polish
+    /// stage on a synthetic / clean-data scenario where the absolute
+    /// tolerance defaults are physically meaningful.
     pub enable_polish: bool,
     /// Polish (Nelder-Mead) configuration.  Used only when
-    /// `enable_polish == true`.  Defaults match memo 35 §P2.1 tolerances.
+    /// `enable_polish == true`.  Default `xatol = 1e-9`, `fatol = 1e-10`
+    /// match the EG5 synthetic benchmark tolerances from memo 35 §P2.1
+    /// — physically meaningful when `D ≈ 1` (clean data) but sub-f64-
+    /// ULP on real counts where `D ≈ 10⁴`–`10⁵`, which is why
+    /// `enable_polish` defaults to `false`.  See #486.
     pub polish: NelderMeadConfig,
     /// Compute and return the Fisher covariance and parameter uncertainties.
     pub compute_covariance: bool,
@@ -477,10 +501,24 @@ impl Default for JointPoissonFitConfig {
             tol_d: 1e-8,
             tol_param: 1e-8,
             fd_step: 1e-6,
-            enable_polish: true,
+            // #486: flipped from `true` to `false` after a three-scenario
+            // ablation on real VENUS data showed polish burning full
+            // `max_iter = 5000` at 70-260× wall cost for ≤ 0.35 Fisher σ
+            // parameter movement.  The absolute tolerances below are
+            // physically meaningful for synthetic (D ≈ 1) benchmarks and
+            // dead on real counts data (D ≈ 10⁵).  Opt in via
+            // `UnifiedFitConfig::with_counts_enable_polish(Some(true))`
+            // when you specifically want the polish stage.  See the
+            // field doc on `enable_polish` for details.
+            enable_polish: false,
             polish: NelderMeadConfig {
-                // EG5 used scipy's xatol=1e-9, fatol=1e-10 for the polish
-                // regime.  Match that here.
+                // Tolerances tuned for the EG5 synthetic regime (memo 35
+                // §P2.1) — `fatol = 1e-10` vs D ≈ 1 is a physically
+                // meaningful "deviance isn't budging" check.  On real
+                // counts data where D ≈ 10⁵ the same absolute value is
+                // sub-ULP; polish can't self-terminate and is disabled
+                // by the default above.  A future scale-aware rescale
+                // (`fatol_rel` vs D_stage1) is tracked as a follow-up.
                 xatol: 1e-9,
                 fatol: 1e-10,
                 max_iter: 5000,

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -3504,7 +3504,15 @@ mod tests {
             c,
             ..Default::default()
         })
-        .with_transmission_background(bg);
+        .with_transmission_background(bg)
+        // #486: polish defaults off for real-data regimes where its
+        // `fatol = 1e-10` is sub-ULP.  This noise-free synthetic fit
+        // is exactly the regime polish was designed for (D → 0
+        // achievable, `fatol` physically meaningful) and the test
+        // asserts `D/dof < 1.0` which Gauss-Newton alone cannot reach
+        // on this 5-free-parameter fit due to the documented n ↔ A_n
+        // correlation stall.  Opt in explicitly.
+        .with_counts_enable_polish(Some(true));
 
         let input = InputData::Counts {
             sample_counts,
@@ -3521,6 +3529,7 @@ mod tests {
         // stress test is the VENUS evaluation in the companion memo.
 
         // Deviance-based GOF populated and → 0 on noise-free expected counts.
+        // Requires polish (see `with_counts_enable_polish(Some(true))` above).
         let dpd = r.deviance_per_dof.expect("joint-Poisson must report D/dof");
         assert!(
             dpd < 1.0,

--- a/crates/nereids-pipeline/src/spatial.rs
+++ b/crates/nereids-pipeline/src/spatial.rs
@@ -1901,7 +1901,7 @@ mod tests {
             "multi-pixel with no override should auto-disable polish"
         );
 
-        // Single-pixel (n = 1) → no change (let single-spectrum default on).
+        // Single-pixel (n = 1) → no change (let the library default decide).
         let resolved = apply_spatial_polish_default(cfg.clone(), 1);
         assert_eq!(
             resolved.counts_enable_polish(),

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -787,6 +787,95 @@ class TestSpatialMapCounts:
 
 
 # ===========================================================================
+# fit_counts_spectrum_typed — single-spectrum counts-KL bindings
+# ===========================================================================
+
+
+class TestFitCountsSpectrumTyped:
+    """Tests for the single-spectrum counts-KL binding."""
+
+    def test_enable_polish_kwarg_accepted_and_toggles_behavior(self, u238_data):
+        """Issue #486: `enable_polish` kwarg must be accepted on the
+        Python `fit_counts_spectrum_typed` binding, default `None` must
+        fall through to the library default (now ``False``), and
+        explicit ``True``/``False`` must produce different iteration
+        counts on a synthetic case.
+
+        This is the regression test guarding against a future binding
+        refactor silently dropping the kwarg or stranding the override
+        plumbing — Copilot Phase B catch on PR #487.
+        """
+        # Tiny synthetic counts setup — uses the U-238 single-resonance
+        # fixture so the test runs without ENDF retrieval.
+        energies = np.linspace(1.0, 30.0, 200)
+        true_density = 0.0008
+        flux = 1000.0  # open-beam mean cts/bin
+
+        t_1d = np.asarray(
+            nereids.forward_model(energies, [(u238_data, true_density)])
+        )
+        rng = np.random.default_rng(20260424)
+        open_beam = rng.poisson(np.full_like(t_1d, flux)).astype(float)
+        sample = rng.poisson(flux * t_1d).astype(float)
+        # Floor open_beam at 1 to avoid divide-by-zero in the c-norm path.
+        open_beam = np.maximum(open_beam, 1.0)
+
+        kwargs = dict(
+            sample_counts=sample,
+            open_beam_counts=open_beam,
+            energies=energies,
+            isotopes=[(u238_data, true_density)],
+            solver="kl",
+            c=1.0,
+            temperature_k=293.6,
+            max_iter=200,
+        )
+
+        # Default kwarg → library default (False post-#486) → fast.
+        r_default = nereids.fit_counts_spectrum_typed(**kwargs)
+        # Explicit False → same path as default, gates against future drift.
+        r_off = nereids.fit_counts_spectrum_typed(**kwargs, enable_polish=False)
+        # Explicit True → opt-in polish → must run more iterations than
+        # polish-off on a regime where polish has any room to move
+        # (NM still runs even if it doesn't improve, so iter count
+        # rises by polish_iters >= 1).
+        r_on = nereids.fit_counts_spectrum_typed(**kwargs, enable_polish=True)
+
+        # All three must converge / produce a valid result.
+        for r in (r_default, r_off, r_on):
+            assert r.densities[0] > 0.0
+            assert r.iterations > 0
+
+        # Default == explicit-False: the kwarg's `None` path must not
+        # accidentally toggle polish on.
+        assert r_default.iterations == r_off.iterations, (
+            f"enable_polish=None must match enable_polish=False; "
+            f"got iter None={r_default.iterations} False={r_off.iterations}"
+        )
+
+        # Explicit True must produce more iterations than False — polish
+        # is the only stage that runs after Gauss-Newton convergence,
+        # so any non-zero polish_iters bumps the summed iteration count.
+        assert r_on.iterations > r_off.iterations, (
+            f"enable_polish=True must run more iterations than =False; "
+            f"got True={r_on.iterations} False={r_off.iterations}"
+        )
+
+        # All three should agree on the converged density to within
+        # Fisher σ — polish should not move the answer beyond solver
+        # noise on this synthetic case (matches issue #486 ablation
+        # finding: shift ≤ 0.35 σ on every parameter / scenario).
+        d_off = float(r_off.densities[0])
+        d_on = float(r_on.densities[0])
+        sigma = float(r_on.uncertainties[0])
+        if np.isfinite(sigma) and sigma > 0.0:
+            assert abs(d_on - d_off) / sigma < 1.0, (
+                f"polish moved density beyond 1σ: "
+                f"|Δn|/σ = {abs(d_on - d_off) / sigma:.3f}"
+            )
+
+
+# ===========================================================================
 # Normalization
 # ===========================================================================
 


### PR DESCRIPTION
Closes #486.

## Summary

Flip `JointPoissonFitConfig::default().enable_polish` from `true` to
`false`.  The Nelder-Mead polish phase added after Gauss-Newton was
burning its full `max_iter = 5000` every fit because its absolute
`fatol = 1e-10` tolerance is sub-f64-ULP vs real VENUS deviance
scales (D ≈ 10⁴–10⁵).  The mechanism is preserved for opt-in use
via `UnifiedFitConfig::with_counts_enable_polish(Some(true))` at
the Rust level or the new `enable_polish=True` kwarg on the Python
`fit_counts_spectrum_typed` binding.

## Regression report (real VENUS Hf 120-min aggregated, 3-scenario ablation)

| Scenario                           | Max shift/σ | ΔD/dof rel | Wall penalty | Polish self-exit? |
|------------------------------------|-------------|------------|--------------|-------------------|
| S1 VENUS grouped (k=1)             | 3.6e-5      | -8.6e-12   | **264×**     | No (5000 max_iter) |
| S2 VENUS per-iso (k=6)             | 0.35        | -7.4e-6    | 67×          | No (5000 max_iter) |
| S3 synthetic low-SNR, D≈1          | 1.3e-4      | -7.4e-11   | 3.5×         | Yes (331 iter)     |

Across all three cases, polish never beat Fisher σ on any parameter
(max 0.35σ on one rail-adjacent isotope, everything else ≤ 0.1σ).
Synthetic S3 confirms the mechanism is sound when tolerances match
the deviance scale — only the EG5-inherited `fatol=1e-10` default
is mis-calibrated for real counts data.

**512×512 single-spectrum projection**: ~143 s → ~1-2 s per fit
(LM-scale).  Spatial maps unchanged (already polish-off for
`n_pixels > 1`).

## Changes (3 commits)

**`733809d`** — default flip
- `crates/nereids-fitting/src/joint_poisson.rs`: `enable_polish: true → false` in `Default`.
- Field doc on `enable_polish` rewritten to explain the new default,
  the tolerance-scale issue, and the opt-in API.
- Doc on `polish: NelderMeadConfig` updated to note the EG5-synthetic
  origin of the tolerances.
- `crates/nereids-pipeline/src/pipeline.rs` test
  `test_joint_poisson_with_transmission_background`: explicit
  `.with_counts_enable_polish(Some(true))` — the test specifically
  checks polish escapes an n↔A_n correlation stall on noise-free
  synthetic data (D → 0 regime).

**`f8cccf2`** — round-1 review fixes
- `bindings/python/src/lib.rs`: added `enable_polish: Option<bool> = None`
  kwarg to `fit_counts_spectrum_typed` (mirrors the existing
  `spatial_map_typed` pattern).  Python callers can now opt back
  into polish for clean/synthetic fits after the default flip.
- `crates/nereids-pipeline/src/spatial.rs`: stale comment updated
  to match the new default.

**`759258f`** — round-2 review fix
- `bindings/python/python/nereids/__init__.pyi`: added the matching
  `enable_polish` kwarg to the type stub so static analyzers and
  IDEs see the new runtime signature.

## Review pipeline (Phase A)

3 rounds × (Claude self-audit + Codex external) — all green by round 3.

| Round | Claude | Codex | Fixes |
|---|---|---|---|
| 1 | 0 P1, 0 P2, 1 P3 stale comment | 1 P2 no Python kwarg | f8cccf2 |
| 2 | 1 P2 `.pyi` gap (committed mid-review; kept) | 1 P2 GUI Auto label | 759258f; GUI deferred to UX revamp (issue #486 comment) |
| 3 | 0 P1, 0 P2, 2 P3 (both GUI-UX deferrals) | 0 findings | none |

**Totals**: 3 P2s fixed, 1 P2 explicitly deferred (GUI — separate UX revamp thread), 3 P3s dismissed/deferred.

## What this PR does NOT do

- **Does not delete polish.**  S3 shows the mechanism is sound on
  synthetic data; keep for opt-in.
- **Does not rescale `fatol`.**  A scale-aware tolerance
  (`fatol_rel` vs `D_stage1`) would let polish self-terminate on
  real data too, making the opt-in actually useful.  Tracked as a
  follow-up.
- **Does not update the GUI Auto-polish label.**  The guided
  analyze step is being redesigned in a separate UX revamp thread;
  triaged to that work per the issue #486 comment.

## Gates

- `cargo fmt --all`: clean
- `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings`: clean
- `cargo test --workspace --exclude nereids-python`: 718 pass
- `pixi run build`: clean
- `pixi run test-python`: 82 passed, 1 skipped (pre-existing)

## Test plan

- [ ] Phase B: trigger GitHub Copilot review
- [ ] Post-merge: `/post-merge` integration gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)