### PR TITLE
fix(endf): use OS trust roots for IAEA fetches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2075,11 +2075,11 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -3271,6 +3271,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4029,6 +4035,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4043,7 +4050,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -4182,6 +4188,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4224,6 +4242,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4246,6 +4273,29 @@ dependencies = [
  "memmap2",
  "smithay-client-toolkit 0.19.2",
  "tiny-skia",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -5333,15 +5383,6 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "url",
  "web-sys",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ num-complex = "0.4"
 rayon = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls-native-roots"] }
 zip = "2"
 dirs = "6"
 tiff = "0.11"

--- a/crates/nereids-endf/src/retrieval.rs
+++ b/crates/nereids-endf/src/retrieval.rs
@@ -12,6 +12,7 @@ use nereids_core::types::Isotope;
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 /// ENDF evaluated nuclear data libraries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -73,6 +74,9 @@ pub struct EndfRetriever {
     cache_root: PathBuf,
     /// Base URL for IAEA downloads.
     base_url: String,
+    /// Shared HTTP client with explicit connect/total timeouts so a transport
+    /// stall surfaces as a clear error instead of hanging the GUI worker.
+    client: reqwest::blocking::Client,
 }
 
 impl EndfRetriever {
@@ -85,6 +89,7 @@ impl EndfRetriever {
         Self {
             cache_root,
             base_url: "https://www-nds.iaea.org/public/download-endf".to_string(),
+            client: build_http_client(),
         }
     }
 
@@ -93,6 +98,7 @@ impl EndfRetriever {
         Self {
             cache_root: cache_dir.into(),
             base_url: "https://www-nds.iaea.org/public/download-endf".to_string(),
+            client: build_http_client(),
         }
     }
 
@@ -152,8 +158,12 @@ impl EndfRetriever {
         let zip_filename = library.zip_filename(isotope, mat);
         let url = format!("{}/{}/{}", self.base_url, library.url_path(), zip_filename);
 
-        let response = reqwest::blocking::get(&url).map_err(|e| {
-            EndfRetrievalError::NetworkError(format!("Failed to connect to {}: {}", url, e))
+        let response = self.client.get(&url).send().map_err(|e| {
+            EndfRetrievalError::NetworkError(format!(
+                "Failed to fetch {}: {}",
+                url,
+                format_error_chain(&e)
+            ))
         })?;
 
         let status = response.status();
@@ -175,7 +185,10 @@ impl EndfRetriever {
         }
 
         let bytes = response.bytes().map_err(|e| {
-            EndfRetrievalError::NetworkError(format!("Failed to read response body: {}", e))
+            EndfRetrievalError::NetworkError(format!(
+                "Failed to read response body: {}",
+                format_error_chain(&e)
+            ))
         })?;
 
         // Extract ENDF file from ZIP archive.
@@ -282,4 +295,31 @@ pub enum EndfRetrievalError {
 
     #[error("Isotope not found in MAT database: {0}")]
     UnknownIsotope(String),
+}
+
+/// Build the shared HTTP client used for ENDF downloads.
+///
+/// Connect timeout is short so DNS/TLS failures surface fast; total timeout
+/// is generous because some library zips are several hundred KB over slow
+/// links. ENDF zip files top out around ~1 MB.
+fn build_http_client() -> reqwest::blocking::Client {
+    reqwest::blocking::Client::builder()
+        .connect_timeout(Duration::from_secs(15))
+        .timeout(Duration::from_secs(60))
+        .build()
+        .expect("failed to build reqwest blocking client")
+}
+
+/// Render an error and its full `source()` chain on one line. reqwest's outer
+/// `Display` is uninformative ("error sending request for url ...") — the
+/// real cause (TLS, DNS, refused, timeout) lives in the source chain.
+fn format_error_chain(err: &dyn std::error::Error) -> String {
+    let mut out = err.to_string();
+    let mut cur = err.source();
+    while let Some(s) = cur {
+        out.push_str(": ");
+        out.push_str(&s.to_string());
+        cur = s.source();
+    }
+    out
 }


### PR DESCRIPTION
## Symptom

GUI showed `Fetch error for Hf-180: Network error: Failed to connect to https://www-nds.iaea.org/...: error sending request for url (...)` for every isotope in ENDF/B-VIII.1, off VPN and on. Curl with the same URL succeeded immediately. The error came back in ~100 ms — too fast for a real network timeout.

## Root cause

The workspace built reqwest with the `rustls-tls` feature, which bakes in Mozilla's static `webpki-roots` bundle as the trust store. Cloudflare in front of `www-nds.iaea.org` is serving a chain rooted in a Google Trust Services certificate (intermediate `WE1`) that the bundled `webpki-roots` does not accept. The handshake fails with `InvalidCertificate(UnknownIssuer)` before any HTTP traffic happens. Curl works because it uses the macOS Keychain, which has Apple's broader, regularly-updated root list.

Reproduced with a standalone reqwest probe matching the workspace features:

```
ERR display: error sending request for url (https://www-nds.iaea.org/...)
  caused by: client error (Connect)
  caused by: invalid peer certificate: UnknownIssuer
elapsed=100ms
```

The GUI swallowed the `caused by` chain — only the outer Display was shown, which is why the message looked like a transport error.

## Fix

1. Switch the reqwest feature from `rustls-tls` → `rustls-tls-native-roots` in [Cargo.toml](Cargo.toml). Keeps the rustls TLS stack but loads root certs from the OS trust store via `rustls-native-certs` (Keychain on macOS, system bundle on Linux). Verified: same probe with the new feature returns HTTP 200 and 203,618 bytes for the Hf-180 zip.

2. Harden [crates/nereids-endf/src/retrieval.rs](crates/nereids-endf/src/retrieval.rs) so the next failure is diagnosable without a side-channel reproducer:
   - Build a shared `reqwest::blocking::Client` once per `EndfRetriever` with `connect_timeout(15s)` and `timeout(60s)`. The old code used `reqwest::blocking::get()` with no timeout, which would have hung the GUI worker indefinitely on a real stalled connection.
   - Add a `format_error_chain()` helper that walks `std::error::Error::source()`. Transport-error messages now look like `Failed to fetch <url>: error sending request for url (...): client error (Connect): invalid peer certificate: UnknownIssuer` instead of the opaque outer message.

## Alternatives considered

- `native-tls` feature: also uses the OS trust store, but pulls in `Security.framework` / OpenSSL and changes the TLS implementation. `rustls-tls-native-roots` keeps the rustls stack we already use; only the trust source changes.
- Bumping `webpki-roots`: not a real fix. The static bundle will go stale again the next time Cloudflare rotates issuer chains; the OS trust store is the right source of truth for end-user machines.

## Validation

- Standalone probe: HTTP 200, 203,618 bytes for `n_072-Hf-180_7243.zip` (the failure case in the bug report) with native roots; fails fast with `UnknownIssuer` with webpki-roots.
- Pre-commit checklist:
  - `cargo fmt --all` — clean
  - `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings` — clean
  - `cargo test --workspace --exclude nereids-python` — all suites pass

## Test plan

- [ ] On a clean machine off VPN, launch the GUI, add a Hf isotope (e.g. Hf-180), select ENDF/B-VIII.1, and confirm the fetch succeeds.
- [ ] Verify cached behavior still works: re-open with the same isotope, confirm no network call (file loaded from `~/.cache/nereids/endf/`).
- [ ] Smoke test on Linux to confirm `rustls-native-certs` finds the system trust store there as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)