### PR TITLE
[codex] Fix GUI baseline regressions

### DIFF
--- a/apps/gui/src/app.rs
+++ b/apps/gui/src/app.rs
@@ -51,18 +51,8 @@ impl NereidsApp {
             memory: crate::telemetry::MemoryTelemetry::new(),
         }
     }
-}
 
-impl eframe::App for NereidsApp {
-    fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
-        // If a background save is in progress, block until it completes
-        // to avoid corrupting the HDF5 file.
-        if let Some(handle) = self.state.save_join_handle.take() {
-            handle.join().ok();
-        }
-    }
-
-    fn save(&mut self, storage: &mut dyn eframe::Storage) {
+    fn save_session_cache(&self, storage: &mut dyn eframe::Storage) {
         if let Some(cache) = SessionCache::from_state(&self.state) {
             eframe::set_value(storage, SESSION_CACHE_KEY, &cache);
         } else {
@@ -71,7 +61,30 @@ impl eframe::App for NereidsApp {
         }
     }
 
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+    fn wait_for_background_save(&mut self) {
+        // If a background save is in progress, block until it completes
+        // to avoid corrupting the HDF5 file.
+        if let Some(handle) = self.state.save_join_handle.take() {
+            handle.join().ok();
+        }
+    }
+}
+
+impl eframe::App for NereidsApp {
+    fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
+        self.wait_for_background_save();
+
+        // macOS/AppKit can abort after eframe returns from `on_exit` while
+        // tearing down winit's NSView touch-bar observer.
+        #[cfg(target_os = "macos")]
+        std::process::exit(0);
+    }
+
+    fn save(&mut self, storage: &mut dyn eframe::Storage) {
+        self.save_session_cache(storage);
+    }
+
+    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
         // Apply theme (skip if unchanged to avoid 80+ color assignments per frame)
         let resolved = theme::resolve_dark_mode(ctx, self.state.theme_preference);
         if self.state.last_applied_dark_mode != Some(resolved) {
@@ -87,6 +100,15 @@ impl eframe::App for NereidsApp {
 
         // Refresh memory telemetry (750ms interval)
         self.memory.refresh(ctx.input(|i| i.time));
+
+        #[cfg(target_os = "macos")]
+        if ctx.input(|i| i.viewport().close_requested()) {
+            if let Some(storage) = frame.storage_mut() {
+                self.save_session_cache(storage);
+            }
+            self.wait_for_background_save();
+            std::process::exit(0);
+        }
 
         // Keep repainting while background work is in progress.
         // Fitting also has a dedicated watcher thread that pokes via

--- a/apps/gui/src/app.rs
+++ b/apps/gui/src/app.rs
@@ -85,6 +85,9 @@ impl eframe::App for NereidsApp {
     }
 
     fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+        #[cfg(not(target_os = "macos"))]
+        let _ = frame;
+
         // Apply theme (skip if unchanged to avoid 80+ color assignments per frame)
         let resolved = theme::resolve_dark_mode(ctx, self.state.theme_preference);
         if self.state.last_applied_dark_mode != Some(resolved) {

--- a/apps/gui/src/widgets/statusbar.rs
+++ b/apps/gui/src/widgets/statusbar.rs
@@ -7,6 +7,7 @@ use crate::theme::{ThemeColors, semantic};
 pub fn status_bar(ctx: &egui::Context, state: &AppState, rss_bytes: u64) {
     let colors = ThemeColors::from_ctx(ctx);
     egui::TopBottomPanel::bottom("status_bar")
+        .exact_height(28.0)
         .frame(
             egui::Frame::NONE
                 .fill(colors.bg2)

--- a/apps/gui/src/widgets/toolbar.rs
+++ b/apps/gui/src/widgets/toolbar.rs
@@ -10,6 +10,7 @@ use crate::widgets::design;
 pub fn toolbar(ctx: &egui::Context, state: &mut AppState) {
     let colors = ThemeColors::from_ctx(ctx);
     egui::TopBottomPanel::top("toolbar")
+        .exact_height(48.0)
         .frame(
             egui::Frame::NONE
                 .fill(colors.bg2)


### PR DESCRIPTION
## Summary

Fix two GUI baseline regressions introduced by the recent GUI dependency update:

- Pin the existing egui toolbar and status bar panels to their intended heights so they cannot consume the full window.
- Add a macOS-only close path that saves session cache state, waits for any background save, and exits before AppKit hits the known touch-bar observer teardown crash.

## Validation

- `cargo fmt -p nereids-gui`
- `cargo check -p nereids-gui`
- `cargo test -p nereids-gui`
