### PR TITLE
[codex] Harden ENDF fetch resilience

### DIFF
--- a/apps/gui/src/widgets/design.rs
+++ b/apps/gui/src/widgets/design.rs
@@ -768,7 +768,7 @@ pub(crate) fn endf_fetch_worker(
     tx: mpsc::Sender<EndfFetchResult>,
 ) {
     let retriever = nereids_endf::retrieval::EndfRetriever::new();
-    for item in work {
+    for (idx, item) in work.iter().enumerate() {
         if cancel.load(Ordering::Relaxed) {
             break;
         }
@@ -791,7 +791,36 @@ pub(crate) fn endf_fetch_worker(
                 Ok(data) => Ok(data),
                 Err(e) => Err(format!("Parse error for {}: {e}", item.symbol)),
             },
-            Err(e) => Err(format!("Fetch error for {}: {e}", item.symbol)),
+            Err(e) => {
+                let blocked = e.is_remote_access_blocked();
+                let msg = format!("Fetch error for {}: {e}", item.symbol);
+                if blocked {
+                    let _ = tx.send(EndfFetchResult {
+                        z: item.z,
+                        a: item.a,
+                        target: item.target,
+                        symbol: item.symbol.clone(),
+                        result: Err(msg.clone()),
+                    });
+                    for skipped in &work[idx + 1..] {
+                        if cancel.load(Ordering::Relaxed) {
+                            break;
+                        }
+                        let _ = tx.send(EndfFetchResult {
+                            z: skipped.z,
+                            a: skipped.a,
+                            target: skipped.target,
+                            symbol: skipped.symbol.clone(),
+                            result: Err(format!(
+                                "Skipped {} because the upstream ENDF server blocked this batch; retry later.",
+                                skipped.symbol
+                            )),
+                        });
+                    }
+                    break;
+                }
+                Err(msg)
+            }
         };
         if cancel.load(Ordering::Relaxed) {
             break;
@@ -800,7 +829,7 @@ pub(crate) fn endf_fetch_worker(
             z: item.z,
             a: item.a,
             target: item.target,
-            symbol: item.symbol,
+            symbol: item.symbol.clone(),
             result,
         });
     }

--- a/crates/nereids-endf/src/retrieval.rs
+++ b/crates/nereids-endf/src/retrieval.rs
@@ -179,11 +179,15 @@ impl EndfRetriever {
         library: EndfLibrary,
         mat: u32,
     ) -> Result<String, EndfRetrievalError> {
-        if let Some(primary_url) = nndc_endf_url(isotope, library) {
-            if let Ok(text) = self.fetch_text(&primary_url, false) {
+        let nndc_url = nndc_endf_url(isotope, library);
+        let nndc_already_tried = if let Some(primary_url) = &nndc_url {
+            if let Ok(text) = self.fetch_text(primary_url, false) {
                 return Ok(text);
             }
-        }
+            true
+        } else {
+            false
+        };
 
         let zip_filename = library.zip_filename(isotope, mat);
         let url = format!("{}/{}/{}", self.base_url, library.url_path(), zip_filename);
@@ -191,9 +195,12 @@ impl EndfRetriever {
         match iaea_result {
             Ok(bytes) => return self.extract_endf_from_zip(&bytes),
             Err(err) if should_try_nndc_fallback(&err) => {
-                if let Some(fallback_url) = nndc_endf_url(isotope, library) {
-                    let text = self.fetch_text(&fallback_url, false)?;
-                    return Ok(text);
+                if !nndc_already_tried {
+                    if let Some(fallback_url) = &nndc_url {
+                        if let Ok(text) = self.fetch_text(fallback_url, false) {
+                            return Ok(text);
+                        }
+                    }
                 }
                 Err(err.into_retrieval_error(isotope, library))
             }

--- a/crates/nereids-endf/src/retrieval.rs
+++ b/crates/nereids-endf/src/retrieval.rs
@@ -1,7 +1,7 @@
 //! ENDF file download and local caching.
 //!
-//! Downloads ENDF files from the IAEA Nuclear Data Services and caches them
-//! locally for offline use. Follows the URL patterns established by PLEIADES.
+//! Downloads ENDF files from official NNDC/IAEA sources and caches them locally
+//! for offline use. Follows the IAEA URL patterns established by PLEIADES.
 //!
 //! ## PLEIADES Reference
 //! - `pleiades/nuclear/manager.py` — URL construction, cache directory layout
@@ -12,7 +12,16 @@ use nereids_core::types::Isotope;
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+const IAEA_BASE_URL: &str = "https://www-nds.iaea.org/public/download-endf";
+const NNDC_ENDF_BASE_URL: &str = "https://www.nndc.bnl.gov/endf-data/ENDF";
+const ENDF_USER_AGENT: &str =
+    "NEREIDS/0.1.8 (https://github.com/ornlneutronimaging/NEREIDS; ENDF cache)";
+const IAEA_MIN_REQUEST_INTERVAL: Duration = Duration::from_secs(3);
+
+static LAST_IAEA_REQUEST: OnceLock<Mutex<Option<Instant>>> = OnceLock::new();
 
 /// ENDF evaluated nuclear data libraries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -86,7 +95,8 @@ impl EndfLibrary {
 pub struct EndfRetriever {
     /// Root cache directory.
     cache_root: PathBuf,
-    /// Base URL for IAEA downloads.
+    /// Base URL for IAEA downloads used by libraries that are not mirrored by
+    /// NNDC as raw ENDF-6 files.
     base_url: String,
     /// Shared HTTP client with explicit connect/total timeouts so a transport
     /// stall surfaces as a clear error instead of hanging the GUI worker.
@@ -102,7 +112,7 @@ impl EndfRetriever {
             .join("endf");
         Self {
             cache_root,
-            base_url: "https://www-nds.iaea.org/public/download-endf".to_string(),
+            base_url: IAEA_BASE_URL.to_string(),
             client: build_http_client(),
         }
     }
@@ -111,7 +121,7 @@ impl EndfRetriever {
     pub fn with_cache_dir(cache_dir: impl Into<PathBuf>) -> Self {
         Self {
             cache_root: cache_dir.into(),
-            base_url: "https://www-nds.iaea.org/public/download-endf".to_string(),
+            base_url: IAEA_BASE_URL.to_string(),
             client: build_http_client(),
         }
     }
@@ -150,7 +160,7 @@ impl EndfRetriever {
             return Ok((cache_path, contents));
         }
 
-        // Download from IAEA.
+        // Download from the remote source.
         let contents = self.download_endf(isotope, library, mat)?;
 
         // Cache the file.
@@ -162,51 +172,72 @@ impl EndfRetriever {
         Ok((cache_path, contents))
     }
 
-    /// Download ENDF file from IAEA and extract from ZIP archive.
+    /// Download an ENDF file from NNDC raw files or IAEA ZIP archives.
     fn download_endf(
         &self,
         isotope: &Isotope,
         library: EndfLibrary,
         mat: u32,
     ) -> Result<String, EndfRetrievalError> {
+        if let Some(primary_url) = nndc_endf_url(isotope, library) {
+            if let Ok(text) = self.fetch_text(&primary_url, false) {
+                return Ok(text);
+            }
+        }
+
         let zip_filename = library.zip_filename(isotope, mat);
         let url = format!("{}/{}/{}", self.base_url, library.url_path(), zip_filename);
+        let iaea_result = self.fetch_bytes(&url, true);
+        match iaea_result {
+            Ok(bytes) => return self.extract_endf_from_zip(&bytes),
+            Err(err) if should_try_nndc_fallback(&err) => {
+                if let Some(fallback_url) = nndc_endf_url(isotope, library) {
+                    let text = self.fetch_text(&fallback_url, false)?;
+                    return Ok(text);
+                }
+                Err(err.into_retrieval_error(isotope, library))
+            }
+            Err(err) => Err(err.into_retrieval_error(isotope, library)),
+        }
+    }
 
-        let response = self.client.get(&url).send().map_err(|e| {
-            EndfRetrievalError::NetworkError(format!(
-                "Failed to fetch {}: {}",
-                url,
-                format_error_chain(&e)
-            ))
-        })?;
+    fn fetch_bytes(&self, url: &str, pace_iaea: bool) -> Result<Vec<u8>, DownloadError> {
+        if pace_iaea {
+            wait_for_iaea_slot();
+        }
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .map_err(|e| DownloadError::Transport {
+                url: url.to_string(),
+                message: format_error_chain(&e),
+            })?;
 
         let status = response.status();
-        if status == reqwest::StatusCode::NOT_FOUND {
-            return Err(EndfRetrievalError::NotInLibrary {
-                isotope: format!(
-                    "{}-{}",
-                    nereids_core::elements::element_symbol(isotope.z()).unwrap_or("?"),
-                    isotope.a()
-                ),
-                library: library.cache_dir_name().to_string(),
+        if !status.is_success() {
+            return Err(DownloadError::Http {
+                url: url.to_string(),
+                status,
+                cloudflare_challenge: has_cloudflare_challenge(&response),
             });
         }
-        if !status.is_success() {
-            return Err(EndfRetrievalError::NetworkError(format!(
-                "HTTP {} for {}",
-                status, url
-            )));
-        }
 
-        let bytes = response.bytes().map_err(|e| {
-            EndfRetrievalError::NetworkError(format!(
-                "Failed to read response body: {}",
-                format_error_chain(&e)
-            ))
-        })?;
+        response
+            .bytes()
+            .map(|bytes| bytes.to_vec())
+            .map_err(|e| DownloadError::Transport {
+                url: url.to_string(),
+                message: format!("Failed to read response body: {}", format_error_chain(&e)),
+            })
+    }
 
-        // Extract ENDF file from ZIP archive.
-        self.extract_endf_from_zip(&bytes)
+    fn fetch_text(&self, url: &str, pace_iaea: bool) -> Result<String, EndfRetrievalError> {
+        let bytes = self
+            .fetch_bytes(url, pace_iaea)
+            .map_err(|err| err.into_retrieval_error_for_url())?;
+        String::from_utf8(bytes)
+            .map_err(|e| EndfRetrievalError::Parse(format!("Invalid UTF-8 ENDF response: {e}")))
     }
 
     /// Extract the ENDF data file from a ZIP archive.
@@ -336,6 +367,14 @@ pub enum EndfRetrievalError {
     #[error("Network error: {0}")]
     NetworkError(String),
 
+    /// Upstream server actively blocked automated retrieval.
+    #[error("Remote access blocked: HTTP {status} for {url}. {message}")]
+    RemoteAccessBlocked {
+        status: u16,
+        url: String,
+        message: String,
+    },
+
     /// The isotope exists in ENDF/B-VIII.0 but is not available in the requested library.
     #[error("{isotope} is not available in the {library} library")]
     NotInLibrary { isotope: String, library: String },
@@ -350,6 +389,66 @@ pub enum EndfRetrievalError {
     UnknownIsotope(String),
 }
 
+impl EndfRetrievalError {
+    /// Whether this error means the upstream server is denying automated access.
+    pub fn is_remote_access_blocked(&self) -> bool {
+        matches!(self, Self::RemoteAccessBlocked { .. })
+    }
+}
+
+#[derive(Debug)]
+enum DownloadError {
+    Http {
+        url: String,
+        status: reqwest::StatusCode,
+        cloudflare_challenge: bool,
+    },
+    Transport {
+        url: String,
+        message: String,
+    },
+}
+
+impl DownloadError {
+    fn into_retrieval_error(self, isotope: &Isotope, library: EndfLibrary) -> EndfRetrievalError {
+        match self {
+            Self::Http { status, .. } if status == reqwest::StatusCode::NOT_FOUND => {
+                EndfRetrievalError::NotInLibrary {
+                    isotope: isotope_label(isotope),
+                    library: library.cache_dir_name().to_string(),
+                }
+            }
+            other => other.into_retrieval_error_for_url(),
+        }
+    }
+
+    fn into_retrieval_error_for_url(self) -> EndfRetrievalError {
+        match self {
+            Self::Http {
+                url,
+                status,
+                cloudflare_challenge,
+            } if is_access_block_status(status) => EndfRetrievalError::RemoteAccessBlocked {
+                status: status.as_u16(),
+                url,
+                message: if cloudflare_challenge {
+                    "The server returned a Cloudflare managed challenge; stop batch fetches and retry later from a normal browser/network."
+                        .to_string()
+                } else {
+                    "The upstream server denied automated access; stop batch fetches and retry later."
+                        .to_string()
+                },
+            },
+            Self::Http { url, status, .. } => {
+                EndfRetrievalError::NetworkError(format!("HTTP {status} for {url}"))
+            }
+            Self::Transport { url, message } => {
+                EndfRetrievalError::NetworkError(format!("Failed to fetch {url}: {message}"))
+            }
+        }
+    }
+}
+
 /// Build the shared HTTP client used for ENDF downloads.
 ///
 /// Connect timeout is short so DNS/TLS failures surface fast; total timeout
@@ -357,10 +456,70 @@ pub enum EndfRetrievalError {
 /// links. ENDF zip files top out around ~1 MB.
 fn build_http_client() -> reqwest::blocking::Client {
     reqwest::blocking::Client::builder()
+        .user_agent(ENDF_USER_AGENT)
         .connect_timeout(Duration::from_secs(15))
         .timeout(Duration::from_secs(60))
         .build()
         .expect("failed to build reqwest blocking client")
+}
+
+fn wait_for_iaea_slot() {
+    let mut last_request = LAST_IAEA_REQUEST
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+        .expect("IAEA request throttle mutex poisoned");
+    if let Some(last) = *last_request {
+        let elapsed = last.elapsed();
+        if elapsed < IAEA_MIN_REQUEST_INTERVAL {
+            std::thread::sleep(IAEA_MIN_REQUEST_INTERVAL - elapsed);
+        }
+    }
+    *last_request = Some(Instant::now());
+}
+
+fn nndc_endf_url(isotope: &Isotope, library: EndfLibrary) -> Option<String> {
+    let version = match library {
+        EndfLibrary::EndfB8_0 => "ENDF-B-VIII.0",
+        EndfLibrary::EndfB8_1 => "ENDF-B-VIII.1",
+        _ => return None,
+    };
+    let sym = elements::element_symbol(isotope.z())?;
+    Some(format!(
+        "{NNDC_ENDF_BASE_URL}/{version}/n-{z:03}_{sym}_{a}.endf",
+        z = isotope.z(),
+        a = isotope.a()
+    ))
+}
+
+fn should_try_nndc_fallback(err: &DownloadError) -> bool {
+    match err {
+        DownloadError::Http { status, .. } => {
+            *status == reqwest::StatusCode::NOT_FOUND || is_access_block_status(*status)
+        }
+        DownloadError::Transport { .. } => true,
+    }
+}
+
+fn is_access_block_status(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::FORBIDDEN
+        || status == reqwest::StatusCode::TOO_MANY_REQUESTS
+        || status == reqwest::StatusCode::SERVICE_UNAVAILABLE
+}
+
+fn has_cloudflare_challenge(response: &reqwest::blocking::Response) -> bool {
+    response
+        .headers()
+        .get("cf-mitigated")
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.eq_ignore_ascii_case("challenge"))
+}
+
+fn isotope_label(isotope: &Isotope) -> String {
+    format!(
+        "{}-{}",
+        nereids_core::elements::element_symbol(isotope.z()).unwrap_or("?"),
+        isotope.a()
+    )
 }
 
 /// Render an error and its full `source()` chain on one line. reqwest's outer
@@ -394,5 +553,25 @@ mod tests {
     fn cendl_neutron_has_library_aware_mat_lookup() {
         let neutron = Isotope::new(0, 1).unwrap();
         assert_eq!(mat_number(&neutron, EndfLibrary::Cendl3_2), Some(25));
+    }
+
+    #[test]
+    fn nndc_fallback_url_uses_raw_endf_naming() {
+        let ba138 = Isotope::new(56, 138).unwrap();
+        assert_eq!(
+            nndc_endf_url(&ba138, EndfLibrary::EndfB8_1).as_deref(),
+            Some("https://www.nndc.bnl.gov/endf-data/ENDF/ENDF-B-VIII.1/n-056_Ba_138.endf")
+        );
+        assert!(nndc_endf_url(&ba138, EndfLibrary::Cendl3_2).is_none());
+    }
+
+    #[test]
+    fn remote_access_blocked_is_identifiable() {
+        let err = EndfRetrievalError::RemoteAccessBlocked {
+            status: 403,
+            url: "https://example.test/file.zip".into(),
+            message: "blocked".into(),
+        };
+        assert!(err.is_remote_access_blocked());
     }
 }

--- a/crates/nereids-endf/src/retrieval.rs
+++ b/crates/nereids-endf/src/retrieval.rs
@@ -193,14 +193,13 @@ impl EndfRetriever {
         let url = format!("{}/{}/{}", self.base_url, library.url_path(), zip_filename);
         let iaea_result = self.fetch_bytes(&url, true);
         match iaea_result {
-            Ok(bytes) => return self.extract_endf_from_zip(&bytes),
+            Ok(bytes) => self.extract_endf_from_zip(&bytes),
             Err(err) if should_try_nndc_fallback(&err) => {
-                if !nndc_already_tried {
-                    if let Some(fallback_url) = &nndc_url {
-                        if let Ok(text) = self.fetch_text(fallback_url, false) {
-                            return Ok(text);
-                        }
-                    }
+                if !nndc_already_tried
+                    && let Some(fallback_url) = &nndc_url
+                    && let Ok(text) = self.fetch_text(fallback_url, false)
+                {
+                    return Ok(text);
                 }
                 Err(err.into_retrieval_error(isotope, library))
             }


### PR DESCRIPTION
## Summary

Harden ENDF retrieval after IAEA started returning Cloudflare managed challenges for bursty automated fetches (observed during #515 ENDF source-comparison research while attempting to fetch 48 isotope/library pairs in 14 s).

- Prefer official NNDC raw ENDF-6 files for ENDF/B-VIII.0 and ENDF/B-VIII.1 cache misses, avoiding IAEA for those libraries.
- Keep IAEA ZIP retrieval for libraries that NNDC does not mirror (JEFF-3.3 / JENDL-5 / TENDL-2023 / CENDL-3.2), with a NEREIDS user agent and process-wide request pacing (≥3 s between IAEA requests).
- Classify upstream `403` / `429` / `503` responses as remote access blocks via a new `EndfRetrievalError::RemoteAccessBlocked` variant so callers can stop batch fetches.
- Stop GUI ENDF batches after a remote access block and mark remaining queued isotopes skipped instead of continuing to hit the upstream server.

## Root Cause

The previous retriever sent every cache miss through IAEA. A rapid batch script could trigger Cloudflare challenge / rate-limit behavior, after which both scripts and the GUI fetch worker kept retrying each isotope independently and made the block worse.

## Impact

ENDF/B-VIII.0 and VIII.1 fetches now have an official non-Cloudflare path through NNDC. CENDL, TENDL, JEFF, and JENDL still use IAEA, but requests are paced and remote blocks stop the batch quickly. Production retriever bypassed the live Cloudflare gate end-to-end on a real W-184 cache-miss in 1.27 s.

## Validation

- \`cargo test -p nereids-endf\`
- \`cargo check -p nereids-gui\`
- Real cache-miss fetch off the existing Cloudflare gate: \`cargo test -p nereids-endf --release -- --ignored test_parse_w184_rml --nocapture\` → success in 1.27 s via NNDC fallback.

## History

Originally opened as KedoKudo/NEREIDS#10 (closed — the KedoKudo fork is a private mirror; the public repo is ornlneutronimaging/NEREIDS). This PR is the same branch (\`codex/endf-fetch-resilience\`) re-targeted at the right repo. Codex authored the fix.