### PR TITLE
ci(docs): install mdbook via pixi; clarify toolchain layout (#535)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,8 +25,11 @@ jobs:
     #                              own rust; the host rustup install is
     #                              the single source of truth.
     #   Swatinem/rust-cache     -> caches target/ for cargo doc + maturin
-    #   setup-pixi              -> Python + mdbook + pdoc (orchestrator
-    #                              deps; no rust here)
+    #   setup-pixi              -> Python + mdbook + pdoc + maturin
+    #                              (orchestrator deps; no rust here —
+    #                              maturin is the build front-end that
+    #                              wraps cargo + the rust toolchain
+    #                              installed above)
     #   pixi run doc-build      -> doc-guide (mdbook) + doc-api (cargo
     #                              doc) + doc-python (pdoc on installed
     #                              wheel)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,18 @@ jobs:
   build:
     name: Build docs
     runs-on: ubuntu-latest
+    # Build provenance (one rust toolchain, not two):
+    #   dtolnay/rust-toolchain  -> rustc + cargo on PATH (used by both
+    #                              `cargo doc` in doc-api AND `maturin
+    #                              develop` in build). Pixi does NOT
+    #                              own rust; the host rustup install is
+    #                              the single source of truth.
+    #   Swatinem/rust-cache     -> caches target/ for cargo doc + maturin
+    #   setup-pixi              -> Python + mdbook + pdoc (orchestrator
+    #                              deps; no rust here)
+    #   pixi run doc-build      -> doc-guide (mdbook) + doc-api (cargo
+    #                              doc) + doc-python (pdoc on installed
+    #                              wheel)
     steps:
       - uses: actions/checkout@v4
 
@@ -27,12 +39,6 @@ jobs:
 
       - name: Install GTK 3 development headers (rfd backend)
         run: sudo apt-get update -qq && sudo apt-get install -y libgtk-3-dev
-
-      - name: Install mdBook
-        run: |
-          mkdir -p "$HOME/.local/bin"
-          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.43/mdbook-v0.4.43-x86_64-unknown-linux-gnu.tar.gz | tar xz -C "$HOME/.local/bin"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install pixi
         uses: prefix-dev/setup-pixi@v0.9.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ h5py = ">=3.15.1,<4"
 pandas = ">=3.0.1,<4"
 scipy = ">=1.17.1,<2"
 pdoc = ">=14"
+mdbook = ">=0.4"
 
 [tool.pixi.pypi-dependencies]
 # fastmcp removed from default env — causes importlib-metadata conflict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ h5py = ">=3.15.1,<4"
 pandas = ">=3.0.1,<4"
 scipy = ">=1.17.1,<2"
 pdoc = ">=14"
-mdbook = ">=0.4"
+mdbook = ">=0.5,<0.6"
 
 [tool.pixi.pypi-dependencies]
 # fastmcp removed from default env — causes importlib-metadata conflict
@@ -93,7 +93,7 @@ lint = { depends-on = ["lint-fmt", "lint-clippy"], description = "Run all linter
 gui = { cmd = "cargo run --release -p nereids-gui", description = "Run the GUI application (release)" }
 gui-debug = { cmd = "cargo run -p nereids-gui", description = "Run the GUI application (debug)" }
 gui-bundle = { cmd = "cargo bundle --release", cwd = "apps/gui", description = "Bundle the GUI as a macOS .app" }
-doc-guide = { cmd = "mdbook build", cwd = "docs/guide", description = "Build the mdBook user guide (requires: cargo install mdbook)" }
+doc-guide = { cmd = "mdbook build", cwd = "docs/guide", description = "Build the mdBook user guide (mdbook is provided by the pixi env)" }
 doc-api = { cmd = "cargo doc --workspace --no-deps --exclude nereids-python", description = "Build rustdoc API reference" }
 doc-python = { cmd = "pdoc -o target/book/python --no-show-source nereids", depends-on = ["build", "doc-guide"], description = "Build Python API reference via pdoc (imports the installed nereids wheel; depends on doc-guide so mdBook's destination-dir clear cannot wipe target/book/python/)" }
 doc-build = { cmd = "cp -r target/doc target/book/api", depends-on = ["doc-guide", "doc-api", "doc-python"], description = "Build full docs site (mdBook + rustdoc + Python API)" }


### PR DESCRIPTION
## Summary

Issue #535's "two Rust toolchains in docs.yml" framing is **incorrect on the facts**: `[tool.pixi.dependencies]` in `pyproject.toml` does not include `rust`, so `pixi run doc-build` uses the same rustc/cargo that `dtolnay/rust-toolchain@stable` installs on PATH. There is — and always has been — exactly one Rust toolchain in CI.

The actual mess worth cleaning up is the manual `curl | tar` mdBook install. mdBook is a self-contained binary on conda-forge, so it belongs in the pixi env alongside pdoc.

Per maintainer guidance, `dtolnay/rust-toolchain@stable` and `Swatinem/rust-cache@v2` are intentionally left in place — they do real work for both `cargo doc` (doc-api) and `maturin develop` (build), and host rustup is the single source of truth for rust across ORNL Rust repos. Adding `rust` to pixi deps would force every ORNL Rust repo to maintain its own pixi-resolved toolchain, which is a maintenance burden we do not want.

## Changes

- `pyproject.toml`: add `mdbook = ">=0.4"` to `[tool.pixi.dependencies]` (conda-forge, no rust dep).
- `.github/workflows/docs.yml`: remove the entire manual `Install mdBook` curl-tar step; mdBook now comes from the pixi env that `setup-pixi` activates.
- `.github/workflows/docs.yml`: add a "Build provenance" comment block at the top of the `build` job listing what each step provides, to head off future "two toolchains" confusion.

The workflow's overall shape is unchanged: checkout → dtolnay-rust → rust-cache → GTK headers → setup-pixi → `pixi run doc-build` → upload-pages-artifact.

Closes #535

## Test plan

- [x] `pixi install --locked` succeeds — manifest and lockfile in sync (lockfile already contained mdbook 0.5.2 from prior workspace state, no update needed).
- [x] `pixi run -- mdbook --version` → `mdbook v0.5.2` (from pixi env).
- [x] `pixi run doc-build` succeeds locally end-to-end. Verified `target/book/index.html`, `target/book/api/`, and `target/book/python/` all exist.
- [x] `cargo fmt --all` clean.
- [x] `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --exclude nereids-python` — all tests pass.
- [ ] CI run on this PR succeeds (Documentation workflow).