### PR TITLE
fix(gui): switch rfd to GTK 3 backend; document Linux deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Install GTK 3 development headers (rfd backend)
+        run: sudo apt-get update -qq && sudo apt-get install -y libgtk-3-dev
       - run: cargo check --workspace --exclude nereids-python
 
   # ── Formatting ─────────────────────────────────────────────────────
@@ -42,6 +44,8 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
+      - name: Install GTK 3 development headers (rfd backend)
+        run: sudo apt-get update -qq && sudo apt-get install -y libgtk-3-dev
       - run: cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings
 
   # ── Tests (cross-platform) ─────────────────────────────────────────
@@ -59,6 +63,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Install GTK 3 development headers (rfd backend, Linux only)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update -qq && sudo apt-get install -y libgtk-3-dev
       - name: Build
         run: cargo build --workspace --exclude nereids-python
       - name: Run tests
@@ -73,6 +80,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Install GTK 3 development headers (rfd backend)
+        run: sudo apt-get update -qq && sudo apt-get install -y libgtk-3-dev
       - name: Build docs
         run: cargo doc --workspace --no-deps --exclude nereids-python
         env:
@@ -106,6 +115,8 @@ jobs:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Install GTK 3 development headers (rfd backend)
+        run: sudo apt-get update -qq && sudo apt-get install -y libgtk-3-dev
       - name: Generate coverage
         run: cargo llvm-cov --workspace --exclude nereids-python --lcov --output-path lcov.info
       - name: Upload to Codecov

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Install GTK 3 development headers (rfd backend)
+        run: sudo apt-get update -qq && sudo apt-get install -y libgtk-3-dev
+
       - name: Install mdBook
         run: |
           mkdir -p "$HOME/.local/bin"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -122,6 +122,7 @@ jobs:
           before-script-linux: |
             yum install -y cmake3 || yum install -y cmake
             ln -sf /usr/bin/cmake3 /usr/bin/cmake || true
+            yum install -y gtk3-devel
 
       # maturin working-directory puts output in apps/gui/dist
       - name: Upload GUI wheel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "atk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,6 +709,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-sys-rs"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
+dependencies = [
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "calloop"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +786,16 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+dependencies = [
+ "smallvec",
+ "target-lexicon 0.12.16",
+]
 
 [[package]]
 name = "cfg-if"
@@ -1655,6 +1687,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdk-pixbuf-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gdk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "pkg-config",
+ "system-deps",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1725,6 +1787,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "gio-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+ "winapi",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1733,6 +1808,16 @@ dependencies = [
  "khronos_api",
  "log",
  "xml-rs",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
+dependencies = [
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -1814,6 +1899,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gobject-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "gpu-alloc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,6 +1958,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "gtk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f29a1c21c59553eb7dd40e918be54dccd60c52b049b75119d5d96ce6b624414"
+dependencies = [
+ "atk-sys",
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gdk-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
 ]
 
 [[package]]
@@ -3321,6 +3435,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pango-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3517,12 +3643,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pollster"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3583,7 +3703,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -3664,7 +3784,7 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
 dependencies = [
- "target-lexicon",
+ "target-lexicon 0.13.5",
 ]
 
 [[package]]
@@ -4074,6 +4194,9 @@ checksum = "20dafead71c16a34e1ff357ddefc8afc11e7d51d6d2b9fbd07eaa48e3e540220"
 dependencies = [
  "block2 0.6.2",
  "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
  "js-sys",
  "libc",
  "log",
@@ -4082,13 +4205,9 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
  "percent-encoding",
- "pollster",
  "raw-window-handle",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
  "web-sys",
  "windows-sys 0.61.2",
 ]
@@ -4356,6 +4475,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4634,6 +4762,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-deps"
+version = "6.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4824,6 +4971,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4834,12 +5002,25 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -5071,6 +5252,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ eframe = { version = "0.33", features = ["persistence"] }
 egui = "0.33"
 egui_extras = { version = "0.33", features = ["image", "svg"] }
 egui_plot = "0.34"
-rfd = "0.17"
+rfd = { version = "0.17", default-features = false, features = ["gtk3"] }
 hdf5 = { package = "hdf5-metno", version = "0.12", features = ["static", "zlib"] }
 rand = "0.9"
 rand_distr = "0.5"

--- a/docs/guide/src/installation.md
+++ b/docs/guide/src/installation.md
@@ -62,23 +62,32 @@ container / server installs do not.
 
 ```bash
 sudo apt-get install -y \
-  libgtk-3-0 libxcursor1 libx11-xcb1 libxi6 libxrandr2 \
+  libgtk-3-0t64 libxcursor1 libx11-xcb1 libxi6 libxrandr2 \
   libxinerama1 libxxf86vm1 libxkbcommon-x11-0 libwayland-client0 \
   libgl1 libegl1
 ```
 
+On Ubuntu releases older than 24.04 the GTK 3 runtime is `libgtk-3-0`
+instead of `libgtk-3-0t64`; the older name still resolves on 24.04 via
+a transitional package.
+
 Contributors building from source additionally need the GTK 3
-development headers (`sudo apt-get install -y libgtk-3-dev`).
+development headers and `pkg-config`:
+
+```bash
+sudo apt-get install -y libgtk-3-dev pkg-config
+```
 
 **Fedora / RHEL (dnf):**
 
 ```bash
 sudo dnf install -y \
   gtk3 libXcursor libXi libXrandr libXinerama libxkbcommon-x11 \
-  wayland mesa-libGL mesa-libEGL
+  libwayland-client libwayland-cursor mesa-libGL mesa-libEGL
 ```
 
-Contributors building from source additionally need `gtk3-devel`.
+Contributors building from source additionally need `gtk3-devel` and
+`pkgconf-pkg-config`.
 
 **Headless / Docker / VM fallback:**
 

--- a/docs/guide/src/installation.md
+++ b/docs/guide/src/installation.md
@@ -62,14 +62,16 @@ container / server installs do not.
 
 ```bash
 sudo apt-get install -y \
-  libgtk-3-0t64 libxcursor1 libx11-xcb1 libxi6 libxrandr2 \
+  libgtk-3-0 libxcursor1 libx11-xcb1 libxi6 libxrandr2 \
   libxinerama1 libxxf86vm1 libxkbcommon-x11-0 libwayland-client0 \
-  libgl1 libegl1
+  libgl1 libgl1-mesa-dri libegl1
 ```
 
-On Ubuntu releases older than 24.04 the GTK 3 runtime is `libgtk-3-0`
-instead of `libgtk-3-0t64`; the older name still resolves on 24.04 via
-a transitional package.
+`libgtk-3-0` is portable across Debian and all current Ubuntu LTS
+releases. On Ubuntu 24.04 (Noble) it pulls in `libgtk-3-0t64` under
+the hood via the t64 transitional package. `libgl1-mesa-dri` is
+needed even with `LIBGL_ALWAYS_SOFTWARE=1` (below) because the
+software rasteriser is shipped as a Mesa DRI driver.
 
 Contributors building from source additionally need the GTK 3
 development headers and `pkg-config`:
@@ -83,7 +85,8 @@ sudo apt-get install -y libgtk-3-dev pkg-config
 ```bash
 sudo dnf install -y \
   gtk3 libXcursor libXi libXrandr libXinerama libxkbcommon-x11 \
-  libwayland-client libwayland-cursor mesa-libGL mesa-libEGL
+  libwayland-client libwayland-cursor \
+  mesa-libGL mesa-libEGL mesa-dri-drivers
 ```
 
 Contributors building from source additionally need `gtk3-devel` and
@@ -93,10 +96,13 @@ Contributors building from source additionally need `gtk3-devel` and
 
 If the GUI fails at startup with a GL initialisation error (common in
 Docker without GPU passthrough, or over SSH-X without GLX), force
-software rasterisation:
+software rasterisation by setting `LIBGL_ALWAYS_SOFTWARE=1` before
+launching the GUI:
 
 ```bash
 export LIBGL_ALWAYS_SOFTWARE=1
+cargo run --release -p nereids-gui   # from source
+# or, if installed as a binary:
 nereids-gui
 ```
 

--- a/docs/guide/src/installation.md
+++ b/docs/guide/src/installation.md
@@ -51,6 +51,46 @@ cargo run --release -p nereids-gui
 
 Building from source requires CMake (for HDF5) and a Rust toolchain.
 
+### Linux system dependencies
+
+NEREIDS uses GTK 3 for native file dialogs (no `xdg-desktop-portal`
+daemon needed) and the standard egui/winit/wgpu stack for the rest of
+the UI. Desktop Linux distros usually ship these, but minimal /
+container / server installs do not.
+
+**Debian / Ubuntu (apt):**
+
+```bash
+sudo apt-get install -y \
+  libgtk-3-0 libxcursor1 libx11-xcb1 libxi6 libxrandr2 \
+  libxinerama1 libxxf86vm1 libxkbcommon-x11-0 libwayland-client0 \
+  libgl1 libegl1
+```
+
+Contributors building from source additionally need the GTK 3
+development headers (`sudo apt-get install -y libgtk-3-dev`).
+
+**Fedora / RHEL (dnf):**
+
+```bash
+sudo dnf install -y \
+  gtk3 libXcursor libXi libXrandr libXinerama libxkbcommon-x11 \
+  wayland mesa-libGL mesa-libEGL
+```
+
+Contributors building from source additionally need `gtk3-devel`.
+
+**Headless / Docker / VM fallback:**
+
+If the GUI fails at startup with a GL initialisation error (common in
+Docker without GPU passthrough, or over SSH-X without GLX), force
+software rasterisation:
+
+```bash
+export LIBGL_ALWAYS_SOFTWARE=1
+nereids-gui
+```
+
 ## Development Setup
 
 For contributors working on NEREIDS itself:


### PR DESCRIPTION
## Summary

Bundles two v0.1.9 release-blocker GUI/install bugs flagged by external evaluator (Tsviki, LANSCE):

- **Closes #526** — `rfd::FileDialog::new().pick_file()` on Linux silently returned `None` whenever `xdg-desktop-portal` was not running (root user, containers, minimal server installs), making every file picker in the NEREIDS GUI appear broken. Switch rfd's Linux backend from `xdg-portal` (default) to `gtk3` so the dialog runs in-process without a D-Bus daemon.
- **Closes #522** — Minimal Ubuntu 24.04 / Docker installs were missing X11 / Wayland / GL system libraries needed by the egui/winit/wgpu stack. Document the apt and dnf package sets, contributor build-from-source deps, and the `LIBGL_ALWAYS_SOFTWARE=1` headless/VM fallback.

## Changes

### Code
- `Cargo.toml:49` — `rfd = "0.17"` → `rfd = { version = "0.17", default-features = false, features = ["gtk3"] }`. Cargo.lock updated as a consequence. macOS and Windows behavior unchanged (the `gtk3` feature is `cfg(target_os = "linux")`).

### CI / release pipeline
The rfd backend flip makes `nereids-gui` depend on `libgtk-3` via gtk-sys, whose build script invokes `pkg-config --libs gtk+-3.0`. Every Linux job that compiles the workspace needs the GTK 3 development headers:
- `.github/workflows/ci.yml` — `check`, `clippy`, `doc`, `coverage` (unconditional Linux) and `test` matrix (Linux branch only via `if: runner.os == 'Linux'`) gain a `libgtk-3-dev` install step.
- `.github/workflows/docs.yml` — same install step in the GitHub Pages rustdoc build.
- `.github/workflows/publish.yml` — `build-gui` (manylinux 2_28 / AlmaLinux 8) gains `yum install -y gtk3-devel` in `before-script-linux`.

The `python` job and `build-wheels` / `build-sdist` are correctly unchanged — they build `bindings/python/Cargo.toml` only, not `apps/gui`.

### Documentation
`docs/guide/src/installation.md` — new `### Linux system dependencies` subsection under Desktop GUI:
- Debian/Ubuntu (`apt`) runtime list, with a note on the `libgtk-3-0` → `libgtk-3-0t64` rename in 24.04.
- Fedora/RHEL (`dnf`) runtime list (uses `libwayland-client` / `libwayland-cursor`, not the umbrella `wayland`).
- Build-from-source headers: `libgtk-3-dev pkg-config` (apt), `gtk3-devel pkgconf-pkg-config` (dnf).
- `LIBGL_ALWAYS_SOFTWARE=1` headless / Docker / VM fallback.

## Review pipeline

Phase A — 3 rounds:
- **Round 1**: Claude self-audit + Codex external review. Codex caught **P1** (the CI/release-pipeline GTK install gap) that the self-audit missed. 6 P2 doc-polish findings.
- **Round 2**: Self-audit on Round-1 fixes caught **P1** — `docs.yml` (GitHub Pages rustdoc deploy) also builds `cargo doc --workspace`, also needed the GTK install, also missed in Round 1.
- **Round 3**: Independent completeness sweep across all three `.github/workflows/*.yml` files. **Zero P1.** Two P2 polish items deferred (composite-action DRY-up for the five identical `apt-get install libgtk-3-dev` snippets; Dev Setup cross-link to the new Linux deps section).

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --exclude nereids-python` — 768 Rust tests pass (matches main pre-PR count)
- [x] `cargo build --release -p nereids-gui` clean on macOS
- [ ] Manual Linux verification: confirm file pickers open under root / minimal Ubuntu Docker following the new docs — defer to a Linux machine after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)