### PR TITLE
ci(docs): add __init__.pyi <-> python-api.md drift gate (#533)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,12 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.4
         with:
           run-install: true
+      # Drift gate: catches public symbols added to bindings/python/python/
+      # nereids/__init__.pyi without a corresponding update to
+      # docs/guide/src/python-api.md or the allowlist (issue #533). Runs
+      # on every PR — the same step in docs.yml only runs post-merge.
+      - name: Check curated Python API page is in sync with .pyi stubs
+        run: pixi run lint-docs
       - name: Build and test Python bindings
         run: pixi run test-python
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,20 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
 
+  # ── Docs drift gate (lightweight; runs in parallel with check) ─────
+  # Stdlib-only script, so it runs WITHOUT pixi/rust/maturin to fail
+  # fast when a PyO3 stub symbol is added without a corresponding
+  # update to docs/guide/src/python-api.md or the allowlist (#533).
+  docs-drift:
+    name: Docs drift gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - run: python scripts/check_python_api_drift.py
+
   # ── Python bindings ────────────────────────────────────────────────
   python:
     name: Python bindings
@@ -104,12 +118,6 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.4
         with:
           run-install: true
-      # Drift gate: catches public symbols added to bindings/python/python/
-      # nereids/__init__.pyi without a corresponding update to
-      # docs/guide/src/python-api.md or the allowlist (issue #533). Runs
-      # on every PR — the same step in docs.yml only runs post-merge.
-      - name: Check curated Python API page is in sync with .pyi stubs
-        run: pixi run lint-docs
       - name: Build and test Python bindings
         run: pixi run test-python
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,14 @@ jobs:
         with:
           run-install: true
 
+      # Fail fast on drift between the PyO3 type stubs and the curated
+      # python-api.md page (issue #533).  The script is stdlib-only, so
+      # no extra deps are pulled in.  Runs before the (slow) site build
+      # so reviewers get the drift signal even if the build step itself
+      # would have failed.
+      - name: Check curated Python API page is in sync with .pyi stubs
+        run: pixi run lint-docs
+
       # Drive the entire docs build through the `doc-build` pixi task. It
       # orchestrates `doc-guide` (mdBook), `doc-api` (cargo doc), and
       # `doc-python` (pdoc on the maturin-installed wheel), then `cp -r

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Fail fast on drift between the PyO3 type stubs and the curated
+      # python-api.md page (issue #533).  The script is stdlib-only;
+      # running it BEFORE the (slow) rust + mdbook + pixi setup avoids
+      # paying ~1 min of environment-install cost when the drift gate
+      # fails.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Check curated Python API page is in sync with .pyi stubs
+        run: python scripts/check_python_api_drift.py
+
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
@@ -38,14 +49,6 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.4
         with:
           run-install: true
-
-      # Fail fast on drift between the PyO3 type stubs and the curated
-      # python-api.md page (issue #533).  The script is stdlib-only, so
-      # no extra deps are pulled in.  Runs before the (slow) site build
-      # so reviewers get the drift signal even if the build step itself
-      # would have failed.
-      - name: Check curated Python API page is in sync with .pyi stubs
-        run: pixi run lint-docs
 
       # Drive the entire docs build through the `doc-build` pixi task. It
       # orchestrates `doc-guide` (mdBook), `doc-api` (cargo doc), and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ clean = { cmd = "cargo clean", description = "Remove all Rust build artifacts (t
 lint-fmt = { cmd = "cargo fmt --all --check", description = "Check formatting without applying" }
 lint-clippy = { cmd = "cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings", description = "Run clippy lints" }
 lint-docs = { cmd = "python scripts/check_python_api_drift.py", description = "Check __init__.pyi <-> python-api.md drift" }
-lint = { depends-on = ["lint-fmt", "lint-clippy"], description = "Run all linters" }
+lint = { depends-on = ["lint-fmt", "lint-clippy", "lint-docs"], description = "Run all linters" }
 gui = { cmd = "cargo run --release -p nereids-gui", description = "Run the GUI application (release)" }
 gui-debug = { cmd = "cargo run -p nereids-gui", description = "Run the GUI application (debug)" }
 gui-bundle = { cmd = "cargo bundle --release", cwd = "apps/gui", description = "Bundle the GUI as a macOS .app" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ check = { depends-on = ["fmt", "clippy", "test"] }
 clean = { cmd = "cargo clean", description = "Remove all Rust build artifacts (target/)" }
 lint-fmt = { cmd = "cargo fmt --all --check", description = "Check formatting without applying" }
 lint-clippy = { cmd = "cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings", description = "Run clippy lints" }
+lint-docs = { cmd = "python scripts/check_python_api_drift.py", description = "Check __init__.pyi <-> python-api.md drift" }
 lint = { depends-on = ["lint-fmt", "lint-clippy"], description = "Run all linters" }
 gui = { cmd = "cargo run --release -p nereids-gui", description = "Run the GUI application (release)" }
 gui-debug = { cmd = "cargo run -p nereids-gui", description = "Run the GUI application (debug)" }

--- a/scripts/check_python_api_drift.py
+++ b/scripts/check_python_api_drift.py
@@ -69,9 +69,13 @@ def collect_documented_symbols(doc_path: Path, candidates: set[str]) -> set[str]
 
 
 def load_allowlist(path: Path) -> set[str]:
-    """Read one-symbol-per-line allowlist; ``#`` and blank lines are ignored."""
-    if not path.exists():
-        return set()
+    """Read one-symbol-per-line allowlist; ``#`` and blank lines are ignored.
+
+    The file is treated as a required input (see ``main``); callers
+    should verify ``path.exists()`` upstream so a missing/renamed
+    allowlist is reported via exit code 2 rather than silently
+    behaving as an empty set.
+    """
     entries: set[str] = set()
     for raw in path.read_text(encoding="utf-8").splitlines():
         line = raw.split("#", 1)[0].strip()
@@ -82,7 +86,7 @@ def load_allowlist(path: Path) -> set[str]:
 
 def main() -> int:
     argparse.ArgumentParser(description=__doc__).parse_args()
-    for required in (STUB_PATH, DOC_PATH):
+    for required in (STUB_PATH, DOC_PATH, ALLOWLIST_PATH):
         if not required.exists():
             print(f"error: required input missing: {required}", file=sys.stderr)
             return 2

--- a/scripts/check_python_api_drift.py
+++ b/scripts/check_python_api_drift.py
@@ -113,4 +113,8 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except Exception as exc:  # noqa: BLE001 — exit code 2 is the contract
+        print(f"unexpected error: {exc.__class__.__name__}: {exc}", file=sys.stderr)
+        sys.exit(2)

--- a/scripts/check_python_api_drift.py
+++ b/scripts/check_python_api_drift.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Check drift between the PyO3 type stubs and the curated Python API page.
+
+Compares the public symbols (top-level ``def`` / ``class`` not prefixed with
+``_``) declared in ``bindings/python/python/nereids/__init__.pyi`` against
+mentions in ``docs/guide/src/python-api.md``.  A symbol counts as documented
+if it appears in a markdown heading, an inline ``code`` span, or as
+``nereids.symbol(...)`` / ``symbol(...)`` in a code block.
+
+Symbols intentionally omitted from the curated narrative (e.g. those covered
+in ``data-io.md`` or low-level utilities not yet given a section) are listed
+in ``scripts/python_api_allowlist.txt``.  The allowlist is the drift ratchet:
+prefer moving entries OUT of it by documenting them, rather than letting it
+grow unboundedly.
+
+Exit codes:
+  0 - no drift; every public stub symbol is either documented or allowlisted.
+  1 - one or more public stub symbols are neither documented nor allowlisted.
+  2 - unexpected error (missing input file, parse failure, etc.).
+
+Run via ``pixi run lint-docs`` or directly with ``python``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+STUB_PATH = REPO_ROOT / "bindings" / "python" / "python" / "nereids" / "__init__.pyi"
+DOC_PATH = REPO_ROOT / "docs" / "guide" / "src" / "python-api.md"
+ALLOWLIST_PATH = REPO_ROOT / "scripts" / "python_api_allowlist.txt"
+
+
+def collect_stub_symbols(stub_path: Path) -> set[str]:
+    """Return public top-level ``def`` / ``class`` names from the stub."""
+    tree = ast.parse(stub_path.read_text(encoding="utf-8"), filename=str(stub_path))
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if not node.name.startswith("_"):
+                names.add(node.name)
+    return names
+
+
+def collect_documented_symbols(doc_path: Path, candidates: set[str]) -> set[str]:
+    """Return the subset of ``candidates`` that appears in ``doc_path``."""
+    text = doc_path.read_text(encoding="utf-8")
+    documented: set[str] = set()
+    for name in candidates:
+        # Match: heading (`# name`), inline `name`, `name(`, `nereids.name`,
+        # or `nereids.name(` — all forms readers actually use to refer to a
+        # symbol.  ``\b`` boundaries keep ``normalize`` from matching
+        # ``normalized``.
+        pattern = re.compile(
+            r"(?:^#+[^\n]*\b" + re.escape(name) + r"\b)"
+            r"|(?:`" + re.escape(name) + r"[`(])"
+            r"|(?:`nereids\." + re.escape(name) + r"[`(])"
+            r"|(?:\bnereids\." + re.escape(name) + r"\s*\()"
+            r"|(?:\b" + re.escape(name) + r"\s*\()",
+            re.MULTILINE,
+        )
+        if pattern.search(text):
+            documented.add(name)
+    return documented
+
+
+def load_allowlist(path: Path) -> set[str]:
+    """Read one-symbol-per-line allowlist; ``#`` and blank lines are ignored."""
+    if not path.exists():
+        return set()
+    entries: set[str] = set()
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if line:
+            entries.add(line)
+    return entries
+
+
+def main() -> int:
+    argparse.ArgumentParser(description=__doc__).parse_args()
+    for required in (STUB_PATH, DOC_PATH):
+        if not required.exists():
+            print(f"error: required input missing: {required}", file=sys.stderr)
+            return 2
+    stub_symbols = collect_stub_symbols(STUB_PATH)
+    documented = collect_documented_symbols(DOC_PATH, stub_symbols)
+    allowlist = load_allowlist(ALLOWLIST_PATH)
+    drift = sorted(stub_symbols - documented - allowlist)
+    if drift:
+        print(
+            "drift detected: the following public symbols in __init__.pyi "
+            "are not documented in docs/guide/src/python-api.md and not in "
+            "scripts/python_api_allowlist.txt:"
+        )
+        for name in drift:
+            print(f"  - {name}")
+        print(
+            "Add a section for each to docs/guide/src/python-api.md, OR if "
+            "the symbol is intentionally omitted from the curated narrative "
+            "reference, add it to scripts/python_api_allowlist.txt with a "
+            "justification comment."
+        )
+        return 1
+    print(
+        f"python-api.md drift check passed: {len(stub_symbols)} public "
+        f"symbols, {len(documented)} documented, {len(allowlist)} allowlisted"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/python_api_allowlist.txt
+++ b/scripts/python_api_allowlist.txt
@@ -1,0 +1,70 @@
+# Symbols exported by bindings/python/python/nereids/__init__.pyi but not
+# narratively documented in docs/guide/src/python-api.md.  Each entry should
+# be revisited at release time — prefer moving entries OUT of this file by
+# documenting them, rather than letting it grow unboundedly.
+#
+# Format: one symbol per line; `#` starts a comment line; blank lines OK.
+# An entry being in this file means the drift gate
+# (scripts/check_python_api_drift.py) will not fail when the symbol is
+# absent from python-api.md.  See issue #533 for the rationale.
+
+# ---------------------------------------------------------------------------
+# Documented narratively in docs/guide/src/data-io.md instead
+# (TIFF/NeXus loaders, normalization, NeXus probe metadata).
+# ---------------------------------------------------------------------------
+probe_nexus
+normalize
+NexusMetadata
+
+# ---------------------------------------------------------------------------
+# Low-level physics building blocks — covered by the auto-generated pdoc
+# reference (/python/) and partially by docs/guide/src/physics.md, but with
+# no dedicated section in the curated python-api.md narrative yet.
+# ---------------------------------------------------------------------------
+cross_sections
+beer_lambert
+doppler_broaden
+resolution_broaden
+apply_resolution
+precompute_cross_sections
+
+# ---------------------------------------------------------------------------
+# Tabulated resolution helper class returned by load_resolution(...); the
+# load_resolution function IS referenced from python-api.md but the result
+# class itself has no narrative section.
+# ---------------------------------------------------------------------------
+TabulatedResolution
+
+# ---------------------------------------------------------------------------
+# Energy-axis calibration API (calibrate_energy + CalibrationResult); no
+# dedicated narrative section yet — pdoc reference covers the signature.
+# ---------------------------------------------------------------------------
+calibrate_energy
+CalibrationResult
+
+# ---------------------------------------------------------------------------
+# Trace-detectability API — used in quickstart-python.md but not given a
+# dedicated section in the curated python-api.md narrative.
+# ---------------------------------------------------------------------------
+trace_detectability
+trace_detectability_survey
+TraceDetectabilityReport
+
+# ---------------------------------------------------------------------------
+# Isotope-group helpers — referenced indirectly via `groups=[...]` rows in
+# the fitting tables but the IsotopeGroup class itself has no section yet.
+# ---------------------------------------------------------------------------
+IsotopeGroup
+
+# ---------------------------------------------------------------------------
+# Dead-pixel detection helper; partially covered by the spatial-mapping
+# "dead_pixels=" kwarg, but the detector itself has no section yet.
+# ---------------------------------------------------------------------------
+detect_dead_pixels
+
+# ---------------------------------------------------------------------------
+# Research-only Jacobian/Fisher evaluator (memo 38 follow-up work); no
+# narrative section yet — pdoc reference covers the signature.
+# ---------------------------------------------------------------------------
+compute_model_jacobian
+ModelJacobianResult


### PR DESCRIPTION
## Summary

Adds a CI gate that catches drift between the PyO3 type stubs
(`bindings/python/python/nereids/__init__.pyi`) and the curated
narrative Python API page (`docs/guide/src/python-api.md`). PR #532
already says "review python-api.md when .pyi changes" in the release
skill — this enforces that contract mechanically.

## Approach: strict gate + allowlist

The curated page is not currently complete: 19 of the 46 public stub
symbols are not mentioned by name in `python-api.md` (some are
documented in `data-io.md` instead; some are low-level physics
utilities with no dedicated section yet). So the gate is seeded with
an explicit allowlist that captures the current state, and FAILS on
any NEW symbol added to `__init__.pyi` without either a section in
`python-api.md` or an allowlist entry.

The allowlist is the drift ratchet — over time entries should move
OUT of it (by being documented), not pile up.

## Files added / changed

- `scripts/check_python_api_drift.py` (new) — stdlib-only Python
  script: ast-parses the .pyi, regex-matches symbols against the
  markdown body, diffs against allowlist. Under 120 LOC.
- `scripts/python_api_allowlist.txt` (new) — 19 entries grouped by
  category (documented in data-io.md, low-level physics utilities,
  calibration API, trace-detectability, isotope groups, dead-pixel
  helper, Jacobian/Fisher research API).
- `pyproject.toml` — `lint-docs` pixi task.
- `.github/workflows/docs.yml` — runs `pixi run lint-docs` before
  `Build complete docs site`, so reviewers get the drift signal even
  if the (slow) site build itself would have failed.

Closes #533.

## Test plan

- [x] `python scripts/check_python_api_drift.py` on clean main exits
  0 with `python-api.md drift check passed: 46 public symbols, 27
  documented, 19 allowlisted`.
- [x] Sanity check: temporarily added `def fake_function():` to
  `__init__.pyi`, re-ran, verified exit 1 with `fake_function` listed
  in the diff. Reverted.
- [x] Sanity check: temporarily removed `beer_lambert` from the
  allowlist, re-ran, verified it surfaced in the diff. Restored.
- [x] `cargo fmt --all` clean.
- [x] `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --exclude nereids-python` all green.
- [x] CI green on the new `lint-docs` step.

Branch: `tech-debt/533-pyi-drift-gate`