### PR TITLE
[codex] Add manifest-driven NEREIDS MCP workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,75 @@ pip install nereids-gui
 nereids-gui
 ```
 
+### MCP server for AI agents
+
+NEREIDS can run as a local [Model Context Protocol](https://modelcontextprotocol.io/)
+server so AI agents can inspect neutron-resonance data, fit spectra, and run
+spatial density-map workflows through the Python bindings.
+
+```bash
+pip install "nereids[mcp]"
+nereids-mcp
+```
+
+Example MCP client configuration:
+
+```json
+{
+  "mcpServers": {
+    "nereids": {
+      "command": "nereids-mcp"
+    }
+  }
+}
+```
+
+The server exposes low-level physics tools (`load_endf`,
+`compute_cross_sections`, `compute_transmission`, `detect_isotopes`) and
+workflow tools for agent-driven processing:
+
+- `extract_resonance_manifest(dataset_path)` reads an sMCP-style manifest.
+- `validate_resonance_dataset(dataset_path)` checks data, isotope, and
+  resolution configuration.
+- `process_resonance_dataset(dataset_path)` runs a `single_spectrum` or
+  `density_map` workflow and writes compact `.npz` result artifacts.
+
+Datasets can include `manifest_intermediate.md`, `smcp_manifest.md`,
+`nereids_manifest.md`, `nereids_mcp.json`, or `analysis.json`. Markdown
+manifests use frontmatter between `---` delimiters; JSON frontmatter is
+supported without extra YAML dependencies.
+
+Minimal spectrum manifest:
+
+```markdown
+---
+{
+  "name": "venus-hf-spectrum",
+  "tool": "nereids",
+  "physics": "neutron-resonance",
+  "analysis": {
+    "mode": "single_spectrum",
+    "data": {
+      "kind": "counts_npz",
+      "path": "aggregated_hf_120min.npz",
+      "pc_ratio": 5.98
+    },
+    "isotopes": [
+      {"isotope": "Hf-177", "endf_file": "Hf-177.endf", "initial_density": 1e-5}
+    ],
+    "fit": {"solver": "lm", "fit_domain": "transmission", "max_iter": 100},
+    "resolution": {
+      "kind": "gaussian",
+      "flight_path_m": 25.0,
+      "delta_t_us": 0.5,
+      "delta_l_m": 0.005
+    },
+    "output": {"directory": "output"}
+  }
+}
+---
+```
+
 ### From source
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Datasets can include `manifest_intermediate.md`, `smcp_manifest.md`,
 manifests use frontmatter between `---` delimiters; JSON frontmatter is
 supported without extra YAML dependencies.
 
+See the [MCP server guide](docs/guide/src/mcp-server.md) for supported data
+kinds, manifest fields, NeXus histogram handling, and output artifacts.
+
 Minimal spectrum manifest:
 
 ```markdown

--- a/bindings/python/python/nereids/mcp/__init__.py
+++ b/bindings/python/python/nereids/mcp/__init__.py
@@ -22,4 +22,12 @@ def __getattr__(name):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__all__ = ["mcp"]
+def main():
+    """Run the NEREIDS MCP server over stdio."""
+    _check_fastmcp()
+    from nereids.mcp.server import mcp
+
+    mcp.run()
+
+
+__all__ = ["mcp", "main"]

--- a/bindings/python/python/nereids/mcp/__main__.py
+++ b/bindings/python/python/nereids/mcp/__main__.py
@@ -1,9 +1,6 @@
-"""Run the NEREIDS MCP server: python -m nereids.mcp"""
+"""Run the NEREIDS MCP server: python -m nereids.mcp."""
 
-from nereids.mcp import _check_fastmcp
+from nereids.mcp import main
 
-_check_fastmcp()
 
-from nereids.mcp.server import mcp  # noqa: E402
-
-mcp.run()
+main()

--- a/bindings/python/python/nereids/mcp/server.py
+++ b/bindings/python/python/nereids/mcp/server.py
@@ -310,6 +310,23 @@ def _npz_arrays(path: Path) -> dict[str, np.ndarray]:
         return {key: np.asarray(data[key]) for key in data.files}
 
 
+def _require_npz_keys(
+    arrays: dict[str, np.ndarray],
+    keys: list[str],
+    *,
+    context: str,
+) -> None:
+    missing = [key for key in keys if key not in arrays]
+    if missing:
+        available = ", ".join(sorted(arrays)) or "<none>"
+        required = ", ".join(keys)
+        missing_text = ", ".join(missing)
+        raise ValueError(
+            f"{context} is missing required key(s): {missing_text}. "
+            f"Required keys: {required}. Available keys: {available}"
+        )
+
+
 def _load_energy_grid(
     base: Path,
     data_config: dict[str, Any],
@@ -541,6 +558,8 @@ def _apply_roi(cube: np.ndarray, roi: dict[str, Any] | None) -> np.ndarray:
     height = int(roi.get("height", cube.shape[1] - y0))
     if x0 < 0 or y0 < 0 or width <= 0 or height <= 0:
         raise ValueError(f"invalid ROI: {roi}")
+    if x0 + width > cube.shape[2] or y0 + height > cube.shape[1]:
+        raise ValueError(f"ROI {roi} exceeds cube bounds {cube.shape[1:]}")
     return np.ascontiguousarray(cube[:, y0 : y0 + height, x0 : x0 + width])
 
 
@@ -630,6 +649,11 @@ def _process_single_spectrum(
     if kind in {"counts_npz", "counts"}:
         sample_key = data_config.get("sample_key", "sample_counts")
         open_beam_key = data_config.get("open_beam_key", "open_beam_counts")
+        _require_npz_keys(
+            arrays,
+            [sample_key, open_beam_key],
+            context="single_spectrum counts data",
+        )
         sample = _validate_array("sample_counts", arrays[sample_key])
         open_beam = _validate_array("open_beam_counts", arrays[open_beam_key])
         _require_same_shape("sample_counts", sample, ("open_beam_counts", open_beam))
@@ -677,6 +701,11 @@ def _process_single_spectrum(
     elif kind in {"transmission_npz", "transmission", "spectrum"}:
         trans_key = data_config.get("transmission_key", "transmission")
         unc_key = data_config.get("uncertainty_key", "uncertainty")
+        _require_npz_keys(
+            arrays,
+            [trans_key],
+            context="single_spectrum transmission data",
+        )
         transmission = _validate_array("transmission", arrays[trans_key])
         if unc_key in arrays:
             uncertainty = _validate_array("uncertainty", arrays[unc_key])
@@ -753,6 +782,11 @@ def _process_density_map(
             raise ValueError("transmission_npz data requires a .npz data.path")
         trans_key = data_config.get("transmission_key", "transmission")
         unc_key = data_config.get("uncertainty_key", "uncertainty")
+        _require_npz_keys(
+            arrays,
+            [trans_key],
+            context="density_map transmission data",
+        )
         transmission = _validate_array("transmission", arrays[trans_key], ndim=3)
         if unc_key in arrays:
             uncertainty = _validate_array("uncertainty", arrays[unc_key], ndim=3)
@@ -804,12 +838,19 @@ def _process_density_map(
     elif kind in {"counts_npz", "counts"}:
         if arrays is None:
             raise ValueError("counts_npz data requires a .npz data.path")
+        sample_key = data_config.get("sample_key", "sample_counts")
+        open_beam_key = data_config.get("open_beam_key", "open_beam_counts")
+        _require_npz_keys(
+            arrays,
+            [sample_key, open_beam_key],
+            context="density_map counts data",
+        )
         sample = _validate_array(
-            "sample_counts", arrays[data_config.get("sample_key", "sample_counts")], ndim=3
+            "sample_counts", arrays[sample_key], ndim=3
         )
         open_beam = _validate_array(
             "open_beam_counts",
-            arrays[data_config.get("open_beam_key", "open_beam_counts")],
+            arrays[open_beam_key],
             ndim=3,
         )
         _require_same_shape("sample_counts", sample, ("open_beam_counts", open_beam))
@@ -832,6 +873,17 @@ def _process_density_map(
         sample = _validate_array("sample_counts", sample_data.counts, ndim=3)
         open_beam = _validate_array("open_beam_counts", ob_data.counts, ndim=3)
         _require_same_shape("sample_counts", sample, ("open_beam_counts", open_beam))
+        sample_tof_edges = _validate_array(
+            "sample_tof_edges_us", sample_data.tof_edges_us, ndim=1
+        )
+        open_beam_tof_edges = _validate_array(
+            "open_beam_tof_edges_us", ob_data.tof_edges_us, ndim=1
+        )
+        if (
+            sample_tof_edges.shape != open_beam_tof_edges.shape
+            or not np.allclose(sample_tof_edges, open_beam_tof_edges)
+        ):
+            raise ValueError("nexus sample and open_beam TOF bin edges must match")
         flight_path = float(
             data_config.get(
                 "flight_path_m",
@@ -840,7 +892,7 @@ def _process_density_map(
         )
         delay_us = float(data_config.get("delay_us", 0.0))
         energies = np.asarray(
-            nereids.tof_to_energy_centers(sample_data.tof_edges_us, flight_path, delay_us),
+            nereids.tof_to_energy_centers(sample_tof_edges, flight_path, delay_us),
             dtype=np.float64,
         )
         # NeXus counts are loaded in TOF-bin order. The Python binding returns
@@ -930,13 +982,16 @@ def _validate_workflow(manifest: dict[str, Any]) -> dict[str, Any]:
 
     tool = str(frontmatter.get("tool", config.get("tool", "nereids"))).lower()
     if tool not in {"nereids", "nereids-mcp", "smcp-nereids"}:
-        errors.append(f"manifest tool must be 'nereids', got {tool!r}")
+        errors.append(
+            "manifest tool must be one of 'nereids', 'nereids-mcp', "
+            f"or 'smcp-nereids', got {tool!r}"
+        )
 
     mode = _normalise_mode(config.get("mode", config.get("analysis_mode")))
     if mode not in {"single_spectrum", "fit_spectrum", "spectrum", "density_map", "spatial_map"}:
         errors.append(
             "analysis mode must be one of single_spectrum, fit_spectrum, "
-            "density_map, or spatial_map"
+            "spectrum, density_map, or spatial_map"
         )
 
     effective_kind = _normalise_kind(

--- a/bindings/python/python/nereids/mcp/server.py
+++ b/bindings/python/python/nereids/mcp/server.py
@@ -843,8 +843,11 @@ def _process_density_map(
             nereids.tof_to_energy_centers(sample_data.tof_edges_us, flight_path, delay_us),
             dtype=np.float64,
         )
-        # Ascending TOF produces descending energy centers; the shared grid helper
-        # reverses energies and aligned counts together exactly once.
+        # NeXus counts are loaded in TOF-bin order. The Python binding returns
+        # ascending energy centers, so reverse the counts to energy order first.
+        if np.all(np.diff(energies) > 0):
+            sample = np.ascontiguousarray(sample[::-1, ...])
+            open_beam = np.ascontiguousarray(open_beam[::-1, ...])
         energies, sample, open_beam = _ascending_energy_grid(energies, sample, open_beam)
         sample = _apply_roi(sample, data_config.get("roi") or config.get("roi"))
         open_beam = _apply_roi(open_beam, data_config.get("roi") or config.get("roi"))

--- a/bindings/python/python/nereids/mcp/server.py
+++ b/bindings/python/python/nereids/mcp/server.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import math
+import re
+from pathlib import Path
+from typing import Any
 
 import numpy as np
 try:
@@ -21,6 +25,938 @@ mcp = FastMCP("nereids")
 # PyO3 objects are not JSON-serializable, so we keep them here
 # and reference by isotope key (e.g., "Fe-56").
 _registry: dict[str, nereids.ResonanceData] = {}
+
+_MANIFEST_NAMES = (
+    "manifest_intermediate.md",
+    "smcp_manifest.md",
+    "nereids_manifest.md",
+    "nereids_mcp.json",
+    "analysis.json",
+)
+_SAFE_KEY = re.compile(r"[^A-Za-z0-9_]+")
+
+
+def _json_safe(value: Any) -> Any:
+    """Convert numpy/path values to JSON-serializable Python objects."""
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    return value
+
+
+def _parse_scalar(value: str) -> Any:
+    """Parse a small YAML-ish scalar without making PyYAML a hard dependency."""
+    value = value.strip()
+    if value == "":
+        return ""
+    if value.lower() in {"true", "false"}:
+        return value.lower() == "true"
+    if value.lower() in {"null", "none"}:
+        return None
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    if value.startswith(("[", "{")):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+
+def _parse_frontmatter(raw: str) -> dict[str, Any]:
+    """Parse JSON frontmatter, PyYAML frontmatter if available, or flat YAML."""
+    text = raw.strip()
+    if not text:
+        return {}
+    if text.startswith("{"):
+        data = json.loads(text)
+        if not isinstance(data, dict):
+            raise ValueError("manifest frontmatter JSON must be an object")
+        return data
+
+    try:
+        import yaml  # type: ignore
+    except ModuleNotFoundError:
+        yaml = None
+    if yaml is not None:
+        data = yaml.safe_load(text)
+        if data is None:
+            return {}
+        if not isinstance(data, dict):
+            raise ValueError("manifest YAML frontmatter must be a mapping")
+        return data
+
+    parsed: dict[str, Any] = {}
+    unsupported_nested = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if line[:1].isspace() or stripped.startswith("- "):
+            unsupported_nested = True
+            continue
+        if ":" not in stripped:
+            raise ValueError(f"cannot parse manifest frontmatter line: {line!r}")
+        key, value = stripped.split(":", 1)
+        parsed[key.strip()] = _parse_scalar(value)
+    if unsupported_nested:
+        raise ValueError(
+            "nested YAML frontmatter requires PyYAML, or use JSON frontmatter"
+        )
+    return parsed
+
+
+def _find_manifest_path(dataset_path: Path) -> Path:
+    """Find a supported sMCP/NEREIDS manifest file."""
+    if dataset_path.is_file() and dataset_path.name in _MANIFEST_NAMES:
+        return dataset_path
+    root = dataset_path if dataset_path.is_dir() else dataset_path.parent
+    for name in _MANIFEST_NAMES:
+        candidate = root / name
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(
+        f"No NEREIDS sMCP manifest found in {root}. "
+        f"Expected one of: {', '.join(_MANIFEST_NAMES)}"
+    )
+
+
+def _read_manifest(dataset_path: str | Path) -> dict[str, Any]:
+    """Read a manifest file and return metadata, frontmatter, and body."""
+    path = Path(dataset_path).expanduser().resolve()
+    manifest_path = _find_manifest_path(path)
+    dataset_root = manifest_path.parent
+
+    if manifest_path.suffix == ".json":
+        frontmatter = json.loads(manifest_path.read_text())
+        if not isinstance(frontmatter, dict):
+            raise ValueError(f"{manifest_path} must contain a JSON object")
+        body = ""
+    else:
+        content = manifest_path.read_text()
+        if not content.lstrip().startswith("---"):
+            raise ValueError(
+                f"{manifest_path} must start with YAML/JSON frontmatter delimited by ---"
+            )
+        parts = content.split("---", 2)
+        if len(parts) < 3:
+            raise ValueError(f"{manifest_path} is missing closing frontmatter ---")
+        frontmatter = _parse_frontmatter(parts[1])
+        body = parts[2].strip()
+
+    return {
+        "dataset_path": str(dataset_root),
+        "manifest_path": str(manifest_path),
+        "frontmatter": frontmatter,
+        "body": body,
+    }
+
+
+def _workflow_config(manifest: dict[str, Any]) -> dict[str, Any]:
+    """Return the workflow config object from a parsed manifest."""
+    frontmatter = manifest["frontmatter"]
+    config = (
+        frontmatter.get("analysis")
+        or frontmatter.get("workflow")
+        or frontmatter.get("processing")
+        or frontmatter
+    )
+    if not isinstance(config, dict):
+        raise ValueError("manifest analysis/workflow section must be an object")
+    return config
+
+
+def _resolve_path(base: Path, value: str | Path | None) -> Path | None:
+    """Resolve a manifest path relative to the dataset root."""
+    if value is None:
+        return None
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = base / path
+    return path.resolve()
+
+
+def _normalise_mode(mode: Any) -> str:
+    return str(mode or "").strip().lower().replace("-", "_")
+
+
+def _normalise_kind(kind: Any, default: str) -> str:
+    return str(kind or default).strip().lower().replace("-", "_")
+
+
+def _get_data_config(config: dict[str, Any]) -> dict[str, Any]:
+    data = config.get("data") or config.get("input") or {}
+    if isinstance(data, str):
+        return {"path": data}
+    if not isinstance(data, dict):
+        raise ValueError("workflow data/input section must be an object or path string")
+    return data
+
+
+def _get_fit_config(config: dict[str, Any]) -> dict[str, Any]:
+    fit = config.get("fit") or config.get("fitting") or {}
+    if not isinstance(fit, dict):
+        raise ValueError("workflow fit/fitting section must be an object")
+    return fit
+
+
+def _get_isotope_entries(config: dict[str, Any], frontmatter: dict[str, Any]) -> list[Any]:
+    entries = config.get("isotopes") or config.get("nuclides")
+    if entries is None and "isotope" in config:
+        entries = [{"isotope": config["isotope"]}]
+    if entries is None and "isotope" in frontmatter:
+        entries = [{"isotope": frontmatter["isotope"]}]
+    if entries is None:
+        return []
+    if isinstance(entries, (str, dict)):
+        return [entries]
+    if not isinstance(entries, list):
+        raise ValueError("isotopes must be a string, object, or list")
+    return entries
+
+
+def _array_stats(values: np.ndarray) -> dict[str, Any]:
+    arr = np.asarray(values, dtype=float)
+    finite = arr[np.isfinite(arr)]
+    stats: dict[str, Any] = {
+        "shape": list(arr.shape),
+        "finite_count": int(finite.size),
+        "nan_count": int(np.isnan(arr).sum()),
+    }
+    if finite.size:
+        stats.update(
+            {
+                "min": float(np.min(finite)),
+                "max": float(np.max(finite)),
+                "mean": float(np.mean(finite)),
+            }
+        )
+    return stats
+
+
+def _validate_array(name: str, values: Any, ndim: int | None = None) -> np.ndarray:
+    arr = np.asarray(values, dtype=np.float64)
+    if ndim is not None and arr.ndim != ndim:
+        raise ValueError(f"{name} must be {ndim}D, got shape {arr.shape}")
+    if arr.size == 0:
+        raise ValueError(f"{name} must not be empty")
+    if not np.all(np.isfinite(arr)):
+        raise ValueError(f"{name} contains non-finite values")
+    return np.ascontiguousarray(arr)
+
+
+def _ascending_energy_grid(
+    energies: np.ndarray, *aligned: np.ndarray
+) -> tuple[np.ndarray, ...]:
+    """Ensure energies are strictly ascending, reversing aligned arrays if needed."""
+    grid = _validate_array("energies", energies, ndim=1)
+    arrays = tuple(np.ascontiguousarray(a) for a in aligned)
+    diffs = np.diff(grid)
+    if np.all(diffs > 0):
+        return (grid, *arrays)
+    if np.all(diffs < 0):
+        reversed_arrays = tuple(np.ascontiguousarray(a[::-1, ...]) for a in arrays)
+        return (np.ascontiguousarray(grid[::-1]), *reversed_arrays)
+    raise ValueError("energies must be strictly monotonic")
+
+
+def _npz_arrays(path: Path) -> dict[str, np.ndarray]:
+    if not path.exists():
+        raise FileNotFoundError(f"data file does not exist: {path}")
+    with np.load(path, allow_pickle=False) as data:
+        return {key: np.asarray(data[key]) for key in data.files}
+
+
+def _load_energy_grid(
+    base: Path,
+    data_config: dict[str, Any],
+    arrays: dict[str, np.ndarray] | None,
+    n_expected: int | None = None,
+) -> np.ndarray:
+    """Load or synthesize an energy grid from manifest config and data arrays."""
+    grid_config = data_config.get("energy_grid") or data_config.get("energies") or {}
+    if isinstance(grid_config, str):
+        grid_config = {"path": grid_config}
+    if not isinstance(grid_config, dict):
+        raise ValueError("energy_grid/energies must be an object or path string")
+
+    key = (
+        grid_config.get("key")
+        or data_config.get("energy_key")
+        or data_config.get("energies_key")
+    )
+    if key and arrays is not None:
+        if key not in arrays:
+            raise ValueError(f"energy key {key!r} not found in data file")
+        return _validate_array("energies", arrays[key], ndim=1)
+
+    if arrays is not None and "energies_ev" in arrays:
+        return _validate_array("energies", arrays["energies_ev"], ndim=1)
+
+    path = _resolve_path(base, grid_config.get("path"))
+    if path is not None:
+        return _validate_array("energies", np.loadtxt(path), ndim=1)
+
+    start = grid_config.get("start_ev", data_config.get("energy_min_ev"))
+    stop = grid_config.get("stop_ev", data_config.get("energy_max_ev"))
+    n_points = grid_config.get("n_points", data_config.get("n_points", n_expected))
+    if start is None or stop is None or n_points is None:
+        raise ValueError(
+            "energy grid is required: provide energies_ev in the data file or "
+            "energy_grid with start_ev, stop_ev, and n_points"
+        )
+    return np.linspace(float(start), float(stop), int(n_points), dtype=np.float64)
+
+
+def _load_isotopes(
+    entries: list[Any],
+    base: Path,
+    default_library: str = "endf8.1",
+) -> tuple[list[tuple[nereids.ResonanceData, float]], list[str]]:
+    """Load isotope entries from ENDF files, ENDF cache/retrieval, or synthetic specs."""
+    loaded: list[tuple[nereids.ResonanceData, float]] = []
+    names: list[str] = []
+    if not entries:
+        raise ValueError("at least one isotope must be configured")
+
+    for raw_entry in entries:
+        entry = {"isotope": raw_entry} if isinstance(raw_entry, str) else dict(raw_entry)
+        isotope = entry.get("isotope") or entry.get("name")
+        library = str(entry.get("library", default_library))
+        initial_density = float(
+            entry.get("initial_density", entry.get("density", 0.001))
+        )
+        if not math.isfinite(initial_density) or initial_density < 0:
+            raise ValueError(
+                f"initial density for {isotope or entry!r} must be finite and non-negative"
+            )
+
+        synthetic = entry.get("synthetic_resonance") or entry.get("resonance_data")
+        endf_file = entry.get("endf_file") or entry.get("endf_path")
+        if synthetic is not None:
+            spec = dict(synthetic)
+            if isotope and ("z" not in spec or "a" not in spec):
+                parsed = nereids.parse_isotope_str(str(isotope))
+                if parsed is not None:
+                    spec.setdefault("z", parsed[0])
+                    spec.setdefault("a", parsed[1])
+            resonances = spec.get("resonances")
+            if resonances is None:
+                resonance = spec.get("resonance")
+                resonances = [resonance] if resonance is not None else None
+            if resonances is None:
+                raise ValueError(f"synthetic isotope {isotope!r} needs resonances")
+            data = nereids.create_resonance_data(
+                z=int(spec["z"]),
+                a=int(spec["a"]),
+                awr=float(spec["awr"]),
+                scattering_radius=float(spec["scattering_radius"]),
+                resonances=[tuple(map(float, r)) for r in resonances],
+                target_spin=float(spec.get("target_spin", 0.0)),
+                formalism=spec.get("formalism"),
+            )
+        elif endf_file is not None:
+            path = _resolve_path(base, endf_file)
+            if path is None or not path.exists():
+                raise FileNotFoundError(f"ENDF file not found for {isotope}: {path}")
+            data = nereids.load_endf_file(str(path))
+        else:
+            parsed = None
+            if isotope:
+                parsed = nereids.parse_isotope_str(str(isotope))
+            if parsed is None and "z" in entry and "a" in entry:
+                parsed = (int(entry["z"]), int(entry["a"]))
+            if parsed is None:
+                raise ValueError(
+                    f"Cannot parse isotope entry {entry!r}; provide isotope, z/a, "
+                    "endf_file, or synthetic_resonance"
+                )
+            data = nereids.load_endf(parsed[0], parsed[1], library=library)
+
+        name = str(isotope or _isotope_key(int(data.z), int(data.a)))
+        loaded.append((data, initial_density))
+        names.append(name)
+    return loaded, names
+
+
+def _resolution_kwargs(base: Path, config: dict[str, Any]) -> dict[str, Any]:
+    """Build NEREIDS resolution keyword arguments from manifest config."""
+    resolution_config = config.get("resolution") or {}
+    if not resolution_config:
+        return {}
+    if isinstance(resolution_config, str):
+        resolution_config = {"kind": resolution_config}
+    if not isinstance(resolution_config, dict):
+        raise ValueError("resolution must be an object")
+
+    kind = _normalise_kind(resolution_config.get("kind", "none"), "none")
+    if kind in {"none", "disabled", "false"}:
+        return {}
+    if kind in {"gaussian", "sammy_gaussian"}:
+        return {
+            "flight_path_m": float(resolution_config["flight_path_m"]),
+            "delta_t_us": float(resolution_config["delta_t_us"]),
+            "delta_l_m": float(resolution_config["delta_l_m"]),
+        }
+    if kind in {"tabulated", "file", "resolution_file"}:
+        path = _resolve_path(base, resolution_config.get("path"))
+        if path is None:
+            raise ValueError("tabulated resolution requires a path")
+        flight_path_m = float(resolution_config["flight_path_m"])
+        return {"resolution": nereids.load_resolution(str(path), flight_path_m)}
+    raise ValueError(f"unknown resolution kind: {kind}")
+
+
+def _fit_energy_range(value: Any) -> tuple[float, float] | None:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        value = (value.get("min_ev"), value.get("max_ev"))
+    if not isinstance(value, (list, tuple)) or len(value) != 2:
+        raise ValueError("fit_energy_range must be [min_ev, max_ev]")
+    return (float(value[0]), float(value[1]))
+
+
+def _single_fit_kwargs(
+    fit_config: dict[str, Any],
+    resolution: dict[str, Any],
+    counts: bool,
+) -> dict[str, Any]:
+    keys = {
+        "temperature_k",
+        "fit_temperature",
+        "max_iter",
+        "solver",
+        "background",
+        "fit_back_d",
+        "fit_back_f",
+        "back_d_init",
+        "back_f_init",
+        "fit_energy_scale",
+        "t0_init_us",
+        "l_scale_init",
+        "energy_scale_flight_path_m",
+        "tzero_jacobian",
+    }
+    if counts:
+        keys.update(
+            {
+                "fit_alpha_1",
+                "fit_alpha_2",
+                "alpha_1_init",
+                "alpha_2_init",
+                "enable_polish",
+            }
+        )
+    kwargs = {key: fit_config[key] for key in keys if key in fit_config}
+    if "fit_energy_range" in fit_config:
+        kwargs["fit_energy_range"] = _fit_energy_range(fit_config["fit_energy_range"])
+    kwargs.update(resolution)
+    return kwargs
+
+
+def _spatial_fit_kwargs(
+    fit_config: dict[str, Any],
+    resolution: dict[str, Any],
+) -> dict[str, Any]:
+    keys = {
+        "temperature_k",
+        "fit_temperature",
+        "max_iter",
+        "solver",
+        "background",
+        "fit_alpha_1",
+        "fit_alpha_2",
+        "alpha_1_init",
+        "alpha_2_init",
+        "c",
+        "enable_polish",
+        "fit_energy_scale",
+        "t0_init_us",
+        "l_scale_init",
+        "energy_scale_flight_path_m",
+        "tzero_jacobian",
+    }
+    kwargs = {key: fit_config[key] for key in keys if key in fit_config}
+    if "fit_energy_range" in fit_config:
+        kwargs["fit_energy_range"] = _fit_energy_range(fit_config["fit_energy_range"])
+    kwargs.update(resolution)
+    return kwargs
+
+
+def _safe_npz_key(name: str) -> str:
+    key = _SAFE_KEY.sub("_", name).strip("_")
+    return key or "isotope"
+
+
+def _apply_roi(cube: np.ndarray, roi: dict[str, Any] | None) -> np.ndarray:
+    if not roi:
+        return cube
+    x0 = int(roi.get("x0", roi.get("x", 0)))
+    y0 = int(roi.get("y0", roi.get("y", 0)))
+    width = int(roi.get("width", cube.shape[2] - x0))
+    height = int(roi.get("height", cube.shape[1] - y0))
+    if x0 < 0 or y0 < 0 or width <= 0 or height <= 0:
+        raise ValueError(f"invalid ROI: {roi}")
+    return np.ascontiguousarray(cube[:, y0 : y0 + height, x0 : x0 + width])
+
+
+def _limit_pixels(
+    cube: np.ndarray, max_pixels: int | None
+) -> tuple[np.ndarray, dict[str, Any] | None]:
+    if max_pixels is None or cube.shape[1] * cube.shape[2] <= max_pixels:
+        return cube, None
+    if max_pixels < 1:
+        raise ValueError("max_pixels must be positive")
+    h, w = cube.shape[1], cube.shape[2]
+    side = max(1, int(math.sqrt(max_pixels)))
+    new_h = min(h, side)
+    new_w = min(w, max(1, max_pixels // new_h))
+    cropped = np.ascontiguousarray(cube[:, :new_h, :new_w])
+    return cropped, {
+        "original_shape": [int(cube.shape[0]), int(h), int(w)],
+        "cropped_shape": [int(cropped.shape[0]), int(new_h), int(new_w)],
+        "reason": f"max_pixels={max_pixels}",
+    }
+
+
+def _fit_result_summary(result: Any, names: list[str]) -> dict[str, Any]:
+    densities = np.asarray(result.densities, dtype=float)
+    uncertainties = np.asarray(result.uncertainties, dtype=float)
+    entries = []
+    for i, name in enumerate(names):
+        entries.append(
+            {
+                "isotope": name,
+                "density_atoms_per_barn": float(densities[i]),
+                "uncertainty_atoms_per_barn": float(uncertainties[i])
+                if i < len(uncertainties)
+                else None,
+            }
+        )
+    return {
+        "density_fits": entries,
+        "reduced_chi_squared": float(result.reduced_chi_squared),
+        "deviance_per_dof": None
+        if getattr(result, "deviance_per_dof", None) is None
+        else float(result.deviance_per_dof),
+        "converged": bool(result.converged),
+        "iterations": int(result.iterations),
+        "temperature_k": None
+        if result.temperature_k is None
+        else float(result.temperature_k),
+        "anorm": float(result.anorm),
+        "background": [float(v) for v in result.background],
+    }
+
+
+def _process_single_spectrum(
+    base: Path,
+    manifest: dict[str, Any],
+    output_dir: Path,
+) -> dict[str, Any]:
+    frontmatter = manifest["frontmatter"]
+    config = _workflow_config(manifest)
+    data_config = _get_data_config(config)
+    fit_config = _get_fit_config(config)
+    data_path = _resolve_path(base, data_config.get("path"))
+    if data_path is None:
+        raise ValueError("single_spectrum workflow requires data.path")
+
+    kind = _normalise_kind(data_config.get("kind"), "counts_npz")
+    arrays = _npz_arrays(data_path) if data_path.suffix == ".npz" else None
+    if arrays is None:
+        loaded = np.loadtxt(data_path, delimiter=data_config.get("delimiter", None))
+        if loaded.ndim != 2 or loaded.shape[1] < 2:
+            raise ValueError("spectrum text input must have at least two columns")
+        arrays = {
+            "energies_ev": loaded[:, int(data_config.get("energy_column", 0))],
+            "transmission": loaded[:, int(data_config.get("transmission_column", 1))],
+        }
+        if loaded.shape[1] > 2:
+            arrays["uncertainty"] = loaded[:, int(data_config.get("uncertainty_column", 2))]
+        kind = "transmission_npz"
+
+    entries = _get_isotope_entries(config, frontmatter)
+    isotopes, names = _load_isotopes(
+        entries, base, default_library=str(config.get("library", "endf8.1"))
+    )
+    resolution = _resolution_kwargs(base, config)
+    solver = str(fit_config.get("solver", "lm")).lower()
+
+    if kind in {"counts_npz", "counts"}:
+        sample_key = data_config.get("sample_key", "sample_counts")
+        open_beam_key = data_config.get("open_beam_key", "open_beam_counts")
+        sample = _validate_array("sample_counts", arrays[sample_key])
+        open_beam = _validate_array("open_beam_counts", arrays[open_beam_key])
+        energies = _load_energy_grid(base, data_config, arrays, n_expected=sample.shape[0])
+        energies, sample, open_beam = _ascending_energy_grid(energies, sample, open_beam)
+        if sample.ndim == 3:
+            sample = np.ascontiguousarray(sample.sum(axis=(1, 2)))
+            open_beam = np.ascontiguousarray(open_beam.sum(axis=(1, 2)))
+        if sample.ndim != 1 or open_beam.ndim != 1:
+            raise ValueError("single_spectrum counts arrays must be 1D or 3D")
+        c = float(data_config.get("pc_ratio", arrays.get("pc_ratio", 1.0)))
+        fit_domain = str(
+            fit_config.get(
+                "fit_domain",
+                "transmission" if solver == "lm" else "counts",
+            )
+        ).lower()
+        if fit_domain == "counts":
+            kwargs = _single_fit_kwargs(fit_config, resolution, counts=True)
+            kwargs["c"] = float(fit_config.get("c", c))
+            result = nereids.fit_counts_spectrum_typed(
+                sample_counts=sample,
+                open_beam_counts=open_beam,
+                energies=energies,
+                isotopes=isotopes,
+                **kwargs,
+            )
+            transmission = sample / np.maximum(kwargs["c"] * open_beam, 1.0)
+            uncertainty = transmission * np.sqrt(
+                1.0 / np.maximum(sample, 1.0) + 1.0 / np.maximum(open_beam, 1.0)
+            )
+        else:
+            transmission = sample / np.maximum(c * open_beam, 1.0)
+            uncertainty = transmission * np.sqrt(
+                1.0 / np.maximum(sample, 1.0) + 1.0 / np.maximum(open_beam, 1.0)
+            )
+            kwargs = _single_fit_kwargs(fit_config, resolution, counts=False)
+            result = nereids.fit_spectrum_typed(
+                transmission=transmission,
+                uncertainty=uncertainty,
+                energies=energies,
+                isotopes=isotopes,
+                **kwargs,
+            )
+    elif kind in {"transmission_npz", "transmission", "spectrum"}:
+        trans_key = data_config.get("transmission_key", "transmission")
+        unc_key = data_config.get("uncertainty_key", "uncertainty")
+        transmission = _validate_array("transmission", arrays[trans_key])
+        if unc_key in arrays:
+            uncertainty = _validate_array("uncertainty", arrays[unc_key])
+        else:
+            uncertainty = np.full_like(
+                transmission, float(data_config.get("uncertainty", 0.01))
+            )
+        energies = _load_energy_grid(base, data_config, arrays, n_expected=transmission.shape[0])
+        energies, transmission, uncertainty = _ascending_energy_grid(
+            energies, transmission, uncertainty
+        )
+        if transmission.ndim == 3:
+            transmission = np.ascontiguousarray(np.nanmean(transmission, axis=(1, 2)))
+            uncertainty = np.ascontiguousarray(
+                np.sqrt(np.nanmean(np.square(uncertainty), axis=(1, 2)))
+            )
+        if transmission.ndim != 1:
+            raise ValueError("single_spectrum transmission arrays must be 1D or 3D")
+        kwargs = _single_fit_kwargs(fit_config, resolution, counts=False)
+        result = nereids.fit_spectrum_typed(
+            transmission=transmission,
+            uncertainty=uncertainty,
+            energies=energies,
+            isotopes=isotopes,
+            **kwargs,
+        )
+    else:
+        raise ValueError(f"unsupported single_spectrum data kind: {kind}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    result_npz = output_dir / "nereids_spectrum_fit.npz"
+    np.savez_compressed(
+        result_npz,
+        energies_ev=energies,
+        transmission=transmission,
+        uncertainty=uncertainty,
+        fitted_densities=np.asarray(result.densities),
+        density_uncertainties=np.asarray(result.uncertainties),
+        isotope_names=np.asarray(names),
+    )
+    summary = _fit_result_summary(result, names)
+    summary.update(
+        {
+            "mode": "single_spectrum",
+            "data_path": str(data_path),
+            "output_npz": str(result_npz),
+            "energy_range_ev": [float(energies[0]), float(energies[-1])],
+            "n_energy": int(energies.size),
+        }
+    )
+    return summary
+
+
+def _process_density_map(
+    base: Path,
+    manifest: dict[str, Any],
+    output_dir: Path,
+    max_pixels: int | None,
+) -> dict[str, Any]:
+    frontmatter = manifest["frontmatter"]
+    config = _workflow_config(manifest)
+    data_config = _get_data_config(config)
+    fit_config = _get_fit_config(config)
+    kind = _normalise_kind(data_config.get("kind"), "transmission_npz")
+
+    arrays: dict[str, np.ndarray] | None = None
+    path = _resolve_path(base, data_config.get("path"))
+    if path is not None and path.suffix == ".npz":
+        arrays = _npz_arrays(path)
+
+    if kind in {"transmission_npz", "transmission"}:
+        if arrays is None:
+            raise ValueError("transmission_npz data requires a .npz data.path")
+        trans_key = data_config.get("transmission_key", "transmission")
+        unc_key = data_config.get("uncertainty_key", "uncertainty")
+        transmission = _validate_array("transmission", arrays[trans_key], ndim=3)
+        if unc_key in arrays:
+            uncertainty = _validate_array("uncertainty", arrays[unc_key], ndim=3)
+        else:
+            uncertainty = np.full_like(
+                transmission, float(data_config.get("uncertainty", 0.01))
+            )
+        energies = _load_energy_grid(
+            base, data_config, arrays, n_expected=transmission.shape[0]
+        )
+        energies, transmission, uncertainty = _ascending_energy_grid(
+            energies, transmission, uncertainty
+        )
+        transmission = _apply_roi(transmission, data_config.get("roi") or config.get("roi"))
+        uncertainty = _apply_roi(uncertainty, data_config.get("roi") or config.get("roi"))
+        transmission, crop = _limit_pixels(transmission, max_pixels)
+        uncertainty = uncertainty[:, : transmission.shape[1], : transmission.shape[2]]
+        input_data = nereids.from_transmission(transmission, uncertainty)
+        input_kind = "transmission"
+        c = None
+    elif kind in {"transmission_tiff", "tiff"}:
+        if path is None:
+            raise ValueError("transmission_tiff data requires data.path")
+        transmission = _validate_array(
+            "transmission", nereids.load_tiff_stack(str(path)), ndim=3
+        )
+        uncertainty_path = _resolve_path(base, data_config.get("uncertainty_path"))
+        if uncertainty_path is not None:
+            uncertainty = _validate_array(
+                "uncertainty", nereids.load_tiff_stack(str(uncertainty_path)), ndim=3
+            )
+        else:
+            uncertainty = np.full_like(
+                transmission, float(data_config.get("uncertainty", 0.01))
+            )
+        energies = _load_energy_grid(base, data_config, None, n_expected=transmission.shape[0])
+        energies, transmission, uncertainty = _ascending_energy_grid(
+            energies, transmission, uncertainty
+        )
+        transmission = _apply_roi(transmission, data_config.get("roi") or config.get("roi"))
+        uncertainty = _apply_roi(uncertainty, data_config.get("roi") or config.get("roi"))
+        transmission, crop = _limit_pixels(transmission, max_pixels)
+        uncertainty = uncertainty[:, : transmission.shape[1], : transmission.shape[2]]
+        input_data = nereids.from_transmission(transmission, uncertainty)
+        input_kind = "transmission"
+        c = None
+    elif kind in {"counts_npz", "counts"}:
+        if arrays is None:
+            raise ValueError("counts_npz data requires a .npz data.path")
+        sample = _validate_array(
+            "sample_counts", arrays[data_config.get("sample_key", "sample_counts")], ndim=3
+        )
+        open_beam = _validate_array(
+            "open_beam_counts",
+            arrays[data_config.get("open_beam_key", "open_beam_counts")],
+            ndim=3,
+        )
+        energies = _load_energy_grid(base, data_config, arrays, n_expected=sample.shape[0])
+        energies, sample, open_beam = _ascending_energy_grid(energies, sample, open_beam)
+        sample = _apply_roi(sample, data_config.get("roi") or config.get("roi"))
+        open_beam = _apply_roi(open_beam, data_config.get("roi") or config.get("roi"))
+        sample, crop = _limit_pixels(sample, max_pixels)
+        open_beam = open_beam[:, : sample.shape[1], : sample.shape[2]]
+        input_data = nereids.from_counts(sample, open_beam)
+        input_kind = "counts"
+        c = float(data_config.get("pc_ratio", arrays.get("pc_ratio", 1.0)))
+    elif kind in {"nexus_histogram", "nexus"}:
+        sample_path = _resolve_path(base, data_config.get("sample_path"))
+        open_beam_path = _resolve_path(base, data_config.get("open_beam_path"))
+        if sample_path is None or open_beam_path is None:
+            raise ValueError("nexus data requires sample_path and open_beam_path")
+        sample_data = nereids.load_nexus_histogram(str(sample_path))
+        ob_data = nereids.load_nexus_histogram(str(open_beam_path))
+        sample = _validate_array("sample_counts", sample_data.counts, ndim=3)
+        open_beam = _validate_array("open_beam_counts", ob_data.counts, ndim=3)
+        flight_path = float(
+            data_config.get(
+                "flight_path_m",
+                sample_data.flight_path_m or ob_data.flight_path_m or 25.0,
+            )
+        )
+        delay_us = float(data_config.get("delay_us", 0.0))
+        energies = np.asarray(
+            nereids.tof_to_energy_centers(sample_data.tof_edges_us, flight_path, delay_us),
+            dtype=np.float64,
+        )
+        # NeXus histograms are ascending TOF; NEREIDS fitting expects arrays
+        # aligned with ascending energy, so reverse the spectral axis.
+        sample = np.ascontiguousarray(sample[::-1, ...])
+        open_beam = np.ascontiguousarray(open_beam[::-1, ...])
+        energies, sample, open_beam = _ascending_energy_grid(energies, sample, open_beam)
+        sample = _apply_roi(sample, data_config.get("roi") or config.get("roi"))
+        open_beam = _apply_roi(open_beam, data_config.get("roi") or config.get("roi"))
+        sample, crop = _limit_pixels(sample, max_pixels)
+        open_beam = open_beam[:, : sample.shape[1], : sample.shape[2]]
+        input_data = nereids.from_counts(sample, open_beam)
+        input_kind = "counts"
+        c = float(data_config.get("pc_ratio", 1.0))
+    else:
+        raise ValueError(f"unsupported density_map data kind: {kind}")
+
+    entries = _get_isotope_entries(config, frontmatter)
+    isotopes, names = _load_isotopes(
+        entries, base, default_library=str(config.get("library", "endf8.1"))
+    )
+    initial_densities = [density for _, density in isotopes]
+    isotope_data = [data for data, _ in isotopes]
+    kwargs = _spatial_fit_kwargs(fit_config, _resolution_kwargs(base, config))
+    if c is not None and "c" not in kwargs:
+        kwargs["c"] = c
+    result = nereids.spatial_map_typed(
+        input_data,
+        energies,
+        isotope_data,
+        initial_densities=initial_densities,
+        **kwargs,
+    )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    result_npz = output_dir / "nereids_density_map.npz"
+    arrays_to_save: dict[str, Any] = {
+        "energies_ev": energies,
+        "chi_squared_map": np.asarray(result.chi_squared_map),
+        "converged_map": np.asarray(result.converged_map),
+        "isotope_names": np.asarray(names),
+    }
+    if result.deviance_per_dof_map is not None:
+        arrays_to_save["deviance_per_dof_map"] = np.asarray(result.deviance_per_dof_map)
+    density_stats = []
+    for name, density_map, uncertainty_map in zip(
+        names, result.density_maps, result.uncertainty_maps
+    ):
+        key = _safe_npz_key(name)
+        density_arr = np.asarray(density_map)
+        uncertainty_arr = np.asarray(uncertainty_map)
+        arrays_to_save[f"density_{key}"] = density_arr
+        arrays_to_save[f"uncertainty_{key}"] = uncertainty_arr
+        density_stats.append(
+            {
+                "isotope": name,
+                "density_atoms_per_barn": _array_stats(density_arr),
+                "uncertainty_atoms_per_barn": _array_stats(uncertainty_arr),
+            }
+        )
+    np.savez_compressed(result_npz, **arrays_to_save)
+
+    return {
+        "mode": "density_map",
+        "input_kind": input_kind,
+        "data_path": None if path is None else str(path),
+        "output_npz": str(result_npz),
+        "energy_range_ev": [float(energies[0]), float(energies[-1])],
+        "n_energy": int(energies.size),
+        "map_shape": list(np.asarray(result.converged_map).shape),
+        "n_converged": int(result.n_converged),
+        "n_total": int(result.n_total),
+        "n_failed": int(result.n_failed),
+        "density_maps": density_stats,
+        "crop": crop,
+    }
+
+
+def _validate_workflow(manifest: dict[str, Any]) -> dict[str, Any]:
+    base = Path(manifest["dataset_path"])
+    frontmatter = manifest["frontmatter"]
+    config = _workflow_config(manifest)
+    data_config = _get_data_config(config)
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    tool = str(frontmatter.get("tool", config.get("tool", "nereids"))).lower()
+    if tool not in {"nereids", "nereids-mcp", "smcp-nereids"}:
+        errors.append(f"manifest tool must be 'nereids', got {tool!r}")
+
+    mode = _normalise_mode(config.get("mode", config.get("analysis_mode")))
+    if mode not in {"single_spectrum", "fit_spectrum", "spectrum", "density_map", "spatial_map"}:
+        errors.append(
+            "analysis mode must be one of single_spectrum, fit_spectrum, "
+            "density_map, or spatial_map"
+        )
+
+    data_paths = []
+    for key in ("path", "sample_path", "open_beam_path", "uncertainty_path"):
+        value = data_config.get(key)
+        if value is None:
+            continue
+        path = _resolve_path(base, value)
+        data_paths.append({"key": key, "path": str(path), "exists": path.exists()})
+        if not path.exists():
+            errors.append(f"{key} does not exist: {path}")
+
+    entries = _get_isotope_entries(config, frontmatter)
+    if not entries:
+        errors.append("no isotopes configured")
+    for entry in entries:
+        if isinstance(entry, str):
+            continue
+        endf_file = entry.get("endf_file") or entry.get("endf_path")
+        if endf_file is not None:
+            path = _resolve_path(base, endf_file)
+            if path is None or not path.exists():
+                errors.append(f"ENDF file does not exist: {path}")
+        elif not (
+            entry.get("synthetic_resonance")
+            or entry.get("resonance_data")
+            or entry.get("isotope")
+            or ("z" in entry and "a" in entry)
+        ):
+            errors.append(f"isotope entry is missing isotope/z/a/endf_file: {entry}")
+
+    resolution = config.get("resolution")
+    if isinstance(resolution, dict):
+        kind = _normalise_kind(resolution.get("kind", "none"), "none")
+        if kind in {"tabulated", "file", "resolution_file"}:
+            path = _resolve_path(base, resolution.get("path"))
+            if path is None or not path.exists():
+                errors.append(f"resolution file does not exist: {path}")
+        if kind in {"none", "disabled", "false"}:
+            warnings.append("resolution disabled; appropriate for synthetic data")
+    elif resolution is None and mode in {"density_map", "spatial_map"}:
+        warnings.append("no resolution configured; OK for synthetic/demo data")
+
+    return {
+        "valid": not errors,
+        "errors": errors,
+        "warnings": warnings,
+        "manifest_path": manifest["manifest_path"],
+        "dataset_path": manifest["dataset_path"],
+        "mode": mode or None,
+        "data_kind": _normalise_kind(data_config.get("kind"), "unspecified"),
+        "data_paths": data_paths,
+        "isotopes": _json_safe(entries),
+    }
 
 
 def _isotope_key(z: int, a: int) -> str:
@@ -332,3 +1268,133 @@ def detect_isotopes(
         }
         for name, report in results
     ]
+
+
+@mcp.tool()
+def extract_resonance_manifest(dataset_path: str) -> dict:
+    """Extract a NEREIDS sMCP manifest without running analysis.
+
+    The manifest may be `manifest_intermediate.md`, `smcp_manifest.md`,
+    `nereids_manifest.md`, `nereids_mcp.json`, or `analysis.json`.
+    Markdown manifests use `---` frontmatter. JSON frontmatter is preferred
+    because it works without optional YAML dependencies.
+
+    Args:
+        dataset_path: Dataset directory or manifest path.
+
+    Returns:
+        Dict containing the manifest path, parsed frontmatter, and body preview.
+    """
+    manifest = _read_manifest(dataset_path)
+    body = manifest["body"]
+    return {
+        "dataset_path": manifest["dataset_path"],
+        "manifest_path": manifest["manifest_path"],
+        "frontmatter": _json_safe(manifest["frontmatter"]),
+        "body_preview": body[:800] + "..." if len(body) > 800 else body,
+    }
+
+
+@mcp.tool()
+def validate_resonance_dataset(dataset_path: str) -> dict:
+    """Validate a NEREIDS sMCP dataset before processing.
+
+    Checks the manifest, data file paths, isotope definitions, and whether
+    instrument resolution is configured. Synthetic demo data may intentionally
+    omit resolution; real VENUS data should normally include Gaussian or
+    tabulated resolution settings.
+
+    Args:
+        dataset_path: Dataset directory or manifest path.
+
+    Returns:
+        Validation report with errors, warnings, inferred mode, and data paths.
+    """
+    try:
+        manifest = _read_manifest(dataset_path)
+        return _validate_workflow(manifest)
+    except Exception as exc:
+        return {
+            "valid": False,
+            "errors": [str(exc)],
+            "warnings": [],
+            "dataset_path": str(Path(dataset_path).expanduser()),
+        }
+
+
+@mcp.tool()
+def process_resonance_dataset(
+    dataset_path: str,
+    output_dir: str | None = None,
+    max_pixels: int | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """Run a manifest-driven NEREIDS resonance analysis workflow.
+
+    This is the high-level demo tool intended for AI-agent orchestration:
+    the agent can call it when a user says "help me process the data here".
+    Supported workflows:
+
+    - `single_spectrum`: fit one transmission/counts spectrum and estimate
+      isotope areal densities.
+    - `density_map` / `spatial_map`: fit every pixel in a 3D transmission or
+      counts cube and write density-map outputs.
+
+    Supported inputs include `.npz` spectra/cubes, multi-frame TIFF
+    transmission stacks, and NeXus histogram sample/open-beam pairs.
+
+    Args:
+        dataset_path: Dataset directory or manifest path.
+        output_dir: Optional output directory. Defaults to `<dataset>/output`.
+        max_pixels: Optional safety crop for spatial workflows.
+        dry_run: If true, only validate and return the intended plan.
+
+    Returns:
+        Small JSON-safe summary plus paths to `.npz` result artifacts.
+    """
+    try:
+        manifest = _read_manifest(dataset_path)
+        validation = _validate_workflow(manifest)
+        if dry_run or not validation["valid"]:
+            return {
+                "success": validation["valid"],
+                "dry_run": dry_run,
+                "validation": validation,
+            }
+
+        base = Path(manifest["dataset_path"])
+        config = _workflow_config(manifest)
+        mode = _normalise_mode(config.get("mode", config.get("analysis_mode")))
+        out = _resolve_path(base, output_dir) if output_dir else None
+        if out is None:
+            output_config = config.get("output")
+            configured = config.get("output_dir")
+            if configured is None and isinstance(output_config, dict):
+                configured = output_config.get("directory")
+            out = _resolve_path(base, configured) if configured else base / "output"
+        out = out.resolve()
+
+        if mode in {"single_spectrum", "fit_spectrum", "spectrum"}:
+            result = _process_single_spectrum(base, manifest, out)
+        elif mode in {"density_map", "spatial_map"}:
+            result = _process_density_map(base, manifest, out, max_pixels=max_pixels)
+        else:
+            raise ValueError(f"unsupported analysis mode: {mode}")
+
+        summary_path = out / "nereids_mcp_result.json"
+        summary = {
+            "success": True,
+            "message": "NEREIDS resonance workflow completed",
+            "manifest_path": manifest["manifest_path"],
+            "validation_warnings": validation["warnings"],
+            "results": _json_safe(result),
+        }
+        summary_path.write_text(json.dumps(summary, indent=2))
+        summary["summary_json"] = str(summary_path)
+        return summary
+    except Exception as exc:
+        return {
+            "success": False,
+            "error": str(exc)[:2000],
+            "dataset_path": str(Path(dataset_path).expanduser()),
+        }

--- a/bindings/python/python/nereids/mcp/server.py
+++ b/bindings/python/python/nereids/mcp/server.py
@@ -41,9 +41,11 @@ def _json_safe(value: Any) -> Any:
     if isinstance(value, Path):
         return str(value)
     if isinstance(value, np.ndarray):
-        return value.tolist()
+        return _json_safe(value.tolist())
     if isinstance(value, np.generic):
-        return value.item()
+        return _json_safe(value.item())
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
     if isinstance(value, dict):
         return {str(k): _json_safe(v) for k, v in value.items()}
     if isinstance(value, (list, tuple)):
@@ -261,12 +263,37 @@ def _validate_array(name: str, values: Any, ndim: int | None = None) -> np.ndarr
     return np.ascontiguousarray(arr)
 
 
+def _require_same_shape(
+    reference_name: str,
+    reference: np.ndarray,
+    *others: tuple[str, np.ndarray],
+) -> None:
+    """Require arrays that share a physical axis/layout to have equal shape."""
+    for name, arr in others:
+        if arr.shape != reference.shape:
+            raise ValueError(
+                f"{reference_name} and {name} must have matching shapes, "
+                f"got {reference.shape} and {arr.shape}"
+            )
+
+
+def _finite_float_or_none(value: Any) -> float | None:
+    scalar = float(value)
+    return scalar if math.isfinite(scalar) else None
+
+
 def _ascending_energy_grid(
     energies: np.ndarray, *aligned: np.ndarray
 ) -> tuple[np.ndarray, ...]:
     """Ensure energies are strictly ascending, reversing aligned arrays if needed."""
     grid = _validate_array("energies", energies, ndim=1)
     arrays = tuple(np.ascontiguousarray(a) for a in aligned)
+    for arr in arrays:
+        if arr.shape[0] != grid.size:
+            raise ValueError(
+                "aligned data first dimension must match energies, "
+                f"got {arr.shape[0]} and {grid.size}"
+            )
     diffs = np.diff(grid)
     if np.all(diffs > 0):
         return (grid, *arrays)
@@ -544,25 +571,25 @@ def _fit_result_summary(result: Any, names: list[str]) -> dict[str, Any]:
         entries.append(
             {
                 "isotope": name,
-                "density_atoms_per_barn": float(densities[i]),
-                "uncertainty_atoms_per_barn": float(uncertainties[i])
+                "density_atoms_per_barn": _finite_float_or_none(densities[i]),
+                "uncertainty_atoms_per_barn": _finite_float_or_none(uncertainties[i])
                 if i < len(uncertainties)
                 else None,
             }
         )
     return {
         "density_fits": entries,
-        "reduced_chi_squared": float(result.reduced_chi_squared),
+        "reduced_chi_squared": _finite_float_or_none(result.reduced_chi_squared),
         "deviance_per_dof": None
         if getattr(result, "deviance_per_dof", None) is None
-        else float(result.deviance_per_dof),
+        else _finite_float_or_none(result.deviance_per_dof),
         "converged": bool(result.converged),
         "iterations": int(result.iterations),
         "temperature_k": None
         if result.temperature_k is None
-        else float(result.temperature_k),
-        "anorm": float(result.anorm),
-        "background": [float(v) for v in result.background],
+        else _finite_float_or_none(result.temperature_k),
+        "anorm": _finite_float_or_none(result.anorm),
+        "background": [_finite_float_or_none(v) for v in result.background],
     }
 
 
@@ -605,6 +632,7 @@ def _process_single_spectrum(
         open_beam_key = data_config.get("open_beam_key", "open_beam_counts")
         sample = _validate_array("sample_counts", arrays[sample_key])
         open_beam = _validate_array("open_beam_counts", arrays[open_beam_key])
+        _require_same_shape("sample_counts", sample, ("open_beam_counts", open_beam))
         energies = _load_energy_grid(base, data_config, arrays, n_expected=sample.shape[0])
         energies, sample, open_beam = _ascending_energy_grid(energies, sample, open_beam)
         if sample.ndim == 3:
@@ -656,6 +684,7 @@ def _process_single_spectrum(
             uncertainty = np.full_like(
                 transmission, float(data_config.get("uncertainty", 0.01))
             )
+        _require_same_shape("transmission", transmission, ("uncertainty", uncertainty))
         energies = _load_energy_grid(base, data_config, arrays, n_expected=transmission.shape[0])
         energies, transmission, uncertainty = _ascending_energy_grid(
             energies, transmission, uncertainty
@@ -731,6 +760,7 @@ def _process_density_map(
             uncertainty = np.full_like(
                 transmission, float(data_config.get("uncertainty", 0.01))
             )
+        _require_same_shape("transmission", transmission, ("uncertainty", uncertainty))
         energies = _load_energy_grid(
             base, data_config, arrays, n_expected=transmission.shape[0]
         )
@@ -759,6 +789,7 @@ def _process_density_map(
             uncertainty = np.full_like(
                 transmission, float(data_config.get("uncertainty", 0.01))
             )
+        _require_same_shape("transmission", transmission, ("uncertainty", uncertainty))
         energies = _load_energy_grid(base, data_config, None, n_expected=transmission.shape[0])
         energies, transmission, uncertainty = _ascending_energy_grid(
             energies, transmission, uncertainty
@@ -781,6 +812,7 @@ def _process_density_map(
             arrays[data_config.get("open_beam_key", "open_beam_counts")],
             ndim=3,
         )
+        _require_same_shape("sample_counts", sample, ("open_beam_counts", open_beam))
         energies = _load_energy_grid(base, data_config, arrays, n_expected=sample.shape[0])
         energies, sample, open_beam = _ascending_energy_grid(energies, sample, open_beam)
         sample = _apply_roi(sample, data_config.get("roi") or config.get("roi"))
@@ -799,6 +831,7 @@ def _process_density_map(
         ob_data = nereids.load_nexus_histogram(str(open_beam_path))
         sample = _validate_array("sample_counts", sample_data.counts, ndim=3)
         open_beam = _validate_array("open_beam_counts", ob_data.counts, ndim=3)
+        _require_same_shape("sample_counts", sample, ("open_beam_counts", open_beam))
         flight_path = float(
             data_config.get(
                 "flight_path_m",
@@ -810,10 +843,8 @@ def _process_density_map(
             nereids.tof_to_energy_centers(sample_data.tof_edges_us, flight_path, delay_us),
             dtype=np.float64,
         )
-        # NeXus histograms are ascending TOF; NEREIDS fitting expects arrays
-        # aligned with ascending energy, so reverse the spectral axis.
-        sample = np.ascontiguousarray(sample[::-1, ...])
-        open_beam = np.ascontiguousarray(open_beam[::-1, ...])
+        # Ascending TOF produces descending energy centers; the shared grid helper
+        # reverses energies and aligned counts together exactly once.
         energies, sample, open_beam = _ascending_energy_grid(energies, sample, open_beam)
         sample = _apply_roi(sample, data_config.get("roi") or config.get("roi"))
         open_beam = _apply_roi(open_beam, data_config.get("roi") or config.get("roi"))
@@ -905,10 +936,43 @@ def _validate_workflow(manifest: dict[str, Any]) -> dict[str, Any]:
             "density_map, or spatial_map"
         )
 
+    effective_kind = _normalise_kind(
+        data_config.get("kind"),
+        "counts_npz"
+        if mode in {"single_spectrum", "fit_spectrum", "spectrum"}
+        else "transmission_npz",
+    )
+    has_path = data_config.get("path") is not None and data_config.get("path") != ""
+    has_sample_path = (
+        data_config.get("sample_path") is not None and data_config.get("sample_path") != ""
+    )
+    has_open_beam_path = (
+        data_config.get("open_beam_path") is not None
+        and data_config.get("open_beam_path") != ""
+    )
+    if mode in {"single_spectrum", "fit_spectrum", "spectrum"} and not has_path:
+        errors.append("single_spectrum workflow requires data.path")
+    elif mode in {"density_map", "spatial_map"}:
+        if effective_kind in {"nexus_histogram", "nexus"}:
+            if not has_sample_path or not has_open_beam_path:
+                errors.append("nexus density_map workflow requires sample_path and open_beam_path")
+        elif effective_kind in {
+            "transmission_npz",
+            "transmission",
+            "transmission_tiff",
+            "tiff",
+            "counts_npz",
+            "counts",
+        }:
+            if not has_path:
+                errors.append(f"{effective_kind} density_map workflow requires data.path")
+        else:
+            errors.append(f"unsupported density_map data kind: {effective_kind}")
+
     data_paths = []
     for key in ("path", "sample_path", "open_beam_path", "uncertainty_path"):
         value = data_config.get(key)
-        if value is None:
+        if value is None or value == "":
             continue
         path = _resolve_path(base, value)
         data_paths.append({"key": key, "path": str(path), "exists": path.exists()})
@@ -953,7 +1017,7 @@ def _validate_workflow(manifest: dict[str, Any]) -> dict[str, Any]:
         "manifest_path": manifest["manifest_path"],
         "dataset_path": manifest["dataset_path"],
         "mode": mode or None,
-        "data_kind": _normalise_kind(data_config.get("kind"), "unspecified"),
+        "data_kind": effective_kind,
         "data_paths": data_paths,
         "isotopes": _json_safe(entries),
     }
@@ -1382,14 +1446,14 @@ def process_resonance_dataset(
             raise ValueError(f"unsupported analysis mode: {mode}")
 
         summary_path = out / "nereids_mcp_result.json"
-        summary = {
+        summary = _json_safe({
             "success": True,
             "message": "NEREIDS resonance workflow completed",
             "manifest_path": manifest["manifest_path"],
             "validation_warnings": validation["warnings"],
-            "results": _json_safe(result),
-        }
-        summary_path.write_text(json.dumps(summary, indent=2))
+            "results": result,
+        })
+        summary_path.write_text(json.dumps(summary, indent=2, allow_nan=False))
         summary["summary_json"] = str(summary_path)
         return summary
     except Exception as exc:

--- a/docs/guide/src/SUMMARY.md
+++ b/docs/guide/src/SUMMARY.md
@@ -4,6 +4,7 @@
 - [Installation](./installation.md)
 - [Quickstart: Rust](./quickstart-rust.md)
 - [Quickstart: Python](./quickstart-python.md)
+- [MCP Server](./mcp-server.md)
 - [GUI Walkthrough](./gui-walkthrough.md)
 - [Architecture](./architecture.md)
 - [Physics Reference](./physics.md)

--- a/docs/guide/src/architecture.md
+++ b/docs/guide/src/architecture.md
@@ -93,8 +93,13 @@ Per-pixel fitting uses [rayon](https://docs.rs/rayon) for data parallelism.
 The outer pixel loop runs on a dedicated thread pool to avoid deadlocking
 with inner parallel operations (cross-section calculation, broadening).
 
-### Python Bindings via PyO3
+### Python Bindings and MCP
 
 The Python bindings expose a high-level API (`load_endf`, `forward_model`,
-`fit_spectrum`, `spatial_map`) that maps directly to the Rust pipeline.
-NumPy arrays are zero-copy where possible via `numpy` crate integration.
+`fit_spectrum_typed`, `fit_counts_spectrum_typed`, `spatial_map_typed`) that
+maps directly to the Rust pipeline. NumPy arrays are zero-copy where possible
+via `numpy` crate integration.
+
+The MCP server is a thin Python package layer over these bindings. It exposes
+low-level physics tools and manifest-driven workflow tools for local AI-agent
+orchestration; it does not add a separate fitting engine.

--- a/docs/guide/src/installation.md
+++ b/docs/guide/src/installation.md
@@ -28,17 +28,30 @@ This requires the HDF5 C library to be installed on your system.
 ## Python Bindings
 
 ```bash
-pip install nereids          # available after first public release
+pip install nereids
 ```
 
 **Requirements**: Python 3.10+ and NumPy.
+
+## MCP Server
+
+The MCP server is installed as an optional Python extra:
+
+```bash
+pip install "nereids[mcp]"
+nereids-mcp
+```
+
+See the [MCP server](./mcp-server.md) chapter for client configuration and
+manifest-driven workflows.
 
 ## Desktop GUI
 
 ### macOS (Homebrew)
 
 ```bash
-brew install --cask ornlneutronimaging/nereids/nereids   # available after first public release
+brew tap ornlneutronimaging/nereids
+brew install --cask nereids
 ```
 
 ### From Source

--- a/docs/guide/src/introduction.md
+++ b/docs/guide/src/introduction.md
@@ -19,15 +19,16 @@ The analysis pipeline:
 4. **Fit** resonance models to measured transmission spectra
 5. **Map** fitted parameters (areal density, temperature) across each pixel
 
-## Three Deliverables
+## Interfaces
 
-NEREIDS ships in three forms:
+NEREIDS ships in several interfaces:
 
 | Deliverable | Use case |
 |-------------|----------|
 | **Rust library** (`nereids-*` crates) | Embed in Rust applications, maximum performance |
 | **Python bindings** (`pip install nereids`) | Jupyter notebooks, scripting, integration with NumPy/SciPy |
 | **Desktop GUI** (`nereids-gui`) | Interactive analysis with visual feedback |
+| **MCP server** (`nereids-mcp`) | Local AI-agent assisted analysis through manifest-driven workflows |
 
 ![NEREIDS landing page](images/landing.png)
 

--- a/docs/guide/src/mcp-server.md
+++ b/docs/guide/src/mcp-server.md
@@ -1,0 +1,219 @@
+# MCP Server
+
+NEREIDS can run as a local Model Context Protocol (MCP) server so an AI
+agent can inspect neutron-resonance inputs, validate a dataset manifest, and
+launch spectrum or density-map fitting through the Python bindings. The MCP
+server is intended for local agent orchestration, for example a user prompt
+such as "help me process the data here" in a directory that contains a NEREIDS
+manifest.
+
+The MCP interface is experimental. It is useful for demos and agent-assisted
+workflows, but the Python and Rust APIs remain the stable interfaces for
+scripted analysis.
+
+## Installation
+
+Install the optional MCP dependency and run the stdio server:
+
+```bash
+pip install "nereids[mcp]"
+nereids-mcp
+```
+
+From a source checkout, build the Python extension first:
+
+```bash
+pip install maturin
+maturin develop --release -m bindings/python/Cargo.toml
+pip install "fastmcp>=3.0"
+python -m nereids.mcp
+```
+
+In the repository Pixi environment, `fastmcp` is intentionally not a default
+dependency because it can conflict with conda metadata packages. Install it
+manually in the environment when MCP support is needed.
+
+## Client Configuration
+
+An MCP client can launch the server with the `nereids-mcp` console script:
+
+```json
+{
+  "mcpServers": {
+    "nereids": {
+      "command": "nereids-mcp"
+    }
+  }
+}
+```
+
+## Tools
+
+The server exposes two groups of tools.
+
+Low-level physics tools operate on an in-memory isotope registry:
+
+- `list_isotopes(z)` lists naturally occurring isotopes.
+- `load_endf(isotope, library="endf8.1")` loads resonance data such as
+  `"U-238"` or `"Fe-56"` into the registry.
+- `get_resonance_parameters(isotope)` returns loaded resonance metadata.
+- `compute_cross_sections(...)`, `compute_transmission(...)`,
+  `forward_model(...)`, and `detect_isotopes(...)` run direct physics
+  calculations.
+
+Workflow tools operate on a dataset directory or a manifest path:
+
+- `extract_resonance_manifest(dataset_path)` reads the manifest and returns
+  parsed metadata.
+- `validate_resonance_dataset(dataset_path)` checks required paths, isotope
+  entries, and resolution configuration.
+- `process_resonance_dataset(dataset_path, output_dir=None, max_pixels=None,
+  dry_run=False)` runs the analysis and writes compact result artifacts.
+
+## Dataset Manifests
+
+The workflow tools look for one of these files in the dataset directory:
+
+- `manifest_intermediate.md`
+- `smcp_manifest.md`
+- `nereids_manifest.md`
+- `nereids_mcp.json`
+- `analysis.json`
+
+Markdown manifests must contain JSON-compatible frontmatter between `---`
+delimiters. Pure JSON manifests must contain the frontmatter object directly.
+The workflow configuration may be placed under `analysis`, `workflow`, or
+`processing`; otherwise the root object is treated as the workflow.
+
+Minimal single-spectrum manifest:
+
+```markdown
+---
+{
+  "name": "u238-spectrum-demo",
+  "tool": "nereids",
+  "physics": "neutron-resonance",
+  "analysis": {
+    "mode": "single_spectrum",
+    "data": {
+      "kind": "transmission_npz",
+      "path": "spectrum.npz"
+    },
+    "isotopes": [
+      {
+        "isotope": "U-238",
+        "initial_density": 0.001,
+        "library": "endf8.1"
+      }
+    ],
+    "fit": {
+      "solver": "lm",
+      "max_iter": 100
+    },
+    "resolution": {
+      "kind": "gaussian",
+      "flight_path_m": 25.0,
+      "delta_t_us": 0.5,
+      "delta_l_m": 0.005
+    },
+    "output": {
+      "directory": "output"
+    }
+  }
+}
+---
+```
+
+For synthetic demo data, resolution can be disabled:
+
+```json
+"resolution": {"kind": "none"}
+```
+
+For real instrument data, use Gaussian resolution parameters or a tabulated
+resolution file. Synthetic data often does not need an instrument resolution
+file; real experiments normally do.
+
+## Supported Workflow Inputs
+
+`single_spectrum` fits one spectrum. It supports:
+
+- `counts_npz` or `counts`: a `.npz` file with `sample_counts`,
+  `open_beam_counts`, and `energies_ev` by default. Arrays may be 1D spectra
+  or 3D cubes; 3D cubes are summed over pixels before fitting one spectrum.
+- `transmission_npz`, `transmission`, or `spectrum`: a `.npz` or text file
+  with `transmission`, optional `uncertainty`, and an energy grid.
+
+`density_map` and `spatial_map` fit every pixel in a 3D cube. They support:
+
+- `transmission_npz` or `transmission`: a `.npz` file with 3D
+  `transmission` and optional 3D `uncertainty` arrays.
+- `transmission_tiff` or `tiff`: a multi-frame TIFF transmission stack plus
+  an `energy_grid` entry.
+- `counts_npz` or `counts`: a `.npz` file with 3D `sample_counts` and
+  `open_beam_counts` arrays.
+- `nexus_histogram` or `nexus`: sample and open-beam NeXus histogram files,
+  configured with `sample_path` and `open_beam_path`.
+
+Paired arrays must have matching shapes. The number of energy points must
+match the first axis of the data arrays. Energy grids must be strictly
+monotonic; descending grids are reversed with the aligned arrays before
+fitting.
+
+For NeXus histogram inputs, NEREIDS loads counts in TOF-bin order and derives
+ascending energy centers with `tof_to_energy_centers(...)`. The MCP workflow
+converts the counts to the same ascending-energy order before fitting. If the
+manifest does not specify `flight_path_m`, the loader metadata is used when
+available, with a 25 m fallback. `delay_us` defaults to 0.
+
+Example NeXus density-map manifest:
+
+```markdown
+---
+{
+  "name": "venus-nexus-density-map",
+  "tool": "nereids",
+  "analysis": {
+    "mode": "density_map",
+    "data": {
+      "kind": "nexus",
+      "sample_path": "sample.nxs",
+      "open_beam_path": "open_beam.nxs",
+      "flight_path_m": 25.0,
+      "delay_us": 0.0
+    },
+    "isotopes": [
+      {"isotope": "U-238", "initial_density": 0.001}
+    ],
+    "fit": {
+      "solver": "lm",
+      "max_iter": 100
+    },
+    "resolution": {
+      "kind": "gaussian",
+      "flight_path_m": 25.0,
+      "delta_t_us": 0.5,
+      "delta_l_m": 0.005
+    }
+  }
+}
+---
+```
+
+## Result Files
+
+`process_resonance_dataset(...)` writes outputs under the configured output
+directory, or under `<dataset>/output` by default.
+
+For `single_spectrum`, it writes:
+
+- `nereids_spectrum_fit.npz`
+- `nereids_mcp_result.json`
+
+For `density_map` or `spatial_map`, it writes:
+
+- `nereids_density_map.npz`
+- `nereids_mcp_result.json`
+
+The JSON summary is strict JSON: non-finite fit values are represented as
+`null`, not `NaN` or `Infinity`.

--- a/docs/guide/src/quickstart-python.md
+++ b/docs/guide/src/quickstart-python.md
@@ -103,5 +103,6 @@ print(f"Peak SNR: {report.peak_snr:.1f} at {report.peak_energy_ev:.2f} eV")
 ## Next Steps
 
 - See the [GUI walkthrough](./gui-walkthrough.md) for interactive analysis
+- Use the [MCP server](./mcp-server.md) for local AI-agent assisted workflows
 - Explore the [Architecture](./architecture.md) chapter for the crate structure
 - Browse the [API Reference](api/nereids_pipeline/) for the full Rust docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ mcp = ["fastmcp>=3.0"]
 gui = ["nereids-gui==0.1.8"]
 
 [project.scripts]
-nereids-mcp = "nereids.mcp:mcp.run"
+nereids-mcp = "nereids.mcp:main"
 
 [build-system]
 requires = ["maturin>=1.0,<2.0"]

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -7,6 +7,7 @@ direct invocation validates all business logic.
 """
 
 import json
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -15,6 +16,8 @@ fastmcp = pytest.importorskip("fastmcp")
 
 import nereids
 from nereids.mcp.server import (
+    _fit_result_summary,
+    _json_safe,
     _registry,
     compute_cross_sections,
     compute_transmission,
@@ -424,3 +427,158 @@ class TestManifestWorkflowTools:
         stats = result["results"]["density_maps"][0]["density_atoms_per_barn"]
         assert stats["mean"] == pytest.approx(true_density, rel=0.15)
         assert (tmp_path / "output" / "nereids_density_map.npz").exists()
+
+    def test_nexus_density_map_aligns_counts_with_ascending_energy(
+        self, tmp_path, monkeypatch
+    ):
+        sample_path = tmp_path / "sample.nxs"
+        open_beam_path = tmp_path / "open_beam.nxs"
+        sample_path.touch()
+        open_beam_path.touch()
+        captured = {}
+
+        def fake_load_nexus_histogram(path):
+            if path == str(sample_path):
+                counts = np.asarray([[[90.0]], [[40.0]], [[10.0]]])
+            else:
+                counts = np.asarray([[[100.0]], [[100.0]], [[100.0]]])
+            return SimpleNamespace(
+                counts=counts,
+                tof_edges_us=np.asarray([1.0, 2.0, 3.0, 4.0]),
+                flight_path_m=25.0,
+            )
+
+        def fake_from_counts(sample, open_beam):
+            captured["sample"] = np.asarray(sample).copy()
+            captured["open_beam"] = np.asarray(open_beam).copy()
+            return {"sample": sample, "open_beam": open_beam}
+
+        def fake_spatial_map_typed(
+            input_data, energies, isotope_data, initial_densities, **kwargs
+        ):
+            captured["energies"] = np.asarray(energies).copy()
+            return SimpleNamespace(
+                chi_squared_map=np.zeros((1, 1)),
+                converged_map=np.ones((1, 1), dtype=bool),
+                deviance_per_dof_map=None,
+                density_maps=[np.full((1, 1), 0.002)],
+                uncertainty_maps=[np.full((1, 1), 0.0001)],
+                n_converged=1,
+                n_total=1,
+                n_failed=0,
+            )
+
+        monkeypatch.setattr(nereids, "load_nexus_histogram", fake_load_nexus_histogram)
+        monkeypatch.setattr(
+            nereids,
+            "tof_to_energy_centers",
+            lambda edges, flight_path, delay_us=0.0: np.asarray([9.0, 4.0, 1.0]),
+        )
+        monkeypatch.setattr(nereids, "from_counts", fake_from_counts)
+        monkeypatch.setattr(nereids, "spatial_map_typed", fake_spatial_map_typed)
+
+        _write_json_frontmatter_manifest(
+            tmp_path,
+            {
+                "mode": "density_map",
+                "data": {
+                    "kind": "nexus",
+                    "sample_path": sample_path.name,
+                    "open_beam_path": open_beam_path.name,
+                },
+                "isotopes": [_synthetic_u238_entry(initial_density=0.001)],
+                "fit": {"solver": "lm", "max_iter": 5},
+                "resolution": {"kind": "none"},
+                "output": {"directory": "output"},
+            },
+        )
+
+        result = process_resonance_dataset(str(tmp_path))
+
+        assert result["success"] is True
+        np.testing.assert_allclose(captured["energies"], [1.0, 4.0, 9.0])
+        np.testing.assert_allclose(captured["sample"][:, 0, 0], [10.0, 40.0, 90.0])
+
+    def test_process_rejects_mismatched_counts_shapes(self, tmp_path):
+        np.savez(
+            tmp_path / "counts.npz",
+            energies_ev=np.linspace(1.0, 5.0, 5),
+            sample_counts=np.ones(5),
+            open_beam_counts=np.ones(6),
+        )
+        _write_json_frontmatter_manifest(
+            tmp_path,
+            {
+                "mode": "single_spectrum",
+                "data": {"kind": "counts_npz", "path": "counts.npz"},
+                "isotopes": [_synthetic_u238_entry()],
+                "fit": {"solver": "lm", "max_iter": 5},
+                "resolution": {"kind": "none"},
+            },
+        )
+
+        result = process_resonance_dataset(str(tmp_path))
+
+        assert result["success"] is False
+        assert "matching shapes" in result["error"]
+
+    def test_process_rejects_mismatched_density_uncertainty_shapes(self, tmp_path):
+        np.savez(
+            tmp_path / "density-map.npz",
+            energies_ev=np.linspace(1.0, 5.0, 5),
+            transmission=np.ones((5, 2, 2)),
+            uncertainty=np.ones((5, 2, 3)),
+        )
+        _write_json_frontmatter_manifest(
+            tmp_path,
+            {
+                "mode": "density_map",
+                "data": {"kind": "transmission_npz", "path": "density-map.npz"},
+                "isotopes": [_synthetic_u238_entry()],
+                "fit": {"solver": "lm", "max_iter": 5},
+                "resolution": {"kind": "none"},
+            },
+        )
+
+        result = process_resonance_dataset(str(tmp_path))
+
+        assert result["success"] is False
+        assert "matching shapes" in result["error"]
+
+    def test_dry_run_rejects_missing_required_data_path(self, tmp_path):
+        _write_json_frontmatter_manifest(
+            tmp_path,
+            {
+                "mode": "single_spectrum",
+                "data": {"kind": "transmission_npz"},
+                "isotopes": [_synthetic_u238_entry()],
+                "fit": {"solver": "lm", "max_iter": 5},
+                "resolution": {"kind": "none"},
+            },
+        )
+
+        result = process_resonance_dataset(str(tmp_path), dry_run=True)
+
+        assert result["success"] is False
+        assert "single_spectrum workflow requires data.path" in result["validation"]["errors"]
+
+    def test_fit_summary_is_strict_json_safe(self):
+        result = SimpleNamespace(
+            densities=np.asarray([np.nan]),
+            uncertainties=np.asarray([np.inf]),
+            reduced_chi_squared=np.nan,
+            deviance_per_dof=np.inf,
+            converged=False,
+            iterations=0,
+            temperature_k=np.nan,
+            anorm=np.inf,
+            background=[np.nan],
+        )
+
+        summary = _fit_result_summary(result, ["U-238"])
+
+        assert summary["density_fits"][0]["density_atoms_per_barn"] is None
+        assert summary["density_fits"][0]["uncertainty_atoms_per_barn"] is None
+        assert summary["reduced_chi_squared"] is None
+        assert summary["deviance_per_dof"] is None
+        json.dumps(_json_safe(summary), allow_nan=False)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -522,6 +522,29 @@ class TestManifestWorkflowTools:
         assert result["success"] is False
         assert "matching shapes" in result["error"]
 
+    def test_process_reports_missing_counts_npz_key(self, tmp_path):
+        np.savez(
+            tmp_path / "counts.npz",
+            energies_ev=np.linspace(1.0, 5.0, 5),
+            sample_counts=np.ones(5),
+        )
+        _write_json_frontmatter_manifest(
+            tmp_path,
+            {
+                "mode": "single_spectrum",
+                "data": {"kind": "counts_npz", "path": "counts.npz"},
+                "isotopes": [_synthetic_u238_entry()],
+                "fit": {"solver": "lm", "max_iter": 5},
+                "resolution": {"kind": "none"},
+            },
+        )
+
+        result = process_resonance_dataset(str(tmp_path))
+
+        assert result["success"] is False
+        assert "missing required key(s): open_beam_counts" in result["error"]
+        assert "Available keys: energies_ev, sample_counts" in result["error"]
+
     def test_process_rejects_mismatched_density_uncertainty_shapes(self, tmp_path):
         np.savez(
             tmp_path / "density-map.npz",
@@ -544,6 +567,138 @@ class TestManifestWorkflowTools:
 
         assert result["success"] is False
         assert "matching shapes" in result["error"]
+
+    def test_process_reports_missing_density_npz_key(self, tmp_path):
+        np.savez(
+            tmp_path / "density-map.npz",
+            energies_ev=np.linspace(1.0, 5.0, 5),
+            sample_counts=np.ones((5, 2, 2)),
+        )
+        _write_json_frontmatter_manifest(
+            tmp_path,
+            {
+                "mode": "density_map",
+                "data": {"kind": "counts_npz", "path": "density-map.npz"},
+                "isotopes": [_synthetic_u238_entry()],
+                "fit": {"solver": "lm", "max_iter": 5},
+                "resolution": {"kind": "none"},
+            },
+        )
+
+        result = process_resonance_dataset(str(tmp_path))
+
+        assert result["success"] is False
+        assert "density_map counts data is missing required key(s)" in result["error"]
+        assert "open_beam_counts" in result["error"]
+
+    def test_process_reports_missing_density_transmission_key(self, tmp_path):
+        np.savez(
+            tmp_path / "density-map.npz",
+            energies_ev=np.linspace(1.0, 5.0, 5),
+            not_transmission=np.ones((5, 2, 2)),
+        )
+        _write_json_frontmatter_manifest(
+            tmp_path,
+            {
+                "mode": "density_map",
+                "data": {"kind": "transmission_npz", "path": "density-map.npz"},
+                "isotopes": [_synthetic_u238_entry()],
+                "fit": {"solver": "lm", "max_iter": 5},
+                "resolution": {"kind": "none"},
+            },
+        )
+
+        result = process_resonance_dataset(str(tmp_path))
+
+        assert result["success"] is False
+        assert "density_map transmission data is missing required key(s)" in result["error"]
+        assert "transmission" in result["error"]
+
+    def test_process_rejects_out_of_bounds_roi(self, tmp_path):
+        np.savez(
+            tmp_path / "density-map.npz",
+            energies_ev=np.linspace(1.0, 5.0, 5),
+            transmission=np.ones((5, 2, 2)),
+            uncertainty=np.ones((5, 2, 2)),
+        )
+        _write_json_frontmatter_manifest(
+            tmp_path,
+            {
+                "mode": "density_map",
+                "data": {
+                    "kind": "transmission_npz",
+                    "path": "density-map.npz",
+                    "roi": {"x0": 1, "y0": 0, "width": 2, "height": 1},
+                },
+                "isotopes": [_synthetic_u238_entry()],
+                "fit": {"solver": "lm", "max_iter": 5},
+                "resolution": {"kind": "none"},
+            },
+        )
+
+        result = process_resonance_dataset(str(tmp_path))
+
+        assert result["success"] is False
+        assert "exceeds cube bounds" in result["error"]
+
+    def test_process_rejects_mismatched_nexus_tof_edges(self, tmp_path, monkeypatch):
+        sample_path = tmp_path / "sample.nxs"
+        open_beam_path = tmp_path / "open_beam.nxs"
+        sample_path.touch()
+        open_beam_path.touch()
+
+        def fake_load_nexus_histogram(path):
+            tof_edges = (
+                np.asarray([1.0, 2.0, 3.0, 4.0])
+                if path == str(sample_path)
+                else np.asarray([1.0, 2.0, 3.2, 4.0])
+            )
+            return SimpleNamespace(
+                counts=np.ones((3, 1, 1)),
+                tof_edges_us=tof_edges,
+                flight_path_m=25.0,
+            )
+
+        monkeypatch.setattr(nereids, "load_nexus_histogram", fake_load_nexus_histogram)
+        _write_json_frontmatter_manifest(
+            tmp_path,
+            {
+                "mode": "density_map",
+                "data": {
+                    "kind": "nexus",
+                    "sample_path": sample_path.name,
+                    "open_beam_path": open_beam_path.name,
+                },
+                "isotopes": [_synthetic_u238_entry()],
+                "fit": {"solver": "lm", "max_iter": 5},
+                "resolution": {"kind": "none"},
+            },
+        )
+
+        result = process_resonance_dataset(str(tmp_path))
+
+        assert result["success"] is False
+        assert "TOF bin edges must match" in result["error"]
+
+    def test_validation_messages_match_allowed_values(self, tmp_path):
+        frontmatter = {
+            "name": "invalid-validation-demo",
+            "tool": "pleiades",
+            "analysis": {
+                "mode": "bad-mode",
+                "data": {"kind": "transmission_npz"},
+                "isotopes": [_synthetic_u238_entry()],
+            },
+        }
+        (tmp_path / "manifest_intermediate.md").write_text(
+            "---\n" + json.dumps(frontmatter) + "\n---\n"
+        )
+
+        result = validate_resonance_dataset(str(tmp_path))
+
+        assert result["valid"] is False
+        assert any("'nereids-mcp'" in error for error in result["errors"])
+        assert any("spectrum" in error for error in result["errors"])
 
     def test_dry_run_rejects_missing_required_data_path(self, tmp_path):
         _write_json_frontmatter_manifest(

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -472,7 +472,7 @@ class TestManifestWorkflowTools:
         monkeypatch.setattr(
             nereids,
             "tof_to_energy_centers",
-            lambda edges, flight_path, delay_us=0.0: np.asarray([9.0, 4.0, 1.0]),
+            lambda edges, flight_path, delay_us=0.0: np.asarray([1.0, 4.0, 9.0]),
         )
         monkeypatch.setattr(nereids, "from_counts", fake_from_counts)
         monkeypatch.setattr(nereids, "spatial_map_typed", fake_spatial_map_typed)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -6,19 +6,26 @@ The functions are plain Python under the @mcp.tool() decorator, so
 direct invocation validates all business logic.
 """
 
+import json
+
+import numpy as np
 import pytest
 
 fastmcp = pytest.importorskip("fastmcp")
 
+import nereids
 from nereids.mcp.server import (
     _registry,
     compute_cross_sections,
     compute_transmission,
     detect_isotopes,
+    extract_resonance_manifest,
     forward_model,
     get_resonance_parameters,
     list_isotopes,
     load_endf,
+    process_resonance_dataset,
+    validate_resonance_dataset,
 )
 
 
@@ -270,3 +277,150 @@ class TestInputValidation:
     def test_list_isotopes_invalid_z(self):
         with pytest.raises(ValueError, match="z must be"):
             list_isotopes(0)
+
+
+# ---------------------------------------------------------------------------
+# Manifest-driven workflow tools
+# ---------------------------------------------------------------------------
+
+
+def _synthetic_u238_entry(initial_density=0.001):
+    return {
+        "isotope": "U-238",
+        "initial_density": initial_density,
+        "synthetic_resonance": {
+            "z": 92,
+            "a": 238,
+            "awr": 236.006,
+            "scattering_radius": 9.48,
+            "target_spin": 0.0,
+            "resonances": [[6.67, 0.5, 0.0015, 0.023]],
+        },
+    }
+
+
+def _synthetic_u238_data():
+    return nereids.create_resonance_data(
+        z=92,
+        a=238,
+        awr=236.006,
+        scattering_radius=9.48,
+        resonances=[(6.67, 0.5, 0.0015, 0.023)],
+        target_spin=0.0,
+    )
+
+
+def _write_json_frontmatter_manifest(tmp_path, analysis):
+    frontmatter = {
+        "name": "synthetic-u238-mcp-demo",
+        "description": "Synthetic U-238 resonance processing test",
+        "tool": "nereids",
+        "physics": "neutron-resonance",
+        "version": "0.1.0",
+        "analysis": analysis,
+    }
+    path = tmp_path / "manifest_intermediate.md"
+    path.write_text(
+        "---\n"
+        + json.dumps(frontmatter, indent=2)
+        + "\n---\n"
+        + "# Synthetic NEREIDS MCP workflow\n"
+    )
+    return path
+
+
+class TestManifestWorkflowTools:
+    def test_extract_and_validate_manifest(self, tmp_path):
+        np.savez(
+            tmp_path / "spectrum.npz",
+            energies_ev=np.linspace(1.0, 30.0, 20),
+            transmission=np.ones(20),
+            uncertainty=np.full(20, 0.01),
+        )
+        manifest_path = _write_json_frontmatter_manifest(
+            tmp_path,
+            {
+                "mode": "single_spectrum",
+                "data": {"kind": "transmission_npz", "path": "spectrum.npz"},
+                "isotopes": [_synthetic_u238_entry()],
+                "fit": {"solver": "lm", "max_iter": 5},
+                "resolution": {"kind": "none"},
+            },
+        )
+
+        extracted = extract_resonance_manifest(str(tmp_path))
+        assert extracted["manifest_path"] == str(manifest_path)
+        assert extracted["frontmatter"]["tool"] == "nereids"
+
+        validation = validate_resonance_dataset(str(tmp_path))
+        assert validation["valid"] is True
+        assert validation["mode"] == "single_spectrum"
+        assert validation["data_paths"][0]["exists"] is True
+
+    def test_process_single_spectrum_manifest(self, tmp_path):
+        energies = np.linspace(1.0, 30.0, 160)
+        true_density = 0.002
+        isotope = _synthetic_u238_data()
+        transmission = np.asarray(
+            nereids.forward_model(energies, [(isotope, true_density)])
+        )
+        np.savez(
+            tmp_path / "spectrum.npz",
+            energies_ev=energies,
+            transmission=transmission,
+            uncertainty=np.full_like(transmission, 0.005),
+        )
+        _write_json_frontmatter_manifest(
+            tmp_path,
+            {
+                "mode": "single_spectrum",
+                "data": {"kind": "transmission_npz", "path": "spectrum.npz"},
+                "isotopes": [_synthetic_u238_entry(initial_density=0.001)],
+                "fit": {"solver": "lm", "max_iter": 50},
+                "resolution": {"kind": "none"},
+                "output": {"directory": "output"},
+            },
+        )
+
+        result = process_resonance_dataset(str(tmp_path))
+
+        assert result["success"] is True
+        fit = result["results"]["density_fits"][0]
+        assert fit["isotope"] == "U-238"
+        assert fit["density_atoms_per_barn"] == pytest.approx(true_density, rel=0.15)
+        assert (tmp_path / "output" / "nereids_spectrum_fit.npz").exists()
+        assert (tmp_path / "output" / "nereids_mcp_result.json").exists()
+
+    def test_process_density_map_manifest(self, tmp_path):
+        energies = np.linspace(1.0, 30.0, 120)
+        true_density = 0.002
+        isotope = _synthetic_u238_data()
+        spectrum = np.asarray(
+            nereids.forward_model(energies, [(isotope, true_density)])
+        )
+        transmission = np.tile(spectrum[:, None, None], (1, 2, 3))
+        np.savez(
+            tmp_path / "density-map.npz",
+            energies_ev=energies,
+            transmission=transmission,
+            uncertainty=np.full_like(transmission, 0.005),
+        )
+        _write_json_frontmatter_manifest(
+            tmp_path,
+            {
+                "mode": "density_map",
+                "data": {"kind": "transmission_npz", "path": "density-map.npz"},
+                "isotopes": [_synthetic_u238_entry(initial_density=0.001)],
+                "fit": {"solver": "lm", "max_iter": 50},
+                "resolution": {"kind": "none"},
+                "output": {"directory": "output"},
+            },
+        )
+
+        result = process_resonance_dataset(str(tmp_path))
+
+        assert result["success"] is True
+        assert result["results"]["n_converged"] == 6
+        stats = result["results"]["density_maps"][0]["density_atoms_per_barn"]
+        assert stats["mean"] == pytest.approx(true_density, rel=0.15)
+        assert (tmp_path / "output" / "nereids_density_map.npz").exists()


### PR DESCRIPTION
## Summary

- Add manifest-driven NEREIDS MCP workflow tools for manifest extraction, validation, single-spectrum fitting, and density-map processing.
- Support `.npz`, TIFF transmission stacks, and NeXus histogram sample/open-beam workflows through the MCP server.
- Fix review findings around NeXus TOF/energy alignment, paired-array shape validation, dry-run required-input validation, and strict JSON summaries.
- Address Copilot review feedback for ROI bounds, missing `.npz` key errors, validation messages, and NeXus sample/open-beam TOF bin consistency.
- Document MCP setup, client configuration, manifest schema, supported data kinds, NeXus handling, and output artifacts in the README and mdBook guide.
- Add synthetic and regression tests for spectrum workflows, density-map workflows, shape validation, dry-run validation, JSON safety, and NeXus alignment.

Refs #309
Related docs follow-up: #527

## Validation

- `python3 -m py_compile bindings/python/python/nereids/mcp/server.py tests/test_mcp.py`
- `pixi run build`
- `pixi run python -m pytest tests/test_mcp.py` -> `39 passed`
- `pixi run test-python` -> `126 passed`
- `cargo test --workspace --exclude nereids-python`
- `pixi run doc-guide`
- `pixi run doc-build`
- `git diff --check`
- Independent review-pipeline subagent verification after review fixes: no P1/P2 findings
- Seminar demo manifests smoke-tested through `process_resonance_dataset`
