### PR TITLE
fix(mcp): emit fitted TZERO + exp-bg parameters in result JSON, add fit_energy_scale recovery test

### DIFF
--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -141,12 +141,12 @@ class FitResult:
 
     @property
     def back_d(self) -> float | None:
-        """Fitted exponential background amplitude (SAMMY BackD), or None when ``fit_back_d=False``."""
+        """Fitted exponential background amplitude (SAMMY BackD), or None when ``background=False`` or ``fit_back_d=False``."""
         ...
 
     @property
     def back_f(self) -> float | None:
-        """Fitted exponential background decay constant (SAMMY BackF), or None when ``fit_back_f=False``."""
+        """Fitted exponential background decay constant (SAMMY BackF), or None when ``background=False`` or ``fit_back_f=False``."""
         ...
 
     @property

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -140,13 +140,13 @@ class FitResult:
         ...
 
     @property
-    def back_d(self) -> float:
-        """Fitted exponential background amplitude (SAMMY BackD). Zero when not fitted."""
+    def back_d(self) -> float | None:
+        """Fitted exponential background amplitude (SAMMY BackD), or None when ``fit_back_d=False``."""
         ...
 
     @property
-    def back_f(self) -> float:
-        """Fitted exponential background decay constant (SAMMY BackF). Zero when not fitted."""
+    def back_f(self) -> float | None:
+        """Fitted exponential background decay constant (SAMMY BackF), or None when ``fit_back_f=False``."""
         ...
 
     @property

--- a/bindings/python/python/nereids/mcp/server.py
+++ b/bindings/python/python/nereids/mcp/server.py
@@ -596,7 +596,7 @@ def _fit_result_summary(result: Any, names: list[str]) -> dict[str, Any]:
                 else None,
             }
         )
-    return {
+    summary: dict[str, Any] = {
         "density_fits": entries,
         "reduced_chi_squared": _finite_float_or_none(result.reduced_chi_squared),
         "deviance_per_dof": None
@@ -610,6 +610,16 @@ def _fit_result_summary(result: Any, names: list[str]) -> dict[str, Any]:
         "anorm": _finite_float_or_none(result.anorm),
         "background": [_finite_float_or_none(v) for v in result.background],
     }
+    # Fitted TZERO (t0_us, l_scale) and exponential-background (back_d, back_f)
+    # parameters are populated on FitResult when the corresponding fit flags
+    # are set in the manifest's analysis.fit block. Emit them only when present
+    # so the schema stays backwards-compatible for fits that don't enable
+    # those flags (key absent rather than null, matching deviance_per_dof).
+    for attr in ("t0_us", "l_scale", "back_d", "back_f"):
+        value = getattr(result, attr, None)
+        if value is not None:
+            summary[attr] = _finite_float_or_none(value)
+    return summary
 
 
 def _process_single_spectrum(
@@ -954,9 +964,41 @@ def _process_density_map(
                 "uncertainty_atoms_per_barn": _array_stats(uncertainty_arr),
             }
         )
+
+    # SpatialResult exposes per-pixel anorm / background / t0 / l_scale maps
+    # when the corresponding fit flags are set on the spatial pipeline.
+    # Save the raw arrays into the NPZ (so downstream consumers can
+    # reconstruct the model curve per-pixel) and surface aggregate stats
+    # in the JSON summary.  Per-pixel back_d_map / back_f_map are not yet
+    # exposed on SpatialResult; tracked as a Rust-side follow-up.
+    fit_param_stats: dict[str, Any] = {}
+    anorm_map = getattr(result, "anorm_map", None)
+    if anorm_map is not None:
+        anorm_arr = np.asarray(anorm_map)
+        arrays_to_save["anorm_map"] = anorm_arr
+        fit_param_stats["anorm"] = _array_stats(anorm_arr)
+    background_maps = getattr(result, "background_maps", None)
+    if background_maps is not None:
+        bm_stats = []
+        for term_idx, bm in enumerate(background_maps):
+            bm_arr = np.asarray(bm)
+            arrays_to_save[f"background_term_{term_idx}_map"] = bm_arr
+            bm_stats.append(_array_stats(bm_arr))
+        fit_param_stats["background"] = bm_stats
+    t0_us_map = getattr(result, "t0_us_map", None)
+    if t0_us_map is not None:
+        t0_arr = np.asarray(t0_us_map)
+        arrays_to_save["t0_us_map"] = t0_arr
+        fit_param_stats["t0_us"] = _array_stats(t0_arr)
+    l_scale_map = getattr(result, "l_scale_map", None)
+    if l_scale_map is not None:
+        l_arr = np.asarray(l_scale_map)
+        arrays_to_save["l_scale_map"] = l_arr
+        fit_param_stats["l_scale"] = _array_stats(l_arr)
+
     np.savez_compressed(result_npz, **arrays_to_save)
 
-    return {
+    summary: dict[str, Any] = {
         "mode": "density_map",
         "input_kind": input_kind,
         "data_path": None if path is None else str(path),
@@ -970,6 +1012,9 @@ def _process_density_map(
         "density_maps": density_stats,
         "crop": crop,
     }
+    if fit_param_stats:
+        summary["fit_param_stats"] = fit_param_stats
+    return summary
 
 
 def _validate_workflow(manifest: dict[str, Any]) -> dict[str, Any]:

--- a/bindings/python/python/nereids/mcp/server.py
+++ b/bindings/python/python/nereids/mcp/server.py
@@ -966,11 +966,15 @@ def _process_density_map(
         )
 
     # SpatialResult exposes per-pixel anorm / background / t0 / l_scale maps
-    # when the corresponding fit flags are set on the spatial pipeline.
-    # Save the raw arrays into the NPZ (so downstream consumers can
-    # reconstruct the model curve per-pixel) and surface aggregate stats
-    # in the JSON summary.  Per-pixel back_d_map / back_f_map are not yet
-    # exposed on SpatialResult; tracked as a Rust-side follow-up.
+    # whenever the spatial pipeline ran with the corresponding *feature*
+    # enabled (e.g. `background=True` materialises all three terms of
+    # `background_maps` — including NaN-per-pixel entries for terms that
+    # were not actually fit — and `fit_energy_scale=True` materialises
+    # both t0/L scale maps).  Save the raw arrays into the NPZ (so
+    # downstream consumers can reconstruct the model curve per-pixel) and
+    # surface aggregate stats in the JSON summary.  Per-pixel
+    # back_d_map / back_f_map are not yet exposed on SpatialResult;
+    # tracked as a Rust-side follow-up (#538).
     fit_param_stats: dict[str, Any] = {}
     anorm_map = getattr(result, "anorm_map", None)
     if anorm_map is not None:

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -404,11 +404,15 @@ struct PyFitResult {
     /// Counts KL background uses `[b0, b1, alpha_2]`.
     background: [f64; 3],
     /// Fitted exponential background amplitude (SAMMY BackD).
-    /// Zero when exponential tail is not fitted.
-    back_d: f64,
+    /// `None` when ``fit_back_d=False`` (the inner Rust ``FitResult.back_d``
+    /// is `0.0` in that case; we surface that as `None` at the Python
+    /// boundary so MCP consumers can distinguish "fit was active and
+    /// recovered 0.0" from "exponential background never engaged" —
+    /// mirroring the `t0_us` / `l_scale` convention).
+    back_d: Option<f64>,
     /// Fitted exponential background decay constant (SAMMY BackF).
-    /// Zero when exponential tail is not fitted.
-    back_f: f64,
+    /// `None` when ``fit_back_f=False``; see `back_d` for rationale.
+    back_f: Option<f64>,
     /// Fitted TOF offset in microseconds (SAMMY TZERO t₀).
     /// None when energy-scale fitting is not enabled.
     t0_us: Option<f64>,
@@ -487,16 +491,16 @@ impl PyFitResult {
     }
 
     /// Fitted exponential background amplitude (SAMMY BackD).
-    /// Zero when exponential tail is not fitted.
+    /// `None` when ``fit_back_d=False``.
     #[getter]
-    fn back_d(&self) -> f64 {
+    fn back_d(&self) -> Option<f64> {
         self.back_d
     }
 
     /// Fitted exponential background decay constant (SAMMY BackF).
-    /// Zero when exponential tail is not fitted.
+    /// `None` when ``fit_back_f=False``.
     #[getter]
-    fn back_f(&self) -> f64 {
+    fn back_f(&self) -> Option<f64> {
         self.back_f
     }
 
@@ -3532,8 +3536,16 @@ fn py_fit_counts_spectrum_typed<'py>(
         temperature_k_unc: result.temperature_k_unc,
         anorm: result.anorm,
         background: result.background,
-        back_d: result.back_d,
-        back_f: result.back_f,
+        back_d: if fit_back_d {
+            Some(result.back_d)
+        } else {
+            None
+        },
+        back_f: if fit_back_f {
+            Some(result.back_f)
+        } else {
+            None
+        },
         t0_us: result.t0_us,
         l_scale: result.l_scale,
         deviance_per_dof: result.deviance_per_dof,
@@ -4025,8 +4037,16 @@ fn py_fit_spectrum_typed<'py>(
         temperature_k_unc: result.temperature_k_unc,
         anorm: result.anorm,
         background: result.background,
-        back_d: result.back_d,
-        back_f: result.back_f,
+        back_d: if fit_back_d {
+            Some(result.back_d)
+        } else {
+            None
+        },
+        back_f: if fit_back_f {
+            Some(result.back_f)
+        } else {
+            None
+        },
         t0_us: result.t0_us,
         l_scale: result.l_scale,
         deviance_per_dof: result.deviance_per_dof,

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -404,14 +404,19 @@ struct PyFitResult {
     /// Counts KL background uses `[b0, b1, alpha_2]`.
     background: [f64; 3],
     /// Fitted exponential background amplitude (SAMMY BackD).
-    /// `None` when ``fit_back_d=False`` (the inner Rust ``FitResult.back_d``
-    /// is `0.0` in that case; we surface that as `None` at the Python
-    /// boundary so MCP consumers can distinguish "fit was active and
-    /// recovered 0.0" from "exponential background never engaged" —
-    /// mirroring the `t0_us` / `l_scale` convention).
+    /// `None` whenever the polynomial background model was not active
+    /// — i.e. either ``background=False`` (the bg model is never
+    /// attached, so the inner Rust ``FitResult.back_d`` is the
+    /// sentinel `0.0`) or ``background=True`` with ``fit_back_d=False``
+    /// (bg model attached but BackD was held at its initial value).
+    /// We surface that as `None` at the Python boundary so MCP
+    /// consumers can distinguish "fit was active and recovered 0.0"
+    /// from "exponential background never engaged" — mirroring the
+    /// `t0_us` / `l_scale` convention.
     back_d: Option<f64>,
     /// Fitted exponential background decay constant (SAMMY BackF).
-    /// `None` when ``fit_back_f=False``; see `back_d` for rationale.
+    /// `None` when ``background=False`` OR ``fit_back_f=False``;
+    /// see `back_d` for the full rationale.
     back_f: Option<f64>,
     /// Fitted TOF offset in microseconds (SAMMY TZERO t₀).
     /// None when energy-scale fitting is not enabled.
@@ -491,14 +496,14 @@ impl PyFitResult {
     }
 
     /// Fitted exponential background amplitude (SAMMY BackD).
-    /// `None` when ``fit_back_d=False``.
+    /// `None` when ``background=False`` OR ``fit_back_d=False``.
     #[getter]
     fn back_d(&self) -> Option<f64> {
         self.back_d
     }
 
     /// Fitted exponential background decay constant (SAMMY BackF).
-    /// `None` when ``fit_back_f=False``.
+    /// `None` when ``background=False`` OR ``fit_back_f=False``.
     #[getter]
     fn back_f(&self) -> Option<f64> {
         self.back_f
@@ -3536,12 +3541,19 @@ fn py_fit_counts_spectrum_typed<'py>(
         temperature_k_unc: result.temperature_k_unc,
         anorm: result.anorm,
         background: result.background,
-        back_d: if fit_back_d {
+        // BackD / BackF are only meaningful when the polynomial background
+        // model was actually attached (the `if background { ... }` block
+        // above never runs when `background=False`, so `result.back_d` and
+        // `result.back_f` are sentinel zeros from the inner Rust
+        // `FitResult`).  Reporting them in that case falsely tells MCP
+        // consumers the exponential tail was fitted, so we gate on both
+        // `background` AND the per-term flag.
+        back_d: if background && fit_back_d {
             Some(result.back_d)
         } else {
             None
         },
-        back_f: if fit_back_f {
+        back_f: if background && fit_back_f {
             Some(result.back_f)
         } else {
             None
@@ -4037,12 +4049,19 @@ fn py_fit_spectrum_typed<'py>(
         temperature_k_unc: result.temperature_k_unc,
         anorm: result.anorm,
         background: result.background,
-        back_d: if fit_back_d {
+        // BackD / BackF are only meaningful when the polynomial background
+        // model was actually attached (the `if background { ... }` block
+        // above never runs when `background=False`, so `result.back_d` and
+        // `result.back_f` are sentinel zeros from the inner Rust
+        // `FitResult`).  Reporting them in that case falsely tells MCP
+        // consumers the exponential tail was fitted, so we gate on both
+        // `background` AND the per-term flag.
+        back_d: if background && fit_back_d {
             Some(result.back_d)
         } else {
             None
         },
-        back_f: if fit_back_f {
+        back_f: if background && fit_back_f {
             Some(result.back_f)
         } else {
             None

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -737,3 +737,264 @@ class TestManifestWorkflowTools:
         assert summary["reduced_chi_squared"] is None
         assert summary["deviance_per_dof"] is None
         json.dumps(_json_safe(summary), allow_nan=False)
+
+    def test_fit_summary_emits_energy_scale_and_background_fields(self):
+        """Issue #530: when the LM solver fits t0/L_scale/back_d/back_f,
+        those values must appear in the result summary.  Before the fix,
+        `_fit_result_summary` only emitted `anorm` and `background`;
+        the four extra scalars were silently dropped, making it
+        impossible to tell whether the manifest's fit flags were
+        exercised and impossible to reconstruct the model curve.
+        """
+        result = SimpleNamespace(
+            densities=np.asarray([0.001]),
+            uncertainties=np.asarray([1.0e-5]),
+            reduced_chi_squared=1.2,
+            deviance_per_dof=None,
+            converged=True,
+            iterations=17,
+            temperature_k=293.6,
+            anorm=0.99,
+            background=[0.01, -1e-4, 5e-7],
+            t0_us=0.4662,
+            l_scale=1.005273,
+            back_d=0.0796,
+            back_f=1.10e-4,
+        )
+
+        summary = _fit_result_summary(result, ["U-238"])
+
+        assert summary["t0_us"] == pytest.approx(0.4662)
+        assert summary["l_scale"] == pytest.approx(1.005273)
+        assert summary["back_d"] == pytest.approx(0.0796)
+        assert summary["back_f"] == pytest.approx(1.10e-4)
+        json.dumps(_json_safe(summary), allow_nan=False)
+
+    def test_fit_summary_omits_energy_scale_fields_when_unset(self):
+        """Backwards-compat: fits without the new flags emit a summary
+        with the four extra keys *absent* (not present-with-null), so
+        downstream consumers can keep using `"key" in summary` to
+        detect whether each flag was active.  Matches the existing
+        `deviance_per_dof` / `temperature_k` pattern.
+        """
+        result = SimpleNamespace(
+            densities=np.asarray([0.001]),
+            uncertainties=np.asarray([1.0e-5]),
+            reduced_chi_squared=1.2,
+            deviance_per_dof=None,
+            converged=True,
+            iterations=12,
+            temperature_k=293.6,
+            anorm=1.0,
+            background=[0.0, 0.0, 0.0],
+            t0_us=None,
+            l_scale=None,
+            back_d=None,
+            back_f=None,
+        )
+
+        summary = _fit_result_summary(result, ["U-238"])
+
+        assert "t0_us" not in summary
+        assert "l_scale" not in summary
+        assert "back_d" not in summary
+        assert "back_f" not in summary
+        # Existing keys must still be present.
+        assert "anorm" in summary
+        assert "background" in summary
+
+    def test_fit_summary_emits_energy_scale_via_real_fit(self):
+        """End-to-end variant of the SimpleNamespace gates above: drive a
+        real `nereids.fit_spectrum_typed` LM fit with `fit_energy_scale=True`
+        and confirm the new keys make it into the summary returned to MCP
+        callers.  Catches regressions where the binding stops populating
+        `result.t0_us` / `result.l_scale` on the actual `PyFitResult`.
+        """
+        energies = np.linspace(4.0, 30.0, 400)
+        isotope = _synthetic_u238_data()
+        t = np.asarray(nereids.forward_model(energies, [(isotope, 1.0e-3)]))
+        sigma = np.full_like(t, 0.005)
+
+        result = nereids.fit_spectrum_typed(
+            transmission=t,
+            uncertainty=sigma,
+            energies=energies,
+            isotopes=[(isotope, 1.0e-3)],
+            solver="lm",
+            temperature_k=293.6,
+            max_iter=100,
+            background=True,
+            fit_back_d=True,
+            fit_back_f=True,
+            fit_energy_scale=True,
+            t0_init_us=0.0,
+            l_scale_init=1.0,
+            energy_scale_flight_path_m=25.0,
+        )
+
+        summary = _fit_result_summary(result, ["U-238"])
+
+        for key in ("t0_us", "l_scale", "back_d", "back_f"):
+            assert key in summary, f"summary missing {key}: {sorted(summary)}"
+            value = summary[key]
+            assert isinstance(value, float) and np.isfinite(value), (
+                f"summary[{key!r}] not a finite float: {value!r}"
+            )
+        # Round-trip strict-JSON-safe so downstream MCP serialization
+        # cannot break on the new fields.
+        json.dumps(_json_safe(summary), allow_nan=False)
+
+    def test_process_single_spectrum_manifest_emits_energy_scale_keys(self, tmp_path):
+        """Manifest-driven path: enabling `fit_energy_scale` / `fit_back_d`
+        / `fit_back_f` in the manifest's analysis.fit block must surface
+        the corresponding scalars in the `results` block of the JSON the
+        MCP server returns.  Closes the #530 acceptance criterion.
+        """
+        energies = np.linspace(4.0, 30.0, 200)
+        true_density = 1.0e-3
+        isotope = _synthetic_u238_data()
+        transmission = np.asarray(
+            nereids.forward_model(energies, [(isotope, true_density)])
+        )
+        np.savez(
+            tmp_path / "spectrum.npz",
+            energies_ev=energies,
+            transmission=transmission,
+            uncertainty=np.full_like(transmission, 0.005),
+        )
+        _write_json_frontmatter_manifest(
+            tmp_path,
+            {
+                "mode": "single_spectrum",
+                "data": {"kind": "transmission_npz", "path": "spectrum.npz"},
+                "isotopes": [_synthetic_u238_entry(initial_density=true_density)],
+                "fit": {
+                    "solver": "lm",
+                    "max_iter": 80,
+                    "background": True,
+                    "fit_back_d": True,
+                    "fit_back_f": True,
+                    "fit_energy_scale": True,
+                    "t0_init_us": 0.0,
+                    "l_scale_init": 1.0,
+                    "energy_scale_flight_path_m": 25.0,
+                },
+                "resolution": {"kind": "none"},
+                "output": {"directory": "output"},
+            },
+        )
+
+        result = process_resonance_dataset(str(tmp_path))
+
+        assert result["success"] is True
+        results_block = result["results"]
+        for key in ("t0_us", "l_scale", "back_d", "back_f"):
+            assert key in results_block, (
+                f"results block missing {key}: keys={sorted(results_block)}"
+            )
+            assert isinstance(results_block[key], float)
+            assert np.isfinite(results_block[key])
+
+    def test_process_density_map_manifest_emits_fit_param_stats(self, tmp_path):
+        """Spatial counterpart of #530: `_process_density_map` previously
+        emitted only `density_maps` — no `anorm` / `background` / `t0` /
+        `L_scale` info, even though `SpatialResult` exposes those as
+        per-pixel maps when `fit_energy_scale` is on.  Backwards-compat:
+        the key is absent when no energy-scale-related maps are populated.
+        """
+        energies = np.linspace(4.0, 30.0, 120)
+        true_density = 1.0e-3
+        isotope = _synthetic_u238_data()
+        spectrum = np.asarray(
+            nereids.forward_model(energies, [(isotope, true_density)])
+        )
+        # Tiny 2x2 cube so the test stays fast.
+        cube = np.tile(spectrum[:, None, None], (1, 2, 2))
+        np.savez(
+            tmp_path / "density-map.npz",
+            energies_ev=energies,
+            transmission=cube,
+            uncertainty=np.full_like(cube, 0.005),
+        )
+        _write_json_frontmatter_manifest(
+            tmp_path,
+            {
+                "mode": "density_map",
+                "data": {"kind": "transmission_npz", "path": "density-map.npz"},
+                "isotopes": [_synthetic_u238_entry(initial_density=true_density)],
+                "fit": {
+                    "solver": "lm",
+                    "max_iter": 80,
+                    "background": True,
+                    "fit_energy_scale": True,
+                    "t0_init_us": 0.0,
+                    "l_scale_init": 1.0,
+                    "energy_scale_flight_path_m": 25.0,
+                },
+                "resolution": {"kind": "none"},
+                "output": {"directory": "output"},
+            },
+        )
+
+        result = process_resonance_dataset(str(tmp_path))
+
+        assert result["success"] is True
+        stats = result["results"].get("fit_param_stats")
+        assert stats is not None, (
+            f"fit_param_stats absent when fit_energy_scale=True; "
+            f"keys={sorted(result['results'])}"
+        )
+        # Per-pixel anorm + 3-term background + t0/L_scale maps must all
+        # be summarised — the four scalars `SpatialResult` exposes.
+        # `back_d` / `back_f` are NOT in the spatial result type yet
+        # (per-pixel back_d_map / back_f_map are not exposed on
+        # SpatialResult); tracked as a follow-up.
+        for key in ("anorm", "background", "t0_us", "l_scale"):
+            assert key in stats, f"fit_param_stats missing {key}: {sorted(stats)}"
+        # The npz must carry the raw arrays so downstream consumers
+        # can reconstruct the model curve per pixel.
+        npz = np.load(tmp_path / "output" / "nereids_density_map.npz")
+        try:
+            for arr_key in ("anorm_map", "t0_us_map", "l_scale_map"):
+                assert arr_key in npz.files, (
+                    f"density-map npz missing {arr_key}: {npz.files}"
+                )
+        finally:
+            npz.close()
+
+    def test_process_density_map_manifest_omits_fit_param_stats_by_default(
+        self, tmp_path
+    ):
+        """When no fit-energy-scale / per-pixel background flags are
+        set, the spatial summary must NOT carry a `fit_param_stats`
+        key — matching the pre-fix schema for unrelated consumers.
+        """
+        energies = np.linspace(4.0, 30.0, 120)
+        true_density = 1.0e-3
+        isotope = _synthetic_u238_data()
+        spectrum = np.asarray(
+            nereids.forward_model(energies, [(isotope, true_density)])
+        )
+        cube = np.tile(spectrum[:, None, None], (1, 2, 2))
+        np.savez(
+            tmp_path / "density-map.npz",
+            energies_ev=energies,
+            transmission=cube,
+            uncertainty=np.full_like(cube, 0.005),
+        )
+        _write_json_frontmatter_manifest(
+            tmp_path,
+            {
+                "mode": "density_map",
+                "data": {"kind": "transmission_npz", "path": "density-map.npz"},
+                "isotopes": [_synthetic_u238_entry(initial_density=true_density)],
+                "fit": {"solver": "lm", "max_iter": 50},
+                "resolution": {"kind": "none"},
+                "output": {"directory": "output"},
+            },
+        )
+
+        result = process_resonance_dataset(str(tmp_path))
+
+        assert result["success"] is True
+        assert "fit_param_stats" not in result["results"]

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -844,6 +844,61 @@ class TestManifestWorkflowTools:
         # cannot break on the new fields.
         json.dumps(_json_safe(summary), allow_nan=False)
 
+    def test_fit_summary_omits_back_d_back_f_via_real_fit_when_disabled(self):
+        """Regression for the "omit-when-unset" contract on the *real*
+        `PyFitResult` (not just a SimpleNamespace stub).  Before the
+        Rust-side fix that changed `PyFitResult.back_d` / `back_f` to
+        `Option<f64>`, a real fit with `fit_back_d=False, fit_back_f=False`
+        produced `result.back_d == 0.0` (and ditto `back_f`), which the
+        summary's ``if value is not None`` gate would emit as
+        ``"back_d": 0.0`` — misleading consumers into thinking the
+        exponential background was enabled.  This test exercises the
+        real binding to lock that contract.
+        """
+        energies = np.linspace(4.0, 30.0, 200)
+        isotope = _synthetic_u238_data()
+        t = np.asarray(nereids.forward_model(energies, [(isotope, 1.0e-3)]))
+        sigma = np.full_like(t, 0.005)
+
+        result = nereids.fit_spectrum_typed(
+            transmission=t,
+            uncertainty=sigma,
+            energies=energies,
+            isotopes=[(isotope, 1.0e-3)],
+            solver="lm",
+            temperature_k=293.6,
+            max_iter=80,
+            # Note: background=True so the polynomial background runs,
+            # but fit_back_d / fit_back_f are deliberately false — only
+            # the exponential terms should be absent from the summary.
+            background=True,
+            fit_back_d=False,
+            fit_back_f=False,
+        )
+
+        # Real binding now returns None for unfit exponential terms.
+        assert result.back_d is None, (
+            f"PyFitResult.back_d should be None when fit_back_d=False, "
+            f"got {result.back_d!r}"
+        )
+        assert result.back_f is None, (
+            f"PyFitResult.back_f should be None when fit_back_f=False, "
+            f"got {result.back_f!r}"
+        )
+
+        summary = _fit_result_summary(result, ["U-238"])
+        assert "back_d" not in summary, (
+            f"summary should not carry back_d when fit_back_d=False, got "
+            f"{summary.get('back_d')!r}"
+        )
+        assert "back_f" not in summary, (
+            f"summary should not carry back_f when fit_back_f=False, got "
+            f"{summary.get('back_f')!r}"
+        )
+        # The polynomial background scalars must still be present.
+        assert "anorm" in summary
+        assert "background" in summary
+
     def test_process_single_spectrum_manifest_emits_energy_scale_keys(self, tmp_path):
         """Manifest-driven path: enabling `fit_energy_scale` / `fit_back_d`
         / `fit_back_f` in the manifest's analysis.fit block must surface
@@ -952,12 +1007,48 @@ class TestManifestWorkflowTools:
         for key in ("anorm", "background", "t0_us", "l_scale"):
             assert key in stats, f"fit_param_stats missing {key}: {sorted(stats)}"
         # The npz must carry the raw arrays so downstream consumers
-        # can reconstruct the model curve per pixel.
+        # can reconstruct the model curve per pixel.  Re-run the spatial
+        # fit independently with the same inputs and assert the NPZ
+        # arrays bit-match `SpatialResult.{anorm_map, t0_us_map,
+        # l_scale_map}`: this defends against a future refactor that
+        # swaps the wrong array into `arrays_to_save` (the inner fit
+        # is deterministic on a fixed cube, so bit-equal is the right
+        # tolerance, not approx).
+        independent = nereids.spatial_map_typed(
+            nereids.from_transmission(
+                cube, np.full_like(cube, 0.005)
+            ),
+            energies,
+            [isotope],
+            initial_densities=[true_density],
+            solver="lm",
+            temperature_k=293.6,
+            max_iter=80,
+            background=True,
+            fit_energy_scale=True,
+            t0_init_us=0.0,
+            l_scale_init=1.0,
+            energy_scale_flight_path_m=25.0,
+        )
         npz = np.load(tmp_path / "output" / "nereids_density_map.npz")
         try:
-            for arr_key in ("anorm_map", "t0_us_map", "l_scale_map"):
+            for arr_key, attr in (
+                ("anorm_map", "anorm_map"),
+                ("t0_us_map", "t0_us_map"),
+                ("l_scale_map", "l_scale_map"),
+            ):
                 assert arr_key in npz.files, (
                     f"density-map npz missing {arr_key}: {npz.files}"
+                )
+                expected = np.asarray(getattr(independent, attr))
+                np.testing.assert_array_equal(
+                    npz[arr_key],
+                    expected,
+                    err_msg=(
+                        f"NPZ {arr_key} does not match SpatialResult.{attr} — "
+                        f"the manifest-driven server may be writing the "
+                        f"wrong array under this key"
+                    ),
                 )
         finally:
             npz.close()

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -899,6 +899,50 @@ class TestManifestWorkflowTools:
         assert "anorm" in summary
         assert "background" in summary
 
+    def test_fit_summary_omits_back_d_back_f_when_background_disabled(self):
+        """Codex Round 1 follow-up: ``fit_back_d=True, fit_back_f=True`` with
+        ``background=False`` is a nonsensical-but-legal kwarg combination
+        — the ``if background { ... }`` block in
+        ``py_fit_spectrum_typed`` never attaches the bg model, so the
+        inner Rust ``FitResult.back_d`` / ``back_f`` are sentinel zeros.
+        Before this fix, the Python binding gated emission solely on
+        ``fit_back_d`` / ``fit_back_f``, so the summary would falsely
+        carry ``"back_d": 0.0`` and tell MCP consumers the exponential
+        tail was fitted.  Now the gate also requires ``background=True``.
+        """
+        energies = np.linspace(4.0, 30.0, 200)
+        isotope = _synthetic_u238_data()
+        t = np.asarray(nereids.forward_model(energies, [(isotope, 1.0e-3)]))
+        sigma = np.full_like(t, 0.005)
+
+        result = nereids.fit_spectrum_typed(
+            transmission=t,
+            uncertainty=sigma,
+            energies=energies,
+            isotopes=[(isotope, 1.0e-3)],
+            solver="lm",
+            temperature_k=293.6,
+            max_iter=80,
+            # The contradictory combination Codex flagged: per-term
+            # flags on, polynomial background OFF.  Should produce
+            # None on the binding regardless of fit_back_d / fit_back_f.
+            background=False,
+            fit_back_d=True,
+            fit_back_f=True,
+        )
+
+        assert result.back_d is None, (
+            f"PyFitResult.back_d should be None when background=False even "
+            f"if fit_back_d=True, got {result.back_d!r}"
+        )
+        assert result.back_f is None, (
+            f"PyFitResult.back_f should be None when background=False even "
+            f"if fit_back_f=True, got {result.back_f!r}"
+        )
+        summary = _fit_result_summary(result, ["U-238"])
+        assert "back_d" not in summary
+        assert "back_f" not in summary
+
     def test_process_single_spectrum_manifest_emits_energy_scale_keys(self, tmp_path):
         """Manifest-driven path: enabling `fit_energy_scale` / `fit_back_d`
         / `fit_back_f` in the manifest's analysis.fit block must surface

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -1675,3 +1675,224 @@ class TestFitEnergyRangeBindingParameter:
             f"would leave the param at the seed)"
         )
 
+
+# ===========================================================================
+# fit_energy_scale recovery (#531 — single-spectrum LM, SAMMY TZERO)
+# ===========================================================================
+
+
+# SAMMY TZERO time-of-flight constant: TOF_FACTOR = sqrt(m_n / (2·eV)) · 1e6.
+# Same formula as `EnergyScaleTransmissionModel::new` in
+# `crates/nereids-fitting/src/transmission_model.rs`, using the CODATA-2018
+# constants from `nereids-core::constants` (NEUTRON_MASS_KG = 1.674927498e-27,
+# EV_TO_JOULES = 1.602176634e-19) so this test stays bit-identical to the
+# Rust side; hardcoding 72.297 would drift by ~1e-5 relative on the energy
+# inversion and silently bias the recovered t0.
+_NEUTRON_MASS_KG = 1.674_927_498_04e-27
+_EV_TO_JOULES = 1.602_176_634e-19
+_TOF_FACTOR = np.sqrt(0.5 * _NEUTRON_MASS_KG / _EV_TO_JOULES) * 1.0e6
+
+
+def _measured_energies_for_known_tzero(
+    e_true: np.ndarray,
+    *,
+    t0_true_us: float,
+    l_scale_true: float,
+    l_nom_m: float,
+) -> np.ndarray:
+    """Inverse of `EnergyScaleTransmissionModel::corrected_energies`.
+
+    Given the *true* corrected energies the physics produced and the
+    instrument's true (t0, L_scale), return the *measured* (nominal)
+    energy grid the data would be reported on so that
+    `corrected_energies(E_meas, t0_true, L_scale_true) ≈ E_true`.
+
+    Forward map (Rust):
+        tof_meas[i] = TOF_FACTOR · L_nom / √E_meas[i]
+        E_corr[i]   = (TOF_FACTOR · L_eff / (tof_meas[i] − t0))²
+                    where L_eff = L_nom · L_scale.
+    Inverting for E_meas given E_true ≡ E_corr:
+        tof_meas[i] = t0 + TOF_FACTOR · L_nom · L_scale_true / √E_true[i]
+        E_meas[i]   = (TOF_FACTOR · L_nom / tof_meas[i])²
+    """
+    tof_meas = t0_true_us + _TOF_FACTOR * l_nom_m * l_scale_true / np.sqrt(e_true)
+    return (_TOF_FACTOR * l_nom_m / tof_meas) ** 2
+
+
+class TestFitEnergyScaleRecovery:
+    """Exercises the `fit_energy_scale=True` branch of `fit_spectrum_typed`
+    end-to-end.  This is the only Python-level test that does so — the
+    existing coverage in `crates/nereids-pipeline/src/spatial.rs` runs
+    the spatial pipeline (a different binding entry point) and would not
+    catch a silent regression in `py_fit_spectrum_typed`'s
+    `config.with_energy_scale(...)` branch.
+
+    Gate strategy (per #531).  The test injects a known (t0, L_scale)
+    calibration offset, then verifies the fit's *physically observable*
+    output — not the individual parameter values — for three reasons:
+
+    1.  (t0, L_scale) are coupled.  At a single resonance, position alone
+        gives one constraint for two unknowns; multiple resonances lift
+        the degeneracy, but the LM cost surface still has a shallow
+        valley along the line  ``t0 ≈ const - L_scale × something(E)``.
+        Tightening individual-parameter tolerances below the valley width
+        produces flaky tests without catching the regression we care
+        about (silent disable).
+    2.  At realistic neutron-imaging temperatures (293 K) the Doppler
+        kernel applied to the *corrected* energies is not bit-identical
+        to the kernel applied during data synthesis on the true grid;
+        this contributes a small residual bias (~few percent) to the
+        recovered density even on noiseless data, distinct from the
+        bug under test.
+    3.  The bug to catch is a silent ``fit_energy_scale=True`` disable.
+        That is detected by  (a) the χ² ratio between baseline (flag off)
+        and calibrated (flag on),  (b) the presence of finite t0_us /
+        l_scale on the FitResult,  and  (c) the recovered *effective*
+        energy mapping agreeing with truth.  All three would fail if the
+        flag silently became a no-op.
+    """
+
+    def test_recovers_injected_t0_and_l_scale(self):
+        L_NOM = 25.0
+        T0_TRUE = 0.5  # μs
+        L_SCALE_TRUE = 1.005
+        TRUE_DENSITY = 3.0e-4
+
+        # Multi-resonance U-238 fixture.  Three well-separated resonances
+        # (6.67 / 20.87 / 36.68 eV, standard SAMMY benchmark values)
+        # supply three position constraints — enough to lift the
+        # (t0, L_scale) degeneracy a single peak would leave (see
+        # class docstring point 1).
+        u238 = nereids.create_resonance_data(
+            z=92,
+            a=238,
+            awr=236.006,
+            scattering_radius=9.48,
+            resonances=[
+                (6.67, 0.5, 0.0015, 0.023),
+                (20.87, 0.5, 0.0103, 0.026),
+                (36.68, 0.5, 0.0344, 0.027),
+            ],
+            target_spin=0.0,
+        )
+
+        # True (corrected) energy grid spanning all three resonances.
+        # Linear-in-TOF sampling so peak widths are sampled uniformly
+        # in the data's native coordinate (matches real instruments).
+        tof_lo = _TOF_FACTOR * L_NOM / np.sqrt(45.0)
+        tof_hi = _TOF_FACTOR * L_NOM / np.sqrt(4.0)
+        tof_grid = np.linspace(tof_lo, tof_hi, 800)
+        e_true = np.sort((_TOF_FACTOR * L_NOM / tof_grid) ** 2)
+
+        # Clean transmission at the TRUE energies.  Match forward_model's
+        # default 293.6 K Doppler temperature on the fit side.
+        t_clean = np.asarray(
+            nereids.forward_model(e_true, [(u238, TRUE_DENSITY)])
+        )
+
+        # Measured energy grid: what the instrument reports given the
+        # unknown (T0_TRUE, L_SCALE_TRUE) calibration offset.  Without
+        # the energy-scale fit branch, the solver evaluates σ at this
+        # *wrong* grid and density / χ² blow up.
+        e_meas = _measured_energies_for_known_tzero(
+            e_true,
+            t0_true_us=T0_TRUE,
+            l_scale_true=L_SCALE_TRUE,
+            l_nom_m=L_NOM,
+        )
+
+        rng = np.random.default_rng(20260514)
+        sigma_noise = 0.005
+        t_obs = t_clean + rng.normal(0.0, sigma_noise, size=t_clean.shape)
+        sigma = np.full_like(t_obs, sigma_noise)
+
+        baseline_kwargs = dict(
+            transmission=t_obs,
+            uncertainty=sigma,
+            energies=e_meas,
+            isotopes=[(u238, TRUE_DENSITY)],
+            solver="lm",
+            temperature_k=293.6,
+            max_iter=200,
+        )
+
+        # Baseline: no energy-scale fit.  σ is evaluated at E_meas
+        # (shifted by the injected calibration), so the model peaks
+        # never line up with the data and χ² stays large.
+        r_baseline = nereids.fit_spectrum_typed(**baseline_kwargs)
+
+        # Energy-scale fit ON.  Solver maps E_meas → estimated E_true
+        # via internal `corrected_energies(t0, L_scale)`.
+        r_calibrated = nereids.fit_spectrum_typed(
+            **baseline_kwargs,
+            fit_energy_scale=True,
+            t0_init_us=0.0,
+            l_scale_init=1.0,
+            energy_scale_flight_path_m=L_NOM,
+        )
+
+        # 1. The calibrated fit must converge.
+        assert bool(r_calibrated.converged) is True, (
+            f"calibrated fit did not converge: "
+            f"iters={int(r_calibrated.iterations)}, "
+            f"chi2_r={float(r_calibrated.reduced_chi_squared):.4e}"
+        )
+
+        # 2. t0_us and l_scale must be populated (not None) on the
+        # FitResult.  A silent regression that dropped
+        # `config.with_energy_scale(...)` would leave these as None.
+        assert r_calibrated.t0_us is not None, (
+            "result.t0_us is None — fit_energy_scale=True was likely "
+            "silently disabled in py_fit_spectrum_typed"
+        )
+        assert r_calibrated.l_scale is not None, (
+            "result.l_scale is None — fit_energy_scale=True was likely "
+            "silently disabled in py_fit_spectrum_typed"
+        )
+        assert np.isfinite(float(r_calibrated.t0_us))
+        assert np.isfinite(float(r_calibrated.l_scale))
+
+        # 3. χ²-ratio gate — the primary silent-disable detector.  With
+        # the injected ~0.5 % calibration offset the baseline fit
+        # produces χ²_r ~ O(10²-10³); the calibrated fit drops it by
+        # at least 10× (typically 100×+).  If the flag is silently
+        # ignored, both fits return the same χ² and this fires.
+        chi2_baseline = float(r_baseline.reduced_chi_squared)
+        chi2_calibrated = float(r_calibrated.reduced_chi_squared)
+        assert chi2_calibrated < chi2_baseline / 10.0, (
+            f"calibrated χ²_r={chi2_calibrated:.4e} not ≥10× better than "
+            f"baseline χ²_r={chi2_baseline:.4e}; fit_energy_scale=True "
+            f"may be silently disabled"
+        )
+
+        # 4. Effective energy-mapping recovery.  Recompute the fit's
+        # corrected energies in Python using the SAME formula as
+        # `EnergyScaleTransmissionModel::corrected_energies`, then
+        # compare against E_true.  This gates the *physics* without
+        # being sensitive to which point in the (t0, L_scale) valley
+        # the LM solver settled at.  1 % relative is well inside the
+        # ~0.5 % calibration offset injected — a silent disable would
+        # leave the mapping at identity (E_corr = E_meas), producing
+        # max-rel-err ~5 % at the low-energy end of the grid.
+        tof_meas = _TOF_FACTOR * L_NOM / np.sqrt(e_meas)
+        l_eff_fit = L_NOM * float(r_calibrated.l_scale)
+        e_corr_fit = (_TOF_FACTOR * l_eff_fit / (tof_meas - float(r_calibrated.t0_us))) ** 2
+        max_rel_err = float(np.max(np.abs(e_corr_fit - e_true) / e_true))
+        assert max_rel_err < 1.0e-2, (
+            f"effective energy mapping not recovered: max rel err "
+            f"{max_rel_err:.3e}, fit_(t0, L_scale)="
+            f"({float(r_calibrated.t0_us):.4f}, "
+            f"{float(r_calibrated.l_scale):.6f})"
+        )
+
+        # 5. L_scale recovery is empirically stable across LM noise to
+        # within 1 % of truth — tighter than the (t0, L_scale) valley
+        # width but loose enough to absorb single-precision-noise-level
+        # LM step variation.  Catches regressions that scramble the L
+        # parameter without dropping the whole flag (where the χ²
+        # gate above would still pass).
+        l_scale_rel_err = abs(float(r_calibrated.l_scale) - L_SCALE_TRUE) / L_SCALE_TRUE
+        assert l_scale_rel_err < 1.0e-2, (
+            f"L_scale rel err {l_scale_rel_err:.3e} exceeds 1 %: "
+            f"got {float(r_calibrated.l_scale):.6f}, truth {L_SCALE_TRUE}"
+        )


### PR DESCRIPTION
## Summary

Closes #530.
Closes #531.

Two tightly-coupled issues landing as one PR (option A per planning discussion). #530 is the actual bug — the MCP server silently dropped fitted `t0_us` / `l_scale` / `back_d` / `back_f` from the result JSON. #531 is the missing test coverage that would have caught the bug if it had ever existed; the new physics test directly exercises the code path whose result the #530 fix surfaces.

### Bug fix (#530) — `bindings/python/python/nereids/mcp/server.py`

- `_fit_result_summary` (single-spectrum) now appends `t0_us` / `l_scale` / `back_d` / `back_f` when present on the FitResult, via `getattr(..., None)` so the schema stays backwards-compatible (keys absent — not null — when the corresponding fit flag wasn't set, matching the existing `deviance_per_dof` / `temperature_k` convention).
- `_process_density_map` (spatial) previously emitted **no** fit-parameter info at all, even though `SpatialResult` exposes per-pixel `anorm_map`, `background_maps`, `t0_us_map`, `l_scale_map`. This PR adds a `fit_param_stats` block summarising those maps via the existing `_array_stats` helper, and writes the raw per-pixel arrays into the result NPZ so downstream consumers can reconstruct the model curve per pixel.

### Test coverage (#531) — `tests/`

- `tests/test_nereids.py::TestFitEnergyScaleRecovery::test_recovers_injected_t0_and_l_scale` — the first Python-level test that exercises `fit_spectrum_typed(..., fit_energy_scale=True)` end-to-end. Synthesizes a 3-resonance U-238 transmission spectrum on a true energy grid, inverts the SAMMY TZERO map to produce a measured grid with injected `(t0, L_scale)`, then fits twice (baseline + energy-scale-on) and gates on:
  1. Calibrated fit converges.
  2. `result.t0_us` / `result.l_scale` are populated finite floats.
  3. χ² ratio: calibrated χ² ≥ 10× better than baseline (primary silent-disable detector).
  4. Effective energy-mapping recovery: `corrected_energies(E_meas, t0_fit, L_scale_fit)` agrees with `E_true` within 1 %.
  5. `L_scale` recovered within 1 % of truth.
- `tests/test_mcp.py` adds five regression tests under `TestManifestWorkflowTools` covering the server.py fix at both unit (SimpleNamespace fake FitResult) and end-to-end (manifest-driven `process_resonance_dataset`) granularity, for both single-spectrum and spatial result paths.

### Scope decision: what's deferred

`SpatialResult` does not expose `back_d_map` / `back_f_map` properties — those fields are not on the Rust `PySpatialResult` struct (`bindings/python/src/lib.rs:605-630`) either. Adding them would require Rust-side per-pixel storage changes in `crates/nereids-pipeline/src/spatial.rs` plus new PyO3 properties — out of scope for this PR. **Filed as a follow-up: #538.** The spatial summary in this PR emits the four maps that ARE available; `back_d` / `back_f` stay single-spectrum-only.

### Why the physics test is structured around observables, not parameter values

The original #531 bug report proposed asserting `abs(result.t0_us - T0_TRUE) < 0.05` and `abs(result.l_scale - L_SCALE_TRUE) < 1e-3` directly. The implementation found this is unrealistic:

- `(t0, L_scale)` are partially degenerate: at a single resonance, peak position alone gives one equation for two unknowns. Multiple resonances lift the degeneracy but the LM cost surface still has a shallow valley along the direction `t0 ≈ const − L_scale × f(E)`. Tightening individual-parameter tolerances below the valley width produces flaky tests without catching the regression we care about.
- The bug to catch is "fit_energy_scale=True silently disabled." That is detected by (a) the χ² ratio, (b) the presence of finite `t0_us` / `l_scale`, and (c) the recovered *effective* energy mapping — all of which would fail under a silent disable. The test docstring explains this trade-off.

### Verification

```
cargo fmt --all                                              # clean
cargo clippy --workspace --exclude nereids-python -- -D warnings  # clean
cargo test  --workspace --exclude nereids-python             # 670+ pass
pixi run pytest tests/                                       # 133 passed in 9s
```

**Negative verification**: temporarily disabled `if fit_energy_scale { config = config.with_energy_scale(...) }` in `bindings/python/src/lib.rs:3987-3990` and rebuilt. All three energy-scale-dependent tests failed as expected (physics recovery + real-fit summary + manifest end-to-end). Reverted; full suite green.

## Test plan

- [x] `cargo fmt`, `cargo clippy -D warnings`, `cargo test --workspace --exclude nereids-python` all clean
- [x] `pixi run pytest tests/` — 133 passed
- [x] Negative-verification check that the three energy-scale tests detect a silent disable in the PyO3 binding
- [ ] CI green (pending push)
- [ ] Verify the spatial `fit_param_stats` JSON schema is reasonable for downstream MCP consumers (reviewer eyeball)