### PR TITLE
fix(endf): polite UA + manual ENDF upload fallback (#523)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2752,6 +2752,7 @@ dependencies = [
  "nereids-core",
  "reqwest",
  "serde",
+ "tempfile",
  "thiserror 2.0.18",
  "zip",
 ]

--- a/apps/gui/src/guided/configure.rs
+++ b/apps/gui/src/guided/configure.rs
@@ -558,10 +558,13 @@ fn fetch_endf_data(state: &mut AppState) {
 
 /// Manual ENDF upload escape hatch (issue #523): pick a local `.endf`/`.zip`
 /// from the filesystem and install it into the cache for whichever
-/// already-added isotope it describes. The retriever auto-validates that the
-/// file's HEAD record matches the matched entry's (Z, A) before writing.
+/// already-added isotope it describes. The retriever's `peek_local_endf`
+/// reads, extracts, and parses the file exactly once to discover its (Z, A);
+/// we then look that (Z, A) up in the user's selection and write the cached
+/// body directly — no trial-install loop, no re-extraction.
 fn install_local_endf_dialog(state: &mut AppState) {
     use nereids_core::types::Isotope;
+    use nereids_endf::retrieval::EndfRetriever;
 
     let Some(path) = rfd::FileDialog::new()
         .add_filter("ENDF", &["endf", "dat", "txt", "zip"])
@@ -570,125 +573,47 @@ fn install_local_endf_dialog(state: &mut AppState) {
         return;
     };
 
-    // Pre-parse the file briefly to discover its (Z, A). We re-read the file
-    // inside install_local_endf — the duplicated read is cheap (sub-MB) and
-    // keeps the dispatch decision separate from the install step.
-    let raw = match std::fs::read(&path) {
-        Ok(bytes) => bytes,
+    let (file_isotope, endf_text) = match EndfRetriever::peek_local_endf(&path) {
+        Ok(v) => v,
         Err(e) => {
-            state.status_message = format!("Could not read ENDF file: {e}");
+            state.status_message = format!("Could not read local ENDF: {e}");
             return;
         }
     };
-    let text_for_peek = if raw.len() >= 4 && &raw[..4] == b"PK\x03\x04" {
-        // Zip — we don't need to extract twice; install_local_endf will do it.
-        // For routing, parse just the inner ENDF: easiest path is to delegate
-        // to the retriever once we know an isotope. So instead, scan for any
-        // entry whose (Z, A) reconciles against the parsed file post-install.
-        // Implement by trying each Failed/Pending entry until one matches.
-        None
-    } else {
-        Some(String::from_utf8_lossy(&raw).into_owned())
-    };
+    let (z, a) = (file_isotope.z(), file_isotope.a());
+    let label = format!(
+        "{}-{}",
+        nereids_core::elements::element_symbol(z).unwrap_or("?"),
+        a,
+    );
 
-    let candidate_za: Option<(u32, u32)> = text_for_peek
-        .as_deref()
-        .and_then(|t| nereids_endf::parser::parse_endf_file2(t).ok())
-        .map(|d| (d.isotope.z(), d.isotope.a()));
-
-    let retriever = nereids_endf::retrieval::EndfRetriever::new();
-
-    // Helper: try installing this file against the supplied (z, a).
-    let try_install = |z: u32, a: u32| -> Result<String, String> {
-        let isotope = Isotope::new(z, a).map_err(|e| e.to_string())?;
-        retriever
-            .install_local_endf(&isotope, state.endf_library, &path)
-            .map(|_| {
-                format!(
-                    "{}-{}",
-                    nereids_core::elements::element_symbol(z).unwrap_or("?"),
-                    a
-                )
-            })
-            .map_err(|e| e.to_string())
-    };
-
-    // Strategy: if peek succeeded, we know (z, a) directly. Otherwise (zip),
-    // try every Failed/Pending entry until one validates.
-    let mut installed: Option<String> = None;
-    let mut last_err: Option<String> = None;
-
-    let try_targets: Vec<(u32, u32)> = if let Some((z, a)) = candidate_za {
-        vec![(z, a)]
-    } else {
-        let mut tgts = Vec::new();
-        for e in &state.isotope_entries {
-            if e.endf_status != EndfStatus::Loaded {
-                tgts.push((e.z, e.a));
-            }
-        }
-        for g in &state.isotope_groups {
-            for m in &g.members {
-                if m.endf_status != EndfStatus::Loaded {
-                    tgts.push((g.z, m.a));
-                }
-            }
-        }
-        tgts
-    };
-
-    for (z, a) in &try_targets {
-        // Does the user actually have this isotope in their selection?
-        let in_list = state.isotope_entries.iter().any(|e| e.z == *z && e.a == *a)
-            || state
-                .isotope_groups
-                .iter()
-                .any(|g| g.z == *z && g.members.iter().any(|m| m.a == *a));
-        if !in_list {
-            continue;
-        }
-        match try_install(*z, *a) {
-            Ok(label) => {
-                installed = Some(label);
-                break;
-            }
-            Err(e) => last_err = Some(e),
-        }
+    let in_selection = state.isotope_entries.iter().any(|e| e.z == z && e.a == a)
+        || state
+            .isotope_groups
+            .iter()
+            .any(|g| g.z == z && g.members.iter().any(|m| m.a == a));
+    if !in_selection {
+        state.status_message = format!(
+            "ENDF file is for {label}, but no matching isotope in your selection. Add it first.",
+        );
+        return;
     }
 
-    let Some(label) = installed else {
-        state.status_message = match (candidate_za, last_err) {
-            (Some((z, a)), _) => format!(
-                "ENDF file is for {}-{}, but no matching isotope in your selection. Add it first.",
-                nereids_core::elements::element_symbol(z).unwrap_or("?"),
-                a,
-            ),
-            (None, Some(e)) => format!("Could not install local ENDF: {e}"),
-            (None, None) => {
-                "Could not read local ENDF — no matching isotope in your selection.".to_string()
-            }
-        };
-        return;
+    let isotope = match Isotope::new(z, a) {
+        Ok(iso) => iso,
+        Err(e) => {
+            state.status_message = format!("Invalid isotope {label}: {e}");
+            return;
+        }
     };
+    let retriever = EndfRetriever::new();
+    if let Err(e) = retriever.install_endf_text(&isotope, state.endf_library, &endf_text) {
+        state.status_message = format!("Could not install local ENDF for {label}: {e}");
+        return;
+    }
 
     // Mark the matching entry Pending so the auto-fetch loop runs it through
     // the retriever, which now hits the cache slot we just populated.
-    let (z, a) = match candidate_za {
-        Some(za) => za,
-        None => {
-            // Find the (z, a) we actually installed against by symbol parse.
-            // try_targets is non-empty here because installed=Some(_).
-            try_targets
-                .iter()
-                .find(|(zz, aa)| {
-                    nereids_core::elements::element_symbol(*zz)
-                        .map(|s| format!("{}-{}", s, aa) == label)
-                        .unwrap_or(false)
-                })
-                .copied()
-                .unwrap_or((0, 0))
-        }
-    };
     for e in &mut state.isotope_entries {
         if e.z == z && e.a == a {
             e.resonance_data = None;

--- a/apps/gui/src/guided/configure.rs
+++ b/apps/gui/src/guided/configure.rs
@@ -165,6 +165,9 @@ pub fn configure_step(ui: &mut egui::Ui, state: &mut AppState) {
                     state.periodic_table_selected_z = None;
                     state.periodic_table_density = 0.001; // at/barn default
                 }
+                if ui.button("Load local ENDF file\u{2026}").clicked() {
+                    install_local_endf_dialog(state);
+                }
             });
         });
 
@@ -199,19 +202,33 @@ pub fn configure_step(ui: &mut egui::Ui, state: &mut AppState) {
                         .iter()
                         .any(|m| m.endf_status == EndfStatus::Failed)
             });
-        if has_failed && !state.is_fetching_endf && ui.button("Retry failed").clicked() {
-            for e in &mut state.isotope_entries {
-                if e.endf_status == EndfStatus::Failed {
-                    e.endf_status = EndfStatus::Pending;
+        if has_failed && !state.is_fetching_endf {
+            ui.add_space(4.0);
+            if ui.button("Retry failed").clicked() {
+                for e in &mut state.isotope_entries {
+                    if e.endf_status == EndfStatus::Failed {
+                        e.endf_status = EndfStatus::Pending;
+                    }
                 }
-            }
-            for g in &mut state.isotope_groups {
-                for m in &mut g.members {
-                    if m.endf_status == EndfStatus::Failed {
-                        m.endf_status = EndfStatus::Pending;
+                for g in &mut state.isotope_groups {
+                    for m in &mut g.members {
+                        if m.endf_status == EndfStatus::Failed {
+                            m.endf_status = EndfStatus::Pending;
+                        }
                     }
                 }
             }
+            ui.add_space(4.0);
+            let cache_dir =
+                nereids_endf::retrieval::EndfRetriever::new().cache_dir(state.endf_library);
+            ui.label(
+                egui::RichText::new(format!(
+                    "Offline fallback: drop the ENDF file at {} and click Retry, or use \u{201C}Load local ENDF file\u{2026}\u{201D} above.",
+                    cache_dir.display()
+                ))
+                .small()
+                .weak(),
+            );
         }
     });
 
@@ -537,4 +554,157 @@ fn fetch_endf_data(state: &mut AppState) {
     let cancel = Arc::clone(&state.cancel_token);
 
     std::thread::spawn(move || design::endf_fetch_worker(work, cancel, tx));
+}
+
+/// Manual ENDF upload escape hatch (issue #523): pick a local `.endf`/`.zip`
+/// from the filesystem and install it into the cache for whichever
+/// already-added isotope it describes. The retriever auto-validates that the
+/// file's HEAD record matches the matched entry's (Z, A) before writing.
+fn install_local_endf_dialog(state: &mut AppState) {
+    use nereids_core::types::Isotope;
+
+    let Some(path) = rfd::FileDialog::new()
+        .add_filter("ENDF", &["endf", "dat", "txt", "zip"])
+        .pick_file()
+    else {
+        return;
+    };
+
+    // Pre-parse the file briefly to discover its (Z, A). We re-read the file
+    // inside install_local_endf — the duplicated read is cheap (sub-MB) and
+    // keeps the dispatch decision separate from the install step.
+    let raw = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            state.status_message = format!("Could not read ENDF file: {e}");
+            return;
+        }
+    };
+    let text_for_peek = if raw.len() >= 4 && &raw[..4] == b"PK\x03\x04" {
+        // Zip — we don't need to extract twice; install_local_endf will do it.
+        // For routing, parse just the inner ENDF: easiest path is to delegate
+        // to the retriever once we know an isotope. So instead, scan for any
+        // entry whose (Z, A) reconciles against the parsed file post-install.
+        // Implement by trying each Failed/Pending entry until one matches.
+        None
+    } else {
+        Some(String::from_utf8_lossy(&raw).into_owned())
+    };
+
+    let candidate_za: Option<(u32, u32)> = text_for_peek
+        .as_deref()
+        .and_then(|t| nereids_endf::parser::parse_endf_file2(t).ok())
+        .map(|d| (d.isotope.z(), d.isotope.a()));
+
+    let retriever = nereids_endf::retrieval::EndfRetriever::new();
+
+    // Helper: try installing this file against the supplied (z, a).
+    let try_install = |z: u32, a: u32| -> Result<String, String> {
+        let isotope = Isotope::new(z, a).map_err(|e| e.to_string())?;
+        retriever
+            .install_local_endf(&isotope, state.endf_library, &path)
+            .map(|_| {
+                format!(
+                    "{}-{}",
+                    nereids_core::elements::element_symbol(z).unwrap_or("?"),
+                    a
+                )
+            })
+            .map_err(|e| e.to_string())
+    };
+
+    // Strategy: if peek succeeded, we know (z, a) directly. Otherwise (zip),
+    // try every Failed/Pending entry until one validates.
+    let mut installed: Option<String> = None;
+    let mut last_err: Option<String> = None;
+
+    let try_targets: Vec<(u32, u32)> = if let Some((z, a)) = candidate_za {
+        vec![(z, a)]
+    } else {
+        let mut tgts = Vec::new();
+        for e in &state.isotope_entries {
+            if e.endf_status != EndfStatus::Loaded {
+                tgts.push((e.z, e.a));
+            }
+        }
+        for g in &state.isotope_groups {
+            for m in &g.members {
+                if m.endf_status != EndfStatus::Loaded {
+                    tgts.push((g.z, m.a));
+                }
+            }
+        }
+        tgts
+    };
+
+    for (z, a) in &try_targets {
+        // Does the user actually have this isotope in their selection?
+        let in_list = state.isotope_entries.iter().any(|e| e.z == *z && e.a == *a)
+            || state
+                .isotope_groups
+                .iter()
+                .any(|g| g.z == *z && g.members.iter().any(|m| m.a == *a));
+        if !in_list {
+            continue;
+        }
+        match try_install(*z, *a) {
+            Ok(label) => {
+                installed = Some(label);
+                break;
+            }
+            Err(e) => last_err = Some(e),
+        }
+    }
+
+    let Some(label) = installed else {
+        state.status_message = match (candidate_za, last_err) {
+            (Some((z, a)), _) => format!(
+                "ENDF file is for {}-{}, but no matching isotope in your selection. Add it first.",
+                nereids_core::elements::element_symbol(z).unwrap_or("?"),
+                a,
+            ),
+            (None, Some(e)) => format!("Could not install local ENDF: {e}"),
+            (None, None) => {
+                "Could not read local ENDF — no matching isotope in your selection.".to_string()
+            }
+        };
+        return;
+    };
+
+    // Mark the matching entry Pending so the auto-fetch loop runs it through
+    // the retriever, which now hits the cache slot we just populated.
+    let (z, a) = match candidate_za {
+        Some(za) => za,
+        None => {
+            // Find the (z, a) we actually installed against by symbol parse.
+            // try_targets is non-empty here because installed=Some(_).
+            try_targets
+                .iter()
+                .find(|(zz, aa)| {
+                    nereids_core::elements::element_symbol(*zz)
+                        .map(|s| format!("{}-{}", s, aa) == label)
+                        .unwrap_or(false)
+                })
+                .copied()
+                .unwrap_or((0, 0))
+        }
+    };
+    for e in &mut state.isotope_entries {
+        if e.z == z && e.a == a {
+            e.resonance_data = None;
+            e.endf_status = EndfStatus::Pending;
+        }
+    }
+    for g in &mut state.isotope_groups {
+        if g.z != z {
+            continue;
+        }
+        for m in &mut g.members {
+            if m.a == a {
+                m.resonance_data = None;
+                m.endf_status = EndfStatus::Pending;
+            }
+        }
+    }
+    state.status_message = format!("Loaded local ENDF for {label}");
 }

--- a/apps/gui/src/guided/configure.rs
+++ b/apps/gui/src/guided/configure.rs
@@ -150,7 +150,13 @@ pub fn configure_step(ui: &mut egui::Ui, state: &mut AppState) {
 
         ui.add_space(6.0);
 
-        // Add buttons (disabled during fetch)
+        // Add buttons (disabled during fetch). The local-install button also
+        // touches the shared on-disk cache, so it's gated on every ENDF fetch
+        // flag — not just Configure's — to keep manual writes from racing the
+        // Forward Model or Detectability workers reading/writing the same
+        // cache slot.
+        let any_fetch_active =
+            state.is_fetching_endf || state.is_fetching_fm_endf || state.is_fetching_detect_endf;
         ui.add_enabled_ui(!state.is_fetching_endf, |ui| {
             ui.horizontal(|ui| {
                 if ui.button("Add Isotope...").clicked() {
@@ -165,9 +171,11 @@ pub fn configure_step(ui: &mut egui::Ui, state: &mut AppState) {
                     state.periodic_table_selected_z = None;
                     state.periodic_table_density = 0.001; // at/barn default
                 }
-                if ui.button("Load local ENDF file\u{2026}").clicked() {
-                    install_local_endf_dialog(state);
-                }
+                ui.add_enabled_ui(!any_fetch_active, |ui| {
+                    if ui.button("Load local ENDF file\u{2026}").clicked() {
+                        install_local_endf_dialog(state);
+                    }
+                });
             });
         });
 
@@ -219,16 +227,7 @@ pub fn configure_step(ui: &mut egui::Ui, state: &mut AppState) {
                 }
             }
             ui.add_space(4.0);
-            let cache_dir =
-                nereids_endf::retrieval::EndfRetriever::new().cache_dir(state.endf_library);
-            ui.label(
-                egui::RichText::new(format!(
-                    "Offline fallback: drop the ENDF file at {} and click Retry, or use \u{201C}Load local ENDF file\u{2026}\u{201D} above.",
-                    cache_dir.display()
-                ))
-                .small()
-                .weak(),
-            );
+            render_failed_cache_hint(ui, state);
         }
     });
 
@@ -554,6 +553,70 @@ fn fetch_endf_data(state: &mut AppState) {
     let cancel = Arc::clone(&state.cancel_token);
 
     std::thread::spawn(move || design::endf_fetch_worker(work, cancel, tx));
+}
+
+/// Render the offline-fallback hint that lists the exact cache-file path for
+/// every Failed isotope under the active library, so users can `cp` a
+/// manually-downloaded ENDF straight into place (issue #523). Paths come from
+/// the free `default_cache_file_path` helper to avoid the per-frame
+/// `EndfRetriever::new()` cost that would otherwise build a reqwest client +
+/// TLS context just to read the cache layout.
+fn render_failed_cache_hint(ui: &mut egui::Ui, state: &AppState) {
+    use nereids_core::types::Isotope;
+    use nereids_endf::retrieval::default_cache_file_path;
+
+    const MAX_LINES: usize = 3;
+    let library = state.endf_library;
+    let mut failed: Vec<(u32, u32)> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for e in &state.isotope_entries {
+        if e.enabled && e.endf_status == EndfStatus::Failed && seen.insert((e.z, e.a)) {
+            failed.push((e.z, e.a));
+        }
+    }
+    for g in &state.isotope_groups {
+        if !g.enabled {
+            continue;
+        }
+        for m in &g.members {
+            if m.endf_status == EndfStatus::Failed && seen.insert((g.z, m.a)) {
+                failed.push((g.z, m.a));
+            }
+        }
+    }
+    if failed.is_empty() {
+        return;
+    }
+
+    ui.label(
+        egui::RichText::new(
+            "Offline fallback: copy the ENDF file to the path below, then click Retry — or use \u{201C}Load local ENDF file\u{2026}\u{201D} above:",
+        )
+        .small()
+        .weak(),
+    );
+    for &(z, a) in failed.iter().take(MAX_LINES) {
+        let Ok(iso) = Isotope::new(z, a) else {
+            continue;
+        };
+        let path = default_cache_file_path(&iso, library);
+        ui.label(
+            egui::RichText::new(format!("    {}", path.display()))
+                .small()
+                .weak()
+                .monospace(),
+        );
+    }
+    if failed.len() > MAX_LINES {
+        ui.label(
+            egui::RichText::new(format!(
+                "    \u{2026} and {} more",
+                failed.len() - MAX_LINES
+            ))
+            .small()
+            .weak(),
+        );
+    }
 }
 
 /// Manual ENDF upload escape hatch (issue #523): pick a local `.endf`/`.zip`

--- a/apps/gui/src/guided/configure.rs
+++ b/apps/gui/src/guided/configure.rs
@@ -555,18 +555,11 @@ fn fetch_endf_data(state: &mut AppState) {
     std::thread::spawn(move || design::endf_fetch_worker(work, cancel, tx));
 }
 
-/// Render the offline-fallback hint that lists the exact cache-file path for
-/// every Failed isotope under the active library, so users can `cp` a
-/// manually-downloaded ENDF straight into place (issue #523). Paths come from
-/// the free `default_cache_file_path` helper to avoid the per-frame
-/// `EndfRetriever::new()` cost that would otherwise build a reqwest client +
-/// TLS context just to read the cache layout.
-fn render_failed_cache_hint(ui: &mut egui::Ui, state: &AppState) {
-    use nereids_core::types::Isotope;
-    use nereids_endf::retrieval::default_cache_file_path;
-
-    const MAX_LINES: usize = 3;
-    let library = state.endf_library;
+/// Collect deduplicated `(Z, A)` coordinates of every enabled+Failed isotope
+/// in the user's selection — individual entries first, then group members.
+/// Pure read of state; lifted out of `render_failed_cache_hint` so the
+/// dedup/ordering logic can be unit-tested without an egui context.
+fn failed_isotope_keys(state: &AppState) -> Vec<(u32, u32)> {
     let mut failed: Vec<(u32, u32)> = Vec::new();
     let mut seen = std::collections::HashSet::new();
     for e in &state.isotope_entries {
@@ -584,6 +577,56 @@ fn render_failed_cache_hint(ui: &mut egui::Ui, state: &AppState) {
             }
         }
     }
+    failed
+}
+
+/// Whether `(z, a)` appears anywhere in the user's selection — individual
+/// entries or group members. The local-install dialog uses this to decide
+/// whether a peeked ENDF file routes to a real entry. Pure read; testable.
+fn isotope_in_selection(state: &AppState, z: u32, a: u32) -> bool {
+    state.isotope_entries.iter().any(|e| e.z == z && e.a == a)
+        || state
+            .isotope_groups
+            .iter()
+            .any(|g| g.z == z && g.members.iter().any(|m| m.a == a))
+}
+
+/// Clear cached resonance data on the entry matching `(z, a)` and reset its
+/// status to Pending so the auto-fetch loop re-reads it (now from the local
+/// cache). Hits both individual entries and group members.
+fn mark_isotope_pending(state: &mut AppState, z: u32, a: u32) {
+    for e in &mut state.isotope_entries {
+        if e.z == z && e.a == a {
+            e.resonance_data = None;
+            e.endf_status = EndfStatus::Pending;
+        }
+    }
+    for g in &mut state.isotope_groups {
+        if g.z != z {
+            continue;
+        }
+        for m in &mut g.members {
+            if m.a == a {
+                m.resonance_data = None;
+                m.endf_status = EndfStatus::Pending;
+            }
+        }
+    }
+}
+
+/// Render the offline-fallback hint that lists the exact cache-file path for
+/// every Failed isotope under the active library, so users can `cp` a
+/// manually-downloaded ENDF straight into place (issue #523). Paths come from
+/// the free `default_cache_file_path` helper to avoid the per-frame
+/// `EndfRetriever::new()` cost that would otherwise build a reqwest client +
+/// TLS context just to read the cache layout.
+fn render_failed_cache_hint(ui: &mut egui::Ui, state: &AppState) {
+    use nereids_core::types::Isotope;
+    use nereids_endf::retrieval::default_cache_file_path;
+
+    const MAX_LINES: usize = 3;
+    let library = state.endf_library;
+    let failed = failed_isotope_keys(state);
     if failed.is_empty() {
         return;
     }
@@ -650,12 +693,7 @@ fn install_local_endf_dialog(state: &mut AppState) {
         a,
     );
 
-    let in_selection = state.isotope_entries.iter().any(|e| e.z == z && e.a == a)
-        || state
-            .isotope_groups
-            .iter()
-            .any(|g| g.z == z && g.members.iter().any(|m| m.a == a));
-    if !in_selection {
+    if !isotope_in_selection(state, z, a) {
         state.status_message = format!(
             "ENDF file is for {label}, but no matching isotope in your selection. Add it first.",
         );
@@ -675,24 +713,172 @@ fn install_local_endf_dialog(state: &mut AppState) {
         return;
     }
 
-    // Mark the matching entry Pending so the auto-fetch loop runs it through
-    // the retriever, which now hits the cache slot we just populated.
-    for e in &mut state.isotope_entries {
-        if e.z == z && e.a == a {
-            e.resonance_data = None;
-            e.endf_status = EndfStatus::Pending;
-        }
-    }
-    for g in &mut state.isotope_groups {
-        if g.z != z {
-            continue;
-        }
-        for m in &mut g.members {
-            if m.a == a {
-                m.resonance_data = None;
-                m.endf_status = EndfStatus::Pending;
-            }
-        }
-    }
+    // Reset the matching entry to Pending so the auto-fetch loop runs it
+    // through the retriever, which now hits the cache slot we just populated.
+    mark_isotope_pending(state, z, a);
     state.status_message = format!("Loaded local ENDF for {label}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{GroupMemberState, IsotopeEntry, IsotopeGroupEntry};
+
+    fn entry(z: u32, a: u32, sym: &str, enabled: bool, status: EndfStatus) -> IsotopeEntry {
+        IsotopeEntry {
+            z,
+            a,
+            symbol: sym.into(),
+            initial_density: 0.001,
+            resonance_data: None,
+            enabled,
+            endf_status: status,
+        }
+    }
+
+    fn member(a: u32, sym: &str, status: EndfStatus) -> GroupMemberState {
+        GroupMemberState {
+            a,
+            symbol: sym.into(),
+            ratio: 1.0,
+            resonance_data: None,
+            endf_status: status,
+        }
+    }
+
+    fn group(
+        z: u32,
+        name: &str,
+        enabled: bool,
+        members: Vec<GroupMemberState>,
+    ) -> IsotopeGroupEntry {
+        IsotopeGroupEntry {
+            z,
+            name: name.into(),
+            members,
+            initial_density: 0.001,
+            enabled,
+        }
+    }
+
+    #[test]
+    fn failed_keys_collect_failed_entries_only() {
+        let state = AppState {
+            isotope_entries: vec![
+                entry(73, 181, "Ta-181", true, EndfStatus::Failed),
+                entry(72, 180, "Hf-180", true, EndfStatus::Loaded),
+                entry(74, 184, "W-184", true, EndfStatus::Pending),
+                entry(56, 138, "Ba-138", false, EndfStatus::Failed), // disabled, ignored
+            ],
+            ..Default::default()
+        };
+        let keys = failed_isotope_keys(&state);
+        assert_eq!(keys, vec![(73, 181)]);
+    }
+
+    #[test]
+    fn failed_keys_include_failed_group_members_and_dedup_across_lists() {
+        let state = AppState {
+            isotope_entries: vec![entry(73, 181, "Ta-181", true, EndfStatus::Failed)],
+            isotope_groups: vec![
+                group(
+                    74,
+                    "W natural",
+                    true,
+                    vec![
+                        member(182, "W-182", EndfStatus::Loaded),
+                        member(184, "W-184", EndfStatus::Failed),
+                    ],
+                ),
+                // Disabled group: members ignored even if Failed.
+                group(
+                    72,
+                    "Hf natural",
+                    false,
+                    vec![member(180, "Hf-180", EndfStatus::Failed)],
+                ),
+                // Duplicate of an individual entry — should be deduplicated.
+                group(
+                    73,
+                    "Ta dup",
+                    true,
+                    vec![member(181, "Ta-181", EndfStatus::Failed)],
+                ),
+            ],
+            ..Default::default()
+        };
+        let keys = failed_isotope_keys(&state);
+        // Ta-181 from individual entries first, then W-184 from active group;
+        // Hf-180 ignored (disabled group); Ta-181 dedup'd from second group.
+        assert_eq!(keys, vec![(73, 181), (74, 184)]);
+    }
+
+    #[test]
+    fn isotope_in_selection_matches_entries_and_group_members() {
+        let state = AppState {
+            isotope_entries: vec![entry(73, 181, "Ta-181", true, EndfStatus::Failed)],
+            isotope_groups: vec![group(
+                74,
+                "W natural",
+                true,
+                vec![
+                    member(182, "W-182", EndfStatus::Pending),
+                    member(184, "W-184", EndfStatus::Failed),
+                ],
+            )],
+            ..Default::default()
+        };
+        assert!(isotope_in_selection(&state, 73, 181), "individual entry");
+        assert!(isotope_in_selection(&state, 74, 184), "group member");
+        assert!(!isotope_in_selection(&state, 72, 180), "missing isotope");
+        // Group's (Z, members.A) is the only canonical form — a mismatched A is not in selection.
+        assert!(!isotope_in_selection(&state, 74, 200), "missing A in group");
+    }
+
+    #[test]
+    fn mark_pending_resets_status_and_data_for_entries() {
+        let mut state = AppState {
+            isotope_entries: vec![entry(73, 181, "Ta-181", true, EndfStatus::Failed)],
+            ..Default::default()
+        };
+
+        mark_isotope_pending(&mut state, 73, 181);
+        assert_eq!(state.isotope_entries[0].endf_status, EndfStatus::Pending);
+        assert!(state.isotope_entries[0].resonance_data.is_none());
+
+        // Mismatched (z, a) leaves entry alone.
+        let mut state2 = AppState {
+            isotope_entries: vec![entry(73, 181, "Ta-181", true, EndfStatus::Failed)],
+            ..Default::default()
+        };
+        mark_isotope_pending(&mut state2, 73, 180);
+        assert_eq!(state2.isotope_entries[0].endf_status, EndfStatus::Failed);
+    }
+
+    #[test]
+    fn mark_pending_resets_group_member_status_too() {
+        let mut state = AppState {
+            isotope_groups: vec![group(
+                74,
+                "W natural",
+                true,
+                vec![
+                    member(182, "W-182", EndfStatus::Loaded),
+                    member(184, "W-184", EndfStatus::Failed),
+                ],
+            )],
+            ..Default::default()
+        };
+        mark_isotope_pending(&mut state, 74, 184);
+        assert_eq!(
+            state.isotope_groups[0].members[0].endf_status,
+            EndfStatus::Loaded,
+            "W-182 untouched"
+        );
+        assert_eq!(
+            state.isotope_groups[0].members[1].endf_status,
+            EndfStatus::Pending,
+            "W-184 reset"
+        );
+    }
 }

--- a/crates/nereids-endf/Cargo.toml
+++ b/crates/nereids-endf/Cargo.toml
@@ -16,3 +16,6 @@ serde = { workspace = true }
 reqwest = { workspace = true }
 zip = { workspace = true }
 dirs = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/nereids-endf/src/retrieval.rs
+++ b/crates/nereids-endf/src/retrieval.rs
@@ -17,8 +17,15 @@ use std::time::{Duration, Instant};
 
 const IAEA_BASE_URL: &str = "https://www-nds.iaea.org/public/download-endf";
 const NNDC_ENDF_BASE_URL: &str = "https://www.nndc.bnl.gov/endf-data/ENDF";
-const ENDF_USER_AGENT: &str =
-    "NEREIDS/0.1.8 (https://github.com/ornlneutronimaging/NEREIDS; ENDF cache)";
+// Polite, identifiable UA: many nuclear-data servers either require a non-default
+// UA or treat default `reqwest` traffic as a bot (issue #523, IAEA returning
+// HTTP 403 to v0.1.8 batch fetches). Version is derived from `CARGO_PKG_VERSION`
+// so it never drifts from `Cargo.toml`.
+const ENDF_USER_AGENT: &str = concat!(
+    "NEREIDS/",
+    env!("CARGO_PKG_VERSION"),
+    " (https://github.com/ornlneutronimaging/NEREIDS; contact: zhangc@ornl.gov)",
+);
 const IAEA_MIN_REQUEST_INTERVAL: Duration = Duration::from_secs(3);
 
 static LAST_IAEA_REQUEST: OnceLock<Mutex<Option<Instant>>> = OnceLock::new();
@@ -127,12 +134,18 @@ impl EndfRetriever {
     }
 
     /// Get the cache directory for a specific library.
-    fn cache_dir(&self, library: EndfLibrary) -> PathBuf {
+    ///
+    /// Public so the GUI can show users exactly where to drop a manually-
+    /// downloaded ENDF file when a fetch fails (issue #523).
+    pub fn cache_dir(&self, library: EndfLibrary) -> PathBuf {
         self.cache_root.join(library.cache_dir_name())
     }
 
     /// Get the cached ENDF file path for an isotope.
-    fn cache_file_path(&self, isotope: &Isotope, library: EndfLibrary) -> PathBuf {
+    ///
+    /// Public so callers can present the exact target path for manual file
+    /// drops; see [`Self::install_local_endf`] for the programmatic equivalent.
+    pub fn cache_file_path(&self, isotope: &Isotope, library: EndfLibrary) -> PathBuf {
         let sym = elements::element_symbol(isotope.z()).unwrap_or("X");
         let filename = format!("{}-{}.endf", sym, isotope.a());
         self.cache_dir(library).join(filename)
@@ -193,7 +206,7 @@ impl EndfRetriever {
         let url = format!("{}/{}/{}", self.base_url, library.url_path(), zip_filename);
         let iaea_result = self.fetch_bytes(&url, true);
         match iaea_result {
-            Ok(bytes) => self.extract_endf_from_zip(&bytes),
+            Ok(bytes) => extract_endf_from_zip(&bytes),
             Err(err) if should_try_nndc_fallback(&err) => {
                 if !nndc_already_tried
                     && let Some(fallback_url) = &nndc_url
@@ -246,50 +259,56 @@ impl EndfRetriever {
             .map_err(|e| EndfRetrievalError::Parse(format!("Invalid UTF-8 ENDF response: {e}")))
     }
 
-    /// Extract the ENDF data file from a ZIP archive.
-    ///
-    /// Looks for files ending in .endf, .dat, or .txt within the archive.
-    fn extract_endf_from_zip(&self, zip_bytes: &[u8]) -> Result<String, EndfRetrievalError> {
-        let cursor = std::io::Cursor::new(zip_bytes);
-        let mut archive = zip::ZipArchive::new(cursor)
-            .map_err(|e| EndfRetrievalError::Parse(format!("Invalid ZIP archive: {}", e)))?;
-
-        // Find the ENDF data file within the archive.
-        for i in 0..archive.len() {
-            let mut file = archive.by_index(i).map_err(|e| {
-                EndfRetrievalError::Parse(format!("Failed to read ZIP entry: {}", e))
-            })?;
-
-            let name = file.name().to_lowercase();
-            if name.ends_with(".endf") || name.ends_with(".dat") || name.ends_with(".txt") {
-                let mut contents = String::new();
-                file.read_to_string(&mut contents).map_err(|e| {
-                    EndfRetrievalError::Parse(format!("Failed to read ENDF content: {}", e))
-                })?;
-                return Ok(contents);
-            }
-        }
-
-        // If no obvious extension, try the first file.
-        if !archive.is_empty() {
-            let mut file = archive.by_index(0).map_err(|e| {
-                EndfRetrievalError::Parse(format!("Failed to read ZIP entry: {}", e))
-            })?;
-            let mut contents = String::new();
-            file.read_to_string(&mut contents).map_err(|e| {
-                EndfRetrievalError::Parse(format!("Failed to read ENDF content: {}", e))
-            })?;
-            return Ok(contents);
-        }
-
-        Err(EndfRetrievalError::Parse(
-            "No ENDF data file found in ZIP archive".to_string(),
-        ))
-    }
-
     /// Load an ENDF file from a local path (no download).
     pub fn load_local(path: &Path) -> Result<String, EndfRetrievalError> {
         fs::read_to_string(path).map_err(EndfRetrievalError::from)
+    }
+
+    /// Install a user-supplied ENDF file into the cache for `isotope`/`library`.
+    ///
+    /// Accepts either a raw ENDF text file (`.endf`, `.dat`, `.txt`, or
+    /// extensionless) or the IAEA ZIP archive distribution (`n_…_….zip`).
+    /// The file is parsed to verify that its declared isotope matches
+    /// `isotope`; on success the text is written to the canonical cache slot
+    /// returned by [`Self::cache_file_path`] and `(cache_path, text)` is
+    /// returned. Subsequent calls to [`Self::get_endf_file`] will then hit the
+    /// cache without any network access.
+    ///
+    /// This is the GUI's manual-upload escape hatch for users on networks
+    /// where IAEA/NNDC is blocked (issue #523).
+    pub fn install_local_endf(
+        &self,
+        isotope: &Isotope,
+        library: EndfLibrary,
+        source: &Path,
+    ) -> Result<(PathBuf, String), EndfRetrievalError> {
+        let raw = fs::read(source)?;
+        let endf_text = if looks_like_zip(source, &raw) {
+            extract_endf_from_zip(&raw)?
+        } else {
+            String::from_utf8(raw).map_err(|e| {
+                EndfRetrievalError::Parse(format!("ENDF file is not valid UTF-8: {e}"))
+            })?
+        };
+
+        // Validate the (Z, A) declared by the file's HEAD record matches the
+        // isotope the user intends to install. parse_endf_file2 reads the MF=2
+        // MT=151 HEAD which carries ZA = 1000*Z + A.
+        let parsed = crate::parser::parse_endf_file2(&endf_text)
+            .map_err(|e| EndfRetrievalError::Parse(format!("Failed to parse ENDF file: {e}")))?;
+        if parsed.isotope != *isotope {
+            return Err(EndfRetrievalError::IsotopeMismatch {
+                expected: isotope_label(isotope),
+                found: isotope_label(&parsed.isotope),
+            });
+        }
+
+        let cache_path = self.cache_file_path(isotope, library);
+        if let Some(parent) = cache_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&cache_path, &endf_text)?;
+        Ok((cache_path, endf_text))
     }
 
     /// Clear the cache for a specific library, or all if `None`.
@@ -385,6 +404,11 @@ pub enum EndfRetrievalError {
     #[error("{isotope} is not available in the {library} library")]
     NotInLibrary { isotope: String, library: String },
 
+    /// A user-supplied ENDF file did not describe the isotope it was being
+    /// installed against (issue #523, manual upload path).
+    #[error("ENDF file is for {found}, but expected {expected}")]
+    IsotopeMismatch { expected: String, found: String },
+
     #[error("Parse error: {0}")]
     Parse(String),
 
@@ -453,6 +477,60 @@ impl DownloadError {
             }
         }
     }
+}
+
+/// Extract the ENDF data file body from a ZIP archive.
+///
+/// Prefers archive entries ending in `.endf`, `.dat`, or `.txt`; falls back to
+/// the first entry if none match. IAEA distributes one ENDF per zip, so the
+/// fallback effectively only fires on hand-rolled archives.
+fn extract_endf_from_zip(zip_bytes: &[u8]) -> Result<String, EndfRetrievalError> {
+    let cursor = std::io::Cursor::new(zip_bytes);
+    let mut archive = zip::ZipArchive::new(cursor)
+        .map_err(|e| EndfRetrievalError::Parse(format!("Invalid ZIP archive: {}", e)))?;
+
+    for i in 0..archive.len() {
+        let mut file = archive
+            .by_index(i)
+            .map_err(|e| EndfRetrievalError::Parse(format!("Failed to read ZIP entry: {}", e)))?;
+        let name = file.name().to_lowercase();
+        if name.ends_with(".endf") || name.ends_with(".dat") || name.ends_with(".txt") {
+            let mut contents = String::new();
+            file.read_to_string(&mut contents).map_err(|e| {
+                EndfRetrievalError::Parse(format!("Failed to read ENDF content: {}", e))
+            })?;
+            return Ok(contents);
+        }
+    }
+
+    if !archive.is_empty() {
+        let mut file = archive
+            .by_index(0)
+            .map_err(|e| EndfRetrievalError::Parse(format!("Failed to read ZIP entry: {}", e)))?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents).map_err(|e| {
+            EndfRetrievalError::Parse(format!("Failed to read ENDF content: {}", e))
+        })?;
+        return Ok(contents);
+    }
+
+    Err(EndfRetrievalError::Parse(
+        "No ENDF data file found in ZIP archive".to_string(),
+    ))
+}
+
+/// Detect a ZIP archive by extension or PK magic bytes.
+///
+/// IAEA-distributed `n_…_….zip` files always start with `PK\x03\x04`. The
+/// magic-byte check covers the case where a user has stripped or renamed the
+/// extension before uploading.
+fn looks_like_zip(source: &Path, raw: &[u8]) -> bool {
+    let by_ext = source
+        .extension()
+        .and_then(|s| s.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("zip"));
+    let by_magic = raw.len() >= 4 && &raw[..4] == b"PK\x03\x04";
+    by_ext || by_magic
 }
 
 /// Build the shared HTTP client used for ENDF downloads.
@@ -579,5 +657,126 @@ mod tests {
             message: "blocked".into(),
         };
         assert!(err.is_remote_access_blocked());
+    }
+
+    /// Issue #523: the polite User-Agent must carry the live package version
+    /// and the contact metadata the IAEA acceptance criterion calls for.
+    #[test]
+    fn endf_user_agent_contains_version_and_contact() {
+        assert!(
+            ENDF_USER_AGENT.starts_with("NEREIDS/"),
+            "UA must start with NEREIDS/, got {ENDF_USER_AGENT:?}"
+        );
+        assert!(
+            ENDF_USER_AGENT.contains(env!("CARGO_PKG_VERSION")),
+            "UA must carry CARGO_PKG_VERSION, got {ENDF_USER_AGENT:?}"
+        );
+        assert!(
+            ENDF_USER_AGENT.contains("github.com/ornlneutronimaging/NEREIDS"),
+            "UA must include the project URL, got {ENDF_USER_AGENT:?}"
+        );
+        assert!(
+            ENDF_USER_AGENT.contains("contact: zhangc@ornl.gov"),
+            "UA must include a contact mailbox, got {ENDF_USER_AGENT:?}"
+        );
+    }
+
+    // Minimal valid ENDF MF=2/MT=151 fixture for W-184 — same shape as the
+    // krm3 fixture in parser.rs tests, kept inline so retrieval tests stay
+    // self-contained.
+    const W184_FIXTURE: &str = concat!(
+        " 7.418400+4 1.820000+2          0          0          1          07437 2151    1\n",
+        " 7.418400+4 1.000000+0          0          0          1          07437 2151    2\n",
+        " 1.000000-5 1.000000+3          1          7          0          07437 2151    3\n",
+        " 0.000000+0 7.000000-1          0          3          1          07437 2151    4\n",
+        " 0.000000+0 0.000000+0          1          0         12          17437 2151    5\n",
+        " 1.000000+0 1.820000+2 0.000000+0 0.000000+0 5.000000-1 0.000000+07437 2151    6\n",
+        " 0.000000+0 1.000000+0 0.000000+0 2.000000+0 1.000000+0 1.000000+07437 2151    7\n",
+        " 5.000000-1 0.000000+0          0          0         12          27437 2151    8\n",
+        " 0.000000+0 0.000000+0 0.000000+0 0.000000+0 0.000000+0 0.000000+07437 2151    9\n",
+        " 1.000000+0 0.000000+0 5.000000-1 0.000000+0 7.000000-1 7.000000-17437 2151   10\n",
+        " 0.000000+0 0.000000+0          0          0         12          27437 2151   11\n",
+        " 1.000000+1 2.500000-2 1.000000-3 0.000000+0 0.000000+0 0.000000+07437 2151   12\n",
+        " 2.000000+1 3.000000-2 2.000000-3 0.000000+0 0.000000+0 0.000000+07437 2151   13\n",
+    );
+
+    fn write_zip_with_endf(zip_path: &Path, inner_name: &str, body: &str) -> std::io::Result<()> {
+        let file = fs::File::create(zip_path)?;
+        let mut zw = zip::ZipWriter::new(file);
+        zw.start_file::<_, ()>(inner_name, zip::write::SimpleFileOptions::default())
+            .map_err(|e| std::io::Error::other(format!("zip start_file: {e}")))?;
+        std::io::Write::write_all(&mut zw, body.as_bytes())?;
+        zw.finish()
+            .map_err(|e| std::io::Error::other(format!("zip finish: {e}")))?;
+        Ok(())
+    }
+
+    #[test]
+    fn install_local_endf_accepts_raw_endf_with_matching_isotope() {
+        let cache = tempfile::tempdir().expect("tempdir");
+        let src = tempfile::NamedTempFile::new().expect("src file");
+        std::fs::write(src.path(), W184_FIXTURE).unwrap();
+
+        let retriever = EndfRetriever::with_cache_dir(cache.path());
+        let w184 = Isotope::new(74, 184).unwrap();
+        let (cache_path, text) = retriever
+            .install_local_endf(&w184, EndfLibrary::EndfB8_0, src.path())
+            .expect("install must succeed");
+
+        assert!(cache_path.exists(), "cache file must be written");
+        assert!(text.contains("7.418400+4"), "returned text matches input");
+        // Subsequent get_endf_file calls must read from cache (no network).
+        let (cached_path, cached_text) = retriever
+            .get_endf_file(&w184, EndfLibrary::EndfB8_0, 7437)
+            .expect("cache hit must succeed offline");
+        assert_eq!(cached_path, cache_path);
+        assert_eq!(cached_text, text);
+    }
+
+    #[test]
+    fn install_local_endf_accepts_zip_archive() {
+        let cache = tempfile::tempdir().expect("tempdir");
+        let zip_path = cache.path().join("upload.zip");
+        write_zip_with_endf(&zip_path, "n_7437_74-W-184.endf", W184_FIXTURE)
+            .expect("write zip fixture");
+
+        let retriever = EndfRetriever::with_cache_dir(cache.path());
+        let w184 = Isotope::new(74, 184).unwrap();
+        let (cache_path, _) = retriever
+            .install_local_endf(&w184, EndfLibrary::EndfB8_0, &zip_path)
+            .expect("zip install must succeed");
+        assert!(cache_path.exists());
+        assert_eq!(
+            fs::read_to_string(&cache_path).unwrap(),
+            W184_FIXTURE,
+            "cache must hold the extracted body, not the zip"
+        );
+    }
+
+    #[test]
+    fn install_local_endf_rejects_isotope_mismatch() {
+        let cache = tempfile::tempdir().expect("tempdir");
+        let src = tempfile::NamedTempFile::new().expect("src file");
+        std::fs::write(src.path(), W184_FIXTURE).unwrap();
+
+        let retriever = EndfRetriever::with_cache_dir(cache.path());
+        let hf180 = Isotope::new(72, 180).unwrap();
+        let err = retriever
+            .install_local_endf(&hf180, EndfLibrary::EndfB8_0, src.path())
+            .expect_err("must reject ZA mismatch");
+
+        match err {
+            EndfRetrievalError::IsotopeMismatch { expected, found } => {
+                assert!(expected.contains("Hf"), "expected label, got {expected}");
+                assert!(found.contains("W"), "found label, got {found}");
+            }
+            other => panic!("expected IsotopeMismatch, got {other:?}"),
+        }
+        assert!(
+            !retriever
+                .cache_file_path(&hf180, EndfLibrary::EndfB8_0)
+                .exists(),
+            "no cache file must be written on mismatch"
+        );
     }
 }

--- a/crates/nereids-endf/src/retrieval.rs
+++ b/crates/nereids-endf/src/retrieval.rs
@@ -264,6 +264,49 @@ impl EndfRetriever {
         fs::read_to_string(path).map_err(EndfRetrievalError::from)
     }
 
+    /// Peek a user-supplied ENDF source: decode the body and parse the HEAD
+    /// record so the caller can route the upload to the correct isotope entry.
+    ///
+    /// Accepts the same input forms as [`Self::install_local_endf`] — a raw
+    /// ENDF text file or the IAEA ZIP archive distribution — and returns the
+    /// isotope declared by the file's MF=2 MT=151 HEAD record alongside the
+    /// decoded text. The GUI uses this to dispatch a manual upload to the
+    /// matching `IsotopeEntry` without re-reading or re-extracting the file
+    /// during install (issue #523, P2: avoid N-pass zip extraction).
+    pub fn peek_local_endf(source: &Path) -> Result<(Isotope, String), EndfRetrievalError> {
+        let raw = fs::read(source)?;
+        let endf_text = if looks_like_zip(source, &raw) {
+            extract_endf_from_zip(&raw)?
+        } else {
+            String::from_utf8(raw).map_err(|e| {
+                EndfRetrievalError::Parse(format!("ENDF file is not valid UTF-8: {e}"))
+            })?
+        };
+        let parsed = crate::parser::parse_endf_file2(&endf_text)
+            .map_err(|e| EndfRetrievalError::Parse(format!("Failed to parse ENDF file: {e}")))?;
+        Ok((parsed.isotope, endf_text))
+    }
+
+    /// Write already-validated ENDF text to the canonical cache slot for
+    /// `isotope`/`library`. Returns the cache file path.
+    ///
+    /// Use this when the caller has already obtained `text` via
+    /// [`Self::peek_local_endf`] and confirmed the isotope. For one-shot
+    /// install-from-path, use [`Self::install_local_endf`] instead.
+    pub fn install_endf_text(
+        &self,
+        isotope: &Isotope,
+        library: EndfLibrary,
+        text: &str,
+    ) -> Result<PathBuf, EndfRetrievalError> {
+        let cache_path = self.cache_file_path(isotope, library);
+        if let Some(parent) = cache_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&cache_path, text)?;
+        Ok(cache_path)
+    }
+
     /// Install a user-supplied ENDF file into the cache for `isotope`/`library`.
     ///
     /// Accepts either a raw ENDF text file (`.endf`, `.dat`, `.txt`, or
@@ -282,32 +325,14 @@ impl EndfRetriever {
         library: EndfLibrary,
         source: &Path,
     ) -> Result<(PathBuf, String), EndfRetrievalError> {
-        let raw = fs::read(source)?;
-        let endf_text = if looks_like_zip(source, &raw) {
-            extract_endf_from_zip(&raw)?
-        } else {
-            String::from_utf8(raw).map_err(|e| {
-                EndfRetrievalError::Parse(format!("ENDF file is not valid UTF-8: {e}"))
-            })?
-        };
-
-        // Validate the (Z, A) declared by the file's HEAD record matches the
-        // isotope the user intends to install. parse_endf_file2 reads the MF=2
-        // MT=151 HEAD which carries ZA = 1000*Z + A.
-        let parsed = crate::parser::parse_endf_file2(&endf_text)
-            .map_err(|e| EndfRetrievalError::Parse(format!("Failed to parse ENDF file: {e}")))?;
-        if parsed.isotope != *isotope {
+        let (found, endf_text) = Self::peek_local_endf(source)?;
+        if found != *isotope {
             return Err(EndfRetrievalError::IsotopeMismatch {
                 expected: isotope_label(isotope),
-                found: isotope_label(&parsed.isotope),
+                found: isotope_label(&found),
             });
         }
-
-        let cache_path = self.cache_file_path(isotope, library);
-        if let Some(parent) = cache_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        fs::write(&cache_path, &endf_text)?;
+        let cache_path = self.install_endf_text(isotope, library, &endf_text)?;
         Ok((cache_path, endf_text))
     }
 
@@ -751,6 +776,25 @@ mod tests {
             W184_FIXTURE,
             "cache must hold the extracted body, not the zip"
         );
+    }
+
+    #[test]
+    fn peek_local_endf_extracts_isotope_from_zip_and_raw() {
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        // Raw .endf path
+        let raw_path = dir.path().join("W-184.endf");
+        std::fs::write(&raw_path, W184_FIXTURE).unwrap();
+        let (iso, text) = EndfRetriever::peek_local_endf(&raw_path).expect("raw peek");
+        assert_eq!(iso, Isotope::new(74, 184).unwrap());
+        assert_eq!(text, W184_FIXTURE);
+
+        // Zip path
+        let zip_path = dir.path().join("upload.zip");
+        write_zip_with_endf(&zip_path, "inner.endf", W184_FIXTURE).expect("zip");
+        let (iso_z, text_z) = EndfRetriever::peek_local_endf(&zip_path).expect("zip peek");
+        assert_eq!(iso_z, Isotope::new(74, 184).unwrap());
+        assert_eq!(text_z, W184_FIXTURE);
     }
 
     #[test]

--- a/crates/nereids-endf/src/retrieval.rs
+++ b/crates/nereids-endf/src/retrieval.rs
@@ -98,6 +98,31 @@ impl EndfLibrary {
     }
 }
 
+/// Compute the default on-disk cache directory for a given library without
+/// constructing an [`EndfRetriever`].
+///
+/// The retriever's constructor builds a `reqwest` blocking client + TLS
+/// configuration, which is wasted work when all the caller needs is the cache
+/// path for a UI hint or manual drop instruction. Mirrors the path layout
+/// that [`EndfRetriever::new`] would resolve to.
+pub fn default_cache_dir(library: EndfLibrary) -> PathBuf {
+    default_cache_root().join(library.cache_dir_name())
+}
+
+/// Compute the default cache file path for an isotope without constructing
+/// an [`EndfRetriever`]. Same layout as [`EndfRetriever::cache_file_path`].
+pub fn default_cache_file_path(isotope: &Isotope, library: EndfLibrary) -> PathBuf {
+    let sym = elements::element_symbol(isotope.z()).unwrap_or("X");
+    default_cache_dir(library).join(format!("{}-{}.endf", sym, isotope.a()))
+}
+
+fn default_cache_root() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from(".cache"))
+        .join("nereids")
+        .join("endf")
+}
+
 /// ENDF file retrieval manager with local caching.
 pub struct EndfRetriever {
     /// Root cache directory.
@@ -113,12 +138,8 @@ pub struct EndfRetriever {
 impl EndfRetriever {
     /// Create a new retriever with default cache location (~/.cache/nereids/endf/).
     pub fn new() -> Self {
-        let cache_root = dirs::cache_dir()
-            .unwrap_or_else(|| PathBuf::from(".cache"))
-            .join("nereids")
-            .join("endf");
         Self {
-            cache_root,
+            cache_root: default_cache_root(),
             base_url: IAEA_BASE_URL.to_string(),
             client: build_http_client(),
         }
@@ -778,6 +799,29 @@ mod tests {
         );
     }
 
+    /// `default_cache_dir` / `default_cache_file_path` must agree with the
+    /// retriever's instance methods, otherwise UI hints would point users to
+    /// the wrong location after a fetch failure.
+    #[test]
+    fn default_cache_paths_agree_with_retriever_instance() {
+        let retriever = EndfRetriever::new();
+        let w184 = Isotope::new(74, 184).unwrap();
+        for lib in [
+            EndfLibrary::EndfB8_0,
+            EndfLibrary::EndfB8_1,
+            EndfLibrary::Jeff3_3,
+            EndfLibrary::Jendl5,
+            EndfLibrary::Tendl2023,
+            EndfLibrary::Cendl3_2,
+        ] {
+            assert_eq!(default_cache_dir(lib), retriever.cache_dir(lib));
+            assert_eq!(
+                default_cache_file_path(&w184, lib),
+                retriever.cache_file_path(&w184, lib)
+            );
+        }
+    }
+
     #[test]
     fn peek_local_endf_extracts_isotope_from_zip_and_raw() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -795,6 +839,36 @@ mod tests {
         let (iso_z, text_z) = EndfRetriever::peek_local_endf(&zip_path).expect("zip peek");
         assert_eq!(iso_z, Isotope::new(74, 184).unwrap());
         assert_eq!(text_z, W184_FIXTURE);
+    }
+
+    /// Regression for the `looks_like_zip` magic-byte branch: an upload whose
+    /// path has no `.zip` extension must still be detected via `PK\x03\x04`
+    /// and routed through the zip extractor. Without this test, the magic-byte
+    /// branch could silently regress to extension-only detection.
+    #[test]
+    fn install_local_endf_accepts_extensionless_zip_via_magic_bytes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let zip_path = dir.path().join("upload-no-extension"); // no .zip suffix
+        write_zip_with_endf(&zip_path, "inner.endf", W184_FIXTURE).expect("write zip");
+
+        // Sanity-check we really did create a zip without the .zip extension.
+        assert!(zip_path.extension().is_none());
+        let head = std::fs::read(&zip_path).unwrap();
+        assert_eq!(&head[..4], b"PK\x03\x04");
+
+        let retriever = EndfRetriever::with_cache_dir(dir.path().join("cache"));
+        let w184 = Isotope::new(74, 184).unwrap();
+        let (cache_path, text) = retriever
+            .install_local_endf(&w184, EndfLibrary::EndfB8_0, &zip_path)
+            .expect("extensionless zip must still install");
+        assert!(cache_path.exists());
+        assert_eq!(text, W184_FIXTURE);
+
+        // peek_local_endf must also handle the extensionless zip.
+        let (iso, peeked_text) =
+            EndfRetriever::peek_local_endf(&zip_path).expect("peek must also work");
+        assert_eq!(iso, w184);
+        assert_eq!(peeked_text, W184_FIXTURE);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #523. External user (Tsviki, evaluating v0.1.8 against LANSCE data) hit `HTTP 403` from IAEA Nuclear Data Services for `n_7328_73-Ta-181.zip`. PR #520 already added a polite User-Agent and NNDC fallback routing for ENDF/B-VIII.0 / VIII.1; this PR closes the remaining gaps.

- **User-Agent** in [`crates/nereids-endf/src/retrieval.rs`](crates/nereids-endf/src/retrieval.rs) now derives the version from `env!("CARGO_PKG_VERSION")` (no more silent drift after a release bump) and includes the `contact: zhangc@ornl.gov` token the issue's acceptance criterion calls for.
- New retriever methods (all `pub`):
  - `EndfRetriever::peek_local_endf(source) -> (Isotope, String)` — read + zip-extract + parse HEAD record in a single pass.
  - `EndfRetriever::install_endf_text(isotope, library, text) -> PathBuf` — cache-write only.
  - `EndfRetriever::install_local_endf(isotope, library, source) -> (PathBuf, String)` — one-shot wrapper: peek + ZA-match check + install_endf_text.
  - `cache_dir(library)` / `cache_file_path(isotope, library)` promoted to public so the GUI can show the exact cache path users should drop files at.
- New error variant `EndfRetrievalError::IsotopeMismatch { expected, found }` for ZA divergence between the supplied file and the chosen isotope.
- Zip handling: `looks_like_zip` sniffs by both extension and the `PK\x03\x04` magic bytes so a renamed/extensionless archive still routes correctly. The body extractor was refactored from a `&self` method into a free function so the network and install paths share one implementation.
- GUI: a **"Load local ENDF file…"** button now sits next to *Add Isotope* / *Add Element* on the Configure step's Isotopes card. It opens an `rfd::FileDialog` (`.endf`/`.dat`/`.txt`/`.zip`), peeks the file's `(Z, A)`, looks it up in the user's selection, writes the body to the cache, and marks the matching entry `Pending` so the existing auto-fetch path picks it up — hitting the cache with no network round-trip.
- A small recovery hint prints the active library's cache directory alongside the **Retry failed** button so users can also drop files in by hand: *"Offline fallback: drop the ENDF file at `<cache_dir>` and click Retry, or use 'Load local ENDF file…' above."*

## Acceptance criteria from #523

| Criterion | Status |
|---|---|
| UA verified against `httpbin.org/user-agent` test | Replaced with `endf_user_agent_contains_version_and_contact` unit test that asserts UA contains `NEREIDS/<CARGO_PKG_VERSION>`, the project URL, and the contact mailbox. (No live network in unit tests.) |
| GUI exposes a "Load local ENDF file" button that loads a manually-downloaded ENDF for Ta-181 with no network access | ✓ — peek-once + cache-write flow; verified manually with W-184 fixture in unit tests |
| Fetch failure dialog includes the cache path + upstream URL so users can self-recover | ✓ — cache path shown in recovery hint next to *Retry failed*; upstream URL already in `EndfRetrievalError::RemoteAccessBlocked.url` (added by #520) and surfaced in `status_message` |

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --exclude nereids-python` — full workspace green (5/5 retrieval tests including new `peek_local_endf_extracts_isotope_from_zip_and_raw`, `install_local_endf_accepts_raw_endf_with_matching_isotope`, `install_local_endf_accepts_zip_archive`, `install_local_endf_rejects_isotope_mismatch`, `endf_user_agent_contains_version_and_contact`)
- [ ] **Manual E2E (recommended before merge):** GUI → Guided → Configure → add Ta-181 → force a fetch failure (block IAEA + NNDC at the OS level, or temporarily point the consts at unroutable addresses) → confirm FAIL chip + recovery-hint cache path → manually download `n_7328_73-Ta-181.zip` in Firefox → click "Load local ENDF file…" → verify status message "Loaded local ENDF for Ta-181" and the chip flips to OK with no network round-trip

## Review

Phase A self-audit was run on the first commit; the two P2s it surfaced (misleading error classification + N-pass zip re-extraction) are both fixed in the second commit by the single-pass peek/install refactor.