### PR TITLE
feat(python): SAMMY-parity for Hf baseline scripts via fit_energy_range (#514 follow-up)

### DIFF
--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -784,6 +784,7 @@ def spatial_map_typed(
     delta_l_m: float | None = None,
     groups: list[IsotopeGroup] | None = None,
     tzero_jacobian: str | None = None,
+    fit_energy_range: tuple[float, float] | None = None,
 ) -> SpatialResult:
     """Spatial mapping using the typed input data API.
 
@@ -851,6 +852,7 @@ def fit_spectrum_typed(
     groups: list[IsotopeGroup] | None = None,
     initial_densities: list[float] | None = None,
     tzero_jacobian: str | None = None,
+    fit_energy_range: tuple[float, float] | None = None,
 ) -> FitResult:
     """Fit a single pre-normalized transmission spectrum.
 
@@ -910,6 +912,7 @@ def fit_counts_spectrum_typed(
     initial_densities: list[float] | None = None,
     enable_polish: bool | None = None,
     tzero_jacobian: str | None = None,
+    fit_energy_range: tuple[float, float] | None = None,
 ) -> FitResult:
     """Fit a single raw-count spectrum (sample + open-beam counts).
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -2966,6 +2966,7 @@ fn spatial_result_to_py(
     delta_l_m = None,
     groups = None,
     tzero_jacobian = None,
+    fit_energy_range = None,
 ))]
 #[allow(clippy::too_many_arguments)]
 fn py_spatial_map_typed<'py>(
@@ -2996,6 +2997,7 @@ fn py_spatial_map_typed<'py>(
     delta_l_m: Option<f64>,
     groups: Option<Vec<PyIsotopeGroup>>,
     tzero_jacobian: Option<&str>,
+    fit_energy_range: Option<(f64, f64)>,
 ) -> PyResult<PySpatialResult> {
     // Validate mutual exclusivity
     let has_isotopes = isotopes.is_some();
@@ -3195,6 +3197,15 @@ fn py_spatial_map_typed<'py>(
     // Dead pixels
     let dead_arr = dead_pixels.map(|dp| dp.as_array().to_owned());
 
+    // SAMMY REGION-equivalent fit-energy-range (#514): mask residuals
+    // to bins inside [E_min, E_max] in both LM and joint-Poisson per-
+    // pixel cost paths.  The model is evaluated on the full grid so
+    // resolution broadening at the boundaries is correct.  No Python
+    // -side data slicing required.
+    config = config
+        .with_fit_energy_range(fit_energy_range)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+
     // GIL held during computation.  InputData3D borrows PyInputData arrays
     // which are not Send, so we cannot use py.allow_threads().  The existing
     // py_spatial_map has the same limitation.  Rayon still parallelizes the
@@ -3272,6 +3283,7 @@ fn py_spatial_map_typed<'py>(
     initial_densities = None,
     enable_polish = None,
     tzero_jacobian = None,
+    fit_energy_range = None,
 ))]
 fn py_fit_counts_spectrum_typed<'py>(
     py: Python<'py>,
@@ -3306,6 +3318,7 @@ fn py_fit_counts_spectrum_typed<'py>(
     initial_densities: Option<Vec<f64>>,
     enable_polish: Option<bool>,
     tzero_jacobian: Option<&str>,
+    fit_energy_range: Option<(f64, f64)>,
 ) -> PyResult<PyFitResult> {
     use nereids_pipeline::pipeline::{
         CountsBackgroundConfig, InputData, UnifiedFitConfig, fit_spectrum_typed,
@@ -3494,6 +3507,16 @@ fn py_fit_counts_spectrum_typed<'py>(
     if let Some(v) = enable_polish {
         config = config.with_counts_enable_polish(Some(v));
     }
+
+    // SAMMY REGION-equivalent fit-energy-range (#514): mask residuals
+    // to bins inside [E_min, E_max]; the joint-Poisson cost path
+    // honours the mask in deviance / gradient / Fisher loops.  No
+    // Python-side data slicing required — the model is evaluated on
+    // the full grid so resolution broadening at the boundaries is
+    // correct.
+    config = config
+        .with_fit_energy_range(fit_energy_range)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
 
     let result = py.detach(move || fit_spectrum_typed(&input, &config).map_err(|e| e.to_string()));
     let result = result.map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e))?;
@@ -3806,6 +3829,7 @@ fn py_compute_model_jacobian<'py>(
     groups = None,
     initial_densities = None,
     tzero_jacobian = None,
+    fit_energy_range = None,
 ))]
 fn py_fit_spectrum_typed<'py>(
     py: Python<'py>,
@@ -3833,6 +3857,7 @@ fn py_fit_spectrum_typed<'py>(
     groups: Option<Vec<PyIsotopeGroup>>,
     initial_densities: Option<Vec<f64>>,
     tzero_jacobian: Option<&str>,
+    fit_energy_range: Option<(f64, f64)>,
 ) -> PyResult<PyFitResult> {
     use nereids_pipeline::pipeline::{InputData, fit_spectrum_typed};
 
@@ -3966,6 +3991,17 @@ fn py_fit_spectrum_typed<'py>(
     if tzero_method.is_some() {
         config = config.with_tzero_jacobian_method(tzero_method);
     }
+
+    // SAMMY REGION-equivalent fit-energy-range (#514): when set, the
+    // LM cost-function masks residuals to bins inside [E_min, E_max].
+    // The Python caller is expected to pass full grid + per-bin data
+    // and let the solver-side mask handle the restriction; the model
+    // is still evaluated on the full grid so resolution broadening at
+    // the boundaries remains correct (no caller-side margin slicing
+    // needed).
+    config = config
+        .with_fit_energy_range(fit_energy_range)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
 
     // Build 1D InputData
     let input = InputData::Transmission {

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -3200,8 +3200,8 @@ fn py_spatial_map_typed<'py>(
     // SAMMY REGION-equivalent fit-energy-range (#514): mask residuals
     // to bins inside [E_min, E_max] in both LM and joint-Poisson per-
     // pixel cost paths.  The model is evaluated on the full grid so
-    // resolution broadening at the boundaries is correct.  No Python
-    // -side data slicing required.
+    // resolution broadening at the boundaries is correct.
+    // No Python-side data slicing required.
     config = config
         .with_fit_energy_range(fit_energy_range)
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;

--- a/scripts/perf/baseline_dump.py
+++ b/scripts/perf/baseline_dump.py
@@ -57,10 +57,17 @@ def run_a1() -> dict:
         O3d_raw = f["Hf/open_beam/counts"][:][::-1, :, :]
         Q_s = float(f["Hf/120min/proton_charges/sample_values_uC"][:].sum())
         Q_ob = float(f["Hf/120min/proton_charges/ob_values_uC"][0])
-    mask = (E_full >= ENERGY_MIN) & (E_full <= ENERGY_MAX)
-    E = np.ascontiguousarray(E_full[mask])
-    S3d = np.ascontiguousarray(S3d_raw[mask]).astype(np.float64)
-    O3d = np.ascontiguousarray(O3d_raw[mask]).astype(np.float64)
+    # SAMMY REGION-equivalent: pass the full energy grid + per-bin
+    # data to NEREIDS and let the LM/JP cost paths mask residuals to
+    # `[ENERGY_MIN, ENERGY_MAX]` via `fit_energy_range`.  The model is
+    # evaluated on the full grid so resolution broadening at the
+    # boundaries is correct (#514) — equivalent to SAMMY's REGION cards
+    # which apply a kernel-margin internally.  Pre-PR-#514 this script
+    # cropped the data array directly, which truncated the kernel at
+    # the upper boundary near 200 eV.
+    E = np.ascontiguousarray(E_full)
+    S3d = np.ascontiguousarray(S3d_raw).astype(np.float64)
+    O3d = np.ascontiguousarray(O3d_raw).astype(np.float64)
     c = Q_s / Q_ob
     S_agg = S3d.sum(axis=(1, 2))
     O_agg = O3d.sum(axis=(1, 2))
@@ -89,6 +96,7 @@ def run_a1() -> dict:
         l_scale_init=1.005,
         energy_scale_flight_path_m=FLIGHT_PATH_M,
         resolution=res,
+        fit_energy_range=(ENERGY_MIN, ENERGY_MAX),
     )
     wall = time.time() - t0
     return {
@@ -112,13 +120,15 @@ def run_b2() -> dict:
         Q_ob = float(f["Hf/120min/proton_charges/ob_values_uC"][0])
     CROP_Y0, CROP_Y1 = 252, 256
     CROP_X0, CROP_X1 = 252, 256
-    mask = (E_full >= ENERGY_MIN) & (E_full <= ENERGY_MAX)
-    E = np.ascontiguousarray(E_full[mask])
+    # SAMMY REGION-equivalent: keep the FULL spectral axis, apply the
+    # pre-calibrated TZERO transformation to the whole grid, and let
+    # `fit_energy_range` mask the cost function (#514).  Spatial cropping
+    # in (y, x) is unchanged.
     S3d = np.ascontiguousarray(
-        S3d_raw[mask][:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
+        S3d_raw[:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
     ).astype(np.float64)
     O3d = np.ascontiguousarray(
-        O3d_raw[mask][:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
+        O3d_raw[:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
     ).astype(np.float64)
     c = Q_s / Q_ob
 
@@ -126,9 +136,21 @@ def run_b2() -> dict:
     L_SCALE = 1.0052452911520162
     tof_factor = (0.5 * 1.67492749804e-27 / 1.602176634e-19) ** 0.5 * 1.0e6
     L_eff = FLIGHT_PATH_M * L_SCALE
-    tof = tof_factor * FLIGHT_PATH_M / np.sqrt(E)
-    tof_corr = tof - T0_US
-    E_cal = np.ascontiguousarray((tof_factor * L_eff / tof_corr) ** 2)
+    # Apply TZERO calibration to the full nominal grid.  The
+    # transformation is monotonic, so the calibrated bins originally
+    # corresponding to nominal `[ENERGY_MIN, ENERGY_MAX]` map to a
+    # well-defined `[fit_min_cal, fit_max_cal]` range on the calibrated
+    # axis.
+    tof_full = tof_factor * FLIGHT_PATH_M / np.sqrt(E_full)
+    tof_corr_full = tof_full - T0_US
+    E_cal_full = np.ascontiguousarray((tof_factor * L_eff / tof_corr_full) ** 2)
+
+    def _tzero_cal(e_nominal: float) -> float:
+        tof = tof_factor * FLIGHT_PATH_M / np.sqrt(e_nominal)
+        return float((tof_factor * L_eff / (tof - T0_US)) ** 2)
+
+    fit_min_cal = _tzero_cal(ENERGY_MIN)
+    fit_max_cal = _tzero_cal(ENERGY_MAX)
 
     hf_group = nereids.IsotopeGroup.natural(72)
     hf_group.load_endf()
@@ -140,7 +162,7 @@ def run_b2() -> dict:
     t0 = time.time()
     r = nereids.spatial_map_typed(
         data=input_data,
-        energies=E_cal,
+        energies=E_cal_full,
         solver="kl",
         c=c,
         temperature_k=TEMP_K,
@@ -150,6 +172,7 @@ def run_b2() -> dict:
         background=True,
         resolution=res,
         dead_pixels=dead_pixels,
+        fit_energy_range=(fit_min_cal, fit_max_cal),
     )
     wall = time.time() - t0
     dens = np.asarray(r.density_maps[0])
@@ -173,13 +196,15 @@ def run_b1() -> dict:
         Q_ob = float(f["Hf/120min/proton_charges/ob_values_uC"][0])
     CROP_Y0, CROP_Y1 = 254, 256
     CROP_X0, CROP_X1 = 254, 256
-    mask = (E_full >= ENERGY_MIN) & (E_full <= ENERGY_MAX)
-    E = np.ascontiguousarray(E_full[mask])
+    # SAMMY REGION-equivalent: full nominal axis + `fit_energy_range`
+    # mask in the LM cost path (#514).  TZERO is FITTED (not pre-
+    # calibrated) here, so the axis stays nominal.
+    E = np.ascontiguousarray(E_full)
     S3d = np.ascontiguousarray(
-        S3d_raw[mask][:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
+        S3d_raw[:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
     ).astype(np.float64)
     O3d = np.ascontiguousarray(
-        O3d_raw[mask][:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
+        O3d_raw[:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
     ).astype(np.float64)
     c = Q_s / Q_ob
     T3d = S3d / np.maximum(c * O3d, 1.0)
@@ -209,6 +234,7 @@ def run_b1() -> dict:
         energy_scale_flight_path_m=FLIGHT_PATH_M,
         resolution=res,
         dead_pixels=dead_pixels,
+        fit_energy_range=(ENERGY_MIN, ENERGY_MAX),
     )
     wall = time.time() - t0
     dens = np.asarray(r.density_maps[0])
@@ -240,10 +266,11 @@ def _run_periso_tzero(solver: str, crop_size: int, label: str, max_iter: int) ->
     x0 = 255 - crop_size // 2
     y1 = y0 + crop_size
     x1 = x0 + crop_size
-    mask = (E_full >= ENERGY_MIN) & (E_full <= ENERGY_MAX)
-    E = np.ascontiguousarray(E_full[mask])
-    S3d = np.ascontiguousarray(S3d_raw[mask][:, y0:y1, x0:x1]).astype(np.float64)
-    O3d = np.ascontiguousarray(O3d_raw[mask][:, y0:y1, x0:x1]).astype(np.float64)
+    # SAMMY REGION-equivalent: full nominal axis + `fit_energy_range`
+    # mask in the per-pixel cost path (#514).
+    E = np.ascontiguousarray(E_full)
+    S3d = np.ascontiguousarray(S3d_raw[:, y0:y1, x0:x1]).astype(np.float64)
+    O3d = np.ascontiguousarray(O3d_raw[:, y0:y1, x0:x1]).astype(np.float64)
     c = Q_s / Q_ob
 
     hf_group = nereids.IsotopeGroup.natural(72)
@@ -279,6 +306,7 @@ def _run_periso_tzero(solver: str, crop_size: int, label: str, max_iter: int) ->
         energy_scale_flight_path_m=FLIGHT_PATH_M,
         resolution=res,
         dead_pixels=dead_pixels,
+        fit_energy_range=(ENERGY_MIN, ENERGY_MAX),
     )
     if solver == "kl":
         kwargs["c"] = c

--- a/scripts/perf/baseline_dump.py
+++ b/scripts/perf/baseline_dump.py
@@ -141,6 +141,12 @@ def run_b2() -> dict:
     # corresponding to nominal `[ENERGY_MIN, ENERGY_MAX]` map to a
     # well-defined `[fit_min_cal, fit_max_cal]` range on the calibrated
     # axis.
+    #
+    # Guard: pre-PR-#519 the `mask = E_full >= 7.0` step filtered any
+    # bin with E ≤ 0 before sqrt; with the mask gone we assert the
+    # input axis is strictly positive so `sqrt(E_full)` can't inject
+    # NaN into `E_cal_full` and silently extend the active mask.
+    assert (E_full > 0).all(), "energy axis must be strictly positive"
     tof_full = tof_factor * FLIGHT_PATH_M / np.sqrt(E_full)
     tof_corr_full = tof_full - T0_US
     E_cal_full = np.ascontiguousarray((tof_factor * L_eff / tof_corr_full) ** 2)

--- a/scripts/perf/baseline_dump.py
+++ b/scripts/perf/baseline_dump.py
@@ -143,10 +143,14 @@ def run_b2() -> dict:
     # axis.
     #
     # Guard: pre-PR-#519 the `mask = E_full >= 7.0` step filtered any
-    # bin with E ≤ 0 before sqrt; with the mask gone we assert the
+    # bin with E ≤ 0 before sqrt; with the mask gone we check the
     # input axis is strictly positive so `sqrt(E_full)` can't inject
     # NaN into `E_cal_full` and silently extend the active mask.
-    assert (E_full > 0).all(), "energy axis must be strictly positive"
+    # Use a runtime check rather than `assert` — `python -O` strips
+    # asserts, and a corrupt input axis injecting NaN downstream is
+    # much harder to debug than an upfront error.
+    if not np.all(E_full > 0):
+        raise ValueError("energy axis must be strictly positive")
     tof_full = tof_factor * FLIGHT_PATH_M / np.sqrt(E_full)
     tof_corr_full = tof_full - T0_US
     E_cal_full = np.ascontiguousarray((tof_factor * L_eff / tof_corr_full) ** 2)

--- a/scripts/perf/profile_a1_lm_grouped.py
+++ b/scripts/perf/profile_a1_lm_grouped.py
@@ -38,10 +38,13 @@ def main() -> None:
         O3d_raw = f["Hf/open_beam/counts"][:][::-1, :, :]
         Q_s = float(f["Hf/120min/proton_charges/sample_values_uC"][:].sum())
         Q_ob = float(f["Hf/120min/proton_charges/ob_values_uC"][0])
-    mask = (E_full >= ENERGY_MIN) & (E_full <= ENERGY_MAX)
-    E = np.ascontiguousarray(E_full[mask])
-    S3d = np.ascontiguousarray(S3d_raw[mask]).astype(np.float64)
-    O3d = np.ascontiguousarray(O3d_raw[mask]).astype(np.float64)
+    # SAMMY REGION-equivalent: full nominal axis + `fit_energy_range`
+    # mask in the LM cost path (#514).  Pre-PR-#514 this script
+    # cropped the data array directly, which truncated the resolution
+    # kernel at the upper boundary near 200 eV.
+    E = np.ascontiguousarray(E_full)
+    S3d = np.ascontiguousarray(S3d_raw).astype(np.float64)
+    O3d = np.ascontiguousarray(O3d_raw).astype(np.float64)
     c = Q_s / Q_ob
     S_agg = S3d.sum(axis=(1, 2))
     O_agg = O3d.sum(axis=(1, 2))
@@ -72,6 +75,7 @@ def main() -> None:
         l_scale_init=L_SCALE_INIT,
         energy_scale_flight_path_m=FLIGHT_PATH_M,
         resolution=res,
+        fit_energy_range=(ENERGY_MIN, ENERGY_MAX),
     )
 
     # Measured: the real workload.
@@ -91,6 +95,7 @@ def main() -> None:
         l_scale_init=L_SCALE_INIT,
         energy_scale_flight_path_m=FLIGHT_PATH_M,
         resolution=res,
+        fit_energy_range=(ENERGY_MIN, ENERGY_MAX),
     )
     wall = time.time() - t0
     print(

--- a/scripts/perf/profile_b1_lm_tzero_grouped.py
+++ b/scripts/perf/profile_b1_lm_tzero_grouped.py
@@ -44,13 +44,15 @@ def main() -> None:
         O3d_raw = f["Hf/open_beam/counts"][:][::-1, :, :]
         Q_s = float(f["Hf/120min/proton_charges/sample_values_uC"][:].sum())
         Q_ob = float(f["Hf/120min/proton_charges/ob_values_uC"][0])
-    mask = (E_full >= ENERGY_MIN) & (E_full <= ENERGY_MAX)
-    E = np.ascontiguousarray(E_full[mask])
+    # SAMMY REGION-equivalent: full nominal axis + `fit_energy_range`
+    # mask in the LM cost path (#514).  TZERO is FITTED here, so the
+    # axis stays nominal.  Spatial cropping in (y, x) is unchanged.
+    E = np.ascontiguousarray(E_full)
     S3d = np.ascontiguousarray(
-        S3d_raw[mask][:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
+        S3d_raw[:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
     ).astype(np.float64)
     O3d = np.ascontiguousarray(
-        O3d_raw[mask][:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
+        O3d_raw[:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
     ).astype(np.float64)
     c = Q_s / Q_ob
 
@@ -83,6 +85,7 @@ def main() -> None:
         energy_scale_flight_path_m=FLIGHT_PATH_M,
         resolution=res,
         dead_pixels=dead_pixels,
+        fit_energy_range=(ENERGY_MIN, ENERGY_MAX),
     )
 
     Path("/tmp/b1_ready").write_text("ready\n")
@@ -103,6 +106,7 @@ def main() -> None:
         energy_scale_flight_path_m=FLIGHT_PATH_M,
         resolution=res,
         dead_pixels=dead_pixels,
+        fit_energy_range=(ENERGY_MIN, ENERGY_MAX),
     )
     wall = time.time() - t0
     n_px = (CROP_Y1 - CROP_Y0) * (CROP_X1 - CROP_X0)

--- a/scripts/perf/profile_b2_kl_grouped.py
+++ b/scripts/perf/profile_b2_kl_grouped.py
@@ -32,23 +32,31 @@ def main() -> None:
         O3d_raw = f["Hf/open_beam/counts"][:][::-1, :, :]
         Q_s = float(f["Hf/120min/proton_charges/sample_values_uC"][:].sum())
         Q_ob = float(f["Hf/120min/proton_charges/ob_values_uC"][0])
-    mask = (E_full >= ENERGY_MIN) & (E_full <= ENERGY_MAX)
-    E = np.ascontiguousarray(E_full[mask])
-    S3d = np.ascontiguousarray(S3d_raw[mask][:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]).astype(np.float64)
-    O3d = np.ascontiguousarray(O3d_raw[mask][:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]).astype(np.float64)
+    # SAMMY REGION-equivalent: keep the FULL spectral axis, apply the
+    # pre-calibrated TZERO transformation to the whole grid, and let
+    # `fit_energy_range` mask the cost function (#514).  Spatial
+    # cropping in (y, x) is unchanged.
+    S3d = np.ascontiguousarray(S3d_raw[:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]).astype(np.float64)
+    O3d = np.ascontiguousarray(O3d_raw[:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]).astype(np.float64)
     c = Q_s / Q_ob
 
-    # Pre-calibrated TZERO (from baseline A.2) applied once to the data grid.
-    # tof_factor_us_sqrtEv * L / sqrt(E)  → TOF, then correct with t0, L_scale
-    # Use hard-coded calibration values from section_A_aggregated.json A2_KL_grouped.
+    # Pre-calibrated TZERO (from baseline A.2) applied to the full
+    # grid.  Hard-coded calibration values from
+    # section_A_aggregated.json A2_KL_grouped.
     T0_US = 0.4809277146701285
     L_SCALE = 1.0052452911520162
     tof_factor = (0.5 * 1.67492749804e-27 / 1.602176634e-19) ** 0.5 * 1.0e6
     L_eff = FLIGHT_PATH_M * L_SCALE
-    tof = tof_factor * FLIGHT_PATH_M / np.sqrt(E)
-    tof_corr = tof - T0_US
-    E_cal = (tof_factor * L_eff / tof_corr) ** 2
-    E_cal = np.ascontiguousarray(E_cal)
+    tof_full = tof_factor * FLIGHT_PATH_M / np.sqrt(E_full)
+    tof_corr_full = tof_full - T0_US
+    E_cal_full = np.ascontiguousarray((tof_factor * L_eff / tof_corr_full) ** 2)
+
+    def _tzero_cal(e_nominal: float) -> float:
+        tof = tof_factor * FLIGHT_PATH_M / np.sqrt(e_nominal)
+        return float((tof_factor * L_eff / (tof - T0_US)) ** 2)
+
+    fit_min_cal = _tzero_cal(ENERGY_MIN)
+    fit_max_cal = _tzero_cal(ENERGY_MAX)
 
     hf_group = nereids.IsotopeGroup.natural(72)
     hf_group.load_endf()
@@ -61,7 +69,7 @@ def main() -> None:
     # Warm
     _ = nereids.spatial_map_typed(
         data=input_data,
-        energies=E_cal,
+        energies=E_cal_full,
         solver="kl",
         c=c,
         temperature_k=TEMP_K,
@@ -71,6 +79,7 @@ def main() -> None:
         background=True,
         resolution=res,
         dead_pixels=dead_pixels,
+        fit_energy_range=(fit_min_cal, fit_max_cal),
     )
 
     Path("/tmp/b2_ready").write_text("ready\n")
@@ -85,7 +94,7 @@ def main() -> None:
     for _ in range(N_REPEATS):
         r = nereids.spatial_map_typed(
             data=input_data,
-            energies=E_cal,
+            energies=E_cal_full,
             solver="kl",
             c=c,
             temperature_k=TEMP_K,
@@ -95,6 +104,7 @@ def main() -> None:
             background=True,
             resolution=res,
             dead_pixels=dead_pixels,
+            fit_energy_range=(fit_min_cal, fit_max_cal),
         )
     wall = time.time() - t0
     n_px = (CROP_Y1 - CROP_Y0) * (CROP_X1 - CROP_X0)

--- a/scripts/perf/profile_b2_kl_grouped.py
+++ b/scripts/perf/profile_b2_kl_grouped.py
@@ -47,6 +47,10 @@ def main() -> None:
     L_SCALE = 1.0052452911520162
     tof_factor = (0.5 * 1.67492749804e-27 / 1.602176634e-19) ** 0.5 * 1.0e6
     L_eff = FLIGHT_PATH_M * L_SCALE
+    # Guard: pre-PR-#519 the `mask = E_full >= 7.0` step filtered any
+    # bin with E ≤ 0 before sqrt; without it we assert the input axis
+    # is strictly positive so `sqrt(E_full)` can't inject NaN.
+    assert (E_full > 0).all(), "energy axis must be strictly positive"
     tof_full = tof_factor * FLIGHT_PATH_M / np.sqrt(E_full)
     tof_corr_full = tof_full - T0_US
     E_cal_full = np.ascontiguousarray((tof_factor * L_eff / tof_corr_full) ** 2)

--- a/scripts/perf/profile_b2_kl_grouped.py
+++ b/scripts/perf/profile_b2_kl_grouped.py
@@ -48,9 +48,11 @@ def main() -> None:
     tof_factor = (0.5 * 1.67492749804e-27 / 1.602176634e-19) ** 0.5 * 1.0e6
     L_eff = FLIGHT_PATH_M * L_SCALE
     # Guard: pre-PR-#519 the `mask = E_full >= 7.0` step filtered any
-    # bin with E ≤ 0 before sqrt; without it we assert the input axis
-    # is strictly positive so `sqrt(E_full)` can't inject NaN.
-    assert (E_full > 0).all(), "energy axis must be strictly positive"
+    # bin with E ≤ 0 before sqrt; without it we check the input axis
+    # is strictly positive so `sqrt(E_full)` can't inject NaN.  Runtime
+    # check (not `assert`) so `python -O` doesn't strip the guard.
+    if not np.all(E_full > 0):
+        raise ValueError("energy axis must be strictly positive")
     tof_full = tof_factor * FLIGHT_PATH_M / np.sqrt(E_full)
     tof_corr_full = tof_full - T0_US
     E_cal_full = np.ascontiguousarray((tof_factor * L_eff / tof_corr_full) ** 2)

--- a/scripts/perf/profile_b2_kl_grouped_at_scale.py
+++ b/scripts/perf/profile_b2_kl_grouped_at_scale.py
@@ -67,6 +67,10 @@ def main() -> None:
     # the full grid.
     tof_factor = (0.5 * 1.67492749804e-27 / 1.602176634e-19) ** 0.5 * 1.0e6
     L_eff = FLIGHT_PATH_M * L_SCALE
+    # Guard: pre-PR-#519 the `mask = E_full >= 7.0` step filtered any
+    # bin with E ≤ 0 before sqrt; without it we assert the input axis
+    # is strictly positive so `sqrt(E_full)` can't inject NaN.
+    assert (E_full > 0).all(), "energy axis must be strictly positive"
     tof_full = tof_factor * FLIGHT_PATH_M / np.sqrt(E_full)
     tof_corr_full = tof_full - T0_US
     E_cal_full = np.ascontiguousarray((tof_factor * L_eff / tof_corr_full) ** 2)

--- a/scripts/perf/profile_b2_kl_grouped_at_scale.py
+++ b/scripts/perf/profile_b2_kl_grouped_at_scale.py
@@ -56,18 +56,27 @@ def main() -> None:
         O3d_raw = f["Hf/open_beam/counts"][:][::-1, :, :]
         Q_s = float(f["Hf/120min/proton_charges/sample_values_uC"][:].sum())
         Q_ob = float(f["Hf/120min/proton_charges/ob_values_uC"][0])
-    mask = (E_full >= ENERGY_MIN) & (E_full <= ENERGY_MAX)
-    E = np.ascontiguousarray(E_full[mask])
-    S3d = np.ascontiguousarray(S3d_raw[mask][:, y0:y1, x0:x1]).astype(np.float64)
-    O3d = np.ascontiguousarray(O3d_raw[mask][:, y0:y1, x0:x1]).astype(np.float64)
+    # SAMMY REGION-equivalent: keep the FULL spectral axis, apply
+    # pre-calibrated TZERO to the whole grid, and let
+    # `fit_energy_range` mask the cost function (#514).
+    S3d = np.ascontiguousarray(S3d_raw[:, y0:y1, x0:x1]).astype(np.float64)
+    O3d = np.ascontiguousarray(O3d_raw[:, y0:y1, x0:x1]).astype(np.float64)
     c = Q_s / Q_ob
 
-    # Pre-calibrated TZERO (A.2 values), same as B.2 gate.
+    # Pre-calibrated TZERO (A.2 values), same as B.2 gate, applied to
+    # the full grid.
     tof_factor = (0.5 * 1.67492749804e-27 / 1.602176634e-19) ** 0.5 * 1.0e6
     L_eff = FLIGHT_PATH_M * L_SCALE
-    tof = tof_factor * FLIGHT_PATH_M / np.sqrt(E)
-    tof_corr = tof - T0_US
-    E_cal = np.ascontiguousarray((tof_factor * L_eff / tof_corr) ** 2)
+    tof_full = tof_factor * FLIGHT_PATH_M / np.sqrt(E_full)
+    tof_corr_full = tof_full - T0_US
+    E_cal_full = np.ascontiguousarray((tof_factor * L_eff / tof_corr_full) ** 2)
+
+    def _tzero_cal(e_nominal: float) -> float:
+        tof = tof_factor * FLIGHT_PATH_M / np.sqrt(e_nominal)
+        return float((tof_factor * L_eff / (tof - T0_US)) ** 2)
+
+    fit_min_cal = _tzero_cal(ENERGY_MIN)
+    fit_max_cal = _tzero_cal(ENERGY_MAX)
 
     hf_group = nereids.IsotopeGroup.natural(72)
     hf_group.load_endf()
@@ -78,7 +87,7 @@ def main() -> None:
     # Warm
     _ = nereids.spatial_map_typed(
         data=input_data,
-        energies=E_cal,
+        energies=E_cal_full,
         solver="kl",
         c=c,
         temperature_k=TEMP_K,
@@ -88,6 +97,7 @@ def main() -> None:
         background=True,
         resolution=res,
         dead_pixels=dead_pixels,
+        fit_energy_range=(fit_min_cal, fit_max_cal),
     )
 
     Path("/tmp/b2_at_scale_ready").write_text("ready\n")
@@ -95,7 +105,7 @@ def main() -> None:
     t0 = time.time()
     r = nereids.spatial_map_typed(
         data=input_data,
-        energies=E_cal,
+        energies=E_cal_full,
         solver="kl",
         c=c,
         temperature_k=TEMP_K,
@@ -105,6 +115,7 @@ def main() -> None:
         background=True,
         resolution=res,
         dead_pixels=dead_pixels,
+        fit_energy_range=(fit_min_cal, fit_max_cal),
     )
     wall = time.time() - t0
     n_px = crop * crop

--- a/scripts/perf/profile_b2_kl_grouped_at_scale.py
+++ b/scripts/perf/profile_b2_kl_grouped_at_scale.py
@@ -68,9 +68,11 @@ def main() -> None:
     tof_factor = (0.5 * 1.67492749804e-27 / 1.602176634e-19) ** 0.5 * 1.0e6
     L_eff = FLIGHT_PATH_M * L_SCALE
     # Guard: pre-PR-#519 the `mask = E_full >= 7.0` step filtered any
-    # bin with E ≤ 0 before sqrt; without it we assert the input axis
-    # is strictly positive so `sqrt(E_full)` can't inject NaN.
-    assert (E_full > 0).all(), "energy axis must be strictly positive"
+    # bin with E ≤ 0 before sqrt; without it we check the input axis
+    # is strictly positive so `sqrt(E_full)` can't inject NaN.  Runtime
+    # check (not `assert`) so `python -O` doesn't strip the guard.
+    if not np.all(E_full > 0):
+        raise ValueError("energy axis must be strictly positive")
     tof_full = tof_factor * FLIGHT_PATH_M / np.sqrt(E_full)
     tof_corr_full = tof_full - T0_US
     E_cal_full = np.ascontiguousarray((tof_factor * L_eff / tof_corr_full) ** 2)

--- a/scripts/perf/profile_b3_lm_periso_tzero.py
+++ b/scripts/perf/profile_b3_lm_periso_tzero.py
@@ -40,13 +40,15 @@ def main() -> None:
         O3d_raw = f["Hf/open_beam/counts"][:][::-1, :, :]
         Q_s = float(f["Hf/120min/proton_charges/sample_values_uC"][:].sum())
         Q_ob = float(f["Hf/120min/proton_charges/ob_values_uC"][0])
-    mask = (E_full >= ENERGY_MIN) & (E_full <= ENERGY_MAX)
-    E = np.ascontiguousarray(E_full[mask])
+    # SAMMY REGION-equivalent: full nominal axis + `fit_energy_range`
+    # mask in the per-pixel LM cost path (#514).  Spatial cropping in
+    # (y, x) is unchanged.
+    E = np.ascontiguousarray(E_full)
     S3d = np.ascontiguousarray(
-        S3d_raw[mask][:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
+        S3d_raw[:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
     ).astype(np.float64)
     O3d = np.ascontiguousarray(
-        O3d_raw[mask][:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
+        O3d_raw[:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
     ).astype(np.float64)
     c = Q_s / Q_ob
 
@@ -82,6 +84,7 @@ def main() -> None:
         energy_scale_flight_path_m=FLIGHT_PATH_M,
         resolution=res,
         dead_pixels=dead_pixels,
+        fit_energy_range=(ENERGY_MIN, ENERGY_MAX),
     )
 
     Path("/tmp/b3_ready").write_text("ready\n")
@@ -102,6 +105,7 @@ def main() -> None:
         energy_scale_flight_path_m=FLIGHT_PATH_M,
         resolution=res,
         dead_pixels=dead_pixels,
+        fit_energy_range=(ENERGY_MIN, ENERGY_MAX),
     )
     wall = time.time() - t0
     n_px = (CROP_Y1 - CROP_Y0) * (CROP_X1 - CROP_X0)

--- a/scripts/perf/profile_kl_periso_tzero.py
+++ b/scripts/perf/profile_kl_periso_tzero.py
@@ -44,13 +44,15 @@ def main() -> None:
         O3d_raw = f["Hf/open_beam/counts"][:][::-1, :, :]
         Q_s = float(f["Hf/120min/proton_charges/sample_values_uC"][:].sum())
         Q_ob = float(f["Hf/120min/proton_charges/ob_values_uC"][0])
-    mask = (E_full >= ENERGY_MIN) & (E_full <= ENERGY_MAX)
-    E = np.ascontiguousarray(E_full[mask])
+    # SAMMY REGION-equivalent: full nominal axis + `fit_energy_range`
+    # mask in the per-pixel KL cost path (#514).  TZERO is FITTED here,
+    # so the axis stays nominal.
+    E = np.ascontiguousarray(E_full)
     S3d = np.ascontiguousarray(
-        S3d_raw[mask][:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
+        S3d_raw[:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
     ).astype(np.float64)
     O3d = np.ascontiguousarray(
-        O3d_raw[mask][:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
+        O3d_raw[:, CROP_Y0:CROP_Y1, CROP_X0:CROP_X1]
     ).astype(np.float64)
     c = Q_s / Q_ob
 
@@ -81,6 +83,7 @@ def main() -> None:
         energy_scale_flight_path_m=FLIGHT_PATH_M,
         resolution=res,
         dead_pixels=dead_pixels,
+        fit_energy_range=(ENERGY_MIN, ENERGY_MAX),
     )
 
     Path("/tmp/kl_periso_tzero_ready").write_text("ready\n")
@@ -105,6 +108,7 @@ def main() -> None:
             energy_scale_flight_path_m=FLIGHT_PATH_M,
             resolution=res,
             dead_pixels=dead_pixels,
+            fit_energy_range=(ENERGY_MIN, ENERGY_MAX),
         )
     wall = time.time() - t0
     n_px = (CROP_Y1 - CROP_Y0) * (CROP_X1 - CROP_X0)

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -1519,3 +1519,142 @@ class TestVenusMlbwRegression:
             f"A dispatch regression can prevent convergence entirely — investigate."
         )
 
+
+# ===========================================================================
+# fit_energy_range Python parameter (#514 / PR #519)
+# ===========================================================================
+
+
+class TestFitEnergyRangeBindingParameter:
+    """Tests for the SAMMY REGION-equivalent `fit_energy_range` parameter
+    on the three Python binding entry points (`fit_spectrum_typed`,
+    `fit_counts_spectrum_typed`, `spatial_map_typed`).  Locks in the
+    behaviour the perf scripts now depend on for SoftwareX-paper SAMMY
+    parity.
+    """
+
+    def test_fit_spectrum_typed_full_grid_with_range_matches_pre_cropped(
+        self, u238_data
+    ):
+        """`fit_spectrum_typed` called with the full grid +
+        `fit_energy_range=(low, high)` must produce the same density as
+        the equivalent pre-cropped fit (within tight numerical tolerance).
+        This is the SAMMY-parity contract: the model is evaluated on the
+        full grid so resolution broadening at the boundaries is correct,
+        and the LM cost path masks residuals to the inner range.
+        """
+        # Synthetic noisy transmission across a wide energy grid with a
+        # single resonance at 6.67 eV.
+        energies = np.linspace(1.0, 30.0, 600)
+        true_density = 0.0008
+        t_clean = np.asarray(
+            nereids.forward_model(energies, [(u238_data, true_density)])
+        )
+        rng = np.random.default_rng(20260430)
+        t_obs = t_clean + rng.normal(0.0, 0.005, size=t_clean.shape)
+        sigma = np.full_like(t_obs, 0.005)
+
+        e_min, e_max = 4.0, 12.0  # window around the 6.67 eV resonance
+
+        # Approach 1: pre-crop in Python (legacy pattern).
+        mask = (energies >= e_min) & (energies <= e_max)
+        r_cropped = nereids.fit_spectrum_typed(
+            transmission=np.ascontiguousarray(t_obs[mask]),
+            uncertainty=np.ascontiguousarray(sigma[mask]),
+            energies=np.ascontiguousarray(energies[mask]),
+            isotopes=[(u238_data, true_density)],
+            solver="lm",
+            temperature_k=293.6,
+            max_iter=200,
+        )
+
+        # Approach 2: full grid + fit_energy_range (the new SAMMY-parity
+        # path).
+        r_ranged = nereids.fit_spectrum_typed(
+            transmission=t_obs,
+            uncertainty=sigma,
+            energies=energies,
+            isotopes=[(u238_data, true_density)],
+            solver="lm",
+            temperature_k=293.6,
+            max_iter=200,
+            fit_energy_range=(e_min, e_max),
+        )
+
+        # Both should converge.
+        assert bool(r_cropped.converged) is True
+        assert bool(r_ranged.converged) is True
+
+        # Densities should agree within ~1% — exact agreement is not
+        # required because pre-cropping truncates the kernel at the
+        # boundary while fit_energy_range applies the full broadening.
+        # Without resolution broadening configured (the default in this
+        # test), the two should be much closer (within ~1e-6 rel) since
+        # there's no kernel truncation effect.
+        rel_err = abs(r_cropped.densities[0] - r_ranged.densities[0]) / abs(
+            r_ranged.densities[0]
+        )
+        assert rel_err < 1e-4, (
+            f"density disagreement: cropped={r_cropped.densities[0]:.6e}, "
+            f"ranged={r_ranged.densities[0]:.6e}, rel_err={rel_err:.3e}"
+        )
+
+    def test_fit_spectrum_typed_rejects_invalid_range(self, u238_data):
+        """Invalid `fit_energy_range` (reversed, non-finite, or empty)
+        must raise `ValueError` from the binding — the underlying
+        `with_fit_energy_range` setter validates these and the binding
+        propagates the error with `?`.
+        """
+        energies = np.linspace(1.0, 30.0, 200)
+        t = np.full_like(energies, 0.95)
+        sigma = np.full_like(energies, 0.01)
+
+        # Reversed range.
+        with pytest.raises(ValueError, match="strictly less than max"):
+            nereids.fit_spectrum_typed(
+                transmission=t,
+                uncertainty=sigma,
+                energies=energies,
+                isotopes=[(u238_data, 0.001)],
+                fit_energy_range=(20.0, 5.0),
+            )
+
+        # Non-finite bound.
+        with pytest.raises(ValueError, match="finite"):
+            nereids.fit_spectrum_typed(
+                transmission=t,
+                uncertainty=sigma,
+                energies=energies,
+                isotopes=[(u238_data, 0.001)],
+                fit_energy_range=(float("nan"), 20.0),
+            )
+
+    def test_fit_spectrum_typed_default_none_unchanged(self, u238_data):
+        """Calling without `fit_energy_range` must produce the same
+        result as before the parameter was added.  Backward-compat
+        regression against accidentally treating `None` as "narrow to
+        the smallest range" or other surprising semantics.
+        """
+        energies = np.linspace(1.0, 30.0, 400)
+        true_density = 0.001
+        # Match temperatures: `forward_model` uses 293.6 K by default,
+        # so the fit must too — otherwise Doppler-broadening mismatch
+        # produces a multi-percent density bias unrelated to the
+        # parameter under test.
+        t = np.asarray(nereids.forward_model(energies, [(u238_data, true_density)]))
+        sigma = np.full_like(t, 0.005)
+
+        r = nereids.fit_spectrum_typed(
+            transmission=t,
+            uncertainty=sigma,
+            energies=energies,
+            isotopes=[(u238_data, true_density)],
+            solver="lm",
+            temperature_k=293.6,
+            max_iter=100,
+        )
+        # Recovery on noiseless data should be tight; this catches a
+        # regression where `None` is treated as a degenerate range.
+        assert bool(r.converged) is True
+        assert abs(r.densities[0] - true_density) / true_density < 1e-3
+

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -1527,10 +1527,12 @@ class TestVenusMlbwRegression:
 
 class TestFitEnergyRangeBindingParameter:
     """Tests for the SAMMY REGION-equivalent `fit_energy_range` parameter
-    on the three Python binding entry points (`fit_spectrum_typed`,
-    `fit_counts_spectrum_typed`, `spatial_map_typed`).  Locks in the
-    behaviour the perf scripts now depend on for SoftwareX-paper SAMMY
-    parity.
+    on `fit_spectrum_typed`.  The other two binding entry points
+    (`fit_counts_spectrum_typed`, `spatial_map_typed`) share the same
+    config-builder code path (`with_fit_energy_range(...).map_err(...)?`
+    after the rest of the chain), so a regression in the validation /
+    plumbing surfaces here too.  Locks in the behaviour the perf
+    scripts now depend on for SoftwareX-paper SAMMY parity.
     """
 
     def test_fit_spectrum_typed_full_grid_with_range_matches_pre_cropped(
@@ -1585,12 +1587,16 @@ class TestFitEnergyRangeBindingParameter:
         assert bool(r_cropped.converged) is True
         assert bool(r_ranged.converged) is True
 
-        # Densities should agree within ~1% — exact agreement is not
-        # required because pre-cropping truncates the kernel at the
-        # boundary while fit_energy_range applies the full broadening.
-        # Without resolution broadening configured (the default in this
-        # test), the two should be much closer (within ~1e-6 rel) since
-        # there's no kernel truncation effect.
+        # No resolution broadening is configured in this test, so the
+        # only difference between "pre-crop" and "full grid + range" is
+        # whether the LM cost path sums residuals over the same set of
+        # active bins — which it does (the mask matches the explicit
+        # crop bin-for-bin).  Densities therefore agree to numerical-
+        # noise tolerance.  We enforce 1e-4 — much tighter than any
+        # broadening-effect tolerance, but loose enough to absorb BLAS
+        # ordering noise across platforms.  Tightening below 1e-4 risks
+        # platform-flapping; loosening above 1e-4 lets a real masking
+        # regression slip through.
         rel_err = abs(r_cropped.densities[0] - r_ranged.densities[0]) / abs(
             r_ranged.densities[0]
         )
@@ -1644,17 +1650,28 @@ class TestFitEnergyRangeBindingParameter:
         t = np.asarray(nereids.forward_model(energies, [(u238_data, true_density)]))
         sigma = np.full_like(t, 0.005)
 
+        # Seed the fit away from the truth (5× too high) so a do-nothing
+        # solver path (e.g. a regression that treats `fit_energy_range
+        # = None` as "no active bins" → returns the initial parameters
+        # unchanged) is detectable: the assertion below would fire on
+        # the seed value `5e-3`, not on the true `1e-3`.
         r = nereids.fit_spectrum_typed(
             transmission=t,
             uncertainty=sigma,
             energies=energies,
-            isotopes=[(u238_data, true_density)],
+            isotopes=[(u238_data, 5.0 * true_density)],
             solver="lm",
             temperature_k=293.6,
             max_iter=100,
         )
-        # Recovery on noiseless data should be tight; this catches a
-        # regression where `None` is treated as a degenerate range.
+        # Recovery on noiseless data should be tight; with the wrong
+        # seed, this catches both "degenerate range" regressions AND
+        # any regression that prevents convergence outright.
         assert bool(r.converged) is True
-        assert abs(r.densities[0] - true_density) / true_density < 1e-3
+        assert abs(r.densities[0] - true_density) / true_density < 1e-3, (
+            f"density did not converge to truth: got {r.densities[0]:.6e}, "
+            f"expected {true_density:.6e} (initial seed was "
+            f"{5.0 * true_density:.6e}, so a do-nothing solver path "
+            f"would leave the param at the seed)"
+        )
 


### PR DESCRIPTION
## Summary

- Expose `fit_energy_range: Option<(f64, f64)>` on the three Python binding entry points (`fit_spectrum_typed`, `fit_counts_spectrum_typed`, `spatial_map_typed`).
- Convert all 8 Hf baseline / perf-profile scripts in `scripts/perf/` to use it instead of pre-cropping the data array.
- Restores apples-to-apples SAMMY parity for the SoftwareX paper baselines.

## Why

The 8 Hf scripts previously cropped the data with a Python boolean mask at `[7.0, 200.0]` eV BEFORE passing to NEREIDS. This truncates the resolution kernel at the upper boundary near 200 eV — resonances near the boundary get convolved with a partial kernel response, biasing densities relative to SAMMY (which extends the broadening grid by ~5×FWHM internally per its REGION cards). PR #517 fixed this in the GUI / Rust path; this PR extends the same fix to the Python baseline scripts.

The user surfaced this concern post-merge: "we want to claim equivalent results to SAMMY in the SoftwareX paper".

## Scripts converted

| Script | Axis | Notes |
|---|---|---|
| `baseline_dump.py` | nominal (A.1, B.1, _run_periso_tzero) + calibrated (B.2) | TZERO pre-calibration in B.2 now applied to the full grid; calibrated equivalent of `(7, 200)` derived via the same TOF→eV chain. |
| `profile_a1_lm_grouped.py` | nominal + TZERO fit | |
| `profile_b1_lm_tzero_grouped.py` | nominal + TZERO fit, 2×2 spatial | |
| `profile_b2_kl_grouped.py` | TZERO pre-calibrated, 4×4 spatial | |
| `profile_b2_kl_grouped_at_scale.py` | TZERO pre-calibrated, configurable crop | |
| `profile_b3_lm_periso_tzero.py` | nominal + TZERO fit, per-isotope | |
| `profile_kl_periso_tzero.py` | nominal + TZERO fit, per-isotope, KL | |

`[ENERGY_MIN, ENERGY_MAX] = (7.0, 200.0)` eV is unchanged in all 8 scripts; only the plumbing changes.

## Performance note

For the spatial scripts the model evaluates on the full ~4071-bin grid per pixel (vs the cropped ~3500-bin slice before). Wall-time per pixel grows ~15-20%; densities + dofs now reflect SAMMY-equivalent broadening at the boundaries. Acceptable for baseline correctness; a Python-side data-slicing optimisation can be a follow-up.

## Out of scope

`scripts/fixtures/extract_venus_aggregated.py` is a fixture-extraction for the #465 MLBW LM regression gate, not a SAMMY-parity baseline. Updating it requires re-capturing the hardcoded `EXPECTED_DENSITY` / `EXPECTED_CHI2_R` / `EXPECTED_ITERATIONS` in `test_mlbw_lm_fit_matches_baseline` — a separate follow-up.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --exclude nereids-python` — all pass (no behavioural changes to any Rust tests)
- [x] `pixi run test-python` — 84 passed, 1 skipped
- [x] `python -m py_compile` on all 8 scripts — all compile cleanly
- [ ] **Smoke-run the 8 scripts on local Hf data** (reviewer-side; the gitignored `.research/.../resonance_data_2cm.h5` is required, not present in CI):
  - `python scripts/perf/baseline_dump.py --out /tmp/new_baseline.json`
  - Diff densities + chi² values against any prior locally-captured baseline; expect small shifts (mostly upper-boundary resonances) consistent with the kernel-margin correction.
  - Confirm `r.density_maps[0]` median is sensible (~1e-4 ish for natural Hf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)