### PR TITLE
feat(fitting): SAMMY REGION-equivalent fit-energy-range (#514)

### DIFF
--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -2007,6 +2007,57 @@ fn build_fit_config(state: &AppState) -> Result<(UnifiedFitConfig, Range<usize>)
         .as_ref()
         .ok_or_else(|| "No energy grid loaded".to_string())?;
 
+    // Validate that all loaded data cubes' spectral (axis-0) length
+    // matches the energy grid before any caller slices into them with
+    // the `energy_range` returned below.  A project-load mismatch (or
+    // a stale energy axis after re-normalising) would otherwise panic
+    // via out-of-bounds when `fit_pixel` / `fit_roi` / `run_spatial_map`
+    // index `data[[e, y, x]]` for `e >= shape[0]`.  This belongs in
+    // `build_fit_config` so all three call sites benefit (#514).
+    let n_energies = full_energies.len();
+    if let Some(norm) = state.normalized.as_ref() {
+        let shape = norm.transmission.shape();
+        if shape[0] != n_energies {
+            return Err(format!(
+                "Energy grid length ({n_energies}) does not match the loaded \
+                 transmission cube spectral axis ({}). Reload the project or \
+                 normalize again.",
+                shape[0]
+            ));
+        }
+        let unc_shape = norm.uncertainty.shape();
+        if unc_shape[0] != n_energies {
+            return Err(format!(
+                "Energy grid length ({n_energies}) does not match the loaded \
+                 transmission-uncertainty cube spectral axis ({}). Reload the \
+                 project or normalize again.",
+                unc_shape[0]
+            ));
+        }
+    }
+    if let Some(sample) = state.sample_data.as_ref() {
+        let shape = sample.shape();
+        if shape[0] != n_energies {
+            return Err(format!(
+                "Energy grid length ({n_energies}) does not match the loaded \
+                 sample-counts cube spectral axis ({}). Reload the project or \
+                 normalize again.",
+                shape[0]
+            ));
+        }
+    }
+    if let Some(open_beam) = state.open_beam_data.as_ref() {
+        let shape = open_beam.shape();
+        if shape[0] != n_energies {
+            return Err(format!(
+                "Energy grid length ({n_energies}) does not match the loaded \
+                 open-beam-counts cube spectral axis ({}). Reload the project \
+                 or normalize again.",
+                shape[0]
+            ));
+        }
+    }
+
     // Resolve the fit-energy-range slice.  When `state.fit_energy_range`
     // is `None`, we slice the entire grid (no behavioural change).
     // Otherwise we extend the active `[E_min, E_max]` by a kernel-FWHM
@@ -2198,8 +2249,12 @@ fn build_fit_config(state: &AppState) -> Result<(UnifiedFitConfig, Range<usize>)
     // Attach the user-specified fit-energy range (provenance + solver
     // mask).  The pipeline / solver paths build a per-bin active mask
     // from this `[E_min, E_max]` against the (already margin-extended)
-    // `energies` grid stored above (#514).
-    config = config.with_fit_energy_range(state.fit_energy_range);
+    // `energies` grid stored above (#514).  `with_fit_energy_range` is
+    // fallible: non-finite or reversed bounds are rejected here rather
+    // than silently producing an empty mask downstream.
+    config = config
+        .with_fit_energy_range(state.fit_energy_range)
+        .map_err(|e| format!("Config validation error: {e}"))?;
 
     Ok((config, energy_range))
 }

--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -1914,27 +1914,33 @@ fn fit_results_panel(ui: &mut egui::Ui, state: &AppState, result: &SpectrumFitRe
 // ---- Fit Helpers ----
 
 /// Number of resolution-FWHM widths to extend the fit-energy-range
-/// slice on each side as a "kernel margin".  SAMMY user manual §IIID.6
-/// (REGION) recommends 3–5×FWHM; we pick 5× for safety so resonance
-/// shoulders just inside the boundaries are correctly broadened.
+/// slice on each side as a "kernel margin" for **Gaussian** resolution.
+/// SAMMY user manual §IIID.6 (REGION) recommends 3–5×FWHM; we pick 5×
+/// for safety so resonance shoulders just inside the boundaries are
+/// correctly broadened.  At 5×FWHM ≈ 5.9σ the Gaussian kernel is below
+/// 10⁻¹³ of peak — well past the broadening footprint.
 const FIT_RANGE_MARGIN_FWHM: f64 = 5.0;
-
-/// Tabulated-resolution fallback fractional kernel width.  The
-/// `TabulatedResolution` type does not expose an in-eV FWHM accessor
-/// (its kernels are TOF-domain), so we fall back to a conservative
-/// fraction of the boundary energy.  Typical neutron-imaging tabulated
-/// resolution is well under 1% FWHM, so 10% × `FIT_RANGE_MARGIN_FWHM`
-/// covers the broadening footprint with a wide safety factor.
-const TABULATED_FRACTIONAL_FALLBACK: f64 = 0.1;
 
 /// Resolution-kernel margin (eV) to add at energy `e_ev` when slicing
 /// for the fit-energy-range filter (SAMMY REGION-equivalent, #514).
-/// Returns `0.0` when no resolution is configured.
+///
+/// - **None**: no resolution → no broadening footprint → `0.0`.
+/// - **Gaussian**: extend by `FIT_RANGE_MARGIN_FWHM × FWHM(E)`.  The
+///   kernel has infinite tails; 5×FWHM puts the residual amplitude
+///   below 10⁻¹³ of peak.
+/// - **Tabulated**: use `TabulatedResolution::kernel_support_ev(E)`,
+///   the eV distance over which the discrete kernel has positive
+///   weight at `E`.  Past this distance the kernel is exactly zero,
+///   so 1× the support fully captures the broadening footprint — no
+///   safety multiplier needed.  The support is computed from the
+///   actual kernel offsets via the chain-rule TOF→eV conversion (see
+///   `TabulatedResolution::kernel_support_ev`), so the margin tracks
+///   the loaded resolution file rather than a hand-picked constant.
 fn kernel_margin_ev(e_ev: f64, resolution: Option<&ResolutionFunction>) -> f64 {
     match resolution {
         None => 0.0,
         Some(ResolutionFunction::Gaussian(p)) => FIT_RANGE_MARGIN_FWHM * p.fwhm(e_ev),
-        Some(ResolutionFunction::Tabulated(_)) => TABULATED_FRACTIONAL_FALLBACK * e_ev.abs(),
+        Some(ResolutionFunction::Tabulated(t)) => t.kernel_support_ev(e_ev),
     }
 }
 

--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -15,10 +15,12 @@ use crate::widgets::image_view::{
     show_viridis_image_with_roi,
 };
 use egui_plot::{Corner, Line, Plot, PlotPoints, PlotTransform, Points, VLine};
-use ndarray::Axis;
+use ndarray::{Axis, s};
+use nereids_physics::resolution::ResolutionFunction;
 use nereids_pipeline::pipeline::{
     BackgroundConfig, InputData, SolverConfig, SpectrumFitResult, UnifiedFitConfig,
 };
+use std::ops::Range;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
@@ -237,6 +239,7 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState, available_height_hint: 
         let prev_kl_polish = state.kl_enable_polish_override;
         let prev_fit_temperature = state.fit_temperature;
         let prev_fit_energy_scale = state.fit_energy_scale;
+        let prev_fit_energy_range = state.fit_energy_range;
         let prev_lm_background_enabled = state.lm_background_enabled;
         let prev_compute_covariance = state.lm_config.compute_covariance;
         let prev_tol_param = state.lm_config.tol_param;
@@ -274,6 +277,56 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState, available_height_hint: 
                  \u{03BC}s, L_scale \u{2208} [0.99, 1.01].  Mutually \
                  exclusive with Fit temperature.",
                 );
+                // SAMMY REGION-equivalent fit-energy-range restriction (#514).
+                // The checkbox toggles the `Option<(f64, f64)>` state field;
+                // toggling on initialises from the current full grid bounds
+                // so the user can narrow incrementally.  When set, the
+                // pipeline slices the data with a 5×FWHM kernel margin and
+                // the solvers mask residuals to the user's `[min, max]`.
+                let mut restrict_enabled = state.fit_energy_range.is_some();
+                let cb = ui
+                    .checkbox(
+                        &mut restrict_enabled,
+                        "Restrict fit energy range (SAMMY REGION)",
+                    )
+                    .on_hover_text(
+                        "Restrict the cost function to bins inside [min, max] eV \
+                         (SAMMY REGION / `MIN ENERGY` / `MAX ENERGY` cards).  \
+                         The resolution-kernel margin (~5×FWHM beyond each \
+                         boundary) is applied automatically so resonances \
+                         near the boundaries remain correctly broadened.  \
+                         Default: full grid.",
+                    );
+                if cb.changed() {
+                    state.fit_energy_range = if restrict_enabled {
+                        // Seed at the full-grid bounds so the user narrows
+                        // from there; if no grid is loaded, leave None
+                        // (the checkbox flips back when the seed fails).
+                        state
+                            .energies
+                            .as_ref()
+                            .and_then(|e| (e.len() >= 2).then_some((e[0], e[e.len() - 1])))
+                    } else {
+                        None
+                    };
+                }
+                if let Some((mut min_ev, mut max_ev)) = state.fit_energy_range {
+                    ui.horizontal(|ui| {
+                        ui.label("Min (eV):");
+                        ui.add(
+                            egui::DragValue::new(&mut min_ev)
+                                .speed(0.01)
+                                .range(0.0..=f64::INFINITY),
+                        );
+                        ui.label("Max (eV):");
+                        ui.add(
+                            egui::DragValue::new(&mut max_ev)
+                                .speed(0.01)
+                                .range(0.0..=f64::INFINITY),
+                        );
+                    });
+                    state.fit_energy_range = Some((min_ev, max_ev));
+                }
                 if matches!(state.solver_method, SolverMethod::LevenbergMarquardt) {
                     ui.checkbox(
                         &mut state.lm_background_enabled,
@@ -377,6 +430,7 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState, available_height_hint: 
             || state.kl_enable_polish_override != prev_kl_polish
             || state.fit_temperature != prev_fit_temperature
             || state.fit_energy_scale != prev_fit_energy_scale
+            || state.fit_energy_range != prev_fit_energy_range
             || state.lm_background_enabled != prev_lm_background_enabled
             || state.lm_config.compute_covariance != prev_compute_covariance
             || state.lm_config.tol_param.to_bits() != prev_tol_param.to_bits()
@@ -1526,6 +1580,20 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
                         .style(egui_plot::LineStyle::dashed_dense()),
                 );
             }
+
+            // SAMMY REGION fit-energy-range guides (#514).  Only render
+            // on the energy axis — the bounds are stored in eV and the
+            // TOF projection would require an extra energy↔TOF
+            // conversion for marginal user value.  Users can toggle to
+            // the eV axis to see the markers.
+            if state.analyze_spectrum_axis == SpectrumAxis::EnergyEv
+                && let Some((min_ev, max_ev)) = state.fit_energy_range
+            {
+                let style = egui_plot::LineStyle::dashed_dense();
+                let colour = egui::Color32::from_rgb(160, 160, 160);
+                plot_ui.vline(VLine::new("Fit min", min_ev).color(colour).style(style));
+                plot_ui.vline(VLine::new("Fit max", max_ev).color(colour).style(style));
+            }
         });
 
     // Tick strips below the main plot.  Render up to `MAX_VISIBLE_STRIPS`
@@ -1845,12 +1913,118 @@ fn fit_results_panel(ui: &mut egui::Ui, state: &AppState, result: &SpectrumFitRe
 
 // ---- Fit Helpers ----
 
-fn build_fit_config(state: &AppState) -> Result<UnifiedFitConfig, String> {
-    let energies = state
+/// Number of resolution-FWHM widths to extend the fit-energy-range
+/// slice on each side as a "kernel margin".  SAMMY user manual §IIID.6
+/// (REGION) recommends 3–5×FWHM; we pick 5× for safety so resonance
+/// shoulders just inside the boundaries are correctly broadened.
+const FIT_RANGE_MARGIN_FWHM: f64 = 5.0;
+
+/// Tabulated-resolution fallback fractional kernel width.  The
+/// `TabulatedResolution` type does not expose an in-eV FWHM accessor
+/// (its kernels are TOF-domain), so we fall back to a conservative
+/// fraction of the boundary energy.  Typical neutron-imaging tabulated
+/// resolution is well under 1% FWHM, so 10% × `FIT_RANGE_MARGIN_FWHM`
+/// covers the broadening footprint with a wide safety factor.
+const TABULATED_FRACTIONAL_FALLBACK: f64 = 0.1;
+
+/// Resolution-kernel margin (eV) to add at energy `e_ev` when slicing
+/// for the fit-energy-range filter (SAMMY REGION-equivalent, #514).
+/// Returns `0.0` when no resolution is configured.
+fn kernel_margin_ev(e_ev: f64, resolution: Option<&ResolutionFunction>) -> f64 {
+    match resolution {
+        None => 0.0,
+        Some(ResolutionFunction::Gaussian(p)) => FIT_RANGE_MARGIN_FWHM * p.fwhm(e_ev),
+        Some(ResolutionFunction::Tabulated(_)) => TABULATED_FRACTIONAL_FALLBACK * e_ev.abs(),
+    }
+}
+
+/// Compute extended-margin slice indices over `energies` for the
+/// active user-specified fit range `[e_min, e_max]`, applying a
+/// `FIT_RANGE_MARGIN_FWHM`×FWHM kernel margin on each side.  Returns
+/// the half-open `[lo, hi)` index range to apply to the energy grid
+/// and per-bin data arrays before passing to `UnifiedFitConfig`.
+///
+/// Validation:
+/// - `e_min` and `e_max` must be finite and `e_min < e_max`.
+/// - The active region must overlap the loaded grid.
+/// - The resulting slice must contain ≥ 2 bins (otherwise the LM /
+///   joint-Poisson cost paths cannot fit anything).
+fn fit_energy_range_indices(
+    energies: &[f64],
+    range: (f64, f64),
+    resolution: Option<&ResolutionFunction>,
+) -> Result<Range<usize>, String> {
+    let (e_min, e_max) = range;
+    if !e_min.is_finite() || !e_max.is_finite() {
+        return Err("Fit energy range bounds must be finite".into());
+    }
+    if e_min >= e_max {
+        return Err(format!(
+            "Fit energy range min ({e_min} eV) must be less than max ({e_max} eV)"
+        ));
+    }
+    if energies.len() < 2 {
+        return Err("Energy grid must have at least 2 points".into());
+    }
+    let grid_lo = energies[0];
+    let grid_hi = energies[energies.len() - 1];
+    if e_max < grid_lo || e_min > grid_hi {
+        return Err(format!(
+            "Fit energy range [{e_min}, {e_max}] eV does not overlap the loaded grid \
+             [{grid_lo}, {grid_hi}] eV"
+        ));
+    }
+
+    // Boundary-specific kernel margins.  At asymmetric resolution
+    // (timing / flight-path contributions scale differently with E),
+    // FWHM at e_max can be much larger than at e_min, so we compute
+    // each independently rather than using a single global margin.
+    let margin_lo = kernel_margin_ev(e_min, resolution);
+    let margin_hi = kernel_margin_ev(e_max, resolution);
+    let lo_target = e_min - margin_lo;
+    let hi_target = e_max + margin_hi;
+
+    // `partition_point` returns the first index where the predicate is
+    // false; for a sorted ascending grid this is exactly the lower /
+    // upper bracketing index for our half-open range.
+    let lo = energies.partition_point(|&e| e < lo_target);
+    let hi = energies.partition_point(|&e| e <= hi_target);
+    let lo = lo.min(energies.len());
+    let hi = hi.min(energies.len()).max(lo);
+
+    if hi.saturating_sub(lo) < 2 {
+        return Err(format!(
+            "Fit energy range [{e_min}, {e_max}] eV (with {FIT_RANGE_MARGIN_FWHM}×FWHM margin) \
+             yields fewer than 2 bins on the loaded grid"
+        ));
+    }
+    Ok(lo..hi)
+}
+
+fn build_fit_config(state: &AppState) -> Result<(UnifiedFitConfig, Range<usize>), String> {
+    let full_energies = state
         .energies
         .as_ref()
-        .ok_or_else(|| "No energy grid loaded".to_string())?
-        .clone();
+        .ok_or_else(|| "No energy grid loaded".to_string())?;
+
+    // Resolve the fit-energy-range slice.  When `state.fit_energy_range`
+    // is `None`, we slice the entire grid (no behavioural change).
+    // Otherwise we extend the active `[E_min, E_max]` by a kernel-FWHM
+    // margin so resonance broadening at the boundaries remains correct;
+    // the solver cost paths then mask residuals back to the inner
+    // active range (SAMMY REGION semantics, #514).
+    let resolution = design::build_resolution_function(
+        state.resolution_enabled,
+        &state.resolution_mode,
+        state.beamline.flight_path_m,
+    )
+    .map_err(|e| format!("{e} \u{2014} load a resolution file or disable broadening"))?;
+
+    let energy_range: Range<usize> = match state.fit_energy_range {
+        Some(range) => fit_energy_range_indices(full_energies, range, resolution.as_ref())?,
+        None => 0..full_energies.len(),
+    };
+    let energies: Vec<f64> = full_energies[energy_range.clone()].to_vec();
 
     let enabled: Vec<&IsotopeEntry> = state
         .isotope_entries
@@ -1868,13 +2042,6 @@ fn build_fit_config(state: &AppState) -> Result<UnifiedFitConfig, String> {
     if enabled.is_empty() && enabled_groups.is_empty() {
         return Err("No enabled isotopes with resonance data".into());
     }
-
-    let resolution = design::build_resolution_function(
-        state.resolution_enabled,
-        &state.resolution_mode,
-        state.beamline.flight_path_m,
-    )
-    .map_err(|e| format!("{e} \u{2014} load a resolution file or disable broadening"))?;
 
     // When groups are present, use with_groups() to build the config.
     // Individual isotopes are wrapped as single-member groups for uniformity.
@@ -2028,13 +2195,19 @@ fn build_fit_config(state: &AppState) -> Result<UnifiedFitConfig, String> {
         }
     }
 
-    Ok(config)
+    // Attach the user-specified fit-energy range (provenance + solver
+    // mask).  The pipeline / solver paths build a per-bin active mask
+    // from this `[E_min, E_max]` against the (already margin-extended)
+    // `energies` grid stored above (#514).
+    config = config.with_fit_energy_range(state.fit_energy_range);
+
+    Ok((config, energy_range))
 }
 
 fn fit_pixel(state: &mut AppState) {
     state.last_fit_feedback = None;
 
-    let config = match build_fit_config(state) {
+    let (config, energy_range) = match build_fit_config(state) {
         Ok(c) => c,
         Err(e) => {
             state.last_fit_feedback = Some(crate::state::FitFeedback {
@@ -2081,11 +2254,17 @@ fn fit_pixel(state: &mut AppState) {
         return;
     }
 
-    let n_energies = shape[0];
-    let t_spectrum: Vec<f64> = (0..n_energies)
+    // Slice per-bin data to the same `energy_range` produced by
+    // `build_fit_config` (SAMMY REGION-equivalent fit-energy-range
+    // restriction with kernel-margin extension, #514).  When the user
+    // hasn't restricted the range, `energy_range` is `0..n_energies`,
+    // so this is identical to the previous full-grid behaviour.
+    let t_spectrum: Vec<f64> = energy_range
+        .clone()
         .map(|e| norm.transmission[[e, y, x]])
         .collect();
-    let sigma: Vec<f64> = (0..n_energies)
+    let sigma: Vec<f64> = energy_range
+        .clone()
         .map(|e| norm.uncertainty[[e, y, x]].max(1e-10))
         .collect();
 
@@ -2109,8 +2288,9 @@ fn fit_pixel(state: &mut AppState) {
     let input = if use_counts
         && let (Some(sample), Some(open_beam)) = (&state.sample_data, &state.open_beam_data)
     {
-        let sample_counts: Vec<f64> = (0..n_energies).map(|e| sample[[e, y, x]]).collect();
-        let open_beam_counts: Vec<f64> = (0..n_energies).map(|e| open_beam[[e, y, x]]).collect();
+        let sample_counts: Vec<f64> = energy_range.clone().map(|e| sample[[e, y, x]]).collect();
+        let open_beam_counts: Vec<f64> =
+            energy_range.clone().map(|e| open_beam[[e, y, x]]).collect();
         InputData::Counts {
             sample_counts,
             open_beam_counts,
@@ -2172,7 +2352,7 @@ fn fit_pixel(state: &mut AppState) {
 fn fit_roi(state: &mut AppState) {
     state.last_fit_feedback = None;
 
-    let config = match build_fit_config(state) {
+    let (config, energy_range) = match build_fit_config(state) {
         Ok(c) => c,
         Err(e) => {
             state.last_fit_feedback = Some(crate::state::FitFeedback {
@@ -2243,17 +2423,24 @@ fn fit_roi(state: &mut AppState) {
         return;
     }
 
-    // Weighted average transmission and propagated uncertainty
-    let avg_t: Vec<f64> = sum_t
+    // Weighted average transmission and propagated uncertainty.
+    //
+    // We build the full-grid averaged arrays first, then slice to
+    // `energy_range` for the fit (SAMMY REGION-equivalent fit-energy-
+    // range restriction with kernel-margin extension, #514).  The
+    // ROI averaging is unaffected by the slice — it's the same
+    // `n_tof` arithmetic regardless of which bins end up in the fit.
+    let avg_t_full: Vec<f64> = sum_t
         .iter()
         .zip(sum_w.iter())
         .map(|(&s, &w)| if w > 0.0 { s / w } else { 0.0 })
         .collect();
-    // Bins with no valid pixels get negligible weight so the fitter ignores them.
-    let sigma: Vec<f64> = sum_w
+    let sigma_full: Vec<f64> = sum_w
         .iter()
         .map(|&w| if w > 0.0 { 1.0 / w.sqrt() } else { 1.0e30 })
         .collect();
+    let avg_t: Vec<f64> = avg_t_full[energy_range.clone()].to_vec();
+    let sigma: Vec<f64> = sigma_full[energy_range.clone()].to_vec();
 
     let mut enabled_symbols: Vec<String> = state
         .isotope_entries
@@ -2274,7 +2461,10 @@ fn fit_roi(state: &mut AppState) {
     let roi_input = if use_counts
         && let (Some(sample), Some(open_beam)) = (&state.sample_data, &state.open_beam_data)
     {
-        let sample_counts: Vec<f64> = (0..shape[0])
+        // Counts paths slice the energy axis to `energy_range` — same
+        // SAMMY REGION semantics as the LM transmission path above.
+        let sample_counts: Vec<f64> = energy_range
+            .clone()
             .map(|t| {
                 pixels
                     .iter()
@@ -2282,7 +2472,8 @@ fn fit_roi(state: &mut AppState) {
                     .sum::<f64>()
             })
             .collect();
-        let open_beam_counts: Vec<f64> = (0..shape[0])
+        let open_beam_counts: Vec<f64> = energy_range
+            .clone()
             .map(|t| {
                 pixels
                     .iter()
@@ -2351,7 +2542,7 @@ fn fit_roi(state: &mut AppState) {
 pub fn run_spatial_map(state: &mut AppState) {
     state.last_fit_feedback = None;
 
-    let config = match build_fit_config(state) {
+    let (config, energy_range) = match build_fit_config(state) {
         Ok(c) => c,
         Err(e) => {
             state.status_message = e;
@@ -2467,18 +2658,25 @@ pub fn run_spatial_map(state: &mut AppState) {
         // share the global pool with inner physics par_iter calls.
         // Use counts-domain only when the solver is Poisson KL AND both
         // sample and open beam are available. LM always uses Transmission.
+        //
+        // SAMMY REGION-equivalent fit-energy-range restriction (#514):
+        // when `state.fit_energy_range` is set, `build_fit_config` slices
+        // the energy grid to `energy_range` (with kernel-margin extension);
+        // here we slice the per-pixel data views to the same axis-0 range
+        // so the pipeline's shape-validation passes and per-pixel fits see
+        // a grid consistent with the configured `energies`.
         let use_counts = matches!(config.solver(), SolverConfig::PoissonKL(_));
         let input = if use_counts
             && let (Some(sample), Some(open_beam)) = (&sample_data, &open_beam_data)
         {
             nereids_pipeline::spatial::InputData3D::Counts {
-                sample_counts: sample.view(),
-                open_beam_counts: open_beam.view(),
+                sample_counts: sample.slice(s![energy_range.clone(), .., ..]),
+                open_beam_counts: open_beam.slice(s![energy_range.clone(), .., ..]),
             }
         } else {
             nereids_pipeline::spatial::InputData3D::Transmission {
-                transmission: norm.transmission.view(),
-                uncertainty: norm.uncertainty.view(),
+                transmission: norm.transmission.slice(s![energy_range.clone(), .., ..]),
+                uncertainty: norm.uncertainty.slice(s![energy_range.clone(), .., ..]),
             }
         };
         let result = pool.install(|| {

--- a/apps/gui/src/project.rs
+++ b/apps/gui/src/project.rs
@@ -299,6 +299,7 @@ pub fn snapshot_from_state(state: &AppState) -> ProjectSnapshot {
         temperature_k: state.temperature_k,
         fit_temperature: state.fit_temperature,
         fit_energy_scale: Some(state.fit_energy_scale),
+        fit_energy_range: state.fit_energy_range,
         uncertainty_is_estimated: Some(state.uncertainty_is_estimated),
         lm_background_enabled: Some(state.lm_background_enabled),
         kl_background_enabled: Some(state.kl_background_enabled),
@@ -887,6 +888,7 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
     state.temperature_k = snap.temperature_k;
     state.fit_temperature = snap.fit_temperature;
     state.fit_energy_scale = snap.fit_energy_scale.unwrap_or(false);
+    state.fit_energy_range = snap.fit_energy_range;
     state.uncertainty_is_estimated = snap.uncertainty_is_estimated.unwrap_or(false);
     state.lm_background_enabled = snap.lm_background_enabled.unwrap_or(false);
     state.kl_background_enabled = snap.kl_background_enabled.unwrap_or(false);

--- a/apps/gui/src/state.rs
+++ b/apps/gui/src/state.rs
@@ -77,6 +77,10 @@ pub struct SessionCache {
     /// as free parameters.  Mutually exclusive with `fit_temperature`.
     #[serde(default)]
     pub fit_energy_scale: bool,
+    /// Fit energy range restriction (SAMMY REGION equivalent).
+    /// `None` (default) = full grid.
+    #[serde(default)]
+    pub fit_energy_range: Option<(f64, f64)>,
     /// Isotope groups: (z, name, members, density, enabled).
     /// ResonanceData is not serialized — members get Pending status on restore.
     #[serde(default)]
@@ -184,6 +188,7 @@ impl SessionCache {
             kl_c_ratio: state.kl_c_ratio,
             kl_enable_polish_override: state.kl_enable_polish_override,
             fit_energy_scale: state.fit_energy_scale,
+            fit_energy_range: state.fit_energy_range,
             isotope_groups: state
                 .isotope_groups
                 .iter()
@@ -305,6 +310,7 @@ impl SessionCache {
         state.kl_c_ratio = self.kl_c_ratio;
         state.kl_enable_polish_override = self.kl_enable_polish_override;
         state.fit_energy_scale = self.fit_energy_scale;
+        state.fit_energy_range = self.fit_energy_range;
 
         // Rebuild pipeline
         state.rebuild_pipeline();
@@ -737,6 +743,13 @@ pub struct AppState {
     /// represents the residual offset on top of the corrected grid;
     /// `L_scale` multiplies the nominal `flight_path_m`.
     pub fit_energy_scale: bool,
+    /// Restrict the fit to `[min_eV, max_eV]` (SAMMY REGION equivalent,
+    /// SAMMY user manual §IIID.6 / SAM52 `MIN ENERGY` / `MAX ENERGY`).
+    /// `None` = full grid (default).  Both bounds must lie inside the
+    /// loaded energy grid; the resolution-kernel margin (~5×FWHM beyond
+    /// each boundary) is applied automatically in `build_fit_config`
+    /// so resonances near the boundaries are correctly broadened.
+    pub fit_energy_range: Option<(f64, f64)>,
     pub show_advanced_solver: bool,
 
     // -- Uncertainty provenance --
@@ -1475,6 +1488,7 @@ impl Default for AppState {
             solver_method: SolverMethod::PoissonKL,
             fit_temperature: false,
             fit_energy_scale: false,
+            fit_energy_range: None,
             show_advanced_solver: false,
             uncertainty_is_estimated: false,
             lm_background_enabled: false,

--- a/crates/nereids-fitting/src/active_mask.rs
+++ b/crates/nereids-fitting/src/active_mask.rs
@@ -1,0 +1,66 @@
+//! Active-bin masking for fit-energy-range restriction.
+//!
+//! SAMMY REGION equivalent (`MIN ENERGY` / `MAX ENERGY` SAM52 cards).
+//! When a user restricts the fit to `[E_min, E_max]`, the GUI extends
+//! the energy grid by ~5×FWHM beyond each boundary so resonances near
+//! the boundaries are correctly broadened, and the cost-function paths
+//! (LM transmission, joint-Poisson PBD) consult the mask returned here
+//! to skip residual contributions outside `[E_min, E_max]`.
+//!
+//! Returns `None` when no range is set; callers treat that as
+//! "all bins active" (default behaviour).
+
+/// Build a per-bin active mask from the energy grid and an optional
+/// user-specified `[E_min, E_max]` range.  Bin `i` is active iff
+/// `E_min ≤ energies[i] ≤ E_max`.
+///
+/// Returns `None` when `range` is `None` so the caller can short-circuit
+/// the all-active common case without allocating.
+pub fn build_active_mask(energies: &[f64], range: Option<(f64, f64)>) -> Option<Vec<bool>> {
+    let (lo, hi) = range?;
+    Some(energies.iter().map(|&e| e >= lo && e <= hi).collect())
+}
+
+/// Active-bin count for a mask.  `None` = all bins active.
+pub fn active_count(mask: Option<&[bool]>, n_total: usize) -> usize {
+    match mask {
+        Some(m) => m.iter().filter(|&&b| b).count(),
+        None => n_total,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_returns_none_for_full_grid() {
+        let energies = [1.0, 2.0, 3.0];
+        assert!(build_active_mask(&energies, None).is_none());
+    }
+
+    #[test]
+    fn build_marks_bins_inside_range_inclusive() {
+        let energies = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let mask = build_active_mask(&energies, Some((2.0, 4.0))).unwrap();
+        assert_eq!(mask, vec![false, true, true, true, false]);
+    }
+
+    #[test]
+    fn build_handles_empty_active_region() {
+        let energies = [1.0, 2.0, 3.0];
+        let mask = build_active_mask(&energies, Some((10.0, 20.0))).unwrap();
+        assert_eq!(mask, vec![false, false, false]);
+    }
+
+    #[test]
+    fn active_count_with_mask_counts_true_bins() {
+        let mask = [true, false, true, true, false];
+        assert_eq!(active_count(Some(&mask), 5), 3);
+    }
+
+    #[test]
+    fn active_count_without_mask_returns_total() {
+        assert_eq!(active_count(None, 42), 42);
+    }
+}

--- a/crates/nereids-fitting/src/joint_poisson.rs
+++ b/crates/nereids-fitting/src/joint_poisson.rs
@@ -62,9 +62,9 @@ pub struct JointPoissonObjective<'a> {
     pub s: &'a [f64],
     /// Proton-charge ratio `c = Q_s / Q_ob`.  Must be strictly positive.
     pub c: f64,
-    /// Optional per-bin active mask (SAMMY REGION-equivalent fit-energy
-    /// -range restriction).  When `Some(m)`, only bins where `m[i]` is
-    /// `true` contribute to the deviance / gradient / Fisher
+    /// Optional per-bin active mask (SAMMY REGION-equivalent
+    /// fit-energy-range restriction).  When `Some(m)`, only bins where
+    /// `m[i]` is `true` contribute to the deviance / gradient / Fisher
     /// information; the model is still evaluated on the full grid so
     /// resolution broadening at the boundaries is correct.  When
     /// `None`, all bins are active (default behaviour).

--- a/crates/nereids-fitting/src/joint_poisson.rs
+++ b/crates/nereids-fitting/src/joint_poisson.rs
@@ -578,8 +578,17 @@ pub struct JointPoissonResult {
     pub deviance: f64,
     /// D / (n − k).  Primary GOF statistic per memo 35 §P1.2.
     pub deviance_per_dof: f64,
-    /// Number of data bins (n).
+    /// Number of data bins on the configured grid (n).  This is the
+    /// total bin count; when a fit-energy-range mask is in effect, the
+    /// count of bins that actually contributed to the cost function is
+    /// reported separately as [`Self::n_active`].
     pub n_data: usize,
+    /// Number of *active* data bins — equal to `n_data` when no mask is
+    /// set, or the count of `true` entries in the objective's
+    /// `active_mask` otherwise.  The deviance / dof ratio uses
+    /// `(n_active − n_free)` so reduced deviance is unbiased when a
+    /// fit-energy-range mask is in effect (SAMMY REGION semantics, #514).
+    pub n_active: usize,
     /// Number of free parameters (k).
     pub n_free: usize,
     /// Iterations performed in the damped-Fisher stage.
@@ -634,6 +643,48 @@ pub fn joint_poisson_fit(
         return Err(FittingError::EmptyData);
     }
 
+    // Validate active-mask length up-front, mirroring the LM solver's
+    // length-mismatch early-return (#514).  A debug-assert deep in the
+    // deviance routines would silently pass through in release builds
+    // with a length mismatch, causing out-of-bounds index reads when
+    // the masked accumulator iterates `o`/`s`/`mask` together.
+    if let Some(m) = objective.active_mask
+        && m.len() != n_data
+    {
+        return Err(FittingError::LengthMismatch {
+            expected: n_data,
+            actual: m.len(),
+            field: "active_mask",
+        });
+    }
+
+    // Underdetermined-check: when a fit-energy-range mask leaves fewer
+    // active bins than free parameters, the problem is rank-deficient
+    // and any deviance / dof ratio would be deceptive (the previous
+    // `.max(1)` divisor produced a finite-looking deviance-per-dof for
+    // empty / too-narrow masks).  Mirror LM's behaviour at
+    // `lm.rs:578-588`: return a non-converged result up-front, before
+    // wasting cycles on the damped-Fisher stage.
+    let n_free_initial = params.n_free();
+    let n_active_initial = objective.n_active();
+    if n_active_initial < n_free_initial {
+        return Ok(JointPoissonResult {
+            deviance: f64::NAN,
+            deviance_per_dof: f64::NAN,
+            n_data,
+            n_active: n_active_initial,
+            n_free: n_free_initial,
+            gn_iterations: 0,
+            polish_iterations: 0,
+            gn_converged: false,
+            polish_converged: false,
+            polish_improved: false,
+            params: params.all_values(),
+            covariance: None,
+            uncertainties: None,
+        });
+    }
+
     // Stage 1: damped Fisher with Armijo backtracking.
     let stage1 = damped_fisher_stage(objective, params, config)?;
 
@@ -684,10 +735,18 @@ pub fn joint_poisson_fit(
     // Active-bin masking (SAMMY REGION): when a fit-energy-range mask
     // is in effect, dof must use the count of bins that contributed to
     // the deviance — otherwise deviance-per-dof is biased low by the
-    // ratio (n_active / n_data).
+    // ratio (n_active / n_data).  The `n_active < n_free` case has
+    // already been short-circuited above; here `n_active >= n_free`,
+    // so `dof` is non-negative and exactly-determined fits
+    // (`n_active == n_free`) report `deviance_per_dof = NaN` (0/0)
+    // as in LM (`lm.rs:784`).
     let n_active = objective.n_active();
-    let dof = (n_active as isize - n_free as isize).max(1) as f64;
-    let deviance_per_dof = final_deviance / dof;
+    let dof = n_active.saturating_sub(n_free);
+    let deviance_per_dof = if dof > 0 {
+        final_deviance / dof as f64
+    } else {
+        f64::NAN
+    };
 
     // Covariance from inverse Fisher at the final θ.  Uses the analytical
     // Jacobian when the transmission model provides one; otherwise falls
@@ -741,6 +800,7 @@ pub fn joint_poisson_fit(
         deviance: final_deviance,
         deviance_per_dof,
         n_data,
+        n_active,
         n_free,
         gn_iterations,
         polish_iterations,
@@ -1850,5 +1910,85 @@ mod tests {
                 "grad component {i}: masked={gm} subset={gs}"
             );
         }
+    }
+
+    /// `joint_poisson_fit` must reject an underdetermined (n_active <
+    /// n_free) configuration with a non-converged result and NaN
+    /// deviance / per-dof, mirroring the LM solver.  An all-`false`
+    /// active mask is the extreme case (`n_active == 0 < n_free`);
+    /// the prior `.max(1)` divisor produced a deceptive
+    /// finite-looking deviance-per-dof for empty / too-narrow masks.
+    /// Regression for Round-2 review fix #2 (#514).
+    #[test]
+    fn test_joint_poisson_rejects_zero_active_mask() {
+        let n_bins = 10;
+        let o: Vec<f64> = vec![50.0; n_bins];
+        let s: Vec<f64> = vec![25.0; n_bins];
+        let mask = vec![false; n_bins]; // n_active = 0
+        let model = ConstModel { n_e: n_bins };
+        let obj = JointPoissonObjective {
+            model: &model,
+            o: &o,
+            s: &s,
+            c: 1.0,
+            active_mask: Some(&mask),
+        };
+        let mut params = ParameterSet::new(vec![FitParameter::non_negative("T", 0.5)]);
+        let cfg = JointPoissonFitConfig::default();
+        let r = joint_poisson_fit(&obj, &mut params, &cfg).unwrap();
+
+        assert!(
+            !r.gn_converged && !r.polish_converged,
+            "underdetermined fit must report non-converged"
+        );
+        assert!(
+            r.deviance.is_nan(),
+            "underdetermined deviance must be NaN, got {}",
+            r.deviance
+        );
+        assert!(
+            r.deviance_per_dof.is_nan(),
+            "underdetermined deviance-per-dof must be NaN, got {}",
+            r.deviance_per_dof
+        );
+        assert_eq!(r.n_data, n_bins);
+        assert_eq!(r.n_active, 0);
+        assert_eq!(r.n_free, 1);
+        assert!(r.covariance.is_none());
+        assert!(r.uncertainties.is_none());
+    }
+
+    /// `joint_poisson_fit` validates active-mask length up-front and
+    /// returns `LengthMismatch` rather than relying on a debug-assert
+    /// deep in the deviance routines (which silently passes through in
+    /// release builds, then panics on out-of-bounds index reads).
+    /// Regression for Round-2 review fix #5 (#514).
+    #[test]
+    fn test_joint_poisson_rejects_active_mask_length_mismatch() {
+        let n_bins = 5;
+        let o: Vec<f64> = vec![10.0; n_bins];
+        let s: Vec<f64> = vec![5.0; n_bins];
+        let mask_wrong = vec![true, true, true]; // wrong length
+        let model = ConstModel { n_e: n_bins };
+        let obj = JointPoissonObjective {
+            model: &model,
+            o: &o,
+            s: &s,
+            c: 1.0,
+            active_mask: Some(&mask_wrong),
+        };
+        let mut params = ParameterSet::new(vec![FitParameter::non_negative("T", 0.5)]);
+        let cfg = JointPoissonFitConfig::default();
+        let err = joint_poisson_fit(&obj, &mut params, &cfg).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                FittingError::LengthMismatch {
+                    field: "active_mask",
+                    ..
+                }
+            ),
+            "expected LengthMismatch on active_mask; got {err:?}"
+        );
     }
 }

--- a/crates/nereids-fitting/src/joint_poisson.rs
+++ b/crates/nereids-fitting/src/joint_poisson.rs
@@ -62,12 +62,36 @@ pub struct JointPoissonObjective<'a> {
     pub s: &'a [f64],
     /// Proton-charge ratio `c = Q_s / Q_ob`.  Must be strictly positive.
     pub c: f64,
+    /// Optional per-bin active mask (SAMMY REGION-equivalent fit-energy
+    /// -range restriction).  When `Some(m)`, only bins where `m[i]` is
+    /// `true` contribute to the deviance / gradient / Fisher
+    /// information; the model is still evaluated on the full grid so
+    /// resolution broadening at the boundaries is correct.  When
+    /// `None`, all bins are active (default behaviour).
+    ///
+    /// Length must equal `o.len()`; the GUI / pipeline dispatch builds
+    /// it from the configured `[E_min, E_max]` against the energy grid.
+    pub active_mask: Option<&'a [bool]>,
 }
 
 impl<'a> JointPoissonObjective<'a> {
     /// Number of data bins.
     pub fn n_data(&self) -> usize {
         self.o.len()
+    }
+
+    /// Number of *active* data bins — `n_data` when no mask is set,
+    /// or the count of `true` entries in `active_mask` otherwise.
+    /// This is the count that should drive deviance-per-dof reporting.
+    pub fn n_active(&self) -> usize {
+        crate::active_mask::active_count(self.active_mask, self.o.len())
+    }
+
+    /// Predicate: is bin `i` active?  Returns `true` when no mask is
+    /// set (full-grid default).
+    #[inline]
+    fn bin_active(&self, i: usize) -> bool {
+        self.active_mask.is_none_or(|m| m[i])
     }
 
     /// Closed-form profile MLE for the per-bin flux: `λ̂ = c·(O+S) / (1+c·T)`.
@@ -109,8 +133,16 @@ impl<'a> JointPoissonObjective<'a> {
     pub fn deviance_from_transmission(&self, t: &[f64]) -> f64 {
         debug_assert_eq!(t.len(), self.o.len());
         debug_assert_eq!(t.len(), self.s.len());
+        debug_assert!(
+            self.active_mask.is_none_or(|m| m.len() == t.len()),
+            "active_mask length must match data"
+        );
         let mut d = 0.0;
-        for ((&t_i, &o_i), &s_i) in t.iter().zip(self.o.iter()).zip(self.s.iter()) {
+        for (i, ((&t_i, &o_i), &s_i)) in t.iter().zip(self.o.iter()).zip(self.s.iter()).enumerate()
+        {
+            if !self.bin_active(i) {
+                continue;
+            }
             d += binomial_deviance_term(s_i, o_i, t_i, self.c);
         }
         d
@@ -164,6 +196,9 @@ impl<'a> JointPoissonObjective<'a> {
         let mut grad = vec![0.0f64; n_free];
         for (i, (&t_i, (&o_i, &s_i))) in t.iter().zip(self.o.iter().zip(self.s.iter())).enumerate()
         {
+            if !self.bin_active(i) {
+                continue;
+            }
             let w = deviance_weight(s_i, o_i, t_i, self.c);
             for (g, col) in grad.iter_mut().zip(0..n_free) {
                 *g += w * jac.get(i, col);
@@ -202,6 +237,9 @@ impl<'a> JointPoissonObjective<'a> {
         let mut info = FlatMatrix::zeros(n_free, n_free);
         for (i, ((&t_i, &o_i), &s_i)) in t.iter().zip(self.o.iter()).zip(self.s.iter()).enumerate()
         {
+            if !self.bin_active(i) {
+                continue;
+            }
             let h = deviance_curvature(s_i, o_i, t_i, self.c);
             for j in 0..n_free {
                 let jij = jac.get(i, j);
@@ -282,6 +320,9 @@ impl<'a> JointPoissonObjective<'a> {
             .zip(self.s.iter())
             .enumerate()
         {
+            if !self.bin_active(i) {
+                continue;
+            }
             let h = deviance_curvature(s_i, o_i, t_i, self.c);
             for j in 0..n_free {
                 let jij = jac.get(i, j);
@@ -640,7 +681,12 @@ pub fn joint_poisson_fit(
     let final_values = params.all_values();
     let final_deviance = objective.deviance(&final_values)?;
     let n_free = params.n_free();
-    let dof = (n_data as isize - n_free as isize).max(1) as f64;
+    // Active-bin masking (SAMMY REGION): when a fit-energy-range mask
+    // is in effect, dof must use the count of bins that contributed to
+    // the deviance — otherwise deviance-per-dof is biased low by the
+    // ratio (n_active / n_data).
+    let n_active = objective.n_active();
+    let dof = (n_active as isize - n_free as isize).max(1) as f64;
     let deviance_per_dof = final_deviance / dof;
 
     // Covariance from inverse Fisher at the final θ.  Uses the analytical
@@ -965,6 +1011,7 @@ mod tests {
                 o: &[o],
                 s: &[s],
                 c,
+                active_mask: None,
             };
             let closed = obj.profile_lambda(t, o, s);
 
@@ -1012,6 +1059,7 @@ mod tests {
             o: &o,
             s: &s,
             c,
+            active_mask: None,
         };
         let d = obj.deviance_from_transmission(&t);
         assert!(d.abs() < 1e-8, "D should be ≈ 0 at exact match, got {d}");
@@ -1045,6 +1093,7 @@ mod tests {
             o: &o,
             s: &s,
             c,
+            active_mask: None,
         };
 
         // Evaluate gradient at a point slightly off truth so it is nonzero.
@@ -1145,6 +1194,7 @@ mod tests {
                 o: &o,
                 s: &s,
                 c,
+                active_mask: None,
             };
 
             // 1D grid search over T, then local refinement via Brent-like
@@ -1219,6 +1269,7 @@ mod tests {
             o: &[0.0, 10.0, 5.0],
             s: &[0.0, 5.0, 2.0],
             c: 1.5,
+            active_mask: None,
         };
         let d_full = obj.deviance_from_transmission(&[0.6, 0.6, 0.6]);
         // Drop the zero-N bin — result must be identical.
@@ -1227,6 +1278,7 @@ mod tests {
             o: &[10.0, 5.0],
             s: &[5.0, 2.0],
             c: 1.5,
+            active_mask: None,
         };
         let d_reduced = obj_reduced.deviance_from_transmission(&[0.6, 0.6]);
         assert!((d_full - d_reduced).abs() < 1e-12);
@@ -1250,6 +1302,7 @@ mod tests {
             o: &o,
             s: &s,
             c,
+            active_mask: None,
         };
         let mut ps = ParameterSet::new(vec![
             FitParameter::non_negative("theta_0", 0.85),
@@ -1284,6 +1337,7 @@ mod tests {
             o: &o,
             s: &s,
             c,
+            active_mask: None,
         };
         let info = obj
             .fisher_information(&theta, &[0, 1])
@@ -1442,6 +1496,7 @@ mod tests {
             o: &o,
             s: &s,
             c,
+            active_mask: None,
         };
         let mut params = ParameterSet::new(vec![FitParameter::non_negative("n", 0.1)]);
         let cfg = JointPoissonFitConfig {
@@ -1512,6 +1567,7 @@ mod tests {
             o: &o,
             s: &s,
             c,
+            active_mask: None,
         };
 
         // x0 analogous to EG2-S1 regime: n near truth, A_n = 1, all
@@ -1610,6 +1666,7 @@ mod tests {
             o: &o,
             s: &s,
             c,
+            active_mask: None,
         };
         let mut params = ParameterSet::new(vec![FitParameter::non_negative("n", 0.1)]);
         let cfg = JointPoissonFitConfig {
@@ -1659,6 +1716,7 @@ mod tests {
             o: &o,
             s: &s,
             c,
+            active_mask: None,
         };
         let mut params = ParameterSet::new(vec![FitParameter::non_negative("T", t_true)]);
         let cfg = JointPoissonFitConfig {
@@ -1683,5 +1741,114 @@ mod tests {
              σ_analytical / √2 ≈ {} which would give rel_err ≈ 0.293",
             sigma_analytical / 2.0_f64.sqrt(),
         );
+    }
+
+    // ------------------------------------------------------------------
+    // Active-bin mask (SAMMY REGION-equivalent fit-energy-range, #514).
+    // ------------------------------------------------------------------
+
+    /// `deviance_from_transmission` with `active_mask` set must equal
+    /// the same call computed only over the `true` bins (subset
+    /// equivalence) — the masking is correct iff dropping out-of-mask
+    /// bins from `o`, `s`, `t` produces the same value.
+    #[test]
+    fn test_jp_active_mask_subset_equivalence() {
+        // 5-bin objective with an arbitrary mask — bins 1 and 3 active.
+        let o_full = [10.0, 20.0, 5.0, 15.0, 25.0];
+        let s_full = [4.0, 8.0, 1.0, 6.0, 12.0];
+        let t_full = [0.4, 0.5, 0.7, 0.6, 0.45];
+        let mask = [false, true, false, true, false];
+        let c = 1.5;
+        let model_full = ConstModel { n_e: 5 };
+        let obj_full = JointPoissonObjective {
+            model: &model_full,
+            o: &o_full,
+            s: &s_full,
+            c,
+            active_mask: Some(&mask),
+        };
+        let d_masked = obj_full.deviance_from_transmission(&t_full);
+
+        // Compare against an objective built directly on the active subset.
+        let o_sub = [o_full[1], o_full[3]];
+        let s_sub = [s_full[1], s_full[3]];
+        let t_sub = [t_full[1], t_full[3]];
+        let model_sub = ConstModel { n_e: 2 };
+        let obj_sub = JointPoissonObjective {
+            model: &model_sub,
+            o: &o_sub,
+            s: &s_sub,
+            c,
+            active_mask: None,
+        };
+        let d_subset = obj_sub.deviance_from_transmission(&t_sub);
+
+        assert!(
+            (d_masked - d_subset).abs() < 1e-12,
+            "masked deviance {d_masked} != subset deviance {d_subset}"
+        );
+
+        // Active-bin count should be 2, not 5.
+        assert_eq!(obj_full.n_active(), 2);
+        assert_eq!(obj_full.n_data(), 5);
+    }
+
+    /// Out-of-mask gradient contributions must drop to zero — verified
+    /// by comparing against an unmasked subset gradient.
+    #[test]
+    fn test_jp_active_mask_gradient_subset_equivalence() {
+        let e_full: Vec<f64> = (0..6).map(|i| 0.1 + 0.1 * i as f64).collect();
+        let theta_true = [0.95_f64, 0.05_f64];
+        let c = 2.0;
+        let lam = 100.0;
+        let model_full = LinearModel { e: &e_full };
+        let t_full = model_full.evaluate(&theta_true).unwrap();
+        let o_full: Vec<f64> = vec![lam / c; e_full.len()];
+        let s_full: Vec<f64> = t_full.iter().map(|&ti| lam * ti).collect();
+
+        // Mask = bins 2..5 active.
+        let mask = vec![false, false, true, true, true, false];
+        let obj_full = JointPoissonObjective {
+            model: &model_full,
+            o: &o_full,
+            s: &s_full,
+            c,
+            active_mask: Some(&mask),
+        };
+
+        let params_full = ParameterSet::new(vec![
+            FitParameter::non_negative("a", theta_true[0]),
+            FitParameter::non_negative("b", theta_true[1]),
+        ]);
+        let free_idx = params_full.free_indices();
+        let theta_eval = [0.9_f64, 0.07_f64];
+        let grad_masked = obj_full
+            .deviance_gradient_analytical(&theta_eval, &free_idx)
+            .unwrap()
+            .expect("analytical gradient");
+
+        // Subset reference: only bins 2..5.
+        let e_sub = e_full[2..5].to_vec();
+        let o_sub = o_full[2..5].to_vec();
+        let s_sub = s_full[2..5].to_vec();
+        let model_sub = LinearModel { e: &e_sub };
+        let obj_sub = JointPoissonObjective {
+            model: &model_sub,
+            o: &o_sub,
+            s: &s_sub,
+            c,
+            active_mask: None,
+        };
+        let grad_sub = obj_sub
+            .deviance_gradient_analytical(&theta_eval, &free_idx)
+            .unwrap()
+            .expect("analytical gradient");
+
+        for (i, (&gm, &gs)) in grad_masked.iter().zip(grad_sub.iter()).enumerate() {
+            assert!(
+                (gm - gs).abs() < 1e-9,
+                "grad component {i}: masked={gm} subset={gs}"
+            );
+        }
     }
 }

--- a/crates/nereids-fitting/src/joint_poisson.rs
+++ b/crates/nereids-fitting/src/joint_poisson.rs
@@ -658,6 +658,34 @@ pub fn joint_poisson_fit(
         });
     }
 
+    // SAMMY REGION-equivalent fit-energy-range (#514): zero active
+    // bins means the user's `[E_min, E_max]` does not overlap the
+    // configured grid.  No data contributes to the deviance — return
+    // non-converged with NaN before falling through.  Without this
+    // the all-bins-masked path would compute deviance = 0 (sum over
+    // zero rows) which combined with `n_free == 0` (all-fixed params)
+    // would report `gn_converged: true, deviance: 0` from a fit that
+    // saw no data.
+    let n_free_initial = params.n_free();
+    let n_active_initial = objective.n_active();
+    if n_active_initial == 0 {
+        return Ok(JointPoissonResult {
+            deviance: f64::NAN,
+            deviance_per_dof: f64::NAN,
+            n_data,
+            n_active: 0,
+            n_free: n_free_initial,
+            gn_iterations: 0,
+            polish_iterations: 0,
+            gn_converged: false,
+            polish_converged: false,
+            polish_improved: false,
+            params: params.all_values(),
+            covariance: None,
+            uncertainties: None,
+        });
+    }
+
     // Underdetermined-check: when a fit-energy-range mask leaves fewer
     // active bins than free parameters, the problem is rank-deficient
     // and any deviance / dof ratio would be deceptive (the previous
@@ -665,8 +693,6 @@ pub fn joint_poisson_fit(
     // empty / too-narrow masks).  Mirror LM's behaviour at
     // `lm.rs:578-588`: return a non-converged result up-front, before
     // wasting cycles on the damped-Fisher stage.
-    let n_free_initial = params.n_free();
-    let n_active_initial = objective.n_active();
     if n_active_initial < n_free_initial {
         return Ok(JointPoissonResult {
             deviance: f64::NAN,
@@ -1956,6 +1982,38 @@ mod tests {
         assert_eq!(r.n_free, 1);
         assert!(r.covariance.is_none());
         assert!(r.uncertainties.is_none());
+    }
+
+    /// Zero active bins with **all parameters fixed** (`n_free == 0`)
+    /// must still return non-converged.  Without the
+    /// `n_active == 0` early-return, the underdetermined check
+    /// `n_active < n_free` is `0 < 0` → false, so the function would
+    /// fall through to the main loop, compute `deviance = 0` from the
+    /// empty sum, and `dof = 0` → `deviance_per_dof = NaN` — but
+    /// `gn_converged` could still be `true`, masquerading as a
+    /// successful fit on no data.  Regression for #517 R3 P1 (#514).
+    #[test]
+    fn test_joint_poisson_rejects_zero_active_with_no_free_params() {
+        let n_bins = 5;
+        let o: Vec<f64> = vec![10.0; n_bins];
+        let s: Vec<f64> = vec![5.0; n_bins];
+        let mask = vec![false; n_bins];
+        let model = ConstModel { n_e: n_bins };
+        let obj = JointPoissonObjective {
+            model: &model,
+            o: &o,
+            s: &s,
+            c: 1.0,
+            active_mask: Some(&mask),
+        };
+        let mut params = ParameterSet::new(vec![FitParameter::fixed("T", 0.5)]);
+        let r = joint_poisson_fit(&obj, &mut params, &JointPoissonFitConfig::default()).unwrap();
+        assert!(!r.gn_converged);
+        assert!(!r.polish_converged);
+        assert!(r.deviance.is_nan());
+        assert!(r.deviance_per_dof.is_nan());
+        assert_eq!(r.n_active, 0);
+        assert_eq!(r.n_free, 0);
     }
 
     /// `joint_poisson_fit` validates active-mask length up-front and

--- a/crates/nereids-fitting/src/lib.rs
+++ b/crates/nereids-fitting/src/lib.rs
@@ -16,6 +16,7 @@
 //! ## TRINIDI Reference
 //! - `trinidi/reconstruct.py` for Poisson-likelihood and APGM approach
 
+pub mod active_mask;
 pub mod error;
 pub mod forward_model;
 pub mod joint_poisson;

--- a/crates/nereids-fitting/src/lm.rs
+++ b/crates/nereids-fitting/src/lm.rs
@@ -455,6 +455,31 @@ pub fn levenberg_marquardt(
     params: &mut ParameterSet,
     config: &LmConfig,
 ) -> Result<LmResult, FittingError> {
+    levenberg_marquardt_with_mask(model, y_obs, sigma, params, config, None)
+}
+
+/// Run the Levenberg-Marquardt optimizer with an optional per-bin
+/// active mask (SAMMY REGION-equivalent fit-energy-range restriction).
+///
+/// When `active_mask` is `Some(m)`:
+/// - bins where `m[i]` is `false` are excluded from χ² and the normal
+///   equations (weight zeroed before assembly), so they contribute
+///   nothing to the gradient or Hessian;
+/// - the model is still evaluated on the full grid so resolution
+///   broadening at the boundaries of the active region is correct;
+/// - `dof = n_active − n_free` where `n_active` is the count of
+///   active bins.
+///
+/// When `active_mask` is `None`, behaviour is identical to
+/// [`levenberg_marquardt`] (all bins active).
+pub fn levenberg_marquardt_with_mask(
+    model: &dyn FitModel,
+    y_obs: &[f64],
+    sigma: &[f64],
+    params: &mut ParameterSet,
+    config: &LmConfig,
+    active_mask: Option<&[bool]>,
+) -> Result<LmResult, FittingError> {
     let n_data = y_obs.len();
     if n_data == 0 {
         return Err(FittingError::EmptyData);
@@ -466,6 +491,16 @@ pub fn levenberg_marquardt(
             field: "sigma",
         });
     }
+    if let Some(m) = active_mask
+        && m.len() != n_data
+    {
+        return Err(FittingError::LengthMismatch {
+            expected: n_data,
+            actual: m.len(),
+            field: "active_mask",
+        });
+    }
+    let n_active = crate::active_mask::active_count(active_mask, n_data);
 
     let n_free = params.n_free();
 
@@ -475,7 +510,13 @@ pub fn levenberg_marquardt(
     if n_free == 0 {
         let weights: Vec<f64> = sigma
             .iter()
-            .map(|&s| {
+            .enumerate()
+            .map(|(i, &s)| {
+                // Active-bin masking (SAMMY REGION): bins outside the
+                // user range contribute zero to χ².
+                if active_mask.is_some_and(|m| !m[i]) {
+                    return 0.0;
+                }
                 if !s.is_finite() || s <= 0.0 {
                     1.0 / 1e30
                 } else {
@@ -507,12 +548,12 @@ pub fn levenberg_marquardt(
             .map(|(&obs, &mdl)| obs - mdl)
             .collect();
         let chi2 = chi_squared(&residuals, &weights);
-        // #125.5: Compute dof via `n_data - n_free` (even though n_free == 0 here)
-        // to mirror the main path and keep a single visible formula.
-        let dof = n_data - n_free;
-        // Note: Given n_free == 0 and the earlier assert that n_data > 0,
-        // dof is always > 0 here; the guard below is a defensive check
-        // kept for consistency with the main path.
+        // #125.5: Compute dof via `n_active - n_free` (with `n_active = n_data`
+        // when no mask is set) to mirror the main path and keep a single
+        // visible formula.  When a fit-energy-range mask is in effect,
+        // `n_active` reflects the count of bins that actually contributed
+        // to χ² (SAMMY REGION semantics).
+        let dof = n_active.saturating_sub(n_free);
         let reduced = if dof > 0 { chi2 / dof as f64 } else { f64::NAN };
         return Ok(LmResult {
             chi_squared: chi2,
@@ -525,12 +566,16 @@ pub fn levenberg_marquardt(
         });
     }
 
-    // #108.3: Underdetermined systems — when n_data < n_free, the problem is
+    // #108.3: Underdetermined systems — when n_active < n_free, the problem is
     // underdetermined and the Jacobian cannot be full rank.  Return early
     // with converged=false so callers can detect the problem.
-    // n_data == n_free is exactly determined (dof=0) and still solvable;
+    // n_active == n_free is exactly determined (dof=0) and still solvable;
     // we allow it and report reduced_chi_squared = NaN (0/0).
-    if n_data < n_free {
+    //
+    // When a fit-energy-range mask is in effect, the underdetermined
+    // check uses the active-bin count (SAMMY REGION semantics) — masked
+    // bins do not contribute information to the fit.
+    if n_active < n_free {
         return Ok(LmResult {
             chi_squared: f64::NAN,
             reduced_chi_squared: f64::NAN,
@@ -541,15 +586,25 @@ pub fn levenberg_marquardt(
             uncertainties: None,
         });
     }
-    let dof = n_data - n_free;
+    let dof = n_active - n_free;
 
     // #104: Validate sigma — division by zero or non-finite sigma would produce
     // NaN/Inf weights and silently corrupt the entire fit.  Clamp to a small
     // floor instead of rejecting outright, so callers with a few zero-sigma
     // bins still get a usable fit.
+    //
+    // Active-bin masking (SAMMY REGION): bins outside the user range
+    // get weight 0 here, which propagates through χ² and the JᵀWJ /
+    // JᵀWr normal-equation assembly to contribute exactly zero —
+    // covering both residual and gradient masking with no further
+    // changes downstream.
     let weights: Vec<f64> = sigma
         .iter()
-        .map(|&s| {
+        .enumerate()
+        .map(|(i, &s)| {
+            if active_mask.is_some_and(|m| !m[i]) {
+                return 0.0;
+            }
             if !s.is_finite() || s <= 0.0 {
                 // Treat as negligible weight (huge sigma) rather than panicking.
                 1.0 / 1e30
@@ -1381,6 +1436,122 @@ mod tests {
             result.params[0],
             result.params[1],
             y_at_4,
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Active-bin mask (SAMMY REGION-equivalent fit-energy-range, #514).
+    // ------------------------------------------------------------------
+
+    /// LM with an `active_mask` that restricts to a subset of bins must
+    /// produce a fit equivalent to running on that subset directly —
+    /// validates that masking propagates through both the residual /
+    /// χ² accumulation AND the dof / reduced-χ² book-keeping.
+    #[test]
+    fn test_lm_active_mask_subset_equivalence() {
+        // Linear fit y = 2x + 3 on x = 0..10.  Mask = bins 0..5 only.
+        let x_full: Vec<f64> = (0..10).map(|i| i as f64).collect();
+        let y_full: Vec<f64> = x_full.iter().map(|&xi| 2.0 * xi + 3.0).collect();
+        let sigma_full = vec![1.0; 10];
+        let mask = vec![
+            true, true, true, true, true, false, false, false, false, false,
+        ];
+
+        let model = LinearModel { x: x_full.clone() };
+        let mut params = ParameterSet::new(vec![
+            FitParameter::unbounded("a", 1.0),
+            FitParameter::unbounded("b", 1.0),
+        ]);
+        let result_masked = levenberg_marquardt_with_mask(
+            &model,
+            &y_full,
+            &sigma_full,
+            &mut params,
+            &LmConfig::default(),
+            Some(&mask),
+        )
+        .unwrap();
+        assert!(result_masked.converged);
+        assert!((result_masked.params[0] - 2.0).abs() < 1e-6);
+        assert!((result_masked.params[1] - 3.0).abs() < 1e-6);
+
+        // Reference: same fit on the subset directly (no mask).
+        let x_sub = x_full[..5].to_vec();
+        let y_sub = y_full[..5].to_vec();
+        let sigma_sub = vec![1.0; 5];
+        let model_sub = LinearModel { x: x_sub };
+        let mut params_sub = ParameterSet::new(vec![
+            FitParameter::unbounded("a", 1.0),
+            FitParameter::unbounded("b", 1.0),
+        ]);
+        let result_sub = levenberg_marquardt(
+            &model_sub,
+            &y_sub,
+            &sigma_sub,
+            &mut params_sub,
+            &LmConfig::default(),
+        )
+        .unwrap();
+
+        // Recovered parameters and reduced-χ² (both fits noiseless,
+        // so reduced-χ² ≈ 0 in either case) must match.
+        for j in 0..2 {
+            assert!(
+                (result_masked.params[j] - result_sub.params[j]).abs() < 1e-6,
+                "param {j}: masked={} subset={}",
+                result_masked.params[j],
+                result_sub.params[j]
+            );
+        }
+        assert!(
+            (result_masked.reduced_chi_squared - result_sub.reduced_chi_squared).abs() < 1e-6,
+            "reduced-χ²: masked={} subset={}",
+            result_masked.reduced_chi_squared,
+            result_sub.reduced_chi_squared
+        );
+    }
+
+    /// Without the mask, residuals from the out-of-range half of the
+    /// grid would dominate χ² and pull the fit way off — the masked
+    /// fit must NOT be biased by them.
+    #[test]
+    fn test_lm_active_mask_excludes_out_of_range_residuals() {
+        // y = 2x + 3 inside the masked range; corrupt outliers outside.
+        let x: Vec<f64> = (0..10).map(|i| i as f64).collect();
+        let mut y: Vec<f64> = x.iter().map(|&xi| 2.0 * xi + 3.0).collect();
+        for yi in y.iter_mut().skip(5) {
+            *yi += 1000.0; // huge corruption outside the active mask
+        }
+        let sigma = vec![1.0; 10];
+        let mask = vec![true; 5]
+            .into_iter()
+            .chain(std::iter::repeat_n(false, 5))
+            .collect::<Vec<bool>>();
+
+        let model = LinearModel { x };
+        let mut params = ParameterSet::new(vec![
+            FitParameter::unbounded("a", 1.0),
+            FitParameter::unbounded("b", 1.0),
+        ]);
+        let result = levenberg_marquardt_with_mask(
+            &model,
+            &y,
+            &sigma,
+            &mut params,
+            &LmConfig::default(),
+            Some(&mask),
+        )
+        .unwrap();
+        assert!(result.converged);
+        assert!(
+            (result.params[0] - 2.0).abs() < 1e-6,
+            "slope should be 2.0 (corrupt outliers must be masked out), got {}",
+            result.params[0]
+        );
+        assert!(
+            (result.params[1] - 3.0).abs() < 1e-6,
+            "intercept should be 3.0 (corrupt outliers must be masked out), got {}",
+            result.params[1]
         );
     }
 }

--- a/crates/nereids-fitting/src/lm.rs
+++ b/crates/nereids-fitting/src/lm.rs
@@ -184,12 +184,23 @@ impl<M: FitModel + ?Sized> FitModel for &M {
 }
 
 /// Compute weighted chi-squared: Σ [(y_obs - y_model)² / σ²].
-fn chi_squared(residuals: &[f64], weights: &[f64]) -> f64 {
-    residuals
-        .iter()
-        .zip(weights.iter())
-        .map(|(&r, &w)| r * r * w)
-        .sum()
+///
+/// When `active_mask` is `Some(m)`, bins where `m[i]` is `false` are
+/// **skipped entirely** rather than zero-weighted.  Explicit row-skip
+/// matters when masked bins may contain non-finite residuals (e.g. NaN
+/// outside the user's fit-energy range): `0.0 * NaN = NaN`, so a
+/// zero-weight strategy would propagate NaN through the χ² accumulator
+/// even though the bin contributes no information.  See SAMMY REGION
+/// semantics (#514) and lm.rs Fix 4.
+fn chi_squared(residuals: &[f64], weights: &[f64], active_mask: Option<&[bool]>) -> f64 {
+    let mut sum = 0.0;
+    for (i, (&r, &w)) in residuals.iter().zip(weights.iter()).enumerate() {
+        if active_mask.is_some_and(|m| !m[i]) {
+            continue;
+        }
+        sum += r * r * w;
+    }
+    sum
 }
 
 /// Infinity norm of the gradient, scaled by local curvature and residual size.
@@ -547,7 +558,7 @@ pub fn levenberg_marquardt_with_mask(
             .zip(y_model.iter())
             .map(|(&obs, &mdl)| obs - mdl)
             .collect();
-        let chi2 = chi_squared(&residuals, &weights);
+        let chi2 = chi_squared(&residuals, &weights, active_mask);
         // #125.5: Compute dof via `n_active - n_free` (with `n_active = n_data`
         // when no mask is set) to mirror the main path and keep a single
         // visible formula.  When a fit-energy-range mask is in effect,
@@ -634,7 +645,7 @@ pub fn levenberg_marquardt_with_mask(
         .zip(y_current.iter())
         .map(|(&obs, &mdl)| obs - mdl)
         .collect();
-    let mut chi2 = chi_squared(&residuals, &weights);
+    let mut chi2 = chi_squared(&residuals, &weights, active_mask);
 
     let mut lambda = config.lambda_init;
     let mut converged = false;
@@ -655,11 +666,20 @@ pub fn levenberg_marquardt_with_mask(
             &mut free_idx_buf,
         )?;
 
-        // Build normal equations: JᵀWJ and JᵀWr
+        // Build normal equations: JᵀWJ and JᵀWr.
+        //
+        // Active-bin masking (SAMMY REGION, #514): explicitly skip
+        // masked rows rather than relying on weights[i] == 0 — the
+        // model or the residual at a masked margin bin may be NaN
+        // (e.g. when y_obs is NaN outside the user's fit-energy range),
+        // and `0.0 * NaN = NaN` would poison both accumulators.
         let mut jtw_j = FlatMatrix::zeros(n_free, n_free);
         let mut jtw_r = vec![0.0; n_free];
 
         for (i, (&wi, &ri)) in weights.iter().zip(residuals.iter()).enumerate() {
+            if active_mask.is_some_and(|m| !m[i]) {
+                continue;
+            }
             for (j, jtw_r_j) in jtw_r.iter_mut().enumerate() {
                 let jij = jacobian.get(i, j);
                 *jtw_r_j += jij * wi * ri;
@@ -725,7 +745,7 @@ pub fn levenberg_marquardt_with_mask(
             .zip(y_trial.iter())
             .map(|(&obs, &mdl)| obs - mdl)
             .collect();
-        let trial_chi2 = chi_squared(&trial_residuals, &weights);
+        let trial_chi2 = chi_squared(&trial_residuals, &weights, active_mask);
         let chi2_delta = (trial_chi2 - chi2).abs();
         let chi2_scale = chi2.abs().max(trial_chi2.abs()).max(1.0);
         let chi2_stagnated = chi2_delta <= config.tol_chi2 * chi2_scale;
@@ -798,8 +818,14 @@ pub fn levenberg_marquardt_with_mask(
             &mut all_vals_buf,
             &mut free_idx_buf,
         )?;
+        // Same active-mask row-skip semantics as the main assembly
+        // loop above — keeps the covariance free of NaN contributions
+        // from masked margin bins (#514).
         let mut jtw_j = FlatMatrix::zeros(n_free, n_free);
         for (i, &wi) in weights.iter().enumerate() {
+            if active_mask.is_some_and(|m| !m[i]) {
+                continue;
+            }
             for j in 0..n_free {
                 let jij = jacobian.get(i, j);
                 for k in 0..n_free {
@@ -1551,6 +1577,63 @@ mod tests {
         assert!(
             (result.params[1] - 3.0).abs() < 1e-6,
             "intercept should be 3.0 (corrupt outliers must be masked out), got {}",
+            result.params[1]
+        );
+    }
+
+    /// Out-of-mask `y_obs` containing `NaN` must not poison χ² /
+    /// JᵀWJ / JᵀWr.  Without explicit row-skip in the accumulator
+    /// loops, `0.0 (weight) * NaN (residual) = NaN` would propagate
+    /// through the fit despite the masked weight being zero.
+    /// Regression for Round-2 review fix #4.
+    #[test]
+    fn test_lm_active_mask_tolerates_nan_outside_range() {
+        // y = 2x + 3 inside the active mask; NaN outside.  A naive
+        // zero-weight implementation would return NaN χ² and fail to
+        // converge; the row-skip path should fit cleanly.
+        let x: Vec<f64> = (0..10).map(|i| i as f64).collect();
+        let mut y: Vec<f64> = x.iter().map(|&xi| 2.0 * xi + 3.0).collect();
+        for yi in y.iter_mut().skip(5) {
+            *yi = f64::NAN;
+        }
+        let sigma = vec![1.0; 10];
+        let mask = vec![true; 5]
+            .into_iter()
+            .chain(std::iter::repeat_n(false, 5))
+            .collect::<Vec<bool>>();
+
+        let model = LinearModel { x };
+        let mut params = ParameterSet::new(vec![
+            FitParameter::unbounded("a", 1.0),
+            FitParameter::unbounded("b", 1.0),
+        ]);
+        let result = levenberg_marquardt_with_mask(
+            &model,
+            &y,
+            &sigma,
+            &mut params,
+            &LmConfig::default(),
+            Some(&mask),
+        )
+        .unwrap();
+
+        assert!(
+            result.converged,
+            "fit should converge despite NaN outside the active mask"
+        );
+        assert!(
+            result.chi_squared.is_finite(),
+            "χ² should be finite (NaN poisoning prevented), got {}",
+            result.chi_squared
+        );
+        assert!(
+            (result.params[0] - 2.0).abs() < 1e-6,
+            "slope should be 2.0, got {}",
+            result.params[0]
+        );
+        assert!(
+            (result.params[1] - 3.0).abs() < 1e-6,
+            "intercept should be 3.0, got {}",
             result.params[1]
         );
     }

--- a/crates/nereids-fitting/src/lm.rs
+++ b/crates/nereids-fitting/src/lm.rs
@@ -541,7 +541,16 @@ pub fn levenberg_marquardt_with_mask(
         // return converged=false rather than silently propagating NaN chi².
         // Covariance/uncertainties are None because the fit did not converge —
         // an unconverged result has no meaningful covariance to report.
-        if !y_model.iter().all(|v| v.is_finite()) {
+        //
+        // SAMMY REGION-equivalent fit-energy-range (#514): masked rows are
+        // skipped throughout the cost / normal-equation accumulators, so a
+        // non-finite model output at a masked bin should not abort the fit
+        // — only check finiteness on active rows.
+        let model_has_active_nonfinite = y_model
+            .iter()
+            .enumerate()
+            .any(|(i, v)| active_mask.is_none_or(|m| m[i]) && !v.is_finite());
+        if model_has_active_nonfinite {
             return Ok(LmResult {
                 chi_squared: f64::NAN,
                 reduced_chi_squared: f64::NAN,
@@ -728,9 +737,16 @@ pub fn levenberg_marquardt_with_mask(
             }
         };
 
-        // #113: If the model produced NaN/Inf, treat as a bad step (same as
-        // chi2 increase) — increase lambda and try again.
-        if y_trial.iter().any(|v| !v.is_finite()) {
+        // #113: If the model produced NaN/Inf at any *active* bin, treat as
+        // a bad step (same as chi2 increase) — increase lambda and try again.
+        // SAMMY REGION-equivalent fit-energy-range (#514): masked rows are
+        // skipped from χ² / JᵀWJ / JᵀWr / covariance, so a non-finite model
+        // output at a masked margin bin must not penalise the trial step.
+        let trial_has_active_nonfinite = y_trial
+            .iter()
+            .enumerate()
+            .any(|(i, v)| active_mask.is_none_or(|m| m[i]) && !v.is_finite());
+        if trial_has_active_nonfinite {
             params.set_free_values(&free_vals_buf);
             lambda *= config.lambda_up;
             if lambda > LAMBDA_BREAKOUT {
@@ -1636,5 +1652,66 @@ mod tests {
             "intercept should be 3.0, got {}",
             result.params[1]
         );
+    }
+
+    /// Regression for Round-2-pass-2 review: the global finite checks
+    /// on `y_model` / `y_trial` must skip masked bins.  A model that
+    /// returns NaN only at masked margin bins should not abort the fit
+    /// or get its trial step rejected.
+    #[test]
+    fn test_lm_active_mask_tolerates_model_nan_outside_range() {
+        // Linear model that injects NaN into masked bins.  The fit
+        // should still converge cleanly — the contract is that masked
+        // rows are completely irrelevant to the fit.
+        struct LinearModelWithMaskedNaN {
+            x: Vec<f64>,
+            mask: Vec<bool>,
+        }
+        impl FitModel for LinearModelWithMaskedNaN {
+            fn evaluate(&self, params: &[f64]) -> Result<Vec<f64>, FittingError> {
+                let a = params[0];
+                let b = params[1];
+                Ok(self
+                    .x
+                    .iter()
+                    .enumerate()
+                    .map(|(i, &x)| if self.mask[i] { a * x + b } else { f64::NAN })
+                    .collect())
+            }
+        }
+
+        let x: Vec<f64> = (0..10).map(|i| i as f64).collect();
+        let y: Vec<f64> = x.iter().map(|&xi| 2.0 * xi + 3.0).collect();
+        let sigma = vec![1.0; 10];
+        let mask: Vec<bool> = vec![true; 5]
+            .into_iter()
+            .chain(std::iter::repeat_n(false, 5))
+            .collect();
+
+        let model = LinearModelWithMaskedNaN {
+            x: x.clone(),
+            mask: mask.clone(),
+        };
+        let mut params = ParameterSet::new(vec![
+            FitParameter::unbounded("a", 1.0),
+            FitParameter::unbounded("b", 1.0),
+        ]);
+        let result = levenberg_marquardt_with_mask(
+            &model,
+            &y,
+            &sigma,
+            &mut params,
+            &LmConfig::default(),
+            Some(&mask),
+        )
+        .unwrap();
+
+        assert!(
+            result.converged,
+            "fit should converge despite model NaN at masked bins"
+        );
+        assert!(result.chi_squared.is_finite());
+        assert!((result.params[0] - 2.0).abs() < 1e-6);
+        assert!((result.params[1] - 3.0).abs() < 1e-6);
     }
 }

--- a/crates/nereids-fitting/src/lm.rs
+++ b/crates/nereids-fitting/src/lm.rs
@@ -513,6 +513,26 @@ pub fn levenberg_marquardt_with_mask(
     }
     let n_active = crate::active_mask::active_count(active_mask, n_data);
 
+    // SAMMY REGION-equivalent fit-energy-range (#514): a mask with
+    // zero active bins means the user's `[E_min, E_max]` does not
+    // overlap the energy grid.  No data contributes to the cost
+    // function — return non-converged with NaN χ² rather than
+    // falling through to the all-fixed fast-return path (which would
+    // report `converged: true, chi_squared: 0` from a zero-row sum)
+    // or to the main optimisation loop (where `n_active < n_free`
+    // would catch it but only after wasted setup work).
+    if n_active == 0 {
+        return Ok(LmResult {
+            chi_squared: f64::NAN,
+            reduced_chi_squared: f64::NAN,
+            iterations: 0,
+            converged: false,
+            params: params.all_values(),
+            covariance: None,
+            uncertainties: None,
+        });
+    }
+
     let n_free = params.n_free();
 
     // Early return when all parameters are fixed: evaluate once and report the
@@ -1713,5 +1733,63 @@ mod tests {
         assert!(result.chi_squared.is_finite());
         assert!((result.params[0] - 2.0).abs() < 1e-6);
         assert!((result.params[1] - 3.0).abs() < 1e-6);
+    }
+
+    /// A zero-active mask (the user's range misses the grid entirely)
+    /// must return non-converged regardless of whether parameters are
+    /// free or fixed.  Pre-fix the all-fixed fast-return path would
+    /// report `converged: true, chi_squared: 0` from a sum over zero
+    /// rows — a deceptive "success" with no data behind it.
+    #[test]
+    fn test_lm_active_mask_all_false_returns_non_converged() {
+        let x: Vec<f64> = (0..5).map(|i| i as f64).collect();
+        let y: Vec<f64> = x.iter().map(|&xi| 2.0 * xi + 3.0).collect();
+        let sigma = vec![1.0; 5];
+        let mask = vec![false; 5];
+        let model = LinearModel { x: x.clone() };
+
+        // (a) All parameters free.
+        let mut params_free = ParameterSet::new(vec![
+            FitParameter::unbounded("a", 1.0),
+            FitParameter::unbounded("b", 1.0),
+        ]);
+        let r_free = levenberg_marquardt_with_mask(
+            &model,
+            &y,
+            &sigma,
+            &mut params_free,
+            &LmConfig::default(),
+            Some(&mask),
+        )
+        .unwrap();
+        assert!(
+            !r_free.converged,
+            "n_free > 0 + zero-active mask must NOT report converged"
+        );
+        assert!(r_free.chi_squared.is_nan());
+        assert!(r_free.reduced_chi_squared.is_nan());
+
+        // (b) All parameters fixed → n_free == 0 (the path #517 R3
+        //     specifically failed before the n_active==0 early-return).
+        let mut params_fixed = ParameterSet::new(vec![
+            FitParameter::fixed("a", 1.0),
+            FitParameter::fixed("b", 0.0),
+        ]);
+        let r_fixed = levenberg_marquardt_with_mask(
+            &model,
+            &y,
+            &sigma,
+            &mut params_fixed,
+            &LmConfig::default(),
+            Some(&mask),
+        )
+        .unwrap();
+        assert!(
+            !r_fixed.converged,
+            "n_free == 0 + zero-active mask must NOT report converged \
+             (sum over zero rows would be 0, masquerading as a perfect fit)"
+        );
+        assert!(r_fixed.chi_squared.is_nan());
+        assert!(r_fixed.reduced_chi_squared.is_nan());
     }
 }

--- a/crates/nereids-io/src/project.rs
+++ b/crates/nereids-io/src/project.rs
@@ -84,6 +84,12 @@ pub struct ProjectSnapshot {
     /// `L_scale`).  `Option` for backwards compatibility — projects
     /// saved before this field was introduced load as `None` (= false).
     pub fit_energy_scale: Option<bool>,
+    /// User-specified fit energy range `[min_eV, max_eV]` (SAMMY REGION
+    /// equivalent, `MIN ENERGY` / `MAX ENERGY` SAM52 cards).
+    /// `None` (default) = full grid.  Projects saved before this field
+    /// was introduced load as `None` via the HDF5 reader's missing-
+    /// dataset handling.
+    pub fit_energy_range: Option<(f64, f64)>,
 
     // -- config/resolution --
     pub resolution_enabled: bool,
@@ -226,6 +232,7 @@ impl Default for ProjectSnapshot {
             temperature_k: 0.0,
             fit_temperature: false,
             fit_energy_scale: None,
+            fit_energy_range: None,
             resolution_enabled: false,
             resolution_kind: String::new(),
             delta_t_us: None,
@@ -568,6 +575,13 @@ fn write_config(file: &hdf5::File, snap: &ProjectSnapshot) -> Result<(), IoError
     write_bool_attr(&solver, "fit_temperature", snap.fit_temperature)?;
     if let Some(fes) = snap.fit_energy_scale {
         write_bool_attr(&solver, "fit_energy_scale", fes)?;
+    }
+    if let Some((fr_min, fr_max)) = snap.fit_energy_range {
+        // SAMMY REGION-equivalent fit-energy-range bounds (#514).
+        // Stored as two scalar attributes so HDF5 introspection tools
+        // can read the values directly without parsing a packed tuple.
+        write_f64_attr(&solver, "fit_energy_range_min_ev", fr_min)?;
+        write_f64_attr(&solver, "fit_energy_range_max_ev", fr_max)?;
     }
     if let Some(ue) = snap.uncertainty_is_estimated {
         write_bool_attr(&solver, "uncertainty_is_estimated", ue)?;
@@ -1249,6 +1263,16 @@ fn read_config(file: &hdf5::File, snap: &mut ProjectSnapshot) -> Result<(), IoEr
     snap.temperature_k = read_f64_attr(&solver, "temperature_k")?;
     snap.fit_temperature = read_bool_attr(&solver, "fit_temperature")?;
     snap.fit_energy_scale = read_bool_attr(&solver, "fit_energy_scale").ok();
+    // SAMMY REGION-equivalent fit-energy-range bounds (#514).  Both
+    // attributes must be present to populate the field; older project
+    // files load as `None` (= full-grid fit, the prior default).
+    snap.fit_energy_range = match (
+        read_f64_attr(&solver, "fit_energy_range_min_ev").ok(),
+        read_f64_attr(&solver, "fit_energy_range_max_ev").ok(),
+    ) {
+        (Some(min), Some(max)) => Some((min, max)),
+        _ => None,
+    };
     snap.uncertainty_is_estimated = read_bool_attr(&solver, "uncertainty_is_estimated").ok();
     snap.lm_background_enabled = read_bool_attr(&solver, "lm_background_enabled").ok();
     snap.kl_background_enabled = read_bool_attr(&solver, "kl_background_enabled").ok();
@@ -1829,6 +1853,7 @@ mod tests {
             temperature_k: 300.0,
             fit_temperature: false,
             fit_energy_scale: None,
+            fit_energy_range: None,
             resolution_enabled: false,
             resolution_kind: "gaussian".into(),
             delta_t_us: Some(1.5),

--- a/crates/nereids-io/src/project.rs
+++ b/crates/nereids-io/src/project.rs
@@ -88,7 +88,9 @@ pub struct ProjectSnapshot {
     /// equivalent, `MIN ENERGY` / `MAX ENERGY` SAM52 cards).
     /// `None` (default) = full grid.  Projects saved before this field
     /// was introduced load as `None` via the HDF5 reader's missing-
-    /// dataset handling.
+    /// attribute handling — the bounds are stored as two scalar
+    /// attributes (`fit_energy_range_min_ev` / `fit_energy_range_max_ev`)
+    /// on `/config/solver`, not as a dataset.
     pub fit_energy_range: Option<(f64, f64)>,
 
     // -- config/resolution --

--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -872,6 +872,77 @@ impl TabulatedResolution {
     pub fn flight_path_m(&self) -> f64 {
         self.flight_path_m
     }
+
+    /// Kernel support at energy `e_ev`, in eV.
+    ///
+    /// Returns the maximum energy offset over which the tabulated
+    /// kernel has non-zero weight at energy `e_ev`.  Past this
+    /// distance the kernel is exactly zero, so the broadening
+    /// footprint at a given target energy is fully contained within
+    /// `[e_ev − support, e_ev + support]`.
+    ///
+    /// Computation:
+    ///
+    /// 1. Find the bracketing reference kernel(s) for `e_ev` via
+    ///    binary search on the sorted `ref_energies` grid.
+    /// 2. Take `max(|tof_offset|)` over all bracketing kernels'
+    ///    entries with positive weight.  Using both bracketing
+    ///    kernels (rather than the single nearest) is conservative —
+    ///    over-estimating the margin is safer than under-estimating
+    ///    when the kernel is interpolated between references.
+    /// 3. Convert TOF offset to energy offset via
+    ///    `|ΔE| = 2·E^(3/2) / (TOF_FACTOR·L) · |Δt|`,
+    ///    the magnitude of `dE/dt` at `e_ev` along the TOF→E mapping
+    ///    `t = TOF_FACTOR·L/√E` (chain rule).
+    ///
+    /// Returns `0.0` for non-positive `e_ev`, an empty kernel set, or
+    /// a non-positive flight path.  Used by the GUI's
+    /// fit-energy-range slicing to extend the model-evaluation grid
+    /// beyond the user's `[E_min, E_max]` so the SAMMY REGION-
+    /// equivalent broadening at the boundaries is correct (#514).
+    #[must_use]
+    pub fn kernel_support_ev(&self, e_ev: f64) -> f64 {
+        if e_ev <= 0.0 || !e_ev.is_finite() {
+            return 0.0;
+        }
+        if self.kernels.is_empty() || self.flight_path_m <= 0.0 {
+            return 0.0;
+        }
+        // Use binary_search to distinguish exact hits from
+        // between-ref interpolation:
+        //   Ok(idx)  → e_ev exactly matches ref_energies[idx]; use
+        //              that single kernel.
+        //   Err(idx) → idx is the insertion point.  Use the
+        //              bracketing kernels at idx-1 (lower) and idx
+        //              (upper); clip to grid bounds when e_ev falls
+        //              outside the ref range.
+        let n = self.ref_energies.len();
+        let mut max_dt_us: f64 = 0.0;
+        let visit = |idx: usize, max_dt_us: &mut f64| {
+            let (offsets, weights) = &self.kernels[idx];
+            for (&dt, &w) in offsets.iter().zip(weights.iter()) {
+                if w > 0.0 && dt.is_finite() {
+                    *max_dt_us = max_dt_us.max(dt.abs());
+                }
+            }
+        };
+        match self.ref_energies.binary_search_by(|probe| {
+            probe
+                .partial_cmp(&e_ev)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        }) {
+            Ok(idx) => visit(idx, &mut max_dt_us),
+            Err(0) => visit(0, &mut max_dt_us),
+            Err(idx) if idx >= n => visit(n - 1, &mut max_dt_us),
+            Err(idx) => {
+                visit(idx - 1, &mut max_dt_us);
+                visit(idx, &mut max_dt_us);
+            }
+        }
+        // |dE/dt| = 2·E^(3/2)/(TOF_FACTOR·L)
+        let de_per_dt = 2.0 * e_ev.powf(1.5) / (TOF_FACTOR * self.flight_path_m);
+        de_per_dt * max_dt_us
+    }
 }
 
 /// Resolution function: either analytical Gaussian or tabulated from Monte Carlo.
@@ -3960,5 +4031,101 @@ mod tests {
             matrix_out[0],
         );
         assert!(matrix_out[0].abs() < 1e-280);
+    }
+
+    // ------------------------------------------------------------------
+    // TabulatedResolution::kernel_support_ev — used by SAMMY REGION
+    // -equivalent fit-energy-range margin computation (#514).
+    // ------------------------------------------------------------------
+
+    /// `synthetic_tab_resolution` uses triangular kernels whose
+    /// outermost entries (`weight = 1 - |dt|/half`) are exactly zero
+    /// at `dt = ±half`; the actual non-zero support is the next-
+    /// outermost entry at `±half · (1 - 1/(n-1))`.
+    fn triangle_dt_max(half: f64, n: usize) -> f64 {
+        // dt_step = 2*half / (n-1); next-outermost = half - dt_step
+        half - 2.0 * half / (n - 1) as f64
+    }
+
+    /// At a reference energy with a known kernel half-width in TOF, the
+    /// support in eV must satisfy `|ΔE| = 2·E^(3/2)/(TOF_FACTOR·L)·|Δt|`.
+    /// At E = 50 eV the triangle kernel has half = 1.0 μs, n = 41, so
+    /// the largest non-zero offset is `1.0 · (1 − 1/40) = 0.975`.
+    #[test]
+    fn test_tabulated_kernel_support_at_ref_energy_matches_chain_rule() {
+        let r = synthetic_tab_resolution();
+        let e: f64 = 50.0;
+        let dt_max = triangle_dt_max(1.0, 41);
+        let expected = 2.0 * e.powf(1.5) / (TOF_FACTOR * 25.0) * dt_max;
+        let got = r.kernel_support_ev(e);
+        assert!(
+            (got - expected).abs() / expected < 1e-12,
+            "support at ref energy: got {got}, expected {expected}"
+        );
+    }
+
+    /// Between two reference energies the support uses the larger of
+    /// the two bracketing kernels (conservative).  At E = 100 eV the
+    /// brackets are 50 eV (half = 1.0, n = 41) and 500 eV (half = 2.0,
+    /// n = 51); the larger non-zero offset is `2.0 · (1 − 1/50) = 1.96`.
+    #[test]
+    fn test_tabulated_kernel_support_uses_larger_bracketing_kernel() {
+        let r = synthetic_tab_resolution();
+        let e: f64 = 100.0;
+        let dt_max = triangle_dt_max(2.0, 51);
+        let expected = 2.0 * e.powf(1.5) / (TOF_FACTOR * 25.0) * dt_max;
+        let got = r.kernel_support_ev(e);
+        assert!(
+            (got - expected).abs() / expected < 1e-12,
+            "support between refs: got {got}, expected {expected}"
+        );
+    }
+
+    /// Below the lowest ref energy: use the lowest ref kernel.
+    /// Above the highest ref energy: use the highest ref kernel.
+    #[test]
+    fn test_tabulated_kernel_support_uses_nearest_outside_grid() {
+        let r = synthetic_tab_resolution();
+        // Below grid (ref_min = 5 eV; triangle(half=0.5, n=31)).
+        let e_low: f64 = 1.0;
+        let exp_low = 2.0 * e_low.powf(1.5) / (TOF_FACTOR * 25.0) * triangle_dt_max(0.5, 31);
+        assert!((r.kernel_support_ev(e_low) - exp_low).abs() / exp_low < 1e-12);
+        // Above grid (ref_max = 500 eV; triangle(half=2.0, n=51)).
+        let e_hi: f64 = 1000.0;
+        let exp_hi = 2.0 * e_hi.powf(1.5) / (TOF_FACTOR * 25.0) * triangle_dt_max(2.0, 51);
+        assert!((r.kernel_support_ev(e_hi) - exp_hi).abs() / exp_hi < 1e-12);
+    }
+
+    /// Non-positive / non-finite energy → 0.0 (no broadening footprint).
+    #[test]
+    fn test_tabulated_kernel_support_returns_zero_for_invalid_energy() {
+        let r = synthetic_tab_resolution();
+        assert_eq!(r.kernel_support_ev(0.0), 0.0);
+        assert_eq!(r.kernel_support_ev(-1.0), 0.0);
+        assert_eq!(r.kernel_support_ev(f64::NAN), 0.0);
+        assert_eq!(r.kernel_support_ev(f64::INFINITY), 0.0);
+    }
+
+    /// Zero-weight tail entries must not inflate the support; only
+    /// `weights[i] > 0` entries count.
+    #[test]
+    fn test_tabulated_kernel_support_ignores_zero_weight_entries() {
+        // Build a kernel where the outermost entries have weight 0.
+        let offsets = vec![-10.0, -1.0, 0.0, 1.0, 10.0];
+        let weights = vec![0.0, 0.5, 1.0, 0.5, 0.0];
+        let r = TabulatedResolution {
+            ref_energies: vec![100.0],
+            kernels: vec![(offsets, weights)],
+            flight_path_m: 25.0,
+        };
+        let e: f64 = 100.0;
+        // Expected support uses dt_max = 1.0 (the outermost zero-weight
+        // entries at ±10 are ignored), not 10.0.
+        let expected = 2.0 * e.powf(1.5) / (TOF_FACTOR * 25.0) * 1.0;
+        let got = r.kernel_support_ev(e);
+        assert!(
+            (got - expected).abs() / expected < 1e-12,
+            "support should ignore zero-weight entries: got {got}, expected {expected}"
+        );
     }
 }

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -344,6 +344,22 @@ pub struct UnifiedFitConfig {
     /// `Some(_)` bypasses both the env var and the default.
     tzero_jacobian_method: Option<nereids_fitting::transmission_model::EnergyScaleJacobianMethod>,
 
+    // ── Fit energy range restriction (SAMMY REGION equivalent) ──
+    /// User-specified fit-energy-range restriction.  When `Some((min,
+    /// max))`, the configured `energies` grid is expected to extend
+    /// beyond `[min, max]` by a kernel-margin (~5×FWHM); the GUI / pre-
+    /// processing layer slices the input data to that extended grid
+    /// before constructing this config.  The solver cost functions
+    /// (LM transmission and joint-Poisson PBD) mask residuals outside
+    /// `[min, max]` to zero so resonance contributions just inside the
+    /// boundaries are correctly broadened.
+    ///
+    /// `None` (default) = full grid, no masking.  Reduced χ² / dof
+    /// counts are computed against the active bin count when masking
+    /// is in effect.  See SAMMY user manual §IIID.6 ("REGION") and the
+    /// `MIN ENERGY` / `MAX ENERGY` SAM52 cards.
+    fit_energy_range: Option<(f64, f64)>,
+
     // ── Isotope group mapping (optional) ──
     /// Maps member isotope index → density parameter index.
     /// `None` = identity mapping (one param per isotope, backward compat).
@@ -416,6 +432,7 @@ impl UnifiedFitConfig {
             density_ratios: None,
             n_density_params: None,
             tzero_jacobian_method: None,
+            fit_energy_range: None,
         })
     }
 
@@ -469,6 +486,19 @@ impl UnifiedFitConfig {
         self.t0_init_us = t0_init_us;
         self.l_scale_init = l_scale_init;
         self.flight_path_m = flight_path_m;
+        self
+    }
+
+    /// Restrict the fit cost function to bins inside `[min_eV, max_eV]`
+    /// (SAMMY REGION equivalent).  The configured `energies` grid is
+    /// expected to extend by ~5×FWHM beyond `[min, max]` on each side
+    /// (the GUI / pre-processing layer handles this); the LM and
+    /// joint-Poisson cost paths mask residuals outside `[min, max]` to
+    /// zero so resonance broadening at the boundaries is correct.
+    /// `None` (default) = full grid, no masking.
+    #[must_use]
+    pub fn with_fit_energy_range(mut self, range: Option<(f64, f64)>) -> Self {
+        self.fit_energy_range = range;
         self
     }
 
@@ -702,6 +732,12 @@ impl UnifiedFitConfig {
     /// (see [`Self::with_energy_scale`]).
     pub fn fit_energy_scale(&self) -> bool {
         self.fit_energy_scale
+    }
+    /// User-specified fit-energy-range restriction (SAMMY REGION
+    /// equivalent), or `None` for full-grid fitting.
+    /// See [`Self::with_fit_energy_range`].
+    pub fn fit_energy_range(&self) -> Option<(f64, f64)> {
+        self.fit_energy_range
     }
     pub fn precomputed_cross_sections(&self) -> Option<&Arc<Vec<Vec<f64>>>> {
         self.precomputed_cross_sections.as_ref()
@@ -1066,6 +1102,14 @@ fn fit_transmission_lm(
         build_transmission_model(config, n_density_params, _temperature_index)?
     };
 
+    // Build the per-bin active mask (SAMMY REGION-equivalent fit-energy
+    // -range restriction).  `None` when no range is configured — the
+    // LM core treats that as "all bins active".
+    let active_mask = nereids_fitting::active_mask::build_active_mask(
+        config.energies(),
+        config.fit_energy_range(),
+    );
+
     // Dispatch with optional background wrapping
     let result = if let Some(bi) = bg_indices {
         let wrapped = if let (Some(di), Some(fi)) = (bi.back_d, bi.back_f) {
@@ -1089,9 +1133,23 @@ fn fit_transmission_lm(
                 bi.back_c,
             )
         };
-        lm::levenberg_marquardt(&wrapped, measured_t, sigma, &mut params, &lm_cfg)?
+        lm::levenberg_marquardt_with_mask(
+            &wrapped,
+            measured_t,
+            sigma,
+            &mut params,
+            &lm_cfg,
+            active_mask.as_deref(),
+        )?
     } else {
-        lm::levenberg_marquardt(&*model, measured_t, sigma, &mut params, &lm_cfg)?
+        lm::levenberg_marquardt_with_mask(
+            &*model,
+            measured_t,
+            sigma,
+            &mut params,
+            &lm_cfg,
+            active_mask.as_deref(),
+        )?
     };
 
     let mut sr = extract_result(config, &result, n_density_params, bg_indices)?;
@@ -1420,6 +1478,16 @@ fn fit_counts_joint_poisson(
     // Its analytical Jacobian chains through the inner model correctly,
     // so JointPoissonObjective picks up gradients for both density and
     // background parameters without further wiring.
+
+    // Build the per-bin active mask (SAMMY REGION-equivalent fit-energy
+    // -range restriction).  `None` when no range is configured — the
+    // JP objective treats that as "all bins active".
+    let active_mask = nereids_fitting::active_mask::build_active_mask(
+        config.energies(),
+        config.fit_energy_range(),
+    );
+    let active_mask_slice = active_mask.as_deref();
+
     let result;
     if let Some(bi) = bg_indices {
         let wrapped = NormalizedTransmissionModel::new(
@@ -1435,6 +1503,7 @@ fn fit_counts_joint_poisson(
             o: flux,
             s: sample_counts,
             c,
+            active_mask: active_mask_slice,
         };
         let mut cfg = jp_cfg.clone();
         cfg.compute_covariance = config.compute_covariance;
@@ -1447,6 +1516,7 @@ fn fit_counts_joint_poisson(
             o: flux,
             s: sample_counts,
             c,
+            active_mask: active_mask_slice,
         };
         let mut cfg = jp_cfg.clone();
         cfg.compute_covariance = config.compute_covariance;
@@ -3799,6 +3869,90 @@ mod tests {
         assert!(
             err.to_string().contains("fit_back_d"),
             "expected partial-BackD/F rejection on transmission-PoissonKL path"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Fit-energy-range provenance + masked equivalence (#514).
+    // ------------------------------------------------------------------
+
+    /// `with_fit_energy_range(...)` round-trips through the accessor.
+    #[test]
+    fn test_unified_fit_config_fit_energy_range_round_trips() {
+        let data = u238_single_resonance();
+        let energies: Vec<f64> = (0..21).map(|i| 1.0 + (i as f64) * 0.1).collect();
+        let cfg = UnifiedFitConfig::new(
+            energies,
+            vec![data],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.001],
+        )
+        .unwrap();
+        assert_eq!(cfg.fit_energy_range(), None);
+
+        let cfg = cfg.with_fit_energy_range(Some((5.0, 50.0)));
+        assert_eq!(cfg.fit_energy_range(), Some((5.0, 50.0)));
+
+        // Setting back to None clears it.
+        let cfg = cfg.with_fit_energy_range(None);
+        assert_eq!(cfg.fit_energy_range(), None);
+    }
+
+    /// LM fit with `fit_energy_range = Some((min, max))` on the full
+    /// grid must yield the same density as the same fit run on the
+    /// `[min, max]` slice directly when the residual outside the range
+    /// is negligible (SAMMY REGION semantics, paper-acceptance test).
+    #[test]
+    fn test_fit_energy_range_lm_matches_subset_when_outside_negligible() {
+        let data = u238_single_resonance();
+        let true_density = 0.002;
+        // Wide grid: 0.5..10.5 eV in 0.05 eV steps.  The U-238 single
+        // resonance sits well inside [4, 8] eV, so a fit restricted to
+        // that range should recover the same density as the full-grid
+        // fit (residual outside is negligible).
+        let energies: Vec<f64> = (0..201).map(|i| 0.5 + (i as f64) * 0.05).collect();
+        let (t, sigma) = synthetic_transmission(&data, true_density, &energies);
+
+        let cfg_full = UnifiedFitConfig::new(
+            energies.clone(),
+            vec![data.clone()],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.001],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig::default()));
+
+        let cfg_masked = UnifiedFitConfig::new(
+            energies.clone(),
+            vec![data],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.001],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig::default()))
+        .with_fit_energy_range(Some((4.0, 8.0)));
+
+        let input = InputData::Transmission {
+            transmission: t,
+            uncertainty: sigma,
+        };
+        let r_full = fit_spectrum_typed(&input, &cfg_full).unwrap();
+        let r_masked = fit_spectrum_typed(&input, &cfg_masked).unwrap();
+        assert!(r_full.converged && r_masked.converged);
+
+        let d_full = r_full.densities[0];
+        let d_masked = r_masked.densities[0];
+        let rel_err = (d_full - d_masked).abs() / d_full.abs();
+        assert!(
+            rel_err < 0.01,
+            "fit_energy_range LM density {d_masked} should match full-grid {d_full} \
+             within 1% (got rel_err = {rel_err})"
         );
     }
 }

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -496,10 +496,29 @@ impl UnifiedFitConfig {
     /// joint-Poisson cost paths mask residuals outside `[min, max]` to
     /// zero so resonance broadening at the boundaries is correct.
     /// `None` (default) = full grid, no masking.
-    #[must_use]
-    pub fn with_fit_energy_range(mut self, range: Option<(f64, f64)>) -> Self {
+    ///
+    /// Validates the range up-front so non-finite or reversed bounds
+    /// (which would silently produce an empty active-bin mask and a
+    /// deceptive fit) are rejected at config-build time rather than
+    /// surfacing as a downstream solver error.
+    pub fn with_fit_energy_range(
+        mut self,
+        range: Option<(f64, f64)>,
+    ) -> Result<Self, FitConfigError> {
+        if let Some((lo, hi)) = range {
+            if !lo.is_finite() || !hi.is_finite() {
+                return Err(FitConfigError::InvalidFitEnergyRange(
+                    "fit_energy_range bounds must be finite",
+                ));
+            }
+            if lo >= hi {
+                return Err(FitConfigError::InvalidFitEnergyRange(
+                    "fit_energy_range min must be strictly less than max",
+                ));
+            }
+        }
         self.fit_energy_range = range;
-        self
+        Ok(self)
     }
 
     #[must_use]
@@ -1175,6 +1194,22 @@ fn fit_transmission_poisson(
     config: &UnifiedFitConfig,
     poisson_cfg: &PoissonConfig,
 ) -> Result<SpectrumFitResult, PipelineError> {
+    // SAMMY REGION-equivalent fit-energy-range (#514): the legacy
+    // transmission-domain `poisson_fit` does not honour an active mask,
+    // so silently routing the data here when the user set a fit range
+    // would bias the fit by including out-of-range bins (margin region)
+    // in the cost function.  Hard-reject up-front rather than producing
+    // a misleading "successful" fit.  Joint-Poisson (counts) and LM
+    // transmission both honour the mask correctly.
+    if config.fit_energy_range().is_some() {
+        return Err(PipelineError::InvalidParameter(
+            "fit_energy_range is not supported for the transmission + \
+             Poisson-KL solver path. Use joint-Poisson (provide sample + \
+             open-beam counts) or switch to the LM transmission solver."
+                .into(),
+        ));
+    }
+
     let mut poisson_cfg = poisson_cfg.clone();
     poisson_cfg.compute_covariance = config.compute_covariance;
     let poisson_cfg = &poisson_cfg;
@@ -2300,6 +2335,8 @@ pub enum FitConfigError {
     NonFiniteTemperature(f64),
     /// Temperature must be non-negative.
     NegativeTemperature(f64),
+    /// `fit_energy_range` bounds were non-finite or reversed/empty.
+    InvalidFitEnergyRange(&'static str),
 }
 
 impl fmt::Display for FitConfigError {
@@ -2341,6 +2378,9 @@ impl fmt::Display for FitConfigError {
             }
             Self::NegativeTemperature(v) => {
                 write!(f, "temperature must be non-negative, got {v}")
+            }
+            Self::InvalidFitEnergyRange(msg) => {
+                write!(f, "invalid fit_energy_range: {msg}")
             }
         }
     }
@@ -3892,12 +3932,57 @@ mod tests {
         .unwrap();
         assert_eq!(cfg.fit_energy_range(), None);
 
-        let cfg = cfg.with_fit_energy_range(Some((5.0, 50.0)));
+        let cfg = cfg.with_fit_energy_range(Some((5.0, 50.0))).unwrap();
         assert_eq!(cfg.fit_energy_range(), Some((5.0, 50.0)));
 
         // Setting back to None clears it.
-        let cfg = cfg.with_fit_energy_range(None);
+        let cfg = cfg.with_fit_energy_range(None).unwrap();
         assert_eq!(cfg.fit_energy_range(), None);
+    }
+
+    /// `with_fit_energy_range` rejects non-finite or reversed bounds
+    /// rather than silently producing an empty active-bin mask
+    /// downstream.
+    #[test]
+    fn test_unified_fit_config_fit_energy_range_rejects_invalid() {
+        let data = u238_single_resonance();
+        let energies: Vec<f64> = (0..21).map(|i| 1.0 + (i as f64) * 0.1).collect();
+        let cfg = UnifiedFitConfig::new(
+            energies,
+            vec![data],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.001],
+        )
+        .unwrap();
+
+        // Reversed range (lo > hi) is rejected.
+        let err = cfg
+            .clone()
+            .with_fit_energy_range(Some((10.0, 5.0)))
+            .unwrap_err();
+        assert!(matches!(err, FitConfigError::InvalidFitEnergyRange(_)));
+
+        // Empty range (lo == hi) is rejected — `lo < hi` strictly required.
+        let err = cfg
+            .clone()
+            .with_fit_energy_range(Some((5.0, 5.0)))
+            .unwrap_err();
+        assert!(matches!(err, FitConfigError::InvalidFitEnergyRange(_)));
+
+        // Non-finite bounds are rejected.
+        let err = cfg
+            .clone()
+            .with_fit_energy_range(Some((f64::NAN, 5.0)))
+            .unwrap_err();
+        assert!(matches!(err, FitConfigError::InvalidFitEnergyRange(_)));
+
+        let err = cfg
+            .clone()
+            .with_fit_energy_range(Some((5.0, f64::INFINITY)))
+            .unwrap_err();
+        assert!(matches!(err, FitConfigError::InvalidFitEnergyRange(_)));
     }
 
     /// LM fit with `fit_energy_range = Some((min, max))` on the full
@@ -3936,7 +4021,8 @@ mod tests {
         )
         .unwrap()
         .with_solver(SolverConfig::LevenbergMarquardt(LmConfig::default()))
-        .with_fit_energy_range(Some((4.0, 8.0)));
+        .with_fit_energy_range(Some((4.0, 8.0)))
+        .unwrap();
 
         let input = InputData::Transmission {
             transmission: t,
@@ -3953,6 +4039,46 @@ mod tests {
             rel_err < 0.01,
             "fit_energy_range LM density {d_masked} should match full-grid {d_full} \
              within 1% (got rel_err = {rel_err})"
+        );
+    }
+
+    /// Transmission + PoissonKL with `fit_energy_range` set must be
+    /// hard-rejected at dispatch.  The legacy `poisson_fit` does not
+    /// honour the active-bin mask, so silently fitting on the
+    /// (margin-extended) grid would bias the result.  Joint-Poisson
+    /// (counts) and LM transmission both honour the mask correctly.
+    /// Regression for Round-2 review fix #1 (#514).
+    #[test]
+    fn test_fit_energy_range_rejected_on_transmission_poisson_path() {
+        let data = u238_single_resonance();
+        let true_density = 0.002;
+        let energies: Vec<f64> = (0..201).map(|i| 0.5 + (i as f64) * 0.05).collect();
+        let (t, sigma) = synthetic_transmission(&data, true_density, &energies);
+
+        let cfg = UnifiedFitConfig::new(
+            energies,
+            vec![data],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.001],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::PoissonKL(PoissonConfig::default()))
+        .with_fit_energy_range(Some((4.0, 8.0)))
+        .unwrap();
+
+        let input = InputData::Transmission {
+            transmission: t,
+            uncertainty: sigma,
+        };
+        let err = fit_spectrum_typed(&input, &cfg).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("fit_energy_range")
+                && (msg.contains("Poisson") || msg.contains("poisson")),
+            "expected rejection message mentioning fit_energy_range and the \
+             Poisson-KL path; got: {msg}"
         );
     }
 }

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -1129,6 +1129,26 @@ fn fit_transmission_lm(
         config.fit_energy_range(),
     );
 
+    // When a fit-energy-range is configured, reject the call early if
+    // the user's `[E_min, E_max]` selects fewer than 2 active bins on
+    // the configured grid.  The LM core's `n_active < n_free` check
+    // would also catch this on the main path, but a dispatcher-level
+    // rejection gives the user a clear "range too narrow" error
+    // instead of a confusing non-converged result.
+    if let Some((e_min, e_max)) = config.fit_energy_range() {
+        let n_active = nereids_fitting::active_mask::active_count(
+            active_mask.as_deref(),
+            config.energies().len(),
+        );
+        if n_active < 2 {
+            return Err(PipelineError::InvalidParameter(format!(
+                "fit_energy_range [{e_min}, {e_max}] eV selects {n_active} active bin(s) \
+                 on the configured energy grid; at least 2 active bins are required \
+                 for LM transmission fitting"
+            )));
+        }
+    }
+
     // Dispatch with optional background wrapping
     let result = if let Some(bi) = bg_indices {
         let wrapped = if let (Some(di), Some(fi)) = (bi.back_d, bi.back_f) {
@@ -1522,6 +1542,24 @@ fn fit_counts_joint_poisson(
         config.fit_energy_range(),
     );
     let active_mask_slice = active_mask.as_deref();
+
+    // Reject early when the configured range selects fewer than 2
+    // active bins on the grid.  `joint_poisson_fit` already rejects
+    // the `n_active < n_free` case (and the new `n_active == 0`
+    // early-return), but a dispatcher-level rejection gives users a
+    // clear "range too narrow" error instead of a non-converged JP
+    // result.
+    if let Some((e_min, e_max)) = config.fit_energy_range() {
+        let n_active =
+            nereids_fitting::active_mask::active_count(active_mask_slice, config.energies().len());
+        if n_active < 2 {
+            return Err(PipelineError::InvalidParameter(format!(
+                "fit_energy_range [{e_min}, {e_max}] eV selects {n_active} active bin(s) \
+                 on the configured energy grid; at least 2 active bins are required \
+                 for joint-Poisson fitting"
+            )));
+        }
+    }
 
     let result;
     if let Some(bi) = bg_indices {
@@ -4079,6 +4117,73 @@ mod tests {
                 && (msg.contains("Poisson") || msg.contains("poisson")),
             "expected rejection message mentioning fit_energy_range and the \
              Poisson-KL path; got: {msg}"
+        );
+    }
+
+    /// LM dispatcher must reject `fit_energy_range` that selects fewer
+    /// than 2 active bins on the configured grid with a clear
+    /// "range too narrow" error — instead of a confusing non-converged
+    /// LM result.  Regression for #517 R3 P2 (Copilot finding #2).
+    #[test]
+    fn test_fit_energy_range_lm_rejects_too_narrow() {
+        let data = u238_single_resonance();
+        // 0.5..10.5 eV in 0.5 eV steps.  Range [4.6, 4.7] selects
+        // exactly zero bins (no grid point inside; closest are 4.5
+        // and 5.0).
+        let energies: Vec<f64> = (0..21).map(|i| 0.5 + (i as f64) * 0.5).collect();
+        let (t, sigma) = synthetic_transmission(&data, 0.002, &energies);
+        let cfg = UnifiedFitConfig::new(
+            energies,
+            vec![data],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.001],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig::default()))
+        .with_fit_energy_range(Some((4.6, 4.7)))
+        .unwrap();
+        let input = InputData::Transmission {
+            transmission: t,
+            uncertainty: sigma,
+        };
+        let err = fit_spectrum_typed(&input, &cfg).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("fit_energy_range") && msg.contains("active bin"),
+            "expected too-narrow-range rejection; got: {msg}"
+        );
+    }
+
+    /// Joint-Poisson dispatcher must reject too-narrow ranges with the
+    /// same clear error.  Regression for #517 R3 P2 (Copilot #3).
+    #[test]
+    fn test_fit_energy_range_jp_rejects_too_narrow() {
+        let data = u238_single_resonance();
+        let energies: Vec<f64> = (0..21).map(|i| 0.5 + (i as f64) * 0.5).collect();
+        let (sample, open_beam) = synthetic_counts(&data, 0.002, &energies, 1000.0);
+        let cfg = UnifiedFitConfig::new(
+            energies,
+            vec![data],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.001],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::PoissonKL(PoissonConfig::default()))
+        .with_fit_energy_range(Some((4.6, 4.7)))
+        .unwrap();
+        let input = InputData::Counts {
+            sample_counts: sample,
+            open_beam_counts: open_beam,
+        };
+        let err = fit_spectrum_typed(&input, &cfg).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("fit_energy_range") && msg.contains("active bin"),
+            "expected too-narrow-range rejection; got: {msg}"
         );
     }
 }

--- a/docs/guide/src/gui-walkthrough.md
+++ b/docs/guide/src/gui-walkthrough.md
@@ -75,6 +75,35 @@ with move, select, and delete operations.
 
 ![Analyze step](images/analyze-step.png)
 
+#### Restricting the fit energy range (SAMMY REGION)
+
+By default NEREIDS fits the entire loaded energy grid. The advanced solver
+panel exposes a **"Restrict fit energy range"** checkbox (SAMMY REGION
+equivalent — `MIN ENERGY` / `MAX ENERGY` SAM52 cards) that limits the cost
+function to a user-specified `[E_min, E_max]` window in eV. Common uses:
+
+- **Resolved-resonance region only** — exclude the unresolved-resonance and
+  high-energy tails where the model can't fit;
+- **Single resonance triplet** — focus on a specific feature for fine-grained
+  density / temperature work;
+- **SAMMY parity** — match the REGION restriction used in a reference SAMMY
+  fit so the comparison is apples-to-apples.
+
+When the checkbox is on, two grey dashed vertical lines on the spectrum plot
+mark the active boundaries (visible on the energy-eV axis). The reduced χ²
+and degrees-of-freedom reported in the fit details count only bins inside
+the active range.
+
+**Resolution-kernel margin (automatic):** the broadening kernel pulls model
+contributions from outside the user range. NEREIDS handles this transparently
+by extending the data slice by ~5×FWHM on each side and masking the cost
+function back to `[E_min, E_max]` — so resonances near the boundaries are
+correctly broadened without the user picking a custom margin. SAMMY user
+manual §IIID.6 recommends 3–5×FWHM; we use 5× for safety.
+
+The setting persists in `.nrd.h5` project files (`Option<(f64, f64)>`,
+default `None` = full grid for backwards compatibility).
+
 ### Results
 
 View density maps for each fitted isotope. Summary statistics show convergence


### PR DESCRIPTION
## Summary

- Add a user-specifiable `[E_min, E_max]` fit window (SAMMY REGION /
  `MIN ENERGY` / `MAX ENERGY` SAM52 cards) — paper-readiness Tier 1.
- Proper resolution-kernel handling: data sliced with 5×FWHM margin so
  resonance broadening at the boundaries is correct; LM and joint-
  Poisson cost paths mask residuals back to the user's inner range.
- Defaults to off → no behavioural change for existing users.

Closes #514.

## Implementation (three layers)

**Solver-side** (`crates/nereids-fitting/`): new `active_mask` module +
`levenberg_marquardt_with_mask(...)` (weight = 0 for masked bins → χ² /
JᵀWJ / JᵀWr zero out automatically) + `JointPoissonObjective.active_mask`
(masked bins skipped in deviance, analytical gradient, analytical Fisher,
and FD Fisher loops). New `n_active()` drives `dof` so reduced-χ² and
deviance-per-dof reflect only active bins.

**Pipeline** (`crates/nereids-pipeline/`):
`UnifiedFitConfig.fit_energy_range` + `with_fit_energy_range(...)` +
accessor. Both LM and joint-Poisson dispatchers build the mask from
`config.energies()` + `config.fit_energy_range()`. Project save/load
round-trip via two HDF5 attributes on `/config/solver` (forward /
backward compatible — absent attrs load as `None`).

**GUI** (`apps/gui/`): `AppState.fit_energy_range`, persisted in
`SessionCache` and `ProjectSnapshot`. `build_fit_config` returns
`(UnifiedFitConfig, Range<usize>)`; the range covers a 5×FWHM kernel-
margin extension on each side (Gaussian: `5×params.fwhm(E)`; tabulated:
10%×E conservative fallback). `fit_pixel` / `fit_roi` / `run_spatial_map`
slice their per-bin data accordingly. New "Restrict fit energy range"
checkbox + Min/Max DragValues in the advanced solver panel; two grey
dashed VLines mark the inner window on the energy-axis spectrum plot.

## Tests (added)

- `nereids-fitting::active_mask` — helper unit tests (5).
- `nereids-fitting::lm` — LM mask subset-equivalence + corruption-
  immunity (2).
- `nereids-fitting::joint_poisson` — JP deviance + gradient subset-
  equivalence (2).
- `nereids-pipeline::pipeline` — `with_fit_energy_range` round-trip +
  LM masked-vs-full-grid density equivalence (within 1%) (2).

All 14 existing `JointPoissonObjective` construction sites updated to
the new public field shape (`active_mask: None` for prior behaviour).

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --exclude nereids-python` — all pass (116 fitting, 70 pipeline, 132 endf, 89 physics, …)
- [ ] **Manual GUI smoke** (reviewer):
  - Default off → existing fits unchanged.
  - Toggle on with full-grid bounds → fit equivalent to default.
  - Narrow to `[5, 50]` eV on Hf data → spectrum shows two grey
    dashed VLines at 5 and 50 eV; reduced-χ² uses `n_active`.
  - Save → quit → reload → checkbox + bounds restore.
  - Old projects (pre-#514) load with `fit_energy_range = None`.

## Out of scope (deferred)

- Multiple disjoint regions (SAMMY `MULTIPLE REGIONS`).
- Auto-suggest range from ENDF resolved-resonance bounds.
- Preset buttons ("RRR only" / "Custom" / "Full grid").
- Spectrum panel shaded exclusion regions (VLines suffice for v1).
- Tunable margin multiplier (currently fixed at 5×FWHM).
- TOF-axis VLine projection (energy-axis only for v1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)