### PR TITLE
feat(gui): per-isotope resonance tick-marks panel in Analyze (#510)

### DIFF
--- a/.agents/skills/post-merge/SKILL.md
+++ b/.agents/skills/post-merge/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: post-merge
+description: Post-merge integration gate — cleanup, build, test, verify issues, update memory
+user-invokable: true
+---
+
+# Post-Merge Pipeline
+
+Run after all PRs in a batch are merged. Verifies the merged main is clean,
+closes out tracking work, and updates project memory.
+
+## Arguments
+
+- No arguments: run the full pipeline
+- `--skip-cleanup`: skip worktree/branch cleanup (already done manually)
+- `--skip-memory`: skip the memory update step
+
+## Step 1: Fetch & Update Local
+
+```bash
+git fetch origin
+git checkout main
+git pull origin main
+```
+
+If not already on main, stash or warn before switching.
+
+## Step 2: Worktree & Branch Cleanup
+
+1. List worktrees: `git worktree list`
+2. For each worktree under `.Codex/worktrees/`:
+   - Check if its branch is merged into main (`git branch --merged main`)
+   - If merged: `git worktree remove {path}` then `git branch -d {branch}`
+   - If not merged: warn the user — do NOT force-delete
+3. Prune stale remote-tracking branches:
+   ```bash
+   git fetch --prune origin
+   git branch -vv | grep ': gone]' | awk '{print $1}'
+   ```
+   Delete local branches whose remote is gone (only if merged).
+
+Skip this step if `--skip-cleanup` is in `$ARGUMENTS`.
+
+## Step 3: Clean Build
+
+**IMPORTANT**: Always `cargo clean` before `pixi run build` after merging
+multiple PRs. Stale incremental artifacts from worktrees cause spurious
+"can't find crate" errors with maturin.
+
+```bash
+pixi run clean
+pixi run build
+```
+
+If `pixi run build` fails, diagnose and fix on main immediately.
+
+## Step 4: Rust Tests
+
+```bash
+cargo test --workspace --exclude nereids-python
+```
+
+All tests must pass. If failures occur:
+1. Diagnose whether the failure is from our changes or pre-existing
+2. Fix on main, commit with descriptive message
+3. Re-run tests to confirm
+
+## Step 5: Python Tests
+
+```bash
+pixi run test-python
+```
+
+Common failure mode: Python test `match=` regex patterns don't align with
+changed Rust error messages. Fix the test patterns to match actual messages.
+
+If failures occur, fix, commit, push, and re-run.
+
+## Step 6: Push Fixes (if any)
+
+If Steps 3-5 required fixes on main:
+
+```bash
+git push origin main
+```
+
+## Step 7: Verify Issue Closure
+
+For each issue that was part of this batch:
+
+```bash
+gh issue view {number} --json state --jq '.state'
+```
+
+- If `CLOSED`: confirmed (auto-closed by PR merge)
+- If `OPEN`: close with comment referencing the merged PR:
+  ```bash
+  gh issue close {number} -c "Resolved in PR #{pr_number}"
+  ```
+
+Also check if any parent epics should be closed (all sub-issues done).
+
+## Step 7.5: Add Issues to Project Tracker
+
+Add all closed issues AND any newly created deferred-P2 issues to the
+NEREIDS Development project (number 8):
+
+```bash
+gh project item-add 8 --owner ornlneutronimaging \
+  --url https://github.com/ornlneutronimaging/NEREIDS/issues/{number}
+```
+
+Repeat for every issue number involved in this batch (closed + deferred).
+This keeps the project board in sync for velocity tracking.
+
+## Step 8: Update Project Memory
+
+Unless `--skip-memory` is in `$ARGUMENTS`:
+
+1. Read `MEMORY.md`
+2. Update the "Project Phase Status" section:
+   - Add the new batch entry with commit hash, PR numbers, closed issues
+   - Update the test count line
+3. Add any new "Multi-AI Review Pipeline Lessons" discovered during this batch
+
+## Step 9: Report
+
+Present a summary table:
+
+| Gate | Status |
+|------|--------|
+| `pixi run build` | PASS/FAIL |
+| `cargo test` | PASS — N tests (M ignored) |
+| `pixi run test-python` | PASS — N tests |
+| Issues closed | #X, #Y, #Z |
+| Fixes on main | N commits (if any) |
+
+If all gates pass: "Post-merge integration complete. Main is clean."

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,0 +1,223 @@
+# Release Pipeline
+
+Cut a new NEREIDS release. The work is mostly bumping versions in 4 files,
+tagging, and pushing — the actual building / publishing / homebrew update
+happens on CI when the tag arrives. This skill is the wrapper that gets
+the bumps right and verifies CI succeeded.
+
+## Arguments
+
+- No arguments: prompts for the new version, defaults to incrementing the
+  patch component of the current version.
+- `<version>`: target version without the leading `v` (e.g. `0.1.8`).
+- `--dry-run`: do everything locally, but use the workflow's `dry_run`
+  dispatch path so PyPI / crates.io / Homebrew aren't touched.
+- `--skip-bump`: skip Step 2 (version bumps) — assumes the user already
+  bumped manually and just wants the tag-and-push automation.
+
+## Pre-flight gates (Step 1)
+
+1. **On main, clean tree.** Stash unrelated working-tree items first; the
+   release commit must be the *next* commit on main with no other staged
+   changes.
+2. **`origin/main` up to date.** `git fetch origin && git status` should
+   confirm `Your branch is up to date with 'origin/main'`. If not, `git
+   pull --ff-only` before proceeding.
+3. **Last batch's post-merge gate passed.** The release tag is cut on the
+   commit you just verified through `/post-merge`. Don't tag a commit
+   that hasn't passed the integration gate.
+4. **Tag does not already exist.** `git tag -l v<version>` should be empty
+   locally and on origin (`git ls-remote --tags origin v<version>`).
+
+## Step 2: Bump versions
+
+Five files (treat as a single atomic edit; do not commit each separately):
+
+- [Cargo.toml](Cargo.toml)
+  - `workspace.package.version = "<NEW>"` (around L16)
+  - 7 inter-crate path deps in `[workspace.dependencies]` — each line
+    `<crate> = { version = "<NEW>", path = "..." }` (around L23-29)
+- [pyproject.toml](pyproject.toml)
+  - `[project] version = "<NEW>"` (around L3)
+  - `[project.optional-dependencies] gui = ["nereids-gui==<NEW>"]`
+    (around L40)
+- [apps/gui/pyproject.toml](apps/gui/pyproject.toml)
+  - `[project] version = "<NEW>"` (around L7)
+- [homebrew/nereids.rb](homebrew/nereids.rb)
+  - `version "<NEW>"` (around L4) — note this is the in-repo template;
+    the CI's `update-homebrew` job substitutes into the *separate*
+    `homebrew-nereids` tap repo (`Casks/nereids.rb`). Bumping the in-repo
+    template anyway keeps it as a useful reference.
+
+Reference: see commit `973bdf2` (Release v0.1.7) for the exact diff
+shape — five files, ~26 line changes total.
+
+**Skip in the bump** anything matching `0.1.<old>` in code/docs that isn't
+a version declaration (e.g. example notebooks may have hardcoded version
+strings — those are reference, not authoritative). If you find such
+references, mention them in the release commit message but don't update
+unless the user asks.
+
+## Step 3: Refresh Cargo.lock
+
+```
+cargo check --workspace --exclude nereids-python
+```
+
+This regenerates `Cargo.lock` with the new internal-crate version pins.
+The lockfile delta should be a clean version bump for the 7 internal
+crates (no drift in third-party deps).
+
+## Step 4: Pre-commit checklist (mandatory)
+
+```
+cargo fmt --all
+cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings
+cargo test --workspace --exclude nereids-python
+pixi run test-python
+```
+
+All four must pass before tagging. If any fails, the release commit
+should NOT be created.
+
+## Step 5: Commit + tag
+
+```
+git add Cargo.toml Cargo.lock pyproject.toml apps/gui/pyproject.toml homebrew/nereids.rb
+git commit -S -m "Release v<NEW>"
+git tag -s v<NEW> -m "Release v<NEW>"
+```
+
+**Always sign the tag** (`-s`) and the commit (`-S`) — the project's
+publish workflow doesn't enforce signatures, but the project AGENTS.md
+mandates GPG-signed commits and the same standard applies to tags. Use
+the same key configured for `git commit -S`.
+
+The tag *message* is what `softprops/action-gh-release@v2 +
+generate_release_notes: true` will surface alongside the auto-generated
+PR list. Keep it short ("Release v<NEW>") — the body comes from the
+auto-generated notes, not the tag message.
+
+## Step 6: Push (this is the trigger)
+
+```
+git push origin main
+git push origin v<NEW>
+```
+
+The `publish.yml` workflow fires on the tag push (matches `tags: ['v*']`).
+**Push the branch first** so the tagged commit is reachable on origin/main
+before CI starts pulling it.
+
+For `--dry-run`: skip the tag push entirely. Instead use
+`gh workflow run publish.yml -f dry_run=true` to exercise the build matrix
+without publishing.
+
+## Step 7: Monitor the pipeline
+
+The pipeline has 9 jobs and runs ~20-30 min end-to-end. Stream:
+
+```
+gh run watch $(gh run list --workflow=publish.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+```
+
+Or check status without blocking:
+
+```
+gh run list --workflow=publish.yml --limit 3
+```
+
+Jobs to expect (from [`.github/workflows/publish.yml`](.github/workflows/publish.yml)):
+
+1. `build-wheels` — Python library wheels for Linux x86_64, macOS arm64,
+   Windows. Windows is `continue-on-error: true` (HDF5 static-link can
+   fail there); a Windows failure is *not* a blocker.
+2. `build-sdist` — source distribution.
+3. `build-gui` — GUI wheels for Linux + macOS.
+4. `build-macos-app` — macOS `.app` bundle + DMG via `cargo bundle`.
+5. `publish-pypi` — uploads `nereids` to PyPI (env: `pypi`).
+6. `publish-gui-pypi` — uploads `nereids-gui` to PyPI (env: `pypi-gui`).
+7. `publish-crates` — publishes 7 crates to crates.io in dependency order
+   with 60s sleeps between, gracefully skipping already-published versions.
+8. `github-release` — creates the GitHub Release with all artifacts and
+   `generate_release_notes: true` (auto-fills from merged PRs since the
+   previous tag).
+9. `update-homebrew` — bumps version + sha256 in the tap repo's
+   `Casks/nereids.rb`. Skipped for prereleases (`rc`/`alpha`/`beta`).
+
+## Step 8: Verify artifacts landed
+
+Run all four checks; report failures explicitly.
+
+```
+# PyPI library
+curl -sf "https://pypi.org/pypi/nereids/<NEW>/json" >/dev/null && echo OK || echo MISSING
+
+# PyPI GUI
+curl -sf "https://pypi.org/pypi/nereids-gui/<NEW>/json" >/dev/null && echo OK || echo MISSING
+
+# crates.io (sample one — others publish in dep order)
+curl -sf "https://crates.io/api/v1/crates/nereids-core/<NEW>" >/dev/null && echo OK || echo MISSING
+
+# GitHub Release
+gh release view v<NEW> >/dev/null 2>&1 && echo OK || echo MISSING
+```
+
+## Step 9: Post-release housekeeping
+
+1. **Visual check** of the GitHub Release page — confirm the auto-generated
+   notes captured the expected PRs and the release-asset list contains
+   wheels (Linux+macOS+Win), sdist, GUI wheels (Linux+macOS), and the
+   macOS DMG.
+2. **Homebrew tap** — visit `https://github.com/ornlneutronimaging/homebrew-nereids`
+   and confirm the latest commit there bumped `Casks/nereids.rb`. (The
+   workflow's `update-homebrew` job needs `HOMEBREW_TAP_TOKEN`; if absent
+   it errors and the tap will be stale.)
+3. **Memory**: only update memory if the *release process itself* surfaced
+   a non-obvious lesson (e.g. a new file location to bump, a CI flake
+   pattern). Routine release outcomes are not memory-worthy.
+
+## Step 10: Report
+
+Present a concise summary table to the user:
+
+```markdown
+### Release v<NEW> — published
+
+| Artifact | Status | URL |
+|----------|--------|-----|
+| GitHub Release | ✓ | https://github.com/ornlneutronimaging/NEREIDS/releases/tag/v<NEW> |
+| PyPI nereids | ✓ | https://pypi.org/project/nereids/<NEW>/ |
+| PyPI nereids-gui | ✓ | https://pypi.org/project/nereids-gui/<NEW>/ |
+| crates.io | ✓ | https://crates.io/crates/nereids-core/<NEW> |
+| Homebrew tap | ✓ | https://github.com/ornlneutronimaging/homebrew-nereids |
+
+Pipeline: [run #N](https://github.com/ornlneutronimaging/NEREIDS/actions/runs/<id>)
+Release notes auto-generated from PRs since v<PREV>.
+```
+
+If a Windows wheel build failed (`continue-on-error: true`), note it
+explicitly so the user can decide whether to investigate or accept.
+
+## Failure modes & remediation
+
+- **Tag exists locally but not on origin (or vice versa).** Resolve with
+  `git tag -d v<NEW>` (local) or `git push --delete origin v<NEW>`
+  (remote). Re-tag and push fresh.
+- **`publish-pypi` succeeded but `publish-gui-pypi` failed.** PyPI
+  rejects re-uploads of the same filename, so deleting the partial
+  release and re-running won't help. Fix: bump to `v<NEW>.1` or `v<NEW>+1`
+  and re-release. (`publish-pypi` uses `skip-existing: true` so a partial
+  retry is safe for the library wheel matrix.)
+- **`publish-crates` halfway through.** The script skips already-published
+  crates (`already (uploaded|exists)` substring match), so re-running
+  the workflow on the same tag is safe. If a *non*-already-published
+  failure happens (network, sleep race), `gh workflow run publish.yml
+  -f dry_run=false` re-runs the workflow on the same tag.
+- **macOS DMG download timeout in `update-homebrew`.** The job retries
+  for 5 minutes; if all 30 attempts fail, the GitHub Release exists but
+  Homebrew is stale. Manual fix: clone the tap, edit Casks/nereids.rb
+  with the new version + sha256, push.
+- **Pipeline doesn't start after tag push.** Verify the tag matches
+  `v*` (not just any tag) and check the Actions tab. If the workflow is
+  disabled, re-enable it.

--- a/.agents/skills/review-pipeline/SKILL.md
+++ b/.agents/skills/review-pipeline/SKILL.md
@@ -1,0 +1,340 @@
+---
+name: review-pipeline
+description: Multi-stage iterative review pipeline across all active worktree branches
+user-invokable: true
+---
+
+# Multi-Stage Review Pipeline
+
+Run an iterative review pipeline on active worktree branches. Repeats
+until zero P1s remain or the iteration limit is reached.
+
+**This is the ONLY review mechanism.** Do not substitute with ad-hoc
+self-review agents, custom subagents, or any improvised review approach.
+The standalone `/self-review` and `/codex-review` skills have been merged
+into this single pipeline. When the user says "review", "run reviews",
+or any variation, invoke THIS skill.
+
+## Arguments
+
+- No arguments: auto-discover all `.Codex/worktrees/*/` branches diverged from main
+- Branch name: scope to a single branch (e.g., `review-pipeline fix/my-branch`)
+- `--skip-codex`: skip the Codex external review stage
+
+## Iteration Policy
+
+- **Goal**: Zero P1s before pushing to remote
+- **Max iterations**: 4 per branch
+- **Escalation**: If P1s persist after 4 rounds, stop and report to the user.
+  Do NOT attempt a 5th round. The user must decide whether to continue,
+  restructure the task, or conduct manual review.
+
+Track the current iteration number and report it in each consolidation
+(e.g., "Round 2 of 4").
+
+---
+
+## Step 1: Discover Targets & Merge Order
+
+Identify worktrees to review:
+
+```bash
+git worktree list
+```
+
+For each worktree under `.Codex/worktrees/`, check if the branch has diverged
+from main (`git log main..HEAD --oneline`). Skip worktrees with no new commits.
+
+If `$ARGUMENTS` specifies a branch name, filter to just that one.
+
+### File Overlap Analysis (Merge Order)
+
+For each discovered branch, collect changed files:
+
+```bash
+cd {worktree_path} && git diff --name-only main...HEAD
+```
+
+Build a file overlap matrix and suggest merge order:
+
+1. **No overlap** branches can merge in any order (parallel-safe)
+2. **Overlapping** branches should merge in order of increasing diff size
+   (smallest first — the larger diff is more likely to need rebasing)
+3. Report the suggested merge order in the Step 4 consolidation
+
+---
+
+## Steps 2 + 3: Self-Audit & External Review (launch together)
+
+Launch **all** review tasks in a **single message** (background mode) so
+they run concurrently. N worktrees produce up to 2N parallel tasks
+(N Codex subagents + N Codex commands).
+
+### Self-Audit (Codex Subagents)
+
+Launch one `Agent(subagent_type="general-purpose", run_in_background=true)`
+per worktree with this prompt:
+
+> You are auditing the branch `{branch}` at `{worktree_path}`.
+>
+> 1. Run `git diff main...HEAD` to see all changes
+> 2. Read each changed file in full
+> 3. Audit for:
+>    - Logic bugs, panics (`unwrap`, `expect`, array indexing)
+>    - Missing input validation
+>    - Numerical stability (division by zero, NaN propagation, overflow)
+>    - Physics correctness (for nereids-physics/nereids-endf)
+>    - API consistency with existing patterns
+>    - Edge cases (empty inputs, zero counts, exactly-determined systems)
+> 4. Report findings as:
+>    - **P1** (must fix) — correctness bugs, panics, data corruption
+>    - **P2** (should fix) — robustness, style, minor improvements
+>    - Include `file:line` references for each finding
+> 5. Run `cargo test --workspace --exclude nereids-python` to verify tests pass
+>    (workspace-wide, because changes often ripple across crates)
+
+### External Review (Codex CLI) — TEMPORARILY DISABLED
+
+**Status (April 2026):** Codex review is currently driven manually by the
+user outside this pipeline. Skip the automated `codex exec` step until the
+local codex-cli access issue is resolved (the installed binary is too old
+for the current API and ChatGPT-account model gating prevents falling back
+to an older model — see "Known pitfalls" below). When the user's local
+codex-cli is upgraded and accepted by the API, re-enable by removing this
+notice and uncommenting the launch step.
+
+When re-enabled, also launch one `Bash` command per worktree in the **same
+message** as the Codex self-audit, unless `--skip-codex` is in
+`$ARGUMENTS`.
+
+There is **no `codex review` subcommand** in current codex-cli (verified
+against 0.46 and 0.125, April 2026). The slash command `/review` exists
+but is interactive-only — it cannot be driven from `codex exec`. The
+canonical headless invocation is `codex exec` with an explicit review
+prompt; a native `codex exec review` is requested in
+[openai/codex#6432](https://github.com/openai/codex/issues/6432) but
+not yet shipped.
+
+Use this pattern (one Bash call per worktree):
+
+```bash
+codex exec --sandbox read-only --skip-git-repo-check \
+  -C {worktree_path} \
+  --output-last-message /tmp/codex-review-{branch_slug}.md \
+  "$(cat <<'PROMPT'
+You are reviewing the changes on the current branch (HEAD) against `main`
+in the NEREIDS repository.
+
+1. Run `git diff main...HEAD` to see all changes.
+2. Read each changed file in full.
+3. Audit for:
+   - Logic bugs, panics (unwrap, expect, array indexing)
+   - Missing input validation
+   - Numerical stability (division by zero, NaN propagation, overflow)
+   - Physics correctness (for nereids-physics / nereids-endf)
+   - API consistency with existing patterns
+   - Edge cases (empty inputs, zero counts, exactly-determined systems)
+4. Report findings as:
+   - **P1** (must fix) — correctness bugs, panics, data corruption
+   - **P2** (should fix) — robustness, style, minor improvements
+   - Include `file:line` references for each finding.
+5. If you find nothing significant, say so explicitly. Be terse.
+PROMPT
+)"
+```
+
+Then read the file at `/tmp/codex-review-{branch_slug}.md` for the final
+review verdict; the JSONL on stdout is the streaming transcript and is
+mostly noise for our purposes.
+
+**Why these flags:**
+- `--sandbox read-only` — review only reads code; no need for write access.
+- `--skip-git-repo-check` — defensive; we always invoke from inside a repo
+  but this avoids friction in nested-worktree edge cases.
+- `-C {worktree_path}` — sets working dir explicitly so `git diff main...HEAD`
+  resolves correctly per worktree.
+- `--output-last-message <file>` — captures the agent's final message
+  cleanly; far easier than parsing JSONL.
+
+**Known pitfalls** (as of April 2026, codex-cli 0.46 → 0.125):
+
+- The `review` subcommand was removed (or was never a thing in 0.x). Do
+  not use `codex review --base main` — it errors with
+  `unexpected argument '--base' found / Usage: codex <PROMPT>`.
+- Slash commands (`/review`, `/test`, etc.) work only in interactive
+  TUI sessions; they cannot be invoked from `codex exec`.
+- The default model in codex-cli config (`~/.codex/config.toml`) must
+  match what the local CLI binary supports. As of 0.46 the default
+  `gpt-5.5` is rejected as *"requires a newer version of Codex"*; as
+  of 0.122+ it works. If the binary is too old, upgrade before relying
+  on Codex review — overriding with `-m gpt-5` does NOT help on
+  ChatGPT-account auth (returns *"not supported when using Codex with
+  a ChatGPT account"*). Per-version compatibility is unstable; keep
+  the binary current.
+- `codex exec` reads the prompt from stdin if you pass `-` or omit the
+  positional, but heredoc-injected positional prompts (as above) are
+  the most reliable form across versions.
+- Avoid `--full-auto` for review — it grants `workspace-write` sandbox,
+  which is broader than the read-only review needs.
+
+If Codex fails (network, license, model rejection, binary out of date),
+note the failure and continue. Codex is supplementary, not blocking. The
+Codex self-audit is the load-bearing reviewer; Codex provides
+cross-confirmation when available.
+
+---
+
+## Step 4: Consolidate Findings
+
+After all reviews complete:
+
+1. Collect self-audit findings (from Agent results) and Codex findings (from Bash output)
+2. Merge into a unified report grouped by worktree/branch:
+   - **Cross-confirmed** issues (found by both Codex and Codex) — highest confidence
+   - **Codex-only** issues
+   - **Codex-only** issues
+3. For each finding, classify as:
+   - **Fix now** — P1s and high-confidence P2s
+   - **Defer** — P2s genuinely out of scope (different crate/subsystem,
+     pre-existing issue not introduced by this PR)
+   - **Dismiss** — false positives, style-only, or impossible edge cases
+
+### P2 Deferral Discipline
+
+**IMPORTANT**: If the PR's purpose is P2 burndown or tech debt reduction,
+the "Defer" category is restricted to findings in a *different crate or
+subsystem* than the one being fixed. Same-crate P2s MUST be classified as
+"Fix now" — otherwise P2 debt accumulates faster than it is paid down.
+
+4. Report the iteration number: "Review Round N of 4"
+5. Include the **Suggested Merge Order** from Step 1
+6. **Present the consolidated report to the user and STOP.**
+
+**MANDATORY GATE**: Do NOT proceed to Step 5 without user approval.
+The user must review the consolidation and tell you which findings to fix.
+End your turn after presenting the report.
+
+**Oscillating findings**: If a finding reappears after being "fixed", flag
+it as **RECURRING** — the user must decide the approach.
+
+---
+
+## Step 5: Fix
+
+After user approves the fix list, launch one
+`Agent(subagent_type="general-purpose")` per worktree **in parallel**.
+
+Each fix agent must:
+1. Apply the approved fixes
+2. **Check downstream consumers** — if the fix changes a public API,
+   grep for all call sites across the workspace and update them
+3. Run `cargo fmt --all`
+4. Run `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings`
+5. Run `cargo test --workspace --exclude nereids-python`
+6. Commit with `scripts/worktree-commit.sh` (GPG-signed)
+
+## Step 6: Verify & Push
+
+After all fix agents complete:
+1. Verify each worktree has clean `git status`
+2. Push each branch: `git push origin {branch}`
+3. Report commit hashes and branch status
+
+---
+
+## Step 7: Iteration Decision
+
+After pushing, check:
+
+- **Zero P1s found this round?** → Phase A complete. Proceed to Phase B.
+- **P1s found and fixed, iteration < 4?** → Loop back to Step 2.
+- **Iteration == 4 and P1s still found?** → STOP. Report:
+  "Iteration limit reached (4 rounds). P1s persist — escalating to human."
+
+---
+
+## Step 8: Phase B — Copilot Review (after push)
+
+After Phase A completes (zero P1s) and branches are pushed:
+
+1. Inform the user that Phase A is complete and branches are pushed.
+   Ask them to trigger Copilot review on GitHub. **STOP and wait.**
+2. When the user says Copilot reviews are in, fetch comments:
+
+```bash
+pixi run copilot-reviews {pr_numbers...} --dedup
+```
+
+3. Classify each Copilot comment as P1 or P2
+4. **Decision criteria**:
+   - 3+ P1s OR P1 ratio > 40% → re-iterate (back to Step 2)
+   - Otherwise → fix P2s inline, commit, push
+5. Dismiss Copilot comments that rehash already-addressed issues or flag
+   impossible edge cases
+6. Present Copilot resolution summary to the user.
+
+---
+
+## Step 9: Pre-Merge Checkpoint
+
+**MANDATORY: End your turn here and wait for user approval.**
+
+Present the user with a concise summary table:
+
+```markdown
+### Pre-Merge Summary — Batch {name}
+
+| PR | Branch | Issue | Key Changes | Review Status |
+|----|--------|-------|-------------|---------------|
+| #{n} | {branch} | #{issue} | {1-line summary} | Phase A ✓ Phase B ✓ |
+
+**Merge order**: {recommendation}
+**Review rounds**: Phase A: {N} round(s), Phase B: {N} Copilot comment(s)
+**Findings resolved**: {X} P1s fixed, {Y} P2s fixed, {Z} P2s deferred
+**Tests on branches**: {N} Rust tests — all pass
+
+Ready to merge? (User must explicitly approve.)
+```
+
+**Do NOT run `gh pr merge` until the user responds with explicit approval.**
+
+---
+
+## Step 10: Merge & Post-Merge
+
+After user approves:
+
+1. Merge PRs in recommended order using `gh pr merge --squash --delete-branch`
+2. Clean up worktrees: `git worktree remove {path} --force` for each merged branch
+3. Delete local branches: `git branch -D {branch}` for each
+4. Run `/post-merge` which handles: pull main, `cargo clean && pixi run build`,
+   workspace tests, Python tests, issue verification, memory updates
+
+**IMPORTANT**: `pixi run build` must run first after `cargo clean`. It catches
+cross-PR signature mismatches that per-branch reviews miss.
+
+---
+
+## Step 11: Track Deferred P2 Findings
+
+**Do NOT skip this step.** Create GitHub issues for every P2 finding deferred
+during consolidation:
+
+1. Group deferred P2s by branch/crate
+2. Create one issue per group with `file:line` references
+3. Add to project tracker (project #8)
+4. Report created issue numbers to the user
+
+---
+
+## Subagent Prompt Requirements
+
+When launching implementation or fix subagents, ALWAYS include:
+
+- **Tooling**: "Use `pixi run build` / `pixi run test-python` — never
+  raw `maturin develop` or `pip install`."
+- **Commits**: "Use `scripts/worktree-commit.sh <worktree-name> '<message>' [files]`
+  for all commits."
+- **GitHub issues**: "Use `pixi run gh-issues` for issue/PR queries."
+- **Pattern matching**: "Match patterns already used in the file you're editing."
+- **Pre-commit**: "Run the pre-commit checklist from AGENTS.md."

--- a/.agents/skills/review-pipeline/SKILL.md
+++ b/.agents/skills/review-pipeline/SKILL.md
@@ -68,9 +68,9 @@ Build a file overlap matrix and suggest merge order:
 
 Launch **all** review tasks in a **single message** (background mode) so
 they run concurrently. N worktrees produce up to 2N parallel tasks
-(N Codex subagents + N Codex commands).
+(N Claude subagents + N Codex commands).
 
-### Self-Audit (Codex Subagents)
+### Self-Audit (Claude Subagents)
 
 Launch one `Agent(subagent_type="general-purpose", run_in_background=true)`
 per worktree with this prompt:
@@ -104,7 +104,7 @@ codex-cli is upgraded and accepted by the API, re-enable by removing this
 notice and uncommenting the launch step.
 
 When re-enabled, also launch one `Bash` command per worktree in the **same
-message** as the Codex self-audit, unless `--skip-codex` is in
+message** as the Claude self-audit, unless `--skip-codex` is in
 `$ARGUMENTS`.
 
 There is **no `codex review` subcommand** in current codex-cli (verified
@@ -179,7 +179,7 @@ mostly noise for our purposes.
 
 If Codex fails (network, license, model rejection, binary out of date),
 note the failure and continue. Codex is supplementary, not blocking. The
-Codex self-audit is the load-bearing reviewer; Codex provides
+Claude self-audit is the load-bearing reviewer; Codex provides
 cross-confirmation when available.
 
 ---
@@ -190,8 +190,8 @@ After all reviews complete:
 
 1. Collect self-audit findings (from Agent results) and Codex findings (from Bash output)
 2. Merge into a unified report grouped by worktree/branch:
-   - **Cross-confirmed** issues (found by both Codex and Codex) — highest confidence
-   - **Codex-only** issues
+   - **Cross-confirmed** issues (found by both Claude and Codex) — highest confidence
+   - **Claude-only** issues
    - **Codex-only** issues
 3. For each finding, classify as:
    - **Fix now** — P1s and high-confidence P2s

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ _fts_*.txt
 .research/
 .claude/settings.json
 tmp/
+
+# do not track manuscript folders
+.manuscripts/

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ _fts_*.txt
 .prototypes/
 .research/
 .claude/settings.json
+tmp/

--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -1,46 +1,44 @@
 //! Step 4: Analyze -- solver configuration, fit execution, spectrum/map display.
 //!
-//! Layout: 2-column outer (controls | content), with the content column
-//! stacked vertically (image on top ≈60%, spectrum on bottom ≈40%).
-//! The previous design docked image + spectrum side-by-side, which forced
-//! the square-aspect detector image and the wide-aspect resonance spectrum
-//! to share the same horizontal width budget — neither fit.  Stacking lets
-//! the image land near 1:1 and gives the spectrum the full content-column
-//! width for its many TOF bins (issue #504).  See `analyze_step` for the
-//! detailed diagram.
+//! Layout: asymmetric analysis cockpit: square image workbench and run controls
+//! on the left, spectrum + resonance tracks in the wide center workspace, and
+//! fit results in an on-demand drawer.  The Guided sidebar and app
+//! toolbar/status live outside this page; `analyze_step` works inside the
+//! remaining central viewport.
 
 use crate::state::{
-    AppState, EndfStatus, GuidedStep, InputMode, IsotopeEntry, SolverMethod, SpectrumAxis,
+    AppState, EndfStatus, InputMode, IsotopeEntry, RoiSelection, SolverMethod, SpectrumAxis,
 };
 use crate::widgets::design::{self, NavAction};
 use crate::widgets::image_view::{
-    RoiEditorResult, show_image_with_roi_editor, show_viridis_image, show_viridis_image_with_roi,
+    RoiEditorResult, apply_colormap, data_range, show_image_with_roi_editor, show_viridis_image,
+    show_viridis_image_with_roi,
 };
-use egui_plot::{Line, Plot, PlotPoints, VLine};
+use egui_plot::{Line, Plot, PlotPoints, PlotTransform, Points, VLine};
 use ndarray::Axis;
-use nereids_pipeline::pipeline::{BackgroundConfig, InputData, SolverConfig, UnifiedFitConfig};
+use nereids_pipeline::pipeline::{
+    BackgroundConfig, InputData, SolverConfig, SpectrumFitResult, UnifiedFitConfig,
+};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 
+struct TickRow<'a> {
+    label: String,
+    color: egui::Color32,
+    data: &'a nereids_endf::resonance::ResonanceData,
+}
+
 /// Draw the Analyze step content.
 ///
-/// Two-column outer layout with the right column stacked:
+/// Two-column cockpit layout:
 /// ```text
-/// +-- Controls (scroll) --+-- Image (top ≈60%) ----------------------+
-/// | Fit Parameters        | viridis density map / preview            |
-/// | Solver method         |  · click = select pixel                  |
-/// | Advanced              |  · shift+drag = draw ROI                 |
-/// | Run buttons           +------------------------------------------+
-/// | Fitting spinner       | Spectrum (bottom ≈40%)                   |
-/// | Isotope selector      | Measured · c·OB · Fit lines (full width) |
-/// | Convergence summary   | Pixel selectors · resonance dips · ...   |
-/// |                       | Per-pixel fit results: chi2_r, ρ̂ list   |
-/// +-----------------------+------------------------------------------+
+/// +-- Image workbench + run controls --+-- Spectrum + isotope tracks -------+
+/// | density/preview + colorbar          | measured · c·OB · fit lines       |
+/// |  · click pixel / shift+drag ROI     | linked resonance tick strips      |
+/// |  · solver/run controls              | shared energy / TOF axis          |
+/// +-------------------------------------+-----------------------------------+
 /// ```
-/// Stacking image + spectrum lets the image land near 1:1 and gives
-/// the spectrum the full content-column width for its many TOF bins
-/// (issue #504).
 pub fn analyze_step(ui: &mut egui::Ui, state: &mut AppState) {
     // Auto-prepare pre-normalized data if the user skipped the Normalize step.
     if matches!(
@@ -56,109 +54,38 @@ pub fn analyze_step(ui: &mut egui::Ui, state: &mut AppState) {
             crate::guided::normalize::prepare_transmission(state);
         }
     }
-
-    ui.horizontal(|ui| {
-        ui.heading("Analyze");
-        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-            design::teleport_pill(ui, "← Forward Model", GuidedStep::ForwardModel, state);
-        });
-    });
-    ui.separator();
+    ensure_selected_pixel(state);
 
     let available_width = ui.available_width();
-    let controls_width = 220.0_f32.min(available_width * 0.2);
+    let spacing_x = ui.spacing().item_spacing.x;
 
-    // Style-derived spacing — adapts to the user's egui scale / theme
-    // overrides instead of baking in default-theme pixel values.
-    // `item_spacing.x` defaults to 8 px; the 6× multiplier covers
-    // (controls↔content separator + 2 inner column edges + outer frame
-    // margin) at default scale and scales with the theme.
-    // `item_spacing.y` is the visual height a `ui.separator()` consumes
-    // between stacked rows.
-    let outer_row_padding = ui.spacing().item_spacing.x * 6.0;
-    let inter_row_padding = ui.spacing().item_spacing.y.max(6.0);
-
-    // Preferred minimum height for the spectrum pane (header rows ~50
-    // + plot floor 200 + fit-result card ~70).  When the window is
-    // tall enough the spectrum gets at least this; when it isn't, the
-    // partition shrinks the spectrum proportionally rather than
-    // forcing the column past the window edge and clipping the nav
-    // strip below.  See partition logic + `.min(stacked_height)` clamp.
-    const MIN_SPECTRUM_HEIGHT: f32 = 280.0;
-
-    // `col_height` is the available room above the nav strip — never
-    // force it higher than what the window allocates.  A previous
-    // attempt set a 440 px floor to guarantee the partition couldn't
-    // produce negative regions; that pushed the nav strip past the
-    // visible area on shorter screens (cross-confirmed by user demo
-    // run, post-Round-1 review).  The partition below is now
-    // overflow-safe by construction via `.min(stacked_height)` instead.
+    // `col_height` is the available room above the nav strip. Keep this bounded
+    // by the real viewport height; Analyze is intentionally not inside a page
+    // ScrollArea so fixed-aspect image sizing can use `available_height()`.
     let col_height = (ui.available_height() - 40.0).max(120.0);
+    let (image_width, spectrum_width) = cockpit_column_widths(available_width, spacing_x);
 
-    // Two-column outer layout: narrow controls column + stacked content.
-    // See module-level docstring + the diagram on `analyze_step`.
     ui.horizontal(|ui| {
-        // Column 1: fit controls (scrollable — content can exceed viewport)
         ui.allocate_ui_with_layout(
-            egui::vec2(controls_width, col_height),
+            egui::vec2(image_width, col_height),
             egui::Layout::top_down(egui::Align::LEFT),
             |ui| {
-                egui::ScrollArea::vertical()
-                    .id_salt("analyze_controls")
-                    .show(ui, |ui| {
-                        fit_controls(ui, state);
-                        convergence_summary(ui, state);
-                    });
+                image_panel(ui, state);
             },
         );
 
         ui.separator();
 
-        // Column 2: stacked content — image on top, spectrum below.
-        // The partition guarantees `image_h + sep + spectrum_h ==
-        // col_height` by construction (overflow-safe), so children
-        // cannot push past the parent and overlap the nav strip.
-        //
-        // Approach:
-        //   1. Compute the preferred 60/40 split.
-        //   2. Bias the spectrum to at least `MIN_SPECTRUM_HEIGHT`
-        //      *when there's room*, otherwise let it use whatever
-        //      stacked_height is available.
-        //   3. The `.min(stacked_height)` clamp on `spectrum_height`
-        //      caps the partition so its sum can never exceed
-        //      `col_height` regardless of how short the window is.
-        //   4. On very short windows, the image collapses before the
-        //      nav strip is sacrificed — a deliberate trade-off.
-        let content_width = (available_width - controls_width - outer_row_padding).max(200.0);
-        let stacked_height = (col_height - inter_row_padding).max(0.0);
-        let preferred_image_height = (stacked_height * 0.60).floor();
-        let preferred_spectrum_height =
-            (stacked_height - preferred_image_height).max(MIN_SPECTRUM_HEIGHT);
-        let spectrum_height = preferred_spectrum_height.min(stacked_height);
-        let image_height = (stacked_height - spectrum_height).max(0.0);
-
         ui.allocate_ui_with_layout(
-            egui::vec2(content_width, col_height),
+            egui::vec2(spectrum_width, col_height),
             egui::Layout::top_down(egui::Align::LEFT),
             |ui| {
-                ui.allocate_ui_with_layout(
-                    egui::vec2(content_width, image_height),
-                    egui::Layout::top_down(egui::Align::LEFT),
-                    |ui| {
-                        image_panel(ui, state);
-                    },
-                );
-                ui.separator();
-                ui.allocate_ui_with_layout(
-                    egui::vec2(content_width, spectrum_height),
-                    egui::Layout::top_down(egui::Align::LEFT),
-                    |ui| {
-                        spectrum_panel(ui, state);
-                    },
-                );
+                spectrum_panel(ui, state);
             },
         );
     });
+
+    fit_info_drawer(ui.ctx(), state);
 
     // -- Navigation --
     let can_continue = state.spatial_result.is_some();
@@ -173,6 +100,52 @@ pub fn analyze_step(ui: &mut egui::Ui, state: &mut AppState) {
         NavAction::Continue => state.nav_next(),
         NavAction::None => {}
     }
+}
+
+fn cockpit_column_widths(available_width: f32, spacing_x: f32) -> (f32, f32) {
+    const IMAGE_MIN: f32 = 340.0;
+    const IMAGE_MAX: f32 = 720.0;
+    const CENTER_MIN: f32 = 520.0;
+
+    // Account for the separator and surrounding horizontal layout spacing.
+    let chrome = spacing_x * 4.0;
+    let usable = (available_width - chrome).max(120.0);
+    let minimum_total = CENTER_MIN + IMAGE_MIN;
+
+    if usable < minimum_total {
+        let image = usable * 0.42;
+        let center = usable - image;
+        return (image, center);
+    }
+
+    let mut image = (usable * 0.38).clamp(IMAGE_MIN, IMAGE_MAX);
+    let mut center = usable - image;
+
+    if center < CENTER_MIN {
+        let deficit = CENTER_MIN - center;
+        let image_take = deficit.min(image - IMAGE_MIN);
+        image -= image_take;
+        center = usable - image;
+    }
+
+    (image, center.max(160.0))
+}
+
+fn ensure_selected_pixel(state: &mut AppState) {
+    if state.selected_pixel.is_some() {
+        return;
+    }
+
+    let Some(ref norm) = state.normalized else {
+        return;
+    };
+
+    let shape = norm.transmission.shape();
+    if shape.len() < 3 || shape[1] == 0 || shape[2] == 0 {
+        return;
+    }
+
+    state.selected_pixel = Some((shape[1] / 2, shape[2] / 2));
 }
 
 // ---- Fit Controls ----
@@ -364,12 +337,20 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState) {
         }
     }
 
-    ui.add_space(8.0);
-    ui.separator();
+    if state.is_fitting {
+        if let Some(ref fp) = state.fitting_progress {
+            let done = fp.done();
+            let total = fp.total();
+            let frac = fp.fraction();
+            crate::widgets::design::progress_mini(ui, frac, &format!("{done}/{total} px"));
+        } else {
+            ui.spinner();
+            ui.label("Fitting...");
+        }
+    }
+}
 
-    // Run buttons
-    ui.label(egui::RichText::new("Run").strong());
-
+fn run_action_buttons(ui: &mut egui::Ui, state: &mut AppState) {
     let has_enabled_iso = state
         .isotope_entries
         .iter()
@@ -384,63 +365,192 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState) {
 
     let can_run = ready && !state.is_fitting;
 
-    ui.add_enabled_ui(can_run, |ui| {
-        if ui.button("Fit Selected Pixel").clicked() {
+    ui.horizontal(|ui| {
+        if ui
+            .add_enabled(can_run, egui::Button::new("●"))
+            .on_hover_text("Fit selected pixel")
+            .clicked()
+        {
             fit_pixel(state);
         }
-        if ui.button("Fit ROI Average").clicked() {
+        if ui
+            .add_enabled(can_run, egui::Button::new("▣"))
+            .on_hover_text("Fit ROI average")
+            .clicked()
+        {
             fit_roi(state);
         }
-        if ui.button("Spatial Map (all pixels)").clicked() {
+        if ui
+            .add_enabled(can_run, egui::Button::new("▦"))
+            .on_hover_text("Fit spatial map for all pixels")
+            .clicked()
+        {
             run_spatial_map(state);
         }
     });
+}
 
-    if state.is_fitting {
-        if let Some(ref fp) = state.fitting_progress {
-            let done = fp.done();
-            let total = fp.total();
-            let frac = fp.fraction();
-            crate::widgets::design::progress_mini(ui, frac, &format!("{done}/{total} px"));
-        } else {
-            ui.spinner();
-            ui.label("Fitting...");
+fn image_tool_strip(ui: &mut egui::Ui, state: &mut AppState, n_tof: Option<usize>) {
+    ui.horizontal(|ui| {
+        let has_sel = state.selected_roi.is_some_and(|i| i < state.rois.len());
+        if ui
+            .add_enabled(has_sel, egui::Button::new("⌫"))
+            .on_hover_text("Delete selected ROI")
+            .clicked()
+            && let Some(idx) = state.selected_roi
+            && idx < state.rois.len()
+        {
+            state.log_provenance(
+                crate::state::ProvenanceEventKind::ConfigChanged,
+                format!("ROI #{} deleted", idx + 1),
+            );
+            state.rois.remove(idx);
+            state.selected_roi = match state.selected_roi {
+                Some(s) if s == idx => None,
+                Some(s) if s > idx => Some(s - 1),
+                other => other,
+            };
+            clear_analyze_downstream(state);
         }
+
+        if ui
+            .add_enabled(!state.rois.is_empty(), egui::Button::new("⊘"))
+            .on_hover_text("Clear all ROIs")
+            .clicked()
+        {
+            let n = state.rois.len();
+            state.log_provenance(
+                crate::state::ProvenanceEventKind::ConfigChanged,
+                format!("Cleared all {n} ROIs"),
+            );
+            state.rois.clear();
+            state.selected_roi = None;
+            clear_analyze_downstream(state);
+        }
+
+        ui.separator();
+
+        if let Some(n_tof) = n_tof {
+            let slider = egui::Slider::new(
+                &mut state.analyze_tof_slice_index,
+                0..=n_tof.saturating_sub(1),
+            )
+            .show_value(true);
+            ui.add_sized([150.0, 18.0], slider)
+                .on_hover_text("TOF slice shown in the image");
+        }
+
+        ui.separator();
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            run_action_buttons(ui, state);
+        });
+    });
+}
+
+fn has_fit_details(state: &AppState) -> bool {
+    if state.pixel_fit_result.is_some() || state.last_fit_feedback.is_some() {
+        return true;
     }
 
-    // -- Fit feedback card --
-    if let Some(ref fb) = state.last_fit_feedback {
-        ui.add_space(8.0);
-        let (border_color, bg_color) = if fb.success {
-            (
-                egui::Color32::from_rgb(60, 160, 60),
-                egui::Color32::from_rgba_premultiplied(30, 80, 30, 40),
-            )
-        } else {
-            (
-                egui::Color32::from_rgb(200, 60, 60),
-                egui::Color32::from_rgba_premultiplied(80, 30, 30, 40),
-            )
-        };
-        egui::Frame::default()
-            .fill(bg_color)
-            .stroke(egui::Stroke::new(1.5, border_color))
-            .corner_radius(4.0)
-            .inner_margin(6.0)
-            .show(ui, |ui| {
-                ui.label(
-                    egui::RichText::new(&fb.summary)
-                        .color(border_color)
-                        .strong(),
-                );
-                for (symbol, density) in &fb.densities {
-                    ui.label(format!("  {symbol}: {density:.4e} at/barn"));
-                }
-                if let Some(t) = fb.temperature_k {
-                    ui.label(format!("  T = {t:.1} K"));
-                }
-            });
+    let Some((y, x)) = state.selected_pixel else {
+        return false;
+    };
+    state.spatial_result.as_ref().is_some_and(|r| {
+        y < r.converged_map.shape()[0] && x < r.converged_map.shape()[1] && r.converged_map[[y, x]]
+    })
+}
+
+fn fit_info_button(ui: &mut egui::Ui, state: &mut AppState) {
+    let enabled = has_fit_details(state);
+    let response = ui.add_enabled(
+        enabled,
+        egui::Button::new(egui::RichText::new("i").strong()).small(),
+    );
+    if response.clicked() {
+        state.show_analyze_fit_info = true;
     }
+    response.on_hover_text(if enabled {
+        "Show fit details"
+    } else {
+        "Run a fit to enable fit details"
+    });
+}
+
+fn fit_info_drawer(ctx: &egui::Context, state: &mut AppState) {
+    if !has_fit_details(state) {
+        state.show_analyze_fit_info = false;
+        return;
+    }
+    if !state.show_analyze_fit_info {
+        return;
+    }
+
+    let mut open = state.show_analyze_fit_info;
+    egui::Window::new("Fit Details")
+        .open(&mut open)
+        .default_width(360.0)
+        .default_height(420.0)
+        .resizable(true)
+        .collapsible(false)
+        .anchor(egui::Align2::RIGHT_TOP, egui::vec2(-24.0, 96.0))
+        .show(ctx, |ui| {
+            egui::ScrollArea::vertical()
+                .id_salt("analyze_fit_details_drawer")
+                .auto_shrink([false, false])
+                .show(ui, |ui| {
+                    fit_feedback_panel(ui, state);
+
+                    let selected_fit = state
+                        .selected_pixel
+                        .and_then(|(y, x)| selected_pixel_fit_result_for_overlay(state, y, x));
+                    if let Some(ref result) = selected_fit {
+                        ui.add_space(8.0);
+                        ui.separator();
+                        ui.label(egui::RichText::new("Selected Fit").strong());
+                        ui.add_space(4.0);
+                        fit_results_panel(ui, state, result);
+                    }
+
+                    convergence_summary(ui, state);
+                });
+        });
+    state.show_analyze_fit_info = open;
+}
+
+fn fit_feedback_panel(ui: &mut egui::Ui, state: &AppState) {
+    let Some(ref fb) = state.last_fit_feedback else {
+        return;
+    };
+
+    let (border_color, bg_color) = if fb.success {
+        (
+            egui::Color32::from_rgb(60, 160, 60),
+            egui::Color32::from_rgba_premultiplied(30, 80, 30, 40),
+        )
+    } else {
+        (
+            egui::Color32::from_rgb(200, 60, 60),
+            egui::Color32::from_rgba_premultiplied(80, 30, 30, 40),
+        )
+    };
+    egui::Frame::default()
+        .fill(bg_color)
+        .stroke(egui::Stroke::new(1.5, border_color))
+        .corner_radius(4.0)
+        .inner_margin(6.0)
+        .show(ui, |ui| {
+            ui.label(
+                egui::RichText::new(&fb.summary)
+                    .color(border_color)
+                    .strong(),
+            );
+            for (symbol, density) in &fb.densities {
+                ui.label(format!("{symbol}: {density:.4e} at/barn"));
+            }
+            if let Some(t) = fb.temperature_k {
+                ui.label(format!("T = {t:.1} K"));
+            }
+        });
 }
 
 /// Small convergence map + summary, shown in the controls column after spatial map.
@@ -498,15 +608,23 @@ fn image_panel(ui: &mut egui::Ui, state: &mut AppState) {
         let idx = state.map_display_isotope.min(n_isotopes - 1);
 
         ui.label("Density (atoms/barn):");
-        let (clicked, _rect) = show_viridis_image_with_roi(
+        let (clicked, image_rect) = show_viridis_image_with_roi(
             ui,
             &result.density_maps[idx],
             "density_tex",
             &state.rois,
             state.selected_pixel,
         );
+        image_color_bar(
+            ui,
+            &result.density_maps[idx],
+            crate::state::Colormap::Viridis,
+            image_rect.width(),
+        );
+        image_tool_strip(ui, state, None);
         if let Some((y, x)) = clicked {
             state.selected_pixel = Some((y, x));
+            state.selected_roi = None;
             state.pixel_fit_result = None;
             state.residuals_cache = None;
             state.last_fit_feedback = None;
@@ -544,8 +662,12 @@ fn image_panel(ui: &mut egui::Ui, state: &mut AppState) {
             ui.label(label);
 
             let sel_roi = state.selected_roi;
-            let sel_px = state.selected_pixel;
-            let (editor_result, _rect) = show_image_with_roi_editor(
+            let sel_px = if sel_roi.is_some() {
+                None
+            } else {
+                state.selected_pixel
+            };
+            let (editor_result, image_rect) = show_image_with_roi_editor(
                 ui,
                 &slice,
                 "analyze_preview_tex",
@@ -555,21 +677,24 @@ fn image_panel(ui: &mut egui::Ui, state: &mut AppState) {
                 sel_px,
             );
             apply_roi_editor_result(state, editor_result);
-
-            ui.add(
-                egui::Slider::new(
-                    &mut state.analyze_tof_slice_index,
-                    0..=n_tof.saturating_sub(1),
-                )
-                .text("TOF bin"),
+            image_color_bar(
+                ui,
+                &slice,
+                crate::state::Colormap::Viridis,
+                image_rect.width(),
             );
+            image_tool_strip(ui, state, Some(n_tof));
         }
     } else if let Some(ref preview) = state.preview_image {
         // -- Raw preview with interactive ROI editor --
         ui.label("Preview (summed counts):");
         let sel_roi = state.selected_roi;
-        let sel_px = state.selected_pixel;
-        let (editor_result, _rect) = show_image_with_roi_editor(
+        let sel_px = if sel_roi.is_some() {
+            None
+        } else {
+            state.selected_pixel
+        };
+        let (editor_result, image_rect) = show_image_with_roi_editor(
             ui,
             preview,
             "preview_tex",
@@ -578,69 +703,75 @@ fn image_panel(ui: &mut egui::Ui, state: &mut AppState) {
             sel_roi,
             sel_px,
         );
+        image_color_bar(
+            ui,
+            preview,
+            crate::state::Colormap::Viridis,
+            image_rect.width(),
+        );
+        image_tool_strip(ui, state, None);
         apply_roi_editor_result(state, editor_result);
     } else {
         ui.label("Load and normalize data to see preview.");
     }
 
-    // ROI toolbar (only in preview mode, not when viewing density maps)
-    if state.spatial_result.is_none()
-        && (state.normalized.is_some() || state.preview_image.is_some())
-    {
-        ui.horizontal(|ui| {
-            let has_sel = state.selected_roi.is_some_and(|i| i < state.rois.len());
-            if ui
-                .add_enabled(has_sel, egui::Button::new("Delete ROI"))
-                .clicked()
-                && let Some(idx) = state.selected_roi
-                && idx < state.rois.len()
-            {
-                state.log_provenance(
-                    crate::state::ProvenanceEventKind::ConfigChanged,
-                    format!("ROI #{} deleted", idx + 1),
-                );
-                state.rois.remove(idx);
-                // Adjust selection: if deleted ROI was selected, clear.
-                // If a higher-indexed ROI was selected, shift down.
-                state.selected_roi = match state.selected_roi {
-                    Some(s) if s == idx => None,
-                    Some(s) if s > idx => Some(s - 1),
-                    other => other,
-                };
-                clear_analyze_downstream(state);
-            }
-            if ui
-                .add_enabled(!state.rois.is_empty(), egui::Button::new("Clear ROIs"))
-                .clicked()
-            {
-                let n = state.rois.len();
-                state.log_provenance(
-                    crate::state::ProvenanceEventKind::ConfigChanged,
-                    format!("Cleared all {n} ROIs"),
-                );
-                state.rois.clear();
-                state.selected_roi = None;
-                clear_analyze_downstream(state);
-            }
-            if !state.rois.is_empty() {
-                ui.label(
-                    egui::RichText::new(format!("{} ROI(s)", state.rois.len()))
-                        .small()
-                        .weak(),
-                );
-            }
-        });
-        ui.label(
-            egui::RichText::new("Click to select pixel · Shift+drag to draw ROI")
-                .small()
-                .weak(),
+    ui.add_space(8.0);
+    ui.separator();
+    egui::ScrollArea::vertical()
+        .id_salt("analyze_image_fit_controls")
+        .max_height((ui.available_height() - 4.0).max(120.0))
+        .show(ui, |ui| fit_controls(ui, state));
+}
+
+fn image_color_bar(
+    ui: &mut egui::Ui,
+    data: &ndarray::Array2<f64>,
+    colormap: crate::state::Colormap,
+    target_width: f32,
+) {
+    let width = target_width.min(ui.available_width()).max(96.0).round();
+    if !width.is_finite() {
+        return;
+    }
+    let (vmin, vmax) = data_range(data);
+    let (response, painter) = ui.allocate_painter(egui::vec2(width, 10.0), egui::Sense::hover());
+    let steps = 96;
+    for i in 0..steps {
+        let t0 = i as f32 / steps as f32;
+        let t1 = (i + 1) as f32 / steps as f32;
+        let (r, g, b) = apply_colormap(colormap, t0 as f64);
+        let x0 = response.rect.left() + t0 * response.rect.width();
+        let x1 = response.rect.left() + t1 * response.rect.width();
+        painter.rect_filled(
+            egui::Rect::from_min_max(
+                egui::pos2(x0, response.rect.top()),
+                egui::pos2(x1, response.rect.bottom()),
+            ),
+            0.0,
+            egui::Color32::from_rgb(r, g, b),
         );
     }
+    painter.rect_stroke(
+        response.rect,
+        0.0,
+        egui::Stroke::new(1.0, ui.visuals().widgets.noninteractive.bg_stroke.color),
+        egui::StrokeKind::Inside,
+    );
+    ui.horizontal(|ui| {
+        ui.label(egui::RichText::new(format_value(vmin)).small().weak());
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            ui.label(egui::RichText::new(format_value(vmax)).small().weak());
+        });
+    });
+}
 
-    // Show selected pixel coordinates as feedback
-    if let Some((y, x)) = state.selected_pixel {
-        ui.add_space(4.0);
-        ui.label(format!("Selected pixel: ({}, {})", y, x));
+fn format_value(value: f64) -> String {
+    if !value.is_finite() {
+        "NaN".to_string()
+    } else if value.abs() >= 1.0e4 || (value != 0.0 && value.abs() < 1.0e-3) {
+        format!("{value:.3e}")
+    } else {
+        format!("{value:.4}")
     }
 }
 
@@ -667,6 +798,7 @@ fn apply_roi_editor_result(state: &mut AppState, result: RoiEditorResult) {
             if index < state.rois.len() {
                 state.rois[index] = new_roi;
                 clear_analyze_downstream(state);
+                state.selected_roi = Some(index);
                 state.log_provenance(
                     crate::state::ProvenanceEventKind::ConfigChanged,
                     format!(
@@ -680,14 +812,29 @@ fn apply_roi_editor_result(state: &mut AppState, result: RoiEditorResult) {
                 );
             }
         }
+        RoiEditorResult::Moving { index, new_roi } => {
+            if index < state.rois.len() {
+                state.rois[index] = new_roi;
+                state.selected_roi = Some(index);
+                state.pixel_fit_result = None;
+                state.residuals_cache = None;
+                state.last_fit_feedback = None;
+                state.show_analyze_fit_info = false;
+            }
+        }
         RoiEditorResult::Selected(idx) => {
             state.selected_roi = Some(idx);
+            state.pixel_fit_result = None;
+            state.residuals_cache = None;
+            state.last_fit_feedback = None;
+            state.show_analyze_fit_info = false;
         }
         RoiEditorResult::Deselected => {
             state.selected_roi = None;
         }
         RoiEditorResult::ClickedPixel(y, x) => {
             state.selected_pixel = Some((y, x));
+            state.selected_roi = None;
             state.pixel_fit_result = None;
             state.residuals_cache = None;
             state.last_fit_feedback = None;
@@ -696,17 +843,13 @@ fn apply_roi_editor_result(state: &mut AppState, result: RoiEditorResult) {
     }
 }
 
-/// Collect all resonance data (without mapping) for draw_resonance_dips.
-fn collect_all_resonance_data(state: &AppState) -> Vec<nereids_endf::resonance::ResonanceData> {
-    design::collect_all_resonance_data_with_mapping(state).0
-}
-
 /// Clear downstream fit results when ROI changes.
 fn clear_analyze_downstream(state: &mut AppState) {
     state.pixel_fit_result = None;
     state.spatial_result = None;
     state.last_fit_feedback = None;
     state.fitting_rois.clear();
+    state.show_analyze_fit_info = false;
 }
 
 // ---- Spectrum Panel (Column 3) ----
@@ -725,14 +868,156 @@ fn display_as_counts(state: &AppState) -> bool {
         && !matches!(state.input_mode, InputMode::TransmissionTiff)
 }
 
+fn selected_pixel_fit_result_for_overlay(
+    state: &AppState,
+    y: usize,
+    x: usize,
+) -> Option<SpectrumFitResult> {
+    if let Some(result) = state.pixel_fit_result.clone() {
+        return Some(result);
+    }
+
+    let result = state.spatial_result.as_ref()?;
+    let shape = result.converged_map.shape();
+    if y >= shape[0] || x >= shape[1] || !result.converged_map[[y, x]] {
+        return None;
+    }
+
+    let densities: Vec<f64> = result.density_maps.iter().map(|map| map[[y, x]]).collect();
+    if densities.is_empty() || densities.iter().any(|v| !v.is_finite()) {
+        return None;
+    }
+
+    let uncertainties = if result.uncertainty_maps.len() == densities.len() {
+        Some(
+            result
+                .uncertainty_maps
+                .iter()
+                .map(|map| map[[y, x]])
+                .collect(),
+        )
+    } else {
+        None
+    };
+
+    let background = result.background_maps.as_ref().map_or([0.0; 3], |maps| {
+        [maps[0][[y, x]], maps[1][[y, x]], maps[2][[y, x]]]
+    });
+
+    Some(SpectrumFitResult {
+        densities,
+        uncertainties,
+        reduced_chi_squared: result.chi_squared_map[[y, x]],
+        converged: true,
+        iterations: 0,
+        temperature_k: result.temperature_map.as_ref().map(|map| map[[y, x]]),
+        temperature_k_unc: result
+            .temperature_uncertainty_map
+            .as_ref()
+            .map(|map| map[[y, x]]),
+        anorm: result.anorm_map.as_ref().map_or(1.0, |map| map[[y, x]]),
+        background,
+        back_d: 0.0,
+        back_f: 0.0,
+        t0_us: result.t0_us_map.as_ref().map(|map| map[[y, x]]),
+        l_scale: result.l_scale_map.as_ref().map(|map| map[[y, x]]),
+        deviance_per_dof: result.deviance_per_dof_map.as_ref().map(|map| map[[y, x]]),
+    })
+}
+
+fn isotope_track_label(symbol: &str, a: u32) -> String {
+    let bare_symbol = symbol.split_once('-').map_or(symbol, |(s, _)| s);
+    format!("{}{}", superscript_u32(a), bare_symbol)
+}
+
+fn superscript_u32(value: u32) -> String {
+    value
+        .to_string()
+        .chars()
+        .map(|c| match c {
+            '0' => '⁰',
+            '1' => '¹',
+            '2' => '²',
+            '3' => '³',
+            '4' => '⁴',
+            '5' => '⁵',
+            '6' => '⁶',
+            '7' => '⁷',
+            '8' => '⁸',
+            '9' => '⁹',
+            _ => c,
+        })
+        .collect()
+}
+
+#[derive(Clone, Copy)]
+enum SpectrumSelection {
+    Pixel { y: usize, x: usize },
+    Roi { index: usize, roi: RoiSelection },
+}
+
+fn active_spectrum_selection(state: &AppState) -> Option<SpectrumSelection> {
+    if let Some(index) = state.selected_roi
+        && let Some(&roi) = state.rois.get(index)
+        && roi.y_end > roi.y_start
+        && roi.x_end > roi.x_start
+    {
+        return Some(SpectrumSelection::Roi { index, roi });
+    }
+
+    state
+        .selected_pixel
+        .map(|(y, x)| SpectrumSelection::Pixel { y, x })
+}
+
+fn roi_mean_at(data: &ndarray::Array3<f64>, i: usize, roi: RoiSelection) -> f64 {
+    let shape = data.shape();
+    let y0 = roi.y_start.min(shape[1]);
+    let y1 = roi.y_end.min(shape[1]);
+    let x0 = roi.x_start.min(shape[2]);
+    let x1 = roi.x_end.min(shape[2]);
+    if y0 >= y1 || x0 >= x1 {
+        return f64::NAN;
+    }
+
+    let mut sum = 0.0;
+    let mut n = 0usize;
+    for yy in y0..y1 {
+        for xx in x0..x1 {
+            let v = data[[i, yy, xx]];
+            if v.is_finite() {
+                sum += v;
+                n += 1;
+            }
+        }
+    }
+    if n == 0 { f64::NAN } else { sum / n as f64 }
+}
+
 fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
-    // Pixel selector (manual override via DragValues)
+    let selection = active_spectrum_selection(state);
+
+    // Active selection selector. Pixel coordinate editing is intentionally
+    // disabled while an ROI is selected because the spectrum is ROI-averaged.
     ui.horizontal(|ui| {
-        ui.label("Pixel:");
-        if let Some((y, x)) = state.selected_pixel {
-            ui.label(format!("({}, {})", y, x));
-        } else {
-            ui.label("(none selected)");
+        ui.label("Selection:");
+        match selection {
+            Some(SpectrumSelection::Roi { index, roi }) => {
+                ui.label(format!(
+                    "ROI {}  y:{}-{} x:{}-{}",
+                    index + 1,
+                    roi.y_start,
+                    roi.y_end.saturating_sub(1),
+                    roi.x_start,
+                    roi.x_end.saturating_sub(1)
+                ));
+            }
+            Some(SpectrumSelection::Pixel { y, x }) => {
+                ui.label(format!("Pixel ({y}, {x})"));
+            }
+            None => {
+                ui.label("(none)");
+            }
         }
         if let Some(ref norm) = state.normalized {
             let shape = norm.transmission.shape();
@@ -741,16 +1026,19 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
 
             let mut y_val = state.selected_pixel.map_or(0, |(y, _)| y);
             let mut x_val = state.selected_pixel.map_or(0, |(_, x)| x);
+            let pixel_mode = !matches!(selection, Some(SpectrumSelection::Roi { .. }));
 
             let y_changed = ui
-                .add(
+                .add_enabled(
+                    pixel_mode,
                     egui::DragValue::new(&mut y_val)
                         .prefix("y: ")
                         .range(0..=height.saturating_sub(1)),
                 )
                 .changed();
             let x_changed = ui
-                .add(
+                .add_enabled(
+                    pixel_mode,
                     egui::DragValue::new(&mut x_val)
                         .prefix("x: ")
                         .range(0..=width.saturating_sub(1)),
@@ -759,10 +1047,14 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
 
             if y_changed || x_changed {
                 state.selected_pixel = Some((y_val, x_val));
+                state.selected_roi = None;
                 state.pixel_fit_result = None;
                 state.residuals_cache = None;
             }
         }
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            fit_info_button(ui, state);
+        });
     });
 
     // Axis toggle + resonance dips
@@ -779,7 +1071,7 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
             "TOF (\u{03bc}s)",
         );
         ui.separator();
-        ui.checkbox(&mut state.show_resonance_dips, "Resonances");
+        ui.checkbox(&mut state.show_resonance_dips, "Resonance tracks");
     });
 
     let norm = match state.normalized {
@@ -807,16 +1099,18 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
         return;
     };
 
-    let (y, x) = match state.selected_pixel {
-        Some(px) => px,
+    let selection = match selection {
+        Some(selection) => selection,
         None => {
-            ui.label("Select a pixel to view its spectrum.");
+            ui.label("Select a pixel or ROI to view its spectrum.");
             return;
         }
     };
 
     let shape = norm.transmission.shape();
-    if y >= shape[1] || x >= shape[2] {
+    if let SpectrumSelection::Pixel { y, x } = selection
+        && (y >= shape[1] || x >= shape[2])
+    {
         ui.label("Selected pixel is out of bounds. Click the image to select a new pixel.");
         return;
     }
@@ -838,7 +1132,12 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
     let counts_scale: Vec<f64> = if show_counts {
         let ob = state.open_beam_data.as_ref().unwrap();
         let c = state.kl_c_ratio;
-        (0..n_plot).map(|i| c * ob[[i, y, x]]).collect()
+        (0..n_plot)
+            .map(|i| match selection {
+                SpectrumSelection::Pixel { y, x } => c * ob[[i, y, x]],
+                SpectrumSelection::Roi { roi, .. } => c * roi_mean_at(ob, i, roi),
+            })
+            .collect()
     } else {
         Vec::new()
     };
@@ -850,15 +1149,29 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
         let sample = state.sample_data.as_ref().unwrap();
         (0..n_plot)
             .filter(|&i| x_values[i].is_finite())
-            .map(|i| [x_values[i], sample[[i, y, x]]])
+            .map(|i| {
+                let y_value = match selection {
+                    SpectrumSelection::Pixel { y, x } => sample[[i, y, x]],
+                    SpectrumSelection::Roi { roi, .. } => roi_mean_at(sample, i, roi),
+                };
+                [x_values[i], y_value]
+            })
             .collect()
     } else {
         (0..n_plot)
             .filter(|&i| x_values[i].is_finite())
-            .map(|i| [x_values[i], norm.transmission[[i, y, x]]])
+            .map(|i| {
+                let y_value = match selection {
+                    SpectrumSelection::Pixel { y, x } => norm.transmission[[i, y, x]],
+                    SpectrumSelection::Roi { roi, .. } => roi_mean_at(&norm.transmission, i, roi),
+                };
+                [x_values[i], y_value]
+            })
             .collect()
     };
-    let measured_line = Line::new("Measured", measured_points);
+    let measured_points = Points::new("Measured", measured_points)
+        .radius(1.4)
+        .color(crate::theme::semantic::RED);
 
     // OB reference line (counts mode only): the c·OB curve the KL
     // model multiplies T against to predict sample counts.  Showing
@@ -879,7 +1192,11 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
     // + LM background polynomial (BackA + BackB/√E + BackC·√E) — both
     // are typically small, and a fully-correct counts overlay needs
     // the joint-Poisson forward model.  Tracked as a follow-up.
-    let fit_line = state.pixel_fit_result.as_ref().and_then(|result| {
+    let fit_result_for_overlay = match selection {
+        SpectrumSelection::Pixel { y, x } => selected_pixel_fit_result_for_overlay(state, y, x),
+        SpectrumSelection::Roi { .. } => state.pixel_fit_result.clone(),
+    };
+    let fit_line = fit_result_for_overlay.as_ref().and_then(|result| {
         let energies = state.energies.as_ref()?;
         let (all_rd, density_indices, density_ratios) =
             design::collect_all_resonance_data_with_mapping(state);
@@ -930,13 +1247,7 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
     // overlay are using — otherwise users fitting an element group would see
     // dips on the spectrum with no per-isotope row to attribute them to.
     const STRIP_HEIGHT: f32 = 18.0;
-    const STRIP_LABEL_WIDTH: f32 = 80.0;
     const MAX_VISIBLE_STRIPS: usize = 6;
-    struct TickRow<'a> {
-        label: String,
-        color: egui::Color32,
-        data: &'a nereids_endf::resonance::ResonanceData,
-    }
     let mut strip_rows: Vec<TickRow<'_>> = Vec::new();
     if state.show_resonance_dips {
         for entry in &state.isotope_entries {
@@ -944,7 +1255,7 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
                 && let Some(data) = entry.resonance_data.as_ref()
             {
                 strip_rows.push(TickRow {
-                    label: format!("{}-{}", entry.symbol, entry.a),
+                    label: isotope_track_label(&entry.symbol, entry.a),
                     color: design::isotope_dot_color(&entry.symbol),
                     data,
                 });
@@ -955,7 +1266,7 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
                 for member in &group.members {
                     if let Some(data) = member.resonance_data.as_ref() {
                         strip_rows.push(TickRow {
-                            label: format!("{}-{}", member.symbol, member.a),
+                            label: isotope_track_label(&member.symbol, member.a),
                             color: design::isotope_dot_color(&member.symbol),
                             data,
                         });
@@ -972,9 +1283,10 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
         0.0
     };
 
-    // Reserve space below the plot for the fit-result summary AND the
-    // tick strips so neither gets clipped at the column bottom.
-    let plot_height = (ui.available_height() - 100.0 - strips_total_height).max(200.0);
+    // Reserve space below the plot for the tick strips so neither the plot nor
+    // the track viewport pushes past the cockpit column. Fit results live in
+    // the right inspector, not below the spectrum.
+    let plot_height = (ui.available_height() - 20.0 - strips_total_height).max(220.0);
 
     // Plot
     let y_label = if show_counts {
@@ -982,14 +1294,14 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
     } else {
         "Transmission"
     };
-    Plot::new("spectrum_plot")
+    let plot_response = Plot::new("spectrum_plot")
         .height(plot_height)
         .x_axis_label(x_label)
         .y_axis_label(y_label)
         .legend(egui_plot::Legend::default())
         .link_axis("analyze_xaxis", [true, false])
         .show(ui, |plot_ui| {
-            plot_ui.line(measured_line);
+            plot_ui.points(measured_points);
             if let Some(ob) = ob_line {
                 plot_ui.line(ob);
             }
@@ -1005,12 +1317,6 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
                         .style(egui_plot::LineStyle::dashed_dense()),
                 );
             }
-
-            // Resonance dip markers (energy axis only, toggled)
-            if state.show_resonance_dips && state.analyze_spectrum_axis == SpectrumAxis::EnergyEv {
-                let all_rd = collect_all_resonance_data(state);
-                design::draw_resonance_dips(plot_ui, &all_rd, &x_values);
-            }
         });
 
     // Tick strips below the main plot.  When n_strips > MAX_VISIBLE_STRIPS,
@@ -1023,131 +1329,182 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
             .max_height(strips_total_height)
             .show(ui, |ui| {
                 for (i, row) in strip_rows.iter().enumerate() {
-                    ui.horizontal(|ui| {
-                        let row_width = ui.available_width();
-                        let plot_width = (row_width - STRIP_LABEL_WIDTH).max(100.0);
-                        ui.allocate_ui(egui::vec2(plot_width, STRIP_HEIGHT), |ui| {
-                            Plot::new(format!("tick_strip_{i}"))
-                                .height(STRIP_HEIGHT)
-                                .show_axes([false, false])
-                                .show_grid([false, false])
-                                .show_x(false)
-                                .show_y(false)
-                                .allow_zoom(false)
-                                .allow_drag(false)
-                                .allow_scroll(false)
-                                .allow_boxed_zoom(false)
-                                // Defensive y-bounds: VLines render against the
-                                // pixel viewport regardless of y-data, but with
-                                // no points pushed egui_plot's auto-bounds is an
-                                // implicit contract.  Pinning [0, 1] makes the
-                                // strip's vertical extent explicit and resilient
-                                // to egui_plot version bumps.
-                                .include_y(0.0)
-                                .include_y(1.0)
-                                .link_axis("analyze_xaxis", [true, false])
-                                .show(ui, |plot_ui| {
-                                    design::draw_isotope_tick_strip(
-                                        plot_ui,
-                                        row.data,
-                                        state.analyze_spectrum_axis,
-                                        state.beamline.flight_path_m,
-                                        state.beamline.delay_us,
-                                        row.color,
-                                    );
-                                });
-                        });
-                        ui.allocate_ui(egui::vec2(STRIP_LABEL_WIDTH, STRIP_HEIGHT), |ui| {
-                            ui.label(egui::RichText::new(&row.label).color(row.color).strong());
-                        });
-                    });
+                    draw_aligned_tick_row(ui, i, row, &plot_response.transform, state);
                 }
             });
     }
+}
 
-    // Fit results below the plot — wrapped in a vertical ScrollArea so
-    // per-isotope fits with many entities (≥5 isotope rows) don't push
-    // the bottom of the card past the spectrum panel allocation and
-    // overlap the nav strip.  At default density list size the scroll
-    // bar simply doesn't appear.
-    if let Some(ref result) = state.pixel_fit_result {
-        ui.separator();
-        egui::ScrollArea::vertical()
-            .id_salt("analyze_fit_results")
-            .show(ui, |ui| {
-                ui.horizontal(|ui| {
-                    let (label, color) = if result.converged {
-                        ("Converged", crate::theme::semantic::GREEN)
-                    } else {
-                        ("NOT converged", crate::theme::semantic::RED)
-                    };
-                    ui.label(egui::RichText::new(label).color(color).strong());
-                    // Memo 35 §P1.2: when the joint-Poisson solver populated
-                    // deviance_per_dof, label as D/dof; else keep chi2_r.
-                    let gof_label = if result.deviance_per_dof.is_some() {
-                        "D/dof"
-                    } else {
-                        "chi2_r"
-                    };
-                    if state.uncertainty_is_estimated {
-                        ui.label(
-                            egui::RichText::new(format!(
-                                "{} = {:.4} (approx.)",
-                                gof_label, result.reduced_chi_squared
-                            ))
-                            .color(crate::theme::semantic::ORANGE),
-                        );
-                    } else {
-                        ui.label(format!("{} = {:.4}", gof_label, result.reduced_chi_squared));
-                    }
-                    ui.label(format!("iter = {}", result.iterations));
-                    if let Some(t) = result.temperature_k {
-                        if !state.uncertainty_is_estimated {
-                            if let Some(u) = result.temperature_k_unc {
-                                ui.label(format!("T = {t:.1} \u{00b1} {u:.1} K"));
-                            } else {
-                                ui.label(format!("T = {t:.1} K"));
-                            }
-                        } else {
-                            ui.label(format!("T = {t:.1} K"));
-                        }
-                    }
-                });
+fn draw_aligned_tick_row(
+    ui: &mut egui::Ui,
+    row_index: usize,
+    row: &TickRow<'_>,
+    transform: &PlotTransform,
+    state: &AppState,
+) {
+    const STRIP_HEIGHT: f32 = 18.0;
 
-                // Display per-entity density results — build labels in the same order
-                // as build_fit_config (individuals first, then groups).
-                let mut fit_labels: Vec<String> = state
-                    .isotope_entries
-                    .iter()
-                    .filter(|e| e.enabled && e.resonance_data.is_some())
-                    .map(|e| e.symbol.clone())
-                    .collect();
-                for g in &state.isotope_groups {
-                    if g.enabled && g.overall_status() == EndfStatus::Loaded {
-                        fit_labels.push(g.name.clone());
-                    }
-                }
-                for i in 0..result.densities.len() {
-                    let name = fit_labels.get(i).map(|s| s.as_str()).unwrap_or("?");
-                    if state.uncertainty_is_estimated {
-                        ui.label(format!(
-                            "  {name}: rho = {:.6e} atoms/barn",
-                            result.densities[i]
-                        ));
-                    } else {
-                        let unc_str = result
-                            .uncertainties
-                            .as_ref()
-                            .and_then(|u| u.get(i))
-                            .map_or("N/A".to_string(), |u| format!("{:.2e}", u));
-                        ui.label(format!(
-                            "  {name}: rho = {:.6e} +/- {unc_str} atoms/barn",
-                            result.densities[i]
-                        ));
-                    }
-                }
-            });
+    let available_width = ui.available_width();
+    let (response, painter) = ui.allocate_painter(
+        egui::vec2(available_width, STRIP_HEIGHT),
+        egui::Sense::hover(),
+    );
+    let plot_frame = *transform.frame();
+    let track_left = plot_frame.left().max(response.rect.left());
+    let track_right = plot_frame.right().min(response.rect.right());
+    if track_right <= track_left {
+        return;
     }
+
+    let track_rect = egui::Rect::from_min_max(
+        egui::pos2(track_left, response.rect.top() + 2.0),
+        egui::pos2(track_right, response.rect.bottom() - 2.0),
+    );
+    painter.rect_stroke(
+        track_rect,
+        2.0,
+        egui::Stroke::new(1.0, ui.visuals().widgets.noninteractive.bg_stroke.color),
+        egui::StrokeKind::Inside,
+    );
+
+    let bounds = transform.bounds();
+    let x_lo = bounds.min()[0];
+    let x_hi = bounds.max()[0];
+    if !x_lo.is_finite() || !x_hi.is_finite() || x_lo >= x_hi {
+        return;
+    }
+
+    for range in row.data.ranges.iter().filter(|r| r.resolved) {
+        for lg in &range.l_groups {
+            for res in &lg.resonances {
+                let Some(x) = design::resonance_energy_to_axis(
+                    res.energy,
+                    state.analyze_spectrum_axis,
+                    state.beamline.flight_path_m,
+                    state.beamline.delay_us,
+                ) else {
+                    continue;
+                };
+                if x < x_lo || x > x_hi {
+                    continue;
+                }
+                let x_pos = transform
+                    .position_from_point_x(x)
+                    .clamp(track_rect.left(), track_rect.right());
+                painter.line_segment(
+                    [
+                        egui::pos2(x_pos, track_rect.top()),
+                        egui::pos2(x_pos, track_rect.bottom()),
+                    ],
+                    egui::Stroke::new(1.0, row.color),
+                );
+            }
+        }
+    }
+
+    let label_right = (track_left - 6.0).max(response.rect.left());
+    if label_right > response.rect.left() + 18.0 {
+        let label_rect = egui::Rect::from_min_max(
+            egui::pos2(response.rect.left(), response.rect.top()),
+            egui::pos2(label_right, response.rect.bottom()),
+        );
+        painter.circle_filled(
+            egui::pos2(label_rect.left() + 7.0, label_rect.center().y),
+            3.0,
+            row.color,
+        );
+        painter.text(
+            egui::pos2(label_rect.left() + 14.0, label_rect.center().y),
+            egui::Align2::LEFT_CENTER,
+            &row.label,
+            egui::FontId::proportional(12.0),
+            row.color,
+        );
+    }
+    response.on_hover_text(format!("{} resonance track #{}", row.label, row_index + 1));
+}
+
+fn fit_results_panel(ui: &mut egui::Ui, state: &AppState, result: &SpectrumFitResult) {
+    ui.horizontal_wrapped(|ui| {
+        let (label, color) = if result.converged {
+            ("Converged", crate::theme::semantic::GREEN)
+        } else {
+            ("NOT converged", crate::theme::semantic::RED)
+        };
+        ui.label(egui::RichText::new(label).color(color).strong());
+        // Memo 35 §P1.2: when the joint-Poisson solver populated
+        // deviance_per_dof, label as D/dof; else keep chi2_r.
+        let gof_label = if result.deviance_per_dof.is_some() {
+            "D/dof"
+        } else {
+            "chi2_r"
+        };
+        if state.uncertainty_is_estimated {
+            ui.label(
+                egui::RichText::new(format!(
+                    "{} = {:.4} (approx.)",
+                    gof_label, result.reduced_chi_squared
+                ))
+                .color(crate::theme::semantic::ORANGE),
+            );
+        } else {
+            ui.label(format!("{} = {:.4}", gof_label, result.reduced_chi_squared));
+        }
+        ui.label(format!("iter = {}", result.iterations));
+        if let Some(t) = result.temperature_k {
+            if !state.uncertainty_is_estimated {
+                if let Some(u) = result.temperature_k_unc {
+                    ui.label(format!("T = {t:.1} \u{00b1} {u:.1} K"));
+                } else {
+                    ui.label(format!("T = {t:.1} K"));
+                }
+            } else {
+                ui.label(format!("T = {t:.1} K"));
+            }
+        }
+    });
+
+    ui.add_space(4.0);
+
+    // Display per-entity density results — build labels in the same order
+    // as build_fit_config (individuals first, then groups).
+    let mut fit_labels: Vec<String> = state
+        .isotope_entries
+        .iter()
+        .filter(|e| e.enabled && e.resonance_data.is_some())
+        .map(|e| e.symbol.clone())
+        .collect();
+    for g in &state.isotope_groups {
+        if g.enabled && g.overall_status() == EndfStatus::Loaded {
+            fit_labels.push(g.name.clone());
+        }
+    }
+    egui::Grid::new("analyze_fit_result_grid")
+        .num_columns(3)
+        .spacing([8.0, 4.0])
+        .show(ui, |ui| {
+            ui.label(egui::RichText::new("Entity").small().strong());
+            ui.label(egui::RichText::new("Density").small().strong());
+            ui.label(egui::RichText::new("Unc.").small().strong());
+            ui.end_row();
+
+            for i in 0..result.densities.len() {
+                let name = fit_labels.get(i).map(|s| s.as_str()).unwrap_or("?");
+                ui.label(name);
+                ui.label(format!("{:.6e}", result.densities[i]));
+                if state.uncertainty_is_estimated {
+                    ui.label("approx.");
+                } else {
+                    let unc_str = result
+                        .uncertainties
+                        .as_ref()
+                        .and_then(|u| u.get(i))
+                        .map_or("N/A".to_string(), |u| format!("{:.2e}", u));
+                    ui.label(unc_str);
+                }
+                ui.end_row();
+            }
+        });
 }
 
 // ---- Fit Helpers ----

--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -914,9 +914,37 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
         .get(state.analyze_tof_slice_index.min(n_plot.saturating_sub(1)))
         .copied();
 
-    // Reserve space below the plot for the fit-result summary so it
-    // doesn't get clipped at the column bottom.
-    let plot_height = (ui.available_height() - 100.0).max(200.0);
+    // Per-isotope resonance tick strips (GSAS-II-style fit-diagnostic panel,
+    // issue #510).  Each loaded isotope gets a thin row below the spectrum
+    // showing its resolved-resonance positions, color-keyed to match the
+    // isotope chips elsewhere in the UI.  Strips share the spectrum's
+    // x-axis via egui_plot's `link_axis`, so panning/zooming the spectrum
+    // moves all strip ticks in lockstep.  Gated on `show_resonance_dips`
+    // (same toggle that controls the on-main-plot dip overlay) so a single
+    // user action turns ALL resonance indicators on or off.
+    const STRIP_HEIGHT: f32 = 18.0;
+    const STRIP_LABEL_WIDTH: f32 = 80.0;
+    const MAX_VISIBLE_STRIPS: usize = 6;
+    let strip_isotopes: Vec<&crate::state::IsotopeEntry> = if state.show_resonance_dips {
+        state
+            .isotope_entries
+            .iter()
+            .filter(|e| e.enabled && e.resonance_data.is_some())
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let n_strips = strip_isotopes.len();
+    let strips_total_height = if n_strips > 0 {
+        // +4.0 padding for the separator above the strip block.
+        (n_strips.min(MAX_VISIBLE_STRIPS) as f32) * STRIP_HEIGHT + 4.0
+    } else {
+        0.0
+    };
+
+    // Reserve space below the plot for the fit-result summary AND the
+    // tick strips so neither gets clipped at the column bottom.
+    let plot_height = (ui.available_height() - 100.0 - strips_total_height).max(200.0);
 
     // Plot
     let y_label = if show_counts {
@@ -929,6 +957,7 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
         .x_axis_label(x_label)
         .y_axis_label(y_label)
         .legend(egui_plot::Legend::default())
+        .link_axis("analyze_xaxis", [true, false])
         .show(ui, |plot_ui| {
             plot_ui.line(measured_line);
             if let Some(ob) = ob_line {
@@ -953,6 +982,55 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
                 design::draw_resonance_dips(plot_ui, &all_rd, &x_values);
             }
         });
+
+    // Tick strips below the main plot.  When n_strips > MAX_VISIBLE_STRIPS,
+    // a vertical scrollbar appears and we cap the area at the visible-cap
+    // height so the strip block never displaces the fit-summary panel.
+    if n_strips > 0 {
+        ui.add_space(2.0);
+        egui::ScrollArea::vertical()
+            .id_salt("analyze_tick_strips")
+            .max_height(strips_total_height)
+            .show(ui, |ui| {
+                for entry in &strip_isotopes {
+                    let Some(data) = entry.resonance_data.as_ref() else {
+                        continue;
+                    };
+                    let color = design::isotope_dot_color(&entry.symbol);
+                    let label = format!("{}-{}", entry.symbol, entry.a);
+                    ui.horizontal(|ui| {
+                        let row_width = ui.available_width();
+                        let plot_width = (row_width - STRIP_LABEL_WIDTH).max(100.0);
+                        ui.allocate_ui(egui::vec2(plot_width, STRIP_HEIGHT), |ui| {
+                            Plot::new(format!("tick_strip_{}_{}", entry.z, entry.a))
+                                .height(STRIP_HEIGHT)
+                                .show_axes([false, false])
+                                .show_grid([false, false])
+                                .show_x(false)
+                                .show_y(false)
+                                .allow_zoom(false)
+                                .allow_drag(false)
+                                .allow_scroll(false)
+                                .allow_boxed_zoom(false)
+                                .link_axis("analyze_xaxis", [true, false])
+                                .show(ui, |plot_ui| {
+                                    design::draw_isotope_tick_strip(
+                                        plot_ui,
+                                        data,
+                                        state.analyze_spectrum_axis,
+                                        state.beamline.flight_path_m,
+                                        state.beamline.delay_us,
+                                        color,
+                                    );
+                                });
+                        });
+                        ui.allocate_ui(egui::vec2(STRIP_LABEL_WIDTH, STRIP_HEIGHT), |ui| {
+                            ui.label(egui::RichText::new(&label).color(color).strong());
+                        });
+                    });
+                }
+            });
+    }
 
     // Fit results below the plot — wrapped in a vertical ScrollArea so
     // per-isotope fits with many entities (≥5 isotope rows) don't push

--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -24,6 +24,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 
 struct TickRow<'a> {
+    z: u32,
+    a: u32,
     label: String,
     color: egui::Color32,
     data: &'a nereids_endf::resonance::ResonanceData,
@@ -106,6 +108,7 @@ pub fn analyze_step(ui: &mut egui::Ui, state: &mut AppState) {
     });
 
     fit_info_drawer(ui.ctx(), state);
+    isotope_track_picker(ui.ctx(), state);
 
     // -- Navigation --
     let can_continue = state.spatial_result.is_some();
@@ -133,22 +136,21 @@ fn cockpit_column_widths(available_width: f32, spacing_x: f32) -> (f32, f32) {
     let minimum_total = CENTER_MIN + IMAGE_MIN;
 
     if usable < minimum_total {
+        // Below the minimum: split proportionally and accept that both
+        // panels will be tight.
         let image = usable * 0.42;
         let center = usable - image;
         return (image, center);
     }
 
-    let mut image = (usable * 0.38).clamp(IMAGE_MIN, IMAGE_MAX);
-    let mut center = usable - image;
-
-    if center < CENTER_MIN {
-        let deficit = CENTER_MIN - center;
-        let image_take = deficit.min(image - IMAGE_MIN);
-        image -= image_take;
-        center = usable - image;
-    }
-
-    (image, center.max(160.0))
+    // Above the minimum: clamp the image to [IMAGE_MIN, IMAGE_MAX] and
+    // give the rest to the center.  Because IMAGE_MIN + CENTER_MIN ==
+    // minimum_total and image grows at 0.38 × usable (center at 0.62 ×
+    // usable), `center >= CENTER_MIN` is guaranteed throughout this
+    // branch — no deficit redistribution is needed.
+    let image = (usable * 0.38).clamp(IMAGE_MIN, IMAGE_MAX);
+    let center = usable - image;
+    (image, center)
 }
 
 fn ensure_selected_pixel(state: &mut AppState) {
@@ -583,6 +585,101 @@ fn fit_info_drawer(ctx: &egui::Context, state: &mut AppState) {
                 });
         });
     state.show_analyze_fit_info = open;
+}
+
+/// Floating popover that lets the user hide / show individual isotope tick
+/// strips when more isotopes are loaded than fit on-screen at once. Mirrors
+/// the iteration order of `collect_all_resonance_data_with_mapping` so the
+/// picker rows match the strip block's ordering exactly.
+fn isotope_track_picker(ctx: &egui::Context, state: &mut AppState) {
+    if !state.show_isotope_track_picker {
+        return;
+    }
+
+    // Snapshot the list of pickable isotopes BEFORE entering the closure so
+    // we don't hold simultaneous shared + mutable borrows on `state`.
+    struct PickerRow {
+        z: u32,
+        a: u32,
+        label: String,
+        color: egui::Color32,
+    }
+    let mut entries: Vec<PickerRow> = Vec::new();
+    for entry in &state.isotope_entries {
+        if entry.enabled && entry.resonance_data.is_some() {
+            entries.push(PickerRow {
+                z: entry.z,
+                a: entry.a,
+                label: isotope_track_label(&entry.symbol, entry.a),
+                color: design::isotope_dot_color(&entry.symbol),
+            });
+        }
+    }
+    for group in &state.isotope_groups {
+        if group.enabled && group.overall_status() == EndfStatus::Loaded {
+            for member in &group.members {
+                if member.resonance_data.is_some() {
+                    entries.push(PickerRow {
+                        z: group.z,
+                        a: member.a,
+                        label: isotope_track_label(&member.symbol, member.a),
+                        color: design::isotope_dot_color(&member.symbol),
+                    });
+                }
+            }
+        }
+    }
+
+    if entries.is_empty() {
+        state.show_isotope_track_picker = false;
+        return;
+    }
+
+    let mut open = state.show_isotope_track_picker;
+    egui::Window::new("Tick Strips")
+        .open(&mut open)
+        .default_width(280.0)
+        .default_height(320.0)
+        .resizable(true)
+        .collapsible(false)
+        .anchor(egui::Align2::RIGHT_BOTTOM, egui::vec2(-24.0, -120.0))
+        .show(ctx, |ui| {
+            ui.label(egui::RichText::new("Show diagnostic tick strip for:").small());
+            ui.add_space(4.0);
+            ui.horizontal(|ui| {
+                if ui.small_button("Show all").clicked() {
+                    state.hidden_isotope_tracks.clear();
+                }
+                if ui.small_button("Hide all").clicked() {
+                    state.hidden_isotope_tracks = entries.iter().map(|r| (r.z, r.a)).collect();
+                }
+            });
+            ui.separator();
+            egui::ScrollArea::vertical()
+                .id_salt("analyze_track_picker")
+                .auto_shrink([false, false])
+                .show(ui, |ui| {
+                    for row in &entries {
+                        let key = (row.z, row.a);
+                        let mut visible = !state.hidden_isotope_tracks.contains(&key);
+                        ui.horizontal(|ui| {
+                            if ui.checkbox(&mut visible, "").changed() {
+                                if visible {
+                                    state.hidden_isotope_tracks.remove(&key);
+                                } else {
+                                    state.hidden_isotope_tracks.insert(key);
+                                }
+                            }
+                            // Colored dot matching the strip's color.
+                            let (rect, _) = ui
+                                .allocate_exact_size(egui::vec2(10.0, 10.0), egui::Sense::hover());
+                            ui.painter().circle_filled(rect.center(), 4.0, row.color);
+                            ui.label(egui::RichText::new(&row.label).color(row.color));
+                        });
+                    }
+                });
+        });
+    state.show_isotope_track_picker = open;
 }
 
 fn fit_feedback_panel(ui: &mut egui::Ui, state: &AppState) {
@@ -1328,6 +1425,8 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
                 && let Some(data) = entry.resonance_data.as_ref()
             {
                 strip_rows.push(TickRow {
+                    z: entry.z,
+                    a: entry.a,
                     label: isotope_track_label(&entry.symbol, entry.a),
                     color: design::isotope_dot_color(&entry.symbol),
                     data,
@@ -1339,6 +1438,8 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
                 for member in &group.members {
                     if let Some(data) = member.resonance_data.as_ref() {
                         strip_rows.push(TickRow {
+                            z: group.z,
+                            a: member.a,
                             label: isotope_track_label(&member.symbol, member.a),
                             color: design::isotope_dot_color(&member.symbol),
                             data,
@@ -1348,10 +1449,29 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
             }
         }
     }
-    let n_strips = strip_rows.len();
-    let strips_total_height = if n_strips > 0 {
+    // Apply the user's visibility filter (set via the picker popover).  Hidden
+    // tracks are still part of the fit — this only suppresses the diagnostic
+    // strip so the visible list stays focused when many isotopes are loaded.
+    let total_strip_count = strip_rows.len();
+    let visible_indices: Vec<usize> = strip_rows
+        .iter()
+        .enumerate()
+        .filter(|(_, r)| !state.hidden_isotope_tracks.contains(&(r.z, r.a)))
+        .map(|(i, _)| i)
+        .take(MAX_VISIBLE_STRIPS)
+        .collect();
+    let n_strips = visible_indices.len();
+    let overflow_count = total_strip_count - n_strips;
+    let footer_height = if total_strip_count > 0
+        && (overflow_count > 0 || !state.hidden_isotope_tracks.is_empty())
+    {
+        STRIP_HEIGHT + 4.0
+    } else {
+        0.0
+    };
+    let strips_total_height = if n_strips > 0 || footer_height > 0.0 {
         // +4.0 padding for the separator above the strip block.
-        (n_strips.min(MAX_VISIBLE_STRIPS) as f32) * STRIP_HEIGHT + 4.0
+        (n_strips as f32) * STRIP_HEIGHT + 4.0 + footer_height
     } else {
         0.0
     };
@@ -1392,27 +1512,48 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
             }
         });
 
-    // Tick strips below the main plot.  When n_strips > MAX_VISIBLE_STRIPS,
-    // a vertical scrollbar appears and we cap the area at the visible-cap
-    // height so the strip block never displaces the fit-summary panel.
+    // Tick strips below the main plot.  Render up to `MAX_VISIBLE_STRIPS`
+    // visible (non-hidden) tracks directly into the spectrum column so the
+    // strip plot widths match the spectrum's plot frame pixel-for-pixel —
+    // no `ScrollArea` chrome to narrow the rightmost ticks.  Overflow and
+    // user-hidden tracks are reachable via the footer chip → picker popover.
     let mut dragged_ruler = None;
+    let mut open_picker = false;
     if n_strips > 0 {
         ui.add_space(2.0);
-        egui::ScrollArea::vertical()
-            .id_salt("analyze_tick_strips")
-            .max_height(strips_total_height)
-            .show(ui, |ui| {
-                for (i, row) in strip_rows.iter().enumerate() {
-                    if let Some(ruler) =
-                        draw_aligned_tick_row(ui, i, row, &plot_response.transform, state)
-                    {
-                        dragged_ruler = Some(ruler);
-                    }
-                }
-            });
+        for (slot, &source_index) in visible_indices.iter().enumerate() {
+            let row = &strip_rows[source_index];
+            if let Some(ruler) =
+                draw_aligned_tick_row(ui, slot, row, &plot_response.transform, state)
+            {
+                dragged_ruler = Some(ruler);
+            }
+        }
+    }
+    if total_strip_count > 0 && (overflow_count > 0 || !state.hidden_isotope_tracks.is_empty()) {
+        let hidden_count = state.hidden_isotope_tracks.len();
+        let label = if overflow_count > 0 && hidden_count > 0 {
+            format!("+{overflow_count} more  ({hidden_count} hidden)  [pick…]")
+        } else if overflow_count > 0 {
+            format!("+{overflow_count} more  [pick…]")
+        } else {
+            format!("{hidden_count} hidden  [pick…]")
+        };
+        ui.horizontal(|ui| {
+            ui.add_space(8.0);
+            if ui
+                .add(egui::Button::new(egui::RichText::new(label).small()).frame(false))
+                .clicked()
+            {
+                open_picker = true;
+            }
+        });
     }
     if let Some(ruler) = dragged_ruler {
         draw_dragged_resonance_ruler(ui, &plot_response.transform, &ruler, state);
+    }
+    if open_picker {
+        state.show_isotope_track_picker = !state.show_isotope_track_picker;
     }
 }
 

--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -1603,6 +1603,7 @@ fn draw_aligned_tick_row(
                 let Some(x) = design::resonance_energy_to_axis(
                     res.energy,
                     state.analyze_spectrum_axis,
+                    state.spectrum_unit,
                     state.beamline.flight_path_m,
                     state.beamline.delay_us,
                 ) else {

--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -922,19 +922,49 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
     // moves all strip ticks in lockstep.  Gated on `show_resonance_dips`
     // (same toggle that controls the on-main-plot dip overlay) so a single
     // user action turns ALL resonance indicators on or off.
+    //
+    // Iteration order MIRRORS `design::collect_all_resonance_data_with_mapping`:
+    // individual isotope_entries first, then enabled-and-fully-loaded group
+    // members.  Keeping the same gate (`g.enabled && overall_status() ==
+    // Loaded`) ensures the strips show exactly the resonances the fit + dip
+    // overlay are using — otherwise users fitting an element group would see
+    // dips on the spectrum with no per-isotope row to attribute them to.
     const STRIP_HEIGHT: f32 = 18.0;
     const STRIP_LABEL_WIDTH: f32 = 80.0;
     const MAX_VISIBLE_STRIPS: usize = 6;
-    let strip_isotopes: Vec<&crate::state::IsotopeEntry> = if state.show_resonance_dips {
-        state
-            .isotope_entries
-            .iter()
-            .filter(|e| e.enabled && e.resonance_data.is_some())
-            .collect()
-    } else {
-        Vec::new()
-    };
-    let n_strips = strip_isotopes.len();
+    struct TickRow<'a> {
+        label: String,
+        color: egui::Color32,
+        data: &'a nereids_endf::resonance::ResonanceData,
+    }
+    let mut strip_rows: Vec<TickRow<'_>> = Vec::new();
+    if state.show_resonance_dips {
+        for entry in &state.isotope_entries {
+            if entry.enabled
+                && let Some(data) = entry.resonance_data.as_ref()
+            {
+                strip_rows.push(TickRow {
+                    label: format!("{}-{}", entry.symbol, entry.a),
+                    color: design::isotope_dot_color(&entry.symbol),
+                    data,
+                });
+            }
+        }
+        for group in &state.isotope_groups {
+            if group.enabled && group.overall_status() == EndfStatus::Loaded {
+                for member in &group.members {
+                    if let Some(data) = member.resonance_data.as_ref() {
+                        strip_rows.push(TickRow {
+                            label: format!("{}-{}", member.symbol, member.a),
+                            color: design::isotope_dot_color(&member.symbol),
+                            data,
+                        });
+                    }
+                }
+            }
+        }
+    }
+    let n_strips = strip_rows.len();
     let strips_total_height = if n_strips > 0 {
         // +4.0 padding for the separator above the strip block.
         (n_strips.min(MAX_VISIBLE_STRIPS) as f32) * STRIP_HEIGHT + 4.0
@@ -992,17 +1022,12 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
             .id_salt("analyze_tick_strips")
             .max_height(strips_total_height)
             .show(ui, |ui| {
-                for entry in &strip_isotopes {
-                    let Some(data) = entry.resonance_data.as_ref() else {
-                        continue;
-                    };
-                    let color = design::isotope_dot_color(&entry.symbol);
-                    let label = format!("{}-{}", entry.symbol, entry.a);
+                for (i, row) in strip_rows.iter().enumerate() {
                     ui.horizontal(|ui| {
                         let row_width = ui.available_width();
                         let plot_width = (row_width - STRIP_LABEL_WIDTH).max(100.0);
                         ui.allocate_ui(egui::vec2(plot_width, STRIP_HEIGHT), |ui| {
-                            Plot::new(format!("tick_strip_{}_{}", entry.z, entry.a))
+                            Plot::new(format!("tick_strip_{i}"))
                                 .height(STRIP_HEIGHT)
                                 .show_axes([false, false])
                                 .show_grid([false, false])
@@ -1012,20 +1037,28 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
                                 .allow_drag(false)
                                 .allow_scroll(false)
                                 .allow_boxed_zoom(false)
+                                // Defensive y-bounds: VLines render against the
+                                // pixel viewport regardless of y-data, but with
+                                // no points pushed egui_plot's auto-bounds is an
+                                // implicit contract.  Pinning [0, 1] makes the
+                                // strip's vertical extent explicit and resilient
+                                // to egui_plot version bumps.
+                                .include_y(0.0)
+                                .include_y(1.0)
                                 .link_axis("analyze_xaxis", [true, false])
                                 .show(ui, |plot_ui| {
                                     design::draw_isotope_tick_strip(
                                         plot_ui,
-                                        data,
+                                        row.data,
                                         state.analyze_spectrum_axis,
                                         state.beamline.flight_path_m,
                                         state.beamline.delay_us,
-                                        color,
+                                        row.color,
                                     );
                                 });
                         });
                         ui.allocate_ui(egui::vec2(STRIP_LABEL_WIDTH, STRIP_HEIGHT), |ui| {
-                            ui.label(egui::RichText::new(&label).color(color).strong());
+                            ui.label(egui::RichText::new(&row.label).color(row.color).strong());
                         });
                     });
                 }

--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -14,7 +14,7 @@ use crate::widgets::image_view::{
     RoiEditorResult, apply_colormap, data_range, show_image_with_roi_editor, show_viridis_image,
     show_viridis_image_with_roi,
 };
-use egui_plot::{Line, Plot, PlotPoints, PlotTransform, Points, VLine};
+use egui_plot::{Corner, Line, Plot, PlotPoints, PlotTransform, Points, VLine};
 use ndarray::Axis;
 use nereids_pipeline::pipeline::{
     BackgroundConfig, InputData, SolverConfig, SpectrumFitResult, UnifiedFitConfig,
@@ -27,6 +27,26 @@ struct TickRow<'a> {
     label: String,
     color: egui::Color32,
     data: &'a nereids_endf::resonance::ResonanceData,
+}
+
+enum ImageToolStripCenter {
+    None,
+    Tof { n_bins: usize },
+    Isotope { labels: Vec<String> },
+}
+
+#[derive(Clone)]
+struct DraggedResonanceRuler {
+    label: String,
+    color: egui::Color32,
+    axis_x: f64,
+    energy_ev: f64,
+}
+
+struct TickCandidate {
+    axis_x: f64,
+    energy_ev: f64,
+    x_pos: f32,
 }
 
 /// Draw the Analyze step content.
@@ -150,17 +170,16 @@ fn ensure_selected_pixel(state: &mut AppState) {
 
 // ---- Fit Controls ----
 
-fn fit_controls(ui: &mut egui::Ui, state: &mut AppState) {
+fn fit_controls(ui: &mut egui::Ui, state: &mut AppState, available_height_hint: f32) {
     // -- Solver configuration --
-    ui.label(egui::RichText::new("Solver").strong());
-
-    ui.horizontal(|ui| {
+    let method_text = match state.solver_method {
+        SolverMethod::LevenbergMarquardt => "Levenberg-Marquardt",
+        SolverMethod::PoissonKL => "Poisson KL",
+    };
+    let draw_method = |ui: &mut egui::Ui, state: &mut AppState| {
         ui.label("Method:");
         egui::ComboBox::from_id_salt("solver_method")
-            .selected_text(match state.solver_method {
-                SolverMethod::LevenbergMarquardt => "Levenberg-Marquardt",
-                SolverMethod::PoissonKL => "Poisson KL",
-            })
+            .selected_text(method_text)
             .show_ui(ui, |ui| {
                 ui.selectable_value(
                     &mut state.solver_method,
@@ -173,15 +192,27 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState) {
                     "Poisson KL",
                 );
             });
-    });
-
-    ui.horizontal(|ui| {
+    };
+    let draw_max_iter = |ui: &mut egui::Ui, state: &mut AppState| {
         ui.label("Max iter:");
         ui.add(egui::DragValue::new(&mut state.lm_config.max_iter).range(1..=10000));
-    });
+    };
+
+    if ui.available_width() >= 330.0 {
+        ui.horizontal(|ui| {
+            draw_method(ui, state);
+            ui.separator();
+            draw_max_iter(ui, state);
+        });
+    } else {
+        ui.horizontal(|ui| draw_method(ui, state));
+        ui.horizontal(|ui| draw_max_iter(ui, state));
+    }
 
     // Advanced solver controls (collapsible)
-    let gear = if state.show_advanced_solver {
+    let auto_show_advanced = available_height_hint > 300.0;
+    let show_advanced = auto_show_advanced || state.show_advanced_solver;
+    let gear = if show_advanced {
         "\u{2699} Advanced \u{25b2}"
     } else {
         "\u{2699} Advanced \u{25bc}"
@@ -193,7 +224,7 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState) {
         state.show_advanced_solver = !state.show_advanced_solver;
     }
 
-    if state.show_advanced_solver {
+    if show_advanced {
         // Snapshot solver controls so we can detect a change after the
         // panel runs and invalidate cached fit results.  egui's
         // `selectable_value` mutates state in place with no change
@@ -209,28 +240,29 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState) {
         let prev_tol_param = state.lm_config.tol_param;
         let prev_lambda_init = state.lm_config.lambda_init;
 
-        ui.indent("advanced_solver", |ui| {
-            // Fit temperature and Fit energy scale are mutually exclusive
-            // (pipeline returns a hard error if both are true — see
-            // `pipeline.rs` ~L977).  Grey out each when the other is on so
-            // the constraint is visible in the UI rather than only at fit
-            // time.
-            ui.add_enabled(
-                !state.fit_energy_scale,
-                egui::Checkbox::new(
-                    &mut state.fit_temperature,
-                    "Fit temperature (slow for Spatial Map)",
-                ),
-            );
-            ui.add_enabled(
-                !state.fit_temperature,
-                egui::Checkbox::new(
-                    &mut state.fit_energy_scale,
-                    "Fit energy scale (TZERO t\u{2080} + L_scale, SAMMY equivalent)",
-                ),
-            )
-            .on_hover_text(
-                "Adds the residual time-zero offset t\u{2080} (\u{03BC}s) \
+        let draw_advanced_solver = |ui: &mut egui::Ui, state: &mut AppState| {
+            ui.indent("advanced_solver", |ui| {
+                // Fit temperature and Fit energy scale are mutually exclusive
+                // (pipeline returns a hard error if both are true — see
+                // `pipeline.rs` ~L977).  Grey out each when the other is on so
+                // the constraint is visible in the UI rather than only at fit
+                // time.
+                ui.add_enabled(
+                    !state.fit_energy_scale,
+                    egui::Checkbox::new(
+                        &mut state.fit_temperature,
+                        "Fit temperature (slow for Spatial Map)",
+                    ),
+                );
+                ui.add_enabled(
+                    !state.fit_temperature,
+                    egui::Checkbox::new(
+                        &mut state.fit_energy_scale,
+                        "Fit energy scale (TZERO t\u{2080} + L_scale, SAMMY equivalent)",
+                    ),
+                )
+                .on_hover_text(
+                    "Adds the residual time-zero offset t\u{2080} (\u{03BC}s) \
                  and flight-path scale L_scale (dimensionless) as free \
                  parameters during the fit.  Both seed at identity \
                  (t\u{2080} = 0.0, L_scale = 1.0) — the nominal Delay \
@@ -239,84 +271,99 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState) {
                  Path.  Optimiser bound: t\u{2080} \u{2208} \u{00B1}10 \
                  \u{03BC}s, L_scale \u{2208} [0.99, 1.01].  Mutually \
                  exclusive with Fit temperature.",
-            );
-            if matches!(state.solver_method, SolverMethod::LevenbergMarquardt) {
-                ui.checkbox(
-                    &mut state.lm_background_enabled,
-                    "LM background (SAMMY: Anorm + BackA/B/C)",
                 );
-            }
-            if matches!(state.solver_method, SolverMethod::PoissonKL) {
-                ui.checkbox(
-                    &mut state.kl_background_enabled,
-                    "KL background (SAMMY: A\u{2099} + B_A + B_B/\u{221A}E + B_C\u{221A}E)",
-                );
-                ui.horizontal(|ui| {
-                    ui.label("c = Q_s / Q_ob:");
-                    ui.add(
-                        egui::DragValue::new(&mut state.kl_c_ratio)
-                            .speed(0.01)
-                            .range(1e-4..=100.0),
-                    )
-                    .on_hover_text(
-                        "Proton-charge ratio for the counts-KL solver \
+                if matches!(state.solver_method, SolverMethod::LevenbergMarquardt) {
+                    ui.checkbox(
+                        &mut state.lm_background_enabled,
+                        "LM background (SAMMY: Anorm + BackA/B/C)",
+                    );
+                }
+                if matches!(state.solver_method, SolverMethod::PoissonKL) {
+                    ui.checkbox(
+                        &mut state.kl_background_enabled,
+                        "KL background (SAMMY: A\u{2099} + B_A + B_B/\u{221A}E + B_C\u{221A}E)",
+                    );
+                    ui.horizontal(|ui| {
+                        ui.label("c = Q_s / Q_ob:");
+                        ui.add(
+                            egui::DragValue::new(&mut state.kl_c_ratio)
+                                .speed(0.01)
+                                .range(1e-4..=100.0),
+                        )
+                        .on_hover_text(
+                            "Proton-charge ratio for the counts-KL solver \
                          (memo 35 §P1.3).  Leave at 1.0 when the \
                          caller has already PC-normalized the flux.",
-                    );
-                });
-                // Polish override (memo 38 §6).  For spatial maps the
-                // default (None = auto-disable when n_pixels > 1) is the
-                // right choice.  Exposing an explicit toggle is
-                // research-oriented; wire as a tri-state via ComboBox
-                // so the distinction between "auto" and "forced off" is
-                // visible.
-                ui.horizontal(|ui| {
-                    ui.label("Polish:");
-                    let selected = match state.kl_enable_polish_override {
-                        None => "Auto (on for single / off for spatial)",
-                        Some(true) => "On (forced)",
-                        Some(false) => "Off (forced)",
-                    };
-                    egui::ComboBox::from_id_salt("kl_polish_override")
-                        .selected_text(selected)
-                        .show_ui(ui, |ui| {
-                            ui.selectable_value(&mut state.kl_enable_polish_override, None, "Auto");
-                            ui.selectable_value(
-                                &mut state.kl_enable_polish_override,
-                                Some(true),
-                                "On (forced)",
-                            );
-                            ui.selectable_value(
-                                &mut state.kl_enable_polish_override,
-                                Some(false),
-                                "Off (forced)",
-                            );
-                        });
-                });
-            }
-            ui.checkbox(
-                &mut state.lm_config.compute_covariance,
-                "Compute covariance (single-pixel/ROI only)",
-            );
-            ui.horizontal(|ui| {
-                ui.label("Tol (param):");
-                ui.add(
-                    egui::DragValue::new(&mut state.lm_config.tol_param)
-                        .speed(1e-9)
-                        .range(1e-12..=1.0),
+                        );
+                    });
+                    // Polish override (memo 38 §6).  For spatial maps the
+                    // default (None = auto-disable when n_pixels > 1) is the
+                    // right choice.  Exposing an explicit toggle is
+                    // research-oriented; wire as a tri-state via ComboBox
+                    // so the distinction between "auto" and "forced off" is
+                    // visible.
+                    ui.horizontal(|ui| {
+                        ui.label("Polish:");
+                        let selected = match state.kl_enable_polish_override {
+                            None => "Auto (on for single / off for spatial)",
+                            Some(true) => "On (forced)",
+                            Some(false) => "Off (forced)",
+                        };
+                        egui::ComboBox::from_id_salt("kl_polish_override")
+                            .selected_text(selected)
+                            .show_ui(ui, |ui| {
+                                ui.selectable_value(
+                                    &mut state.kl_enable_polish_override,
+                                    None,
+                                    "Auto",
+                                );
+                                ui.selectable_value(
+                                    &mut state.kl_enable_polish_override,
+                                    Some(true),
+                                    "On (forced)",
+                                );
+                                ui.selectable_value(
+                                    &mut state.kl_enable_polish_override,
+                                    Some(false),
+                                    "Off (forced)",
+                                );
+                            });
+                    });
+                }
+                ui.checkbox(
+                    &mut state.lm_config.compute_covariance,
+                    "Compute covariance (single-pixel/ROI only)",
                 );
-            });
-            if state.solver_method == SolverMethod::LevenbergMarquardt {
                 ui.horizontal(|ui| {
-                    ui.label("Lambda init:");
+                    ui.label("Tol (param):");
                     ui.add(
-                        egui::DragValue::new(&mut state.lm_config.lambda_init)
-                            .speed(1e-4)
-                            .range(1e-10..=1e6),
+                        egui::DragValue::new(&mut state.lm_config.tol_param)
+                            .speed(1e-9)
+                            .range(1e-12..=1.0),
                     );
                 });
-            }
-        });
+                if state.solver_method == SolverMethod::LevenbergMarquardt {
+                    ui.horizontal(|ui| {
+                        ui.label("Lambda init:");
+                        ui.add(
+                            egui::DragValue::new(&mut state.lm_config.lambda_init)
+                                .speed(1e-4)
+                                .range(1e-10..=1e6),
+                        );
+                    });
+                }
+            });
+        };
+
+        if auto_show_advanced {
+            draw_advanced_solver(ui, state);
+        } else {
+            egui::ScrollArea::vertical()
+                .id_salt("advanced_solver_scroll")
+                .max_height(160.0)
+                .auto_shrink([false, false])
+                .show(ui, |ui| draw_advanced_solver(ui, state));
+        }
 
         // If any solver control changed, downstream fit results no
         // longer reflect the active configuration — invalidate them so
@@ -390,7 +437,7 @@ fn run_action_buttons(ui: &mut egui::Ui, state: &mut AppState) {
     });
 }
 
-fn image_tool_strip(ui: &mut egui::Ui, state: &mut AppState, n_tof: Option<usize>) {
+fn image_tool_strip(ui: &mut egui::Ui, state: &mut AppState, center: ImageToolStripCenter) {
     ui.horizontal(|ui| {
         let has_sel = state.selected_roi.is_some_and(|i| i < state.rois.len());
         if ui
@@ -430,14 +477,35 @@ fn image_tool_strip(ui: &mut egui::Ui, state: &mut AppState, n_tof: Option<usize
 
         ui.separator();
 
-        if let Some(n_tof) = n_tof {
-            let slider = egui::Slider::new(
-                &mut state.analyze_tof_slice_index,
-                0..=n_tof.saturating_sub(1),
-            )
-            .show_value(true);
-            ui.add_sized([150.0, 18.0], slider)
-                .on_hover_text("TOF slice shown in the image");
+        match center {
+            ImageToolStripCenter::None => {}
+            ImageToolStripCenter::Tof { n_bins } => {
+                let slider_width = (ui.available_width() - 118.0).clamp(180.0, 360.0);
+                let slider = egui::Slider::new(
+                    &mut state.analyze_tof_slice_index,
+                    0..=n_bins.saturating_sub(1),
+                )
+                .show_value(true);
+                ui.add_sized([slider_width, 18.0], slider)
+                    .on_hover_text("TOF slice shown in the image");
+            }
+            ImageToolStripCenter::Isotope { labels } => {
+                let n_isotopes = labels.len();
+                if n_isotopes > 1 {
+                    let idx = state.map_display_isotope.min(n_isotopes - 1);
+                    let current = labels.get(idx).map(String::as_str).unwrap_or("?");
+                    egui::ComboBox::from_id_salt("isotope_map_select")
+                        .selected_text(current)
+                        .width(88.0)
+                        .show_ui(ui, |ui| {
+                            for (i, name) in labels.iter().enumerate() {
+                                ui.selectable_value(&mut state.map_display_isotope, i, name);
+                            }
+                        })
+                        .response
+                        .on_hover_text("Density map isotope");
+                }
+            }
         }
 
         ui.separator();
@@ -581,39 +649,28 @@ fn image_panel(ui: &mut egui::Ui, state: &mut AppState) {
     if let Some(ref result) = state.spatial_result {
         // -- Density map display (read-only ROI overlay) --
         let n_isotopes = result.density_maps.len();
-        if n_isotopes > 1 {
-            let labels = &result.isotope_labels;
-            let current_name = labels
-                .get(state.map_display_isotope.min(n_isotopes - 1))
-                .map(|s| s.as_str())
-                .unwrap_or("?");
-            ui.horizontal(|ui| {
-                ui.label("Isotope:");
-                egui::ComboBox::from_id_salt("isotope_map_select")
-                    .selected_text(current_name)
-                    .show_ui(ui, |ui| {
-                        for i in 0..n_isotopes {
-                            let name = labels.get(i).map(|s| s.as_str()).unwrap_or("?");
-                            ui.selectable_value(&mut state.map_display_isotope, i, name);
-                        }
-                    });
-            });
-        }
-
         if n_isotopes == 0 {
             ui.label("No density maps available.");
             return;
         }
 
         let idx = state.map_display_isotope.min(n_isotopes - 1);
+        let isotope_labels = result
+            .isotope_labels
+            .iter()
+            .map(|s| compact_isotope_label_from_name(s))
+            .collect();
 
-        ui.label("Density (atoms/barn):");
         let (clicked, image_rect) = show_viridis_image_with_roi(
             ui,
             &result.density_maps[idx],
             "density_tex",
             &state.rois,
-            state.selected_pixel,
+            if state.selected_roi.is_some() {
+                None
+            } else {
+                state.selected_pixel
+            },
         );
         image_color_bar(
             ui,
@@ -621,7 +678,13 @@ fn image_panel(ui: &mut egui::Ui, state: &mut AppState) {
             crate::state::Colormap::Viridis,
             image_rect.width(),
         );
-        image_tool_strip(ui, state, None);
+        image_tool_strip(
+            ui,
+            state,
+            ImageToolStripCenter::Isotope {
+                labels: isotope_labels,
+            },
+        );
         if let Some((y, x)) = clicked {
             state.selected_pixel = Some((y, x));
             state.selected_roi = None;
@@ -683,7 +746,7 @@ fn image_panel(ui: &mut egui::Ui, state: &mut AppState) {
                 crate::state::Colormap::Viridis,
                 image_rect.width(),
             );
-            image_tool_strip(ui, state, Some(n_tof));
+            image_tool_strip(ui, state, ImageToolStripCenter::Tof { n_bins: n_tof });
         }
     } else if let Some(ref preview) = state.preview_image {
         // -- Raw preview with interactive ROI editor --
@@ -709,7 +772,7 @@ fn image_panel(ui: &mut egui::Ui, state: &mut AppState) {
             crate::state::Colormap::Viridis,
             image_rect.width(),
         );
-        image_tool_strip(ui, state, None);
+        image_tool_strip(ui, state, ImageToolStripCenter::None);
         apply_roi_editor_result(state, editor_result);
     } else {
         ui.label("Load and normalize data to see preview.");
@@ -717,10 +780,11 @@ fn image_panel(ui: &mut egui::Ui, state: &mut AppState) {
 
     ui.add_space(8.0);
     ui.separator();
+    let fit_controls_height = (ui.available_height() - 4.0).max(120.0);
     egui::ScrollArea::vertical()
         .id_salt("analyze_image_fit_controls")
-        .max_height((ui.available_height() - 4.0).max(120.0))
-        .show(ui, |ui| fit_controls(ui, state));
+        .max_height(fit_controls_height)
+        .show(ui, |ui| fit_controls(ui, state, fit_controls_height));
 }
 
 fn image_color_bar(
@@ -928,6 +992,15 @@ fn selected_pixel_fit_result_for_overlay(
 fn isotope_track_label(symbol: &str, a: u32) -> String {
     let bare_symbol = symbol.split_once('-').map_or(symbol, |(s, _)| s);
     format!("{}{}", superscript_u32(a), bare_symbol)
+}
+
+fn compact_isotope_label_from_name(name: &str) -> String {
+    if let Some((symbol, mass)) = name.split_once('-')
+        && let Ok(a) = mass.parse::<u32>()
+    {
+        return format!("{}{}", superscript_u32(a), symbol);
+    }
+    name.to_string()
 }
 
 fn superscript_u32(value: u32) -> String {
@@ -1298,7 +1371,7 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
         .height(plot_height)
         .x_axis_label(x_label)
         .y_axis_label(y_label)
-        .legend(egui_plot::Legend::default())
+        .legend(egui_plot::Legend::default().position(Corner::RightBottom))
         .link_axis("analyze_xaxis", [true, false])
         .show(ui, |plot_ui| {
             plot_ui.points(measured_points);
@@ -1322,6 +1395,7 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
     // Tick strips below the main plot.  When n_strips > MAX_VISIBLE_STRIPS,
     // a vertical scrollbar appears and we cap the area at the visible-cap
     // height so the strip block never displaces the fit-summary panel.
+    let mut dragged_ruler = None;
     if n_strips > 0 {
         ui.add_space(2.0);
         egui::ScrollArea::vertical()
@@ -1329,9 +1403,16 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
             .max_height(strips_total_height)
             .show(ui, |ui| {
                 for (i, row) in strip_rows.iter().enumerate() {
-                    draw_aligned_tick_row(ui, i, row, &plot_response.transform, state);
+                    if let Some(ruler) =
+                        draw_aligned_tick_row(ui, i, row, &plot_response.transform, state)
+                    {
+                        dragged_ruler = Some(ruler);
+                    }
                 }
             });
+    }
+    if let Some(ruler) = dragged_ruler {
+        draw_dragged_resonance_ruler(ui, &plot_response.transform, &ruler, state);
     }
 }
 
@@ -1341,19 +1422,19 @@ fn draw_aligned_tick_row(
     row: &TickRow<'_>,
     transform: &PlotTransform,
     state: &AppState,
-) {
+) -> Option<DraggedResonanceRuler> {
     const STRIP_HEIGHT: f32 = 18.0;
 
     let available_width = ui.available_width();
     let (response, painter) = ui.allocate_painter(
         egui::vec2(available_width, STRIP_HEIGHT),
-        egui::Sense::hover(),
+        egui::Sense::click_and_drag(),
     );
     let plot_frame = *transform.frame();
     let track_left = plot_frame.left().max(response.rect.left());
     let track_right = plot_frame.right().min(response.rect.right());
     if track_right <= track_left {
-        return;
+        return None;
     }
 
     let track_rect = egui::Rect::from_min_max(
@@ -1371,9 +1452,10 @@ fn draw_aligned_tick_row(
     let x_lo = bounds.min()[0];
     let x_hi = bounds.max()[0];
     if !x_lo.is_finite() || !x_hi.is_finite() || x_lo >= x_hi {
-        return;
+        return None;
     }
 
+    let mut candidates = Vec::new();
     for range in row.data.ranges.iter().filter(|r| r.resolved) {
         for lg in &range.l_groups {
             for res in &lg.resonances {
@@ -1391,6 +1473,11 @@ fn draw_aligned_tick_row(
                 let x_pos = transform
                     .position_from_point_x(x)
                     .clamp(track_rect.left(), track_rect.right());
+                candidates.push(TickCandidate {
+                    axis_x: x,
+                    energy_ev: res.energy,
+                    x_pos,
+                });
                 painter.line_segment(
                     [
                         egui::pos2(x_pos, track_rect.top()),
@@ -1421,7 +1508,98 @@ fn draw_aligned_tick_row(
             row.color,
         );
     }
-    response.on_hover_text(format!("{} resonance track #{}", row.label, row_index + 1));
+    let response = response.on_hover_text(format!(
+        "{} resonance track #{}\nDrag a tick upward to compare it against the spectrum",
+        row.label,
+        row_index + 1
+    ));
+    dragged_resonance_from_response(ui, response, &candidates, row)
+}
+
+fn dragged_resonance_from_response(
+    ui: &mut egui::Ui,
+    response: egui::Response,
+    candidates: &[TickCandidate],
+    row: &TickRow<'_>,
+) -> Option<DraggedResonanceRuler> {
+    let drag_key = egui::Id::new("analyze_dragged_resonance_ruler");
+
+    if response.drag_started()
+        && let Some(pointer) = response.interact_pointer_pos()
+        && let Some(candidate) = candidates
+            .iter()
+            .min_by(|a, b| {
+                (a.x_pos - pointer.x)
+                    .abs()
+                    .total_cmp(&(b.x_pos - pointer.x).abs())
+            })
+            .filter(|candidate| (candidate.x_pos - pointer.x).abs() <= 12.0)
+    {
+        ui.data_mut(|data| {
+            data.insert_temp(
+                drag_key,
+                DraggedResonanceRuler {
+                    label: row.label.clone(),
+                    color: row.color,
+                    axis_x: candidate.axis_x,
+                    energy_ev: candidate.energy_ev,
+                },
+            );
+        });
+    }
+
+    if response.drag_stopped() {
+        ui.data_mut(|data| data.remove::<DraggedResonanceRuler>(drag_key));
+        return None;
+    }
+
+    if response.dragged() {
+        return ui.data(|data| data.get_temp::<DraggedResonanceRuler>(drag_key));
+    }
+
+    None
+}
+
+fn draw_dragged_resonance_ruler(
+    ui: &egui::Ui,
+    transform: &PlotTransform,
+    ruler: &DraggedResonanceRuler,
+    state: &AppState,
+) {
+    let frame = *transform.frame();
+    let x = transform
+        .position_from_point_x(ruler.axis_x)
+        .clamp(frame.left(), frame.right());
+    let pointer_y = ui
+        .input(|i| i.pointer.hover_pos())
+        .map_or(frame.top() + 14.0, |pos| {
+            pos.y.clamp(frame.top() + 14.0, frame.bottom() - 14.0)
+        });
+    let label = match state.analyze_spectrum_axis {
+        SpectrumAxis::EnergyEv => format!("{}  {:.4} eV", ruler.label, ruler.energy_ev),
+        SpectrumAxis::TofMicroseconds => {
+            format!(
+                "{}  {:.4} \u{03bc}s ({:.4} eV)",
+                ruler.label, ruler.axis_x, ruler.energy_ev
+            )
+        }
+    };
+
+    let painter = ui.ctx().layer_painter(egui::LayerId::new(
+        egui::Order::Foreground,
+        egui::Id::new("analyze_dragged_resonance_ruler_layer"),
+    ));
+    painter.line_segment(
+        [egui::pos2(x, frame.top()), egui::pos2(x, frame.bottom())],
+        egui::Stroke::new(2.0, ruler.color),
+    );
+    painter.text(
+        egui::pos2(x + 6.0, pointer_y),
+        egui::Align2::LEFT_CENTER,
+        label,
+        egui::FontId::proportional(12.0),
+        ruler.color,
+    );
 }
 
 fn fit_results_panel(ui: &mut egui::Ui, state: &AppState, result: &SpectrumFitResult) {

--- a/apps/gui/src/guided/sidebar.rs
+++ b/apps/gui/src/guided/sidebar.rs
@@ -44,10 +44,8 @@ fn collapsed_sidebar(
     colors: &ThemeColors,
     force_compact: bool,
 ) {
-    // Expand toggle
     if force_compact {
-        ui.label(RichText::new(">>").size(11.0).color(colors.fg3))
-            .on_hover_text("Analyze uses the compact sidebar");
+        ui.add_space(12.0);
     } else if ui
         .add(egui::Button::new(RichText::new(">>").size(11.0).color(colors.fg2)).frame(false))
         .on_hover_text("Expand sidebar")
@@ -225,17 +223,11 @@ fn collapsed_step_badge(
     let step = entry.step;
     let is_active = state.guided_step == step;
     let is_complete = step_is_complete(step, state);
-    let display_num = state.step_display_number(step);
     let sub = step_subtitle(step, state);
     let tooltip = if sub.is_empty() {
         step.label().to_string()
     } else {
         format!("{}\n{}", step.label(), sub)
-    };
-
-    let badge_text = match display_num {
-        Some(n) => n.to_string(),
-        None => "\u{2014}".to_string(),
     };
 
     let row_fill = if is_active {
@@ -253,6 +245,7 @@ fn collapsed_step_badge(
             ui.with_layout(Layout::top_down(Align::Center), |ui| {
                 let (rect, _) = ui.allocate_exact_size(egui::vec2(20.0, 20.0), Sense::hover());
                 let center = rect.center();
+                let icon = step_icon(step);
 
                 if is_active {
                     ui.painter()
@@ -260,7 +253,7 @@ fn collapsed_step_badge(
                     ui.painter().text(
                         center,
                         egui::Align2::CENTER_CENTER,
-                        &badge_text,
+                        icon,
                         egui::FontId::proportional(11.0),
                         Color32::WHITE,
                     );
@@ -269,18 +262,17 @@ fn collapsed_step_badge(
                     ui.painter().text(
                         center,
                         egui::Align2::CENTER_CENTER,
-                        "\u{2713}",
+                        icon,
                         egui::FontId::proportional(11.0),
                         Color32::WHITE,
                     );
                 } else {
-                    ui.painter().circle_filled(center, 10.0, colors.bg3);
                     ui.painter()
                         .circle_stroke(center, 10.0, Stroke::new(1.0, colors.border));
                     ui.painter().text(
                         center,
                         egui::Align2::CENTER_CENTER,
-                        &badge_text,
+                        icon,
                         egui::FontId::proportional(11.0),
                         colors.fg3,
                     );
@@ -350,6 +342,21 @@ fn collapsed_tool_badge(
     resp.on_hover_text(title);
 }
 
+fn step_icon(step: GuidedStep) -> &'static str {
+    match step {
+        GuidedStep::Configure => "\u{2699}",
+        GuidedStep::Load => "\u{21E9}",
+        GuidedStep::Bin => "\u{25A6}",
+        GuidedStep::Rebin => "\u{21C4}",
+        GuidedStep::Normalize => "\u{25D2}",
+        GuidedStep::Analyze => "\u{25CE}",
+        GuidedStep::Results => "\u{25A3}",
+        GuidedStep::Landing | GuidedStep::Wizard => "\u{25CB}",
+        GuidedStep::ForwardModel => "\u{21D2}",
+        GuidedStep::Detectability => "\u{2605}",
+    }
+}
+
 /// Render the provenance history popup window (call from top-level update).
 pub fn history_window(ctx: &egui::Context, state: &mut AppState) {
     if !state.show_history_window || state.provenance_log.is_empty() {
@@ -417,7 +424,6 @@ fn pipeline_step_row(
     let step = entry.step;
     let is_active = state.guided_step == step;
     let is_complete = step_is_complete(step, state);
-    let display_num = state.step_display_number(step);
 
     let row_fill = if is_active {
         colors.accent
@@ -433,15 +439,10 @@ fn pipeline_step_row(
             ui.horizontal(|ui| {
                 ui.spacing_mut().item_spacing.x = 8.0;
 
-                // Number badge (20×20)
+                // Step badge (20×20)
                 let (rect, _) = ui.allocate_exact_size(egui::vec2(20.0, 20.0), Sense::hover());
                 let center = rect.center();
-
-                // Badge text: number for required, "—" for optional
-                let badge_text = match display_num {
-                    Some(n) => n.to_string(),
-                    None => "\u{2014}".to_string(), // em dash
-                };
+                let icon = step_icon(step);
 
                 if is_active {
                     ui.painter()
@@ -449,7 +450,7 @@ fn pipeline_step_row(
                     ui.painter().text(
                         center,
                         egui::Align2::CENTER_CENTER,
-                        &badge_text,
+                        icon,
                         egui::FontId::proportional(11.0),
                         Color32::WHITE,
                     );
@@ -458,19 +459,18 @@ fn pipeline_step_row(
                     ui.painter().text(
                         center,
                         egui::Align2::CENTER_CENTER,
-                        "\u{2713}",
+                        icon,
                         egui::FontId::proportional(11.0),
                         Color32::WHITE,
                     );
                 } else {
-                    // Pending: bg3 fill + border
-                    ui.painter().circle_filled(center, 10.0, colors.bg3);
+                    // Pending: outlined icon, not a filled status dot.
                     ui.painter()
                         .circle_stroke(center, 10.0, Stroke::new(1.0, colors.border));
                     ui.painter().text(
                         center,
                         egui::Align2::CENTER_CENTER,
-                        &badge_text,
+                        icon,
                         egui::FontId::proportional(11.0),
                         colors.fg3,
                     );

--- a/apps/gui/src/guided/sidebar.rs
+++ b/apps/gui/src/guided/sidebar.rs
@@ -7,8 +7,13 @@ use egui::{Align, Color32, CornerRadius, Layout, Margin, RichText, Sense, Stroke
 /// Render the guided mode sidebar with step navigation.
 pub fn guided_sidebar(ctx: &egui::Context, state: &mut AppState) {
     let colors = ThemeColors::from_ctx(ctx);
-    let panel_width = if state.sidebar_collapsed { 56.0 } else { 240.0 };
-    let margin = if state.sidebar_collapsed {
+    let force_compact = state.guided_step == GuidedStep::Analyze;
+    let panel_width = if state.sidebar_collapsed || force_compact {
+        56.0
+    } else {
+        240.0
+    };
+    let margin = if state.sidebar_collapsed || force_compact {
         Margin::symmetric(4, 12)
     } else {
         Margin::symmetric(12, 16)
@@ -24,8 +29,8 @@ pub fn guided_sidebar(ctx: &egui::Context, state: &mut AppState) {
                 .stroke(Stroke::new(1.0, colors.border)),
         )
         .show(ctx, |ui| {
-            if state.sidebar_collapsed {
-                collapsed_sidebar(ui, state, &colors);
+            if state.sidebar_collapsed || force_compact {
+                collapsed_sidebar(ui, state, &colors, force_compact);
             } else {
                 expanded_sidebar(ui, state, &colors);
             }
@@ -33,9 +38,17 @@ pub fn guided_sidebar(ctx: &egui::Context, state: &mut AppState) {
 }
 
 /// Collapsed sidebar: toggle button + badge-only step rows with tooltips.
-fn collapsed_sidebar(ui: &mut egui::Ui, state: &mut AppState, colors: &ThemeColors) {
+fn collapsed_sidebar(
+    ui: &mut egui::Ui,
+    state: &mut AppState,
+    colors: &ThemeColors,
+    force_compact: bool,
+) {
     // Expand toggle
-    if ui
+    if force_compact {
+        ui.label(RichText::new(">>").size(11.0).color(colors.fg3))
+            .on_hover_text("Analyze uses the compact sidebar");
+    } else if ui
         .add(egui::Button::new(RichText::new(">>").size(11.0).color(colors.fg2)).frame(false))
         .on_hover_text("Expand sidebar")
         .clicked()

--- a/apps/gui/src/state.rs
+++ b/apps/gui/src/state.rs
@@ -775,6 +775,8 @@ pub struct AppState {
     pub fitting_rois: Vec<RoiSelection>,
     /// Toggle: show provenance history popup window.
     pub show_history_window: bool,
+    /// Toggle: show the on-demand Analyze fit-details drawer.
+    pub show_analyze_fit_info: bool,
 
     // -- Results --
     pub pixel_fit_result: Option<SpectrumFitResult>,
@@ -1478,6 +1480,7 @@ impl Default for AppState {
             selected_roi: None,
             fitting_rois: Vec::new(),
             show_history_window: false,
+            show_analyze_fit_info: false,
 
             pixel_fit_result: None,
             fit_result_gen: 0,

--- a/apps/gui/src/state.rs
+++ b/apps/gui/src/state.rs
@@ -777,6 +777,13 @@ pub struct AppState {
     pub show_history_window: bool,
     /// Toggle: show the on-demand Analyze fit-details drawer.
     pub show_analyze_fit_info: bool,
+    /// Toggle: show the Analyze isotope tick-strip picker popover.
+    pub show_isotope_track_picker: bool,
+    /// Per-`(z, a)` set of isotope tick strips the user has hidden via the
+    /// picker. Hidden tracks are still part of the fit; only the diagnostic
+    /// strip is suppressed so the visible track list stays focused when many
+    /// isotopes are loaded.
+    pub hidden_isotope_tracks: std::collections::HashSet<(u32, u32)>,
 
     // -- Results --
     pub pixel_fit_result: Option<SpectrumFitResult>,
@@ -1481,6 +1488,8 @@ impl Default for AppState {
             fitting_rois: Vec::new(),
             show_history_window: false,
             show_analyze_fit_info: false,
+            show_isotope_track_picker: false,
+            hidden_isotope_tracks: std::collections::HashSet::new(),
 
             pixel_fit_result: None,
             fit_result_gen: 0,

--- a/apps/gui/src/widgets/design.rs
+++ b/apps/gui/src/widgets/design.rs
@@ -958,6 +958,69 @@ pub(crate) fn draw_resonance_dips(
     }
 }
 
+/// Convert a resonance energy (eV) into the spectrum's active x-axis units.
+///
+/// Returns `None` when the conversion is undefined (TOF axis with non-positive
+/// energy or a missing flight path). Mirrors the energy→TOF transform used in
+/// [`build_spectrum_x_axis`] so tick positions in the per-isotope strips align
+/// pixel-for-pixel with the main spectrum's resonance dips.
+pub(crate) fn resonance_energy_to_axis(
+    energy_ev: f64,
+    axis: SpectrumAxis,
+    flight_path_m: f64,
+    delay_us: f64,
+) -> Option<f64> {
+    match axis {
+        SpectrumAxis::EnergyEv => Some(energy_ev),
+        SpectrumAxis::TofMicroseconds => {
+            if energy_ev > 0.0 && flight_path_m.is_finite() && flight_path_m > 0.0 {
+                Some(nereids_core::constants::energy_to_tof(energy_ev, flight_path_m) + delay_us)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+/// Render one isotope's resolved-resonance positions as tick marks inside a
+/// linked-axis strip plot. Resolves `(z, a)` colour via [`isotope_dot_color`]
+/// at the call site; this helper just iterates the resonance tree, converts
+/// each energy to the active axis units, culls to the visible x-window, and
+/// emits one `VLine` per in-range tick.
+///
+/// Used by the GSAS-II-style per-isotope tick-marks panel ([analyze.rs])
+/// to attribute each spectrum dip to a specific isotope. URR ranges are
+/// skipped (no per-resonance grid, only bounds).
+pub(crate) fn draw_isotope_tick_strip(
+    plot_ui: &mut egui_plot::PlotUi,
+    resonance_data: &nereids_endf::resonance::ResonanceData,
+    axis: SpectrumAxis,
+    flight_path_m: f64,
+    delay_us: f64,
+    color: Color32,
+) {
+    let bounds = plot_ui.transform().bounds();
+    let (x_lo, x_hi) = (bounds.min()[0], bounds.max()[0]);
+    // Plot bounds can be inverted/empty on the very first frame before egui
+    // has laid out the linked-axis group; bail to avoid plotting garbage.
+    if !x_lo.is_finite() || !x_hi.is_finite() || x_lo >= x_hi {
+        return;
+    }
+    for range in resonance_data.ranges.iter().filter(|r| r.resolved) {
+        for lg in &range.l_groups {
+            for res in &lg.resonances {
+                let Some(x) = resonance_energy_to_axis(res.energy, axis, flight_path_m, delay_us)
+                else {
+                    continue;
+                };
+                if x >= x_lo && x <= x_hi {
+                    plot_ui.vline(VLine::new("", x).color(color).width(1.0));
+                }
+            }
+        }
+    }
+}
+
 /// Parameters for building a fit overlay line.
 pub(crate) struct FitLineParams<'a> {
     pub result: &'a nereids_pipeline::pipeline::SpectrumFitResult,

--- a/apps/gui/src/widgets/design.rs
+++ b/apps/gui/src/widgets/design.rs
@@ -960,21 +960,38 @@ pub(crate) fn draw_resonance_dips(
 
 /// Convert a resonance energy (eV) into the spectrum's active x-axis units.
 ///
-/// Returns `None` when the conversion is undefined (TOF axis with non-positive
-/// energy or a missing flight path). Mirrors the energy→TOF transform used in
-/// [`build_spectrum_x_axis`] so tick positions in the per-isotope strips align
-/// pixel-for-pixel with the main spectrum's resonance dips.
+/// Mirrors the energy→TOF transform in [`build_spectrum_x_axis`] **including
+/// the fallback branch**: when the TOF axis is selected but `flight_path_m`
+/// is invalid (zero, negative, or non-finite), `build_spectrum_x_axis` falls
+/// back to plotting energy values whenever the input data is in `EnergyEv`
+/// units (and silently relabels the axis). To keep tick positions aligned
+/// with the actual rendered x-axis in that fallback case, this helper does
+/// the same — returns `Some(energy_ev)` when the TOF conversion is undefined
+/// AND the spectrum input is energy-valued.
+///
+/// Returns `None` only when no axis position can be derived: TOF axis with
+/// invalid `flight_path_m` AND spectrum input is already in TOF units (in
+/// which case the spectrum cannot be aligned with energy-input resonances
+/// without a flight path).
 pub(crate) fn resonance_energy_to_axis(
     energy_ev: f64,
     axis: SpectrumAxis,
+    spectrum_unit: SpectrumUnit,
     flight_path_m: f64,
     delay_us: f64,
 ) -> Option<f64> {
     match axis {
         SpectrumAxis::EnergyEv => Some(energy_ev),
         SpectrumAxis::TofMicroseconds => {
-            if energy_ev > 0.0 && flight_path_m.is_finite() && flight_path_m > 0.0 {
+            let can_convert = energy_ev > 0.0 && flight_path_m.is_finite() && flight_path_m > 0.0;
+            if can_convert {
                 Some(nereids_core::constants::energy_to_tof(energy_ev, flight_path_m) + delay_us)
+            } else if matches!(spectrum_unit, SpectrumUnit::EnergyEv) {
+                // Mirror `build_spectrum_x_axis` fallback: when TOF
+                // conversion is unavailable but input is energy-valued,
+                // the spectrum falls back to plotting energy. Strips
+                // need to do the same to stay aligned.
+                Some(energy_ev)
             } else {
                 None
             }

--- a/apps/gui/src/widgets/design.rs
+++ b/apps/gui/src/widgets/design.rs
@@ -982,45 +982,6 @@ pub(crate) fn resonance_energy_to_axis(
     }
 }
 
-/// Render one isotope's resolved-resonance positions as tick marks inside a
-/// linked-axis strip plot. Resolves `(z, a)` colour via [`isotope_dot_color`]
-/// at the call site; this helper just iterates the resonance tree, converts
-/// each energy to the active axis units, culls to the visible x-window, and
-/// emits one `VLine` per in-range tick.
-///
-/// Used by the GSAS-II-style per-isotope tick-marks panel ([analyze.rs])
-/// to attribute each spectrum dip to a specific isotope. URR ranges are
-/// skipped (no per-resonance grid, only bounds).
-pub(crate) fn draw_isotope_tick_strip(
-    plot_ui: &mut egui_plot::PlotUi,
-    resonance_data: &nereids_endf::resonance::ResonanceData,
-    axis: SpectrumAxis,
-    flight_path_m: f64,
-    delay_us: f64,
-    color: Color32,
-) {
-    let bounds = plot_ui.transform().bounds();
-    let (x_lo, x_hi) = (bounds.min()[0], bounds.max()[0]);
-    // Plot bounds can be inverted/empty on the very first frame before egui
-    // has laid out the linked-axis group; bail to avoid plotting garbage.
-    if !x_lo.is_finite() || !x_hi.is_finite() || x_lo >= x_hi {
-        return;
-    }
-    for range in resonance_data.ranges.iter().filter(|r| r.resolved) {
-        for lg in &range.l_groups {
-            for res in &lg.resonances {
-                let Some(x) = resonance_energy_to_axis(res.energy, axis, flight_path_m, delay_us)
-                else {
-                    continue;
-                };
-                if x >= x_lo && x <= x_hi {
-                    plot_ui.vline(VLine::new("", x).color(color).width(1.0));
-                }
-            }
-        }
-    }
-}
-
 /// Parameters for building a fit overlay line.
 pub(crate) struct FitLineParams<'a> {
     pub result: &'a nereids_pipeline::pipeline::SpectrumFitResult,
@@ -1082,7 +1043,11 @@ pub(crate) fn build_fit_line(p: &FitLineParams<'_>) -> Option<Line<'static>> {
             [p.x_values[i], y]
         })
         .collect();
-    Some(Line::new("Fit", fit_points).width(2.0))
+    Some(
+        Line::new("Fit", fit_points)
+            .width(1.25)
+            .color(egui::Color32::from_rgba_unmultiplied(0, 122, 255, 170)),
+    )
 }
 
 // ── Resonance Data Collection ──────────────────────────────────

--- a/apps/gui/src/widgets/image_view.rs
+++ b/apps/gui/src/widgets/image_view.rs
@@ -37,6 +37,8 @@ pub enum RoiEditorResult {
     DrawnNew(RoiSelection),
     /// User finished moving an existing ROI to a new position.
     Moved { index: usize, new_roi: RoiSelection },
+    /// User is moving an existing ROI; update dependent views without logging.
+    Moving { index: usize, new_roi: RoiSelection },
     /// User clicked on an existing ROI to select it.
     Selected(usize),
     /// User clicked on empty space, deselecting the current ROI.
@@ -239,10 +241,16 @@ pub fn show_image_with_roi_editor(
                     orig,
                     grab_y,
                     grab_x,
-                    ..
+                    index,
                 } => {
                     let moved = move_roi(&orig, grab_y, grab_x, cy, cx, dims);
                     draw_roi_draft_overlay(&painter, image_rect, dims, &moved);
+                    if moved.y_end > moved.y_start && moved.x_end > moved.x_start {
+                        result = RoiEditorResult::Moving {
+                            index,
+                            new_roi: moved,
+                        };
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #510.

Adds a GSAS-II-style stacked-subplot view below the spectrum: one short tick-mark strip per loaded isotope, color-keyed to match the isotope chips elsewhere in the UI. Strips share the spectrum's x-axis via egui_plot's `link_axis`, so panning or zooming the spectrum moves all strip ticks in lockstep.

## Why

When a residual feature appears in the Analyze step's spectrum, the existing UI offers no way to attribute the dip to a specific isotope — the on-main-plot resonance overlay is monochrome (`draw_resonance_dips`, single `RESONANCE_DIP_COLOR`). A stakeholder cited the GSAS-II diffraction viewer as the target visual: spectrum on top, per-phase tick rows below. Same idea, swap "phase" for "isotope".

## Design choices (user-confirmed during planning)

- **Stacked subplots, not overlay band** — true GSAS-II fidelity.
- **Resolved-resonance positions only** — URR exposes only `energy_low`/`energy_high` bounds in `ResonanceData`, not a per-resonance grid; ticks denote real dips.
- **Render-time bounds culling** via `PlotUi::transform().bounds()` so U-238 (~3,345 resolved resonances) pans/zooms smoothly. First-frame inverted bounds are skipped to avoid a flash of garbage on initial render.

## What's added

**`apps/gui/src/widgets/design.rs`:**

- `resonance_energy_to_axis(energy_ev, axis, flight_path_m, delay_us) -> Option<f64>` — mirrors the energy→TOF transform [build_spectrum_x_axis](apps/gui/src/widgets/design.rs#L853) uses, so tick positions in the strips align pixel-for-pixel with the main plot in both axis modes.
- `draw_isotope_tick_strip(plot_ui, resonance_data, axis, flight_path, delay, color)` — iterates resolved resonances, converts each energy to the active axis, culls to the visible x-window, emits one `VLine` per in-range tick.

**`apps/gui/src/guided/analyze.rs` (`spectrum_panel`):**

- Counts visible isotopes and reserves `n_strips × 18px + 4px` from the spectrum panel's height budget.
- Adds `link_axis(\"analyze_xaxis\", [true, false])` to the main `Plot::new(\"spectrum_plot\")`.
- Renders per-isotope strips inside a `ScrollArea::vertical().max_height(...)` capped at 6 visible strips.
- Each strip is a `Plot` with axes/grid/zoom/drag/scroll all disabled — interactivity stays on the main plot only.
- Strips honour the existing `state.show_resonance_dips` toggle so a single user action turns ALL resonance indicators on or off.

## Backward compat preserved

The existing on-main-plot `draw_resonance_dips` overlay is **unchanged**. The strips are an *additional* channel, not a replacement. A follow-up can decide whether to retire the on-main overlay once users see strips in practice.

## Out of scope (per #510)

- Click-to-highlight tick → resonance row table cross-link
- Per-resonance Γ_n / Γ_γ width glyphs on ticks
- URR-region depiction beyond resolved resonances
- Smart tick declutter at low zoom (clustering nearby resonances)
- Residual-band integration below the bottom strip

## Validation

- `cargo fmt --all` — clean
- `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings` — clean
- `cargo test --workspace --exclude nereids-python` — 729 tests pass
- **Manual UI smoke is reviewer-side.** There's no automated test scaffolding for egui interactions and the visual outcome (strip alignment, tick density at U-238 scale, axis-mode switching, scroll cap at >6 isotopes) can't be validated from CLI.

## Recommended reviewer smoke test

1. `pixi run build` and launch the GUI.
2. Configure step → load 4 Hf isotopes (Hf-176, 177, 178, 180).
3. Analyze step → confirm 4 tick strips render below the spectrum, color-keyed to their symbols (use `isotope_dot_color`'s deterministic hash → HSL).
4. Pan/zoom on the main spectrum → confirm all strips track in real time.
5. Toggle x-axis between Energy and TOF → confirm tick positions in strips remain at the correct converted positions.
6. Add U-238 to the isotope list → confirm rendering stays smooth (3,345 resonances → bounds-culling test).
7. Add 8+ isotopes → confirm the strip area scrolls vertically.
8. Run a fit → confirm strips don't disappear or get re-laid-out.
9. Toggle the **Resonances** checkbox off → confirm BOTH the on-main-plot overlay AND the strip area disappear together.

## Test plan checklist

- [ ] CI: cargo fmt, clippy, test
- [ ] Manual smoke per steps above
- [ ] Phase A self-audit + Phase B Copilot review via `/review-pipeline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)