### PR TITLE
docs(mcp): dedupe NeXus/TOF prose with data-io.md (#534)

### DIFF
--- a/docs/guide/src/data-io.md
+++ b/docs/guide/src/data-io.md
@@ -66,6 +66,9 @@ counts-domain likelihood.
 
 ## NeXus Histogram Loading
 
+For agent-orchestrated NeXus workflows driven by a manifest, see
+[MCP Server](./mcp-server.md). This section covers the raw-Python loader.
+
 Use `probe_nexus(...)` to inspect a file without loading full data:
 
 ```python

--- a/docs/guide/src/mcp-server.md
+++ b/docs/guide/src/mcp-server.md
@@ -11,6 +11,9 @@ The MCP interface is experimental. It is useful for demos and agent-assisted
 workflows, but the Python and Rust APIs remain the stable interfaces for
 scripted analysis.
 
+See also: [Data I/O and NeXus/TOF](./data-io.md) for the raw-Python NeXus,
+TIFF, normalization, and TOF energy-grid flow that the MCP workflow wraps.
+
 ## Installation
 
 Install the optional MCP dependency and run the stdio server:
@@ -172,15 +175,17 @@ file; real experiments normally do.
   configured with `sample_path` and `open_beam_path`.
 
 Paired arrays must have matching shapes. The number of energy points must
-match the first axis of the data arrays. Energy grids must be strictly
-monotonic; descending grids are reversed with the aligned arrays before
-fitting.
+match the first axis of the data arrays. See
+[Data I/O and NeXus/TOF](./data-io.md#tof-edges-to-energy-centers) for the
+energy-ordering contract (descending grids are reversed with the aligned
+arrays before fitting).
 
-For NeXus histogram inputs, NEREIDS loads counts in TOF-bin order and derives
-ascending energy centers with `tof_to_energy_centers(...)`. The MCP workflow
-converts the counts to the same ascending-energy order before fitting. If the
-manifest does not specify `flight_path_m`, the loader metadata is used when
-available, with a 25 m fallback. `delay_us` defaults to 0.
+For NeXus histogram inputs, MCP follows the conventions documented in
+[Data I/O and NeXus/TOF](./data-io.md). Briefly: NeXus loaders return counts
+in ascending TOF order; the workflow reverses counts to ascending-energy order
+via `tof_to_energy_centers(...)` before fitting. If the manifest does not
+specify `flight_path_m`, the loader metadata is used when available, with a
+25 m fallback. `delay_us` defaults to 0.
 
 Example NeXus density-map manifest:
 

--- a/docs/guide/src/mcp-server.md
+++ b/docs/guide/src/mcp-server.md
@@ -175,17 +175,18 @@ file; real experiments normally do.
   configured with `sample_path` and `open_beam_path`.
 
 Paired arrays must have matching shapes. The number of energy points must
-match the first axis of the data arrays. See
+match the first axis of the data arrays. Energy grids must be strictly
+monotonic. See
 [Data I/O and NeXus/TOF](./data-io.md#tof-edges-to-energy-centers) for the
 energy-ordering contract (descending grids are reversed with the aligned
 arrays before fitting).
 
 For NeXus histogram inputs, MCP follows the conventions documented in
 [Data I/O and NeXus/TOF](./data-io.md). Briefly: NeXus loaders return counts
-in ascending TOF order; the workflow reverses counts to ascending-energy order
-via `tof_to_energy_centers(...)` before fitting. If the manifest does not
-specify `flight_path_m`, the loader metadata is used when available, with a
-25 m fallback. `delay_us` defaults to 0.
+in ascending TOF order; the workflow derives ascending energy centers with
+`tof_to_energy_centers(...)` and reverses counts along axis 0 to match before
+fitting. If the manifest does not specify `flight_path_m`, the loader metadata
+is used when available, with a 25 m fallback. `delay_us` defaults to 0.
 
 Example NeXus density-map manifest:
 


### PR DESCRIPTION
## Summary

PR #532 introduced `docs/guide/src/data-io.md` to cover NeXus/TOF mechanics outside the MCP-specific workflow page, but `docs/guide/src/mcp-server.md` was not touched and still duplicated the same prose. This PR reconciles the overlap with cross-references so each page has a single source of truth.

## Changes

- `mcp-server.md`: add "See also" link to `data-io.md` under the "experimental" callout for users who want the raw-Python NeXus/TOF flow.
- `mcp-server.md`: collapse the descending-grid sentence into a pointer to `data-io.md`'s "TOF Edges to Energy Centers" section; keep the MCP-relevant shape/axis sentences.
- `mcp-server.md`: replace the NeXus-histogram TOF-order paragraph with a brief pointer to `data-io.md`; preserve the MCP-only config behavior (25 m `flight_path_m` fallback, `delay_us=0` default).
- `data-io.md`: add a back-reference under "NeXus Histogram Loading" pointing manifest-driven users to `mcp-server.md` for symmetry.

Closes #534

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude nereids-python`
- [x] `pixi run doc-guide` builds with no broken-link warnings
- [x] Cross-links resolve in rendered HTML (`./data-io.html`, `./data-io.html#tof-edges-to-energy-centers`, `./mcp-server.html`)