### PR TITLE
fix(gui): invalidate cached fit on solver-control changes (#503)

### DIFF
--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -231,6 +231,7 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState) {
         let prev_kl_polish = state.kl_enable_polish_override;
         let prev_fit_temperature = state.fit_temperature;
         let prev_fit_energy_scale = state.fit_energy_scale;
+        let prev_lm_background_enabled = state.lm_background_enabled;
 
         ui.indent("advanced_solver", |ui| {
             // Fit temperature and Fit energy scale are mutually exclusive
@@ -341,7 +342,7 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState) {
             }
         });
 
-        // If any KL-solver control changed, downstream fit results no
+        // If any solver control changed, downstream fit results no
         // longer reflect the active configuration — invalidate them so
         // the Results panel doesn't show stale densities/D-per-dof.
         // Compare bit-pattern for the f64 to avoid the +0.0 == -0.0
@@ -350,7 +351,8 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState) {
             || state.kl_c_ratio.to_bits() != prev_kl_c_ratio.to_bits()
             || state.kl_enable_polish_override != prev_kl_polish
             || state.fit_temperature != prev_fit_temperature
-            || state.fit_energy_scale != prev_fit_energy_scale;
+            || state.fit_energy_scale != prev_fit_energy_scale
+            || state.lm_background_enabled != prev_lm_background_enabled;
         if solver_changed {
             clear_analyze_downstream(state);
         }

--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -221,7 +221,7 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState) {
     }
 
     if state.show_advanced_solver {
-        // Snapshot KL solver controls so we can detect a change after the
+        // Snapshot solver controls so we can detect a change after the
         // panel runs and invalidate cached fit results.  egui's
         // `selectable_value` mutates state in place with no change
         // callback, so the previous-value-capture pattern (per MEMORY.md
@@ -232,6 +232,9 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState) {
         let prev_fit_temperature = state.fit_temperature;
         let prev_fit_energy_scale = state.fit_energy_scale;
         let prev_lm_background_enabled = state.lm_background_enabled;
+        let prev_compute_covariance = state.lm_config.compute_covariance;
+        let prev_tol_param = state.lm_config.tol_param;
+        let prev_lambda_init = state.lm_config.lambda_init;
 
         ui.indent("advanced_solver", |ui| {
             // Fit temperature and Fit energy scale are mutually exclusive
@@ -352,7 +355,10 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState) {
             || state.kl_enable_polish_override != prev_kl_polish
             || state.fit_temperature != prev_fit_temperature
             || state.fit_energy_scale != prev_fit_energy_scale
-            || state.lm_background_enabled != prev_lm_background_enabled;
+            || state.lm_background_enabled != prev_lm_background_enabled
+            || state.lm_config.compute_covariance != prev_compute_covariance
+            || state.lm_config.tol_param.to_bits() != prev_tol_param.to_bits()
+            || state.lm_config.lambda_init.to_bits() != prev_lambda_init.to_bits();
         if solver_changed {
             clear_analyze_downstream(state);
         }


### PR DESCRIPTION
Fixes #503, plus extends the same fix to three additional LM-solver controls of the same shape (scope expanded from the original issue with maintainer approval — see commit history for the two atomic steps).

## Root cause

In the Analyze step's `fit_controls`, the `solver_changed` snapshot/diff at [apps/gui/src/guided/analyze.rs:223-364](apps/gui/src/guided/analyze.rs#L223-L364) was supposed to invalidate cached fit results whenever the user toggles any solver control between fits. But the diff was missing four LM-side fields, so flipping any of them would silently leave stale densities/D-per-dof visible in the Results panel.

## What changed

Single file, two atomic commits:

1. **Commit 1 — original #503 scope**: add `lm_background_enabled` to the snapshot/diff.
2. **Commit 2 — scope expansion**: add three more LM-side fields:
   - `lm_config.compute_covariance` (bool) — toggling between fits left users staring at no-uncertainty results without re-fitting.
   - `lm_config.tol_param` (f64) — tightening/loosening the parameter-tolerance LM stop criterion can converge to a different iterate for stiff fits.
   - `lm_config.lambda_init` (f64) — initial LM damping affects step path and can change final values in non-convex regions.

   Also drop "KL solver" from the header comment at [analyze.rs:224](apps/gui/src/guided/analyze.rs#L224) since the snapshot now covers KL, LM, and shared controls — "Snapshot solver controls" is the accurate framing.

## Why expand scope from #503

`tol_param` and `lambda_init` are real scientific-correctness bugs (silently produce different fit values across runs); `compute_covariance` is a less critical UX bug. With a release imminent, holding these for a follow-up PR would mean shipping a release where users can hit "wrong densities depending on the order I clicked things" — exactly the user-facing bug the original #503 fix is trying to prevent.

The fix is mechanically uniform with the existing KL-bg / kl_c_ratio pattern: bool fields use direct comparison, f64 fields use `.to_bits()` to handle the `+0.0 == -0.0` edge case (matching how `kl_c_ratio` is already handled in the same expression).

## What's still NOT covered

`lm_config.max_iter` (the iteration cap) lives outside the snapshot region in this function and is rendered elsewhere. Tracked separately if needed; not in scope here.

## Validation

- `cargo fmt --all` — clean
- `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings` — clean
- `cargo test --workspace --exclude nereids-python` — all suites pass
- Phase A self-audit (Claude) — clean, including verification that the prev-captures happen before the indent block where the widgets can mutate them, that `clear_analyze_downstream` is the right invalidation entry point, and that the new pattern is symmetric to the existing KL pattern.
- **Manual UI smoke**: not automated (no egui integration test scaffolding). Recommend reviewer reproduces:
  1. Load a project, switch to Levenberg-Marquardt, run a fit.
  2. Toggle each of: **LM background**, **Compute covariance**, **Tol (param)**, **Lambda init**.
  3. After each toggle, confirm the Results panel clears and stays cleared until the next fit click.

## Test plan

- [ ] `cargo fmt`, clippy, test all green (re-run on CI)
- [ ] Manual smoke per steps above for all four controls
- [ ] Regression check: KL-side invalidation still works (toggle KL bg / KL c-ratio / KL polish in PoissonKL mode, expect the same clearing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)