### PR TITLE
test(physics): relocate VENUS USR fixture tests + correct PLEIADES misnomer (#497)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2987,6 +2987,7 @@ dependencies = [
  "microlp",
  "nereids-core",
  "nereids-endf",
+ "nereids-physics",
  "num-complex",
  "rayon",
 ]

--- a/crates/nereids-physics/Cargo.toml
+++ b/crates/nereids-physics/Cargo.toml
@@ -30,5 +30,11 @@ microlp = { workspace = true }
 # they cannot see items gated only by `#[cfg(test)]`.  Enabling the
 # `test-support` feature here exposes `resolution::test_support` to
 # the integration suite without leaking it into release builds.
-nereids-physics = { path = ".", features = ["test-support"] }
+#
+# Inherits version + path from `[workspace.dependencies]` (see
+# workspace Cargo.toml) so `scripts/bump-version.sh` keeps the
+# version in sync automatically.  A path-only self-dep (without a
+# version) breaks `cargo publish` because crates.io rejects
+# manifests whose declared deps lack version constraints.
+nereids-physics = { workspace = true, features = ["test-support"] }
 

--- a/crates/nereids-physics/Cargo.toml
+++ b/crates/nereids-physics/Cargo.toml
@@ -24,3 +24,11 @@ num-complex = { workspace = true }
 rayon = { workspace = true }
 microlp = { workspace = true }
 
+[dev-dependencies]
+# Integration tests under `tests/` are compiled as a separate crate
+# that links against the production build of `nereids-physics`, so
+# they cannot see items gated only by `#[cfg(test)]`.  Enabling the
+# `test-support` feature here exposes `resolution::test_support` to
+# the integration suite without leaking it into release builds.
+nereids-physics = { path = ".", features = ["test-support"] }
+

--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -2192,6 +2192,38 @@ pub mod test_support {
             flight_path_m,
         }
     }
+
+    /// Thin shim exposing the crate-internal
+    /// [`TabulatedResolution::broaden_presorted`] to integration
+    /// tests living under `crates/nereids-physics/tests/`.  The
+    /// internal method stays `pub(crate)` so the broader public
+    /// API surface (the operator-style `apply_resolution`,
+    /// `plan` / `apply` / `compile_to_matrix`) remains the
+    /// recommended entry point; this shim exists solely so the
+    /// fixture-gated bit-exact regression and microbenchmark
+    /// tests can call the optimized two-pointer walk directly.
+    pub fn broaden_presorted(
+        tab: &TabulatedResolution,
+        energies: &[f64],
+        spectrum: &[f64],
+    ) -> Vec<f64> {
+        tab.broaden_presorted(energies, spectrum)
+    }
+
+    /// Thin shim exposing the crate-internal
+    /// `TabulatedResolution::interpolated_kernel` to integration
+    /// tests.  Needed by the bit-exact equivalence oracle that
+    /// the fixture-gated regression test runs against the
+    /// optimized `broaden_presorted` path.
+    pub fn interpolated_kernel(tab: &TabulatedResolution, energy: f64) -> (Vec<f64>, Vec<f64>) {
+        tab.interpolated_kernel(energy)
+    }
+
+    /// The TOF↔energy conversion factor used by
+    /// `broaden_presorted` and its oracle.  Exposed so the
+    /// integration-test oracle uses the exact same constant as
+    /// the SUT, preserving bit-exact equivalence.
+    pub const TOF_FACTOR: f64 = super::TOF_FACTOR;
 }
 
 #[cfg(test)]
@@ -2802,62 +2834,16 @@ mod tests {
         assert_bit_exact(&reference, &actual, "random_spectrum");
     }
 
-    /// Real PLEIADES bl10 resolution file + real Hf-like resonance
-    /// spectrum on the full VENUS analysis grid.  This is the closest
-    /// regression of the production A.1 / B.2 workload.
-    ///
-    /// Marked `#[ignore]` because `_fts_bl10_0p5meV_1keV_25pts.txt` is
-    /// gitignored at the repo root per the "not approved for public
-    /// release" policy (.gitignore line 48).  Run locally with:
-    ///
-    /// ```text
-    /// cargo test -p nereids-physics \
-    ///   test_broaden_presorted_bit_exact_on_pleiades_resolution \
-    ///   -- --ignored --nocapture
-    /// ```
-    #[test]
-    #[ignore = "requires PLEIADES resolution file `_fts_bl10_0p5meV_1keV_25pts.txt` at repo root (gitignored by policy)"]
-    fn test_broaden_presorted_bit_exact_on_pleiades_resolution() {
-        let res_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join("_fts_bl10_0p5meV_1keV_25pts.txt");
-        let text = std::fs::read_to_string(&res_path).expect(
-            "missing PLEIADES resolution file `_fts_bl10_0p5meV_1keV_25pts.txt` at the repo root \
-             (the file is gitignored per policy; place it locally before running this test)",
-        );
-        let tab = TabulatedResolution::from_text(&text, 25.0).unwrap();
+    // ---------------------------------------------------------------
+    // Fixture-gated regression test moved to
+    // `crates/nereids-physics/tests/venus_usr_resolution.rs`
+    // (`test_broaden_presorted_bit_exact_on_venus_usr`) — see issue
+    // #497.  The fixture (`_fts_bl10_0p5meV_1keV_25pts.txt`) is the
+    // VENUS instrument SAMMY-format tabulated resolution kernel; the
+    // integration test uses an early-return idiom keyed off
+    // `common::venus_usr_resolution_path()` instead of `#[ignore]`.
+    // ---------------------------------------------------------------
 
-        // Production-like grid: uniform 7..200 eV with ~3500 bins
-        let n = 3471;
-        let energies: Vec<f64> = (0..n)
-            .map(|i| 7.0 + i as f64 * ((200.0 - 7.0) / (n - 1) as f64))
-            .collect();
-        // Resonance-dip spectrum (toy model, exercises the math regardless
-        // of actual Hf σ, which is what we want for an interp test).
-        let spectrum: Vec<f64> = energies
-            .iter()
-            .map(|&e| {
-                1.0 - 0.8 * (-((e - 7.8).powi(2) / 0.01)).exp()
-                    - 0.5 * (-((e - 13.9).powi(2) / 0.04)).exp()
-                    - 0.6 * (-((e - 22.4).powi(2) / 0.1)).exp()
-            })
-            .collect();
-
-        let reference = broaden_presorted_reference(&tab, &energies, &spectrum);
-        let actual = tab.broaden_presorted(&energies, &spectrum);
-        assert_bit_exact(&reference, &actual, "pleiades_real_resolution");
-    }
-
-    /// Microbenchmark: two-pointer broaden_presorted vs binary-search
-    /// reference.  Run with:
-    ///
-    /// ```text
-    /// cargo test --release -p nereids-physics \
-    ///   test_broaden_presorted_bench -- --ignored --nocapture
-    /// ```
     #[test]
     fn test_plan_reuse_bit_exact_across_multiple_spectra() {
         // Core promise of ResolutionPlan: building the plan once and
@@ -3185,191 +3171,29 @@ mod tests {
         assert!(matches!(result, Err(ResolutionError::UnsortedEnergies)));
     }
 
-    #[test]
-    #[ignore = "microbenchmark; requires PLEIADES resolution file `_fts_bl10_0p5meV_1keV_25pts.txt` at repo root"]
-    fn test_broaden_presorted_bench() {
-        let res_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join("_fts_bl10_0p5meV_1keV_25pts.txt");
-        let text = std::fs::read_to_string(&res_path).expect(
-            "missing PLEIADES resolution file at repo root (see `#[ignore]` message for details)",
-        );
-        let tab = TabulatedResolution::from_text(&text, 25.0).unwrap();
-
-        let n = 3471;
-        let energies: Vec<f64> = (0..n)
-            .map(|i| 7.0 + i as f64 * ((200.0 - 7.0) / (n - 1) as f64))
-            .collect();
-        let spectrum: Vec<f64> = energies
-            .iter()
-            .map(|&e| {
-                1.0 - 0.8 * (-((e - 7.8).powi(2) / 0.01)).exp()
-                    - 0.6 * (-((e - 22.4).powi(2) / 0.1)).exp()
-            })
-            .collect();
-
-        let repeats = 30;
-
-        let start = std::time::Instant::now();
-        let mut sink_ref = 0.0f64;
-        for _ in 0..repeats {
-            let r = broaden_presorted_reference(&tab, &energies, &spectrum);
-            sink_ref += r.iter().sum::<f64>();
-        }
-        let t_ref = start.elapsed();
-
-        let start = std::time::Instant::now();
-        let mut sink_new = 0.0f64;
-        for _ in 0..repeats {
-            let r = tab.broaden_presorted(&energies, &spectrum);
-            sink_new += r.iter().sum::<f64>();
-        }
-        let t_new = start.elapsed();
-
-        let speedup = t_ref.as_secs_f64() / t_new.as_secs_f64();
-        println!(
-            "broaden_presorted microbench (n_grid={n}, repeats={repeats}, 499-pt kernel):\n\
-             reference (binary search): {t_ref:?}  (sink={sink_ref:.3})\n\
-             two-pointer walk         : {t_new:?}  (sink={sink_new:.3})\n\
-             speedup                  : {speedup:.2}x"
-        );
-        assert_eq!(sink_ref.to_bits(), sink_new.to_bits());
-    }
-
-    /// Microbenchmark: plan-reuse path vs per-call `broaden_presorted`.
-    ///
-    /// This is the payoff the `plan()` + `ResolutionPlan::apply()` API
-    /// is designed to deliver: when broadening many spectra on the same
-    /// target grid (e.g., LM iterations with fixed TZERO, spatial maps
-    /// with pre-calibrated energies), building the plan once and
-    /// applying it N times beats rebuilding the plan internally on
-    /// every call.
-    ///
-    /// Run manually with:
-    ///
-    /// ```text
-    /// cargo test --release -p nereids-physics \
-    ///   test_plan_reuse_bench -- --ignored --nocapture
-    /// ```
-    #[test]
-    #[ignore = "microbenchmark; requires PLEIADES resolution file `_fts_bl10_0p5meV_1keV_25pts.txt` at repo root"]
-    fn test_plan_reuse_bench() {
-        let res_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join("_fts_bl10_0p5meV_1keV_25pts.txt");
-        let text = std::fs::read_to_string(&res_path).expect(
-            "missing PLEIADES resolution file at repo root (see `#[ignore]` message for details)",
-        );
-        let tab = TabulatedResolution::from_text(&text, 25.0).unwrap();
-
-        let n = 3471;
-        let energies: Vec<f64> = (0..n)
-            .map(|i| 7.0 + i as f64 * ((200.0 - 7.0) / (n - 1) as f64))
-            .collect();
-
-        // Many spectra simulating an LM fit's sequence of evaluations.
-        let repeats = 100;
-        let mut state: u64 = 0xA5A5_A5A5_DEAD_BEEF;
-        let spectra: Vec<Vec<f64>> = (0..repeats)
-            .map(|_| {
-                energies
-                    .iter()
-                    .map(|&e| {
-                        state = state
-                            .wrapping_mul(6364136223846793005)
-                            .wrapping_add(1442695040888963407);
-                        let noise = ((state >> 33) as f64) / (u32::MAX as f64);
-                        1.0 - 0.8 * (-((e - 7.8).powi(2) / 0.01)).exp() + 1e-3 * noise
-                    })
-                    .collect()
-            })
-            .collect();
-
-        // Per-call path: same pipeline as today.  Build cost paid every call.
-        let start = std::time::Instant::now();
-        let mut sink_percall = 0.0f64;
-        for spec in &spectra {
-            let r = tab.broaden_presorted(&energies, spec);
-            sink_percall += r.iter().sum::<f64>();
-        }
-        let t_percall = start.elapsed();
-
-        // Plan-reuse path: one build, many applies.
-        let start = std::time::Instant::now();
-        let plan = tab.plan(&energies).expect("sorted grid must validate");
-        let t_build = start.elapsed();
-        let mut sink_plan = 0.0f64;
-        for spec in &spectra {
-            let r = plan.apply(spec);
-            sink_plan += r.iter().sum::<f64>();
-        }
-        let t_apply_total = start.elapsed() - t_build;
-
-        let speedup = t_percall.as_secs_f64() / (t_build + t_apply_total).as_secs_f64();
-        println!(
-            "plan-reuse microbench (n_grid={n}, {repeats} spectra, 499-pt kernel):\n\
-             per-call broaden_presorted : {t_percall:?}  (sink={sink_percall:.3})\n\
-             plan build (once)          : {t_build:?}\n\
-             apply × {repeats}          : {t_apply_total:?}\n\
-             total plan path            : {:?}  (sink={sink_plan:.3})\n\
-             speedup vs per-call        : {speedup:.2}x",
-            t_build + t_apply_total,
-        );
-        assert_eq!(sink_percall.to_bits(), sink_plan.to_bits());
-    }
+    // ---------------------------------------------------------------
+    // Fixture-gated microbenchmarks moved to
+    // `crates/nereids-physics/tests/venus_usr_resolution_microbench.rs`
+    // (`test_broaden_presorted_bench`, `test_plan_reuse_bench`,
+    // `resolution_matrix_apply_microbench`) — see issue #497.  They
+    // use the early-return idiom keyed off
+    // `common::venus_usr_resolution_path()` instead of `#[ignore]`.
+    // ---------------------------------------------------------------
 
     // ---------- ResolutionMatrix (CSR compile) tests ----------
     //
-    // Two tiers of tests:
+    // CI-hermetic synthetic tests — use hand-constructed
+    // `ResolutionPlan`s via `make_synthetic_plan`; no fixture
+    // dependency, run on every `cargo test` invocation.  Cover
+    // passthrough rows, `-0.0` sentinel rows, regular linear-interp
+    // rows, CSR invariants, and the non-finite contract exclusion.
     //
-    // 1. **CI-hermetic synthetic tests** — use hand-constructed
-    //    `ResolutionPlan`s via `make_synthetic_plan`; no fixture
-    //    dependency, run on every `cargo test` invocation.  Cover
-    //    passthrough rows, `-0.0` sentinel rows, regular
-    //    linear-interp rows, CSR invariants, and the non-finite
-    //    contract exclusion.
-    //
-    // 2. **Fixture-dependent tests** (`#[ignore]`) — require
-    //    `_fts_bl10_0p5meV_1keV_25pts.txt` at the repo root (a
-    //    gitignored PLEIADES file).  Cover end-to-end equivalence
-    //    against the production VENUS operator at realistic grid
-    //    sizes (512, 3471).  Run locally with `-- --ignored`.  Same
-    //    pattern as `test_broaden_presorted_bit_exact_on_pleiades_resolution`
-    //    already in this module.
-
-    /// Helper: build a TabulatedResolution + plan + matrix on a
-    /// uniform energy grid using the VENUS fixture kernel.  Only used
-    /// by `#[ignore]`d tests because the fixture file is gitignored
-    /// at the repo root per the "not approved for public release"
-    /// policy (.gitignore line 49).
-    fn build_fixture_plan_and_matrix(
-        n_grid: usize,
-    ) -> (Vec<f64>, ResolutionPlan, ResolutionMatrix) {
-        let res_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join("_fts_bl10_0p5meV_1keV_25pts.txt");
-        let text = std::fs::read_to_string(&res_path).expect(
-            "missing PLEIADES resolution file `_fts_bl10_0p5meV_1keV_25pts.txt` at the repo root \
-             (the file is gitignored per policy; place it locally before running this test)",
-        );
-        let res =
-            TabulatedResolution::from_text(&text, 25.0).expect("parse VENUS resolution fixture");
-        let energies: Vec<f64> = (0..n_grid)
-            .map(|i| 7.0 + (200.0 - 7.0) * (i as f64) / ((n_grid - 1) as f64))
-            .collect();
-        let plan = res.plan(&energies).expect("build plan on sorted grid");
-        let matrix = plan.compile_to_matrix();
-        (energies, plan, matrix)
-    }
+    // Fixture-dependent end-to-end equivalence tests against the
+    // production VENUS USR operator (SAMMY-format kernel) at
+    // realistic grid sizes (512, 3471) live in
+    // `crates/nereids-physics/tests/venus_usr_resolution.rs` — see
+    // issue #497.  They use the early-return idiom keyed off
+    // `common::venus_usr_resolution_path()` instead of `#[ignore]`.
 
     /// Hybrid abs+rel tolerance used across equivalence tests.  Guards
     /// against the `a ≈ 0` trap where `a.abs().max(1e-300)` produces
@@ -3516,165 +3340,19 @@ mod tests {
         assert!(matches!(err, ResolutionError::LengthMismatch { .. }));
     }
 
-    /// End-to-end bit-level equivalence on the real VENUS kernel,
-    /// 512-point grid.  Gated on the PLEIADES fixture per the
-    /// established `#[ignore]` pattern in this module.
-    #[test]
-    #[ignore = "requires PLEIADES resolution file `_fts_bl10_0p5meV_1keV_25pts.txt` at repo root (gitignored by policy)"]
-    fn resolution_matrix_is_row_stochastic_on_venus_kernel() {
-        let (_energies, _plan, matrix) = build_fixture_plan_and_matrix(512);
-        for i in 0..matrix.len() {
-            let start = matrix.row_starts()[i] as usize;
-            let end = matrix.row_starts()[i + 1] as usize;
-            let row_sum: f64 = matrix.values()[start..end].iter().sum();
-            assert!(
-                (row_sum - 1.0).abs() < 1e-13,
-                "row {} sum = {} (expected 1.0 within 1e-13)",
-                i,
-                row_sum,
-            );
-        }
-    }
-
-    #[test]
-    #[ignore = "requires PLEIADES resolution file `_fts_bl10_0p5meV_1keV_25pts.txt` at repo root (gitignored by policy)"]
-    fn resolution_matrix_apply_equivalent_to_plan_apply_on_venus_kernel() {
-        let (_energies, plan, matrix) = build_fixture_plan_and_matrix(512);
-        let n_grid = matrix.len();
-        let spec: Vec<f64> = (0..n_grid)
-            .map(|i| {
-                let e = 7.0 + (200.0 - 7.0) * (i as f64) / ((n_grid - 1) as f64);
-                let sigma = 50.0 * (-((e - 80.0).powi(2)) / 8.0).exp()
-                    + 10.0 * (-((e - 150.0).powi(2)) / 4.0).exp();
-                (-1.6e-4 * sigma).exp()
-            })
-            .collect();
-        let plan_out = plan.apply(&spec);
-        let matrix_out = apply_r(&matrix, &spec);
-        let max_err = max_hybrid_err(&plan_out, &matrix_out);
-        assert!(
-            max_err < 1e-12,
-            "apply_r vs plan.apply max hybrid err = {:.3e} (expected < 1e-12)",
-            max_err,
-        );
-    }
-
-    /// Production-grid guardrail for the `1e-12` tolerance documented
-    /// on [`ResolutionPlan::compile_to_matrix`].  The 3471-bin VENUS
-    /// grid has ~82 entries per row, so accumulation error is an
-    /// order of magnitude larger than on the synthetic multi-row
-    /// tests above; this test pins the equivalence bound at
-    /// production scale so a future regression in either `apply` or
-    /// `apply_r` summation order fails loudly.  Logs the observed
-    /// `max_hybrid_err` via `eprintln!` so `-- --ignored --nocapture`
-    /// runs surface the actual headroom against the 1e-12 ceiling.
-    #[test]
-    #[ignore = "requires PLEIADES resolution file `_fts_bl10_0p5meV_1keV_25pts.txt` at repo root (gitignored by policy)"]
-    fn resolution_matrix_apply_equivalent_at_production_grid() {
-        let (_energies, plan, matrix) = build_fixture_plan_and_matrix(3471);
-        let n_grid = matrix.len();
-        // Same Beer-Lambert test spectrum as the 512-point test.
-        let spec: Vec<f64> = (0..n_grid)
-            .map(|i| {
-                let e = 7.0 + (200.0 - 7.0) * (i as f64) / ((n_grid - 1) as f64);
-                let sigma = 50.0 * (-((e - 80.0).powi(2)) / 8.0).exp()
-                    + 10.0 * (-((e - 150.0).powi(2)) / 4.0).exp();
-                (-1.6e-4 * sigma).exp()
-            })
-            .collect();
-        let plan_out = plan.apply(&spec);
-        let matrix_out = apply_r(&matrix, &spec);
-        let max_err = max_hybrid_err(&plan_out, &matrix_out);
-        eprintln!(
-            "3471-grid apply_r vs plan.apply observed max_hybrid_err = {:.3e} \
-             (ceiling 1e-12; theoretical bound ~1e-13 per row × 82 rows/entry)",
-            max_err,
-        );
-        assert!(
-            max_err < 1e-12,
-            "3471-grid apply_r vs plan.apply max hybrid err = {:.3e} (expected < 1e-12)",
-            max_err,
-        );
-    }
-
-    #[test]
-    #[ignore = "requires PLEIADES resolution file `_fts_bl10_0p5meV_1keV_25pts.txt` at repo root (gitignored by policy)"]
-    fn resolution_matrix_apply_equivalent_across_densities() {
-        let (_energies, plan, matrix) = build_fixture_plan_and_matrix(512);
-        let n_grid = matrix.len();
-        for &n_density in &[1e-5_f64, 1e-4, 1.6e-4, 1e-3] {
-            let spec: Vec<f64> = (0..n_grid)
-                .map(|i| {
-                    let e = 7.0 + (200.0 - 7.0) * (i as f64) / ((n_grid - 1) as f64);
-                    let sigma = 50.0 * (-((e - 80.0).powi(2)) / 8.0).exp()
-                        + 10.0 * (-((e - 150.0).powi(2)) / 4.0).exp();
-                    (-n_density * sigma).exp()
-                })
-                .collect();
-            let plan_out = plan.apply(&spec);
-            let matrix_out = apply_r(&matrix, &spec);
-            let max_err = max_hybrid_err(&plan_out, &matrix_out);
-            assert!(
-                max_err < 1e-12,
-                "density n={:.1e}: max hybrid err {:.3e} (expected < 1e-12)",
-                n_density,
-                max_err,
-            );
-        }
-    }
-
-    #[test]
-    #[ignore = "requires PLEIADES resolution file `_fts_bl10_0p5meV_1keV_25pts.txt` at repo root (gitignored by policy)"]
-    fn resolution_matrix_csr_column_indices_sorted_per_row() {
-        let (_energies, _plan, matrix) = build_fixture_plan_and_matrix(256);
-        for i in 0..matrix.len() {
-            let start = matrix.row_starts()[i] as usize;
-            let end = matrix.row_starts()[i + 1] as usize;
-            let row_cols = &matrix.col_indices()[start..end];
-            for w in row_cols.windows(2) {
-                assert!(
-                    w[0] < w[1],
-                    "row {} col_indices not strictly ascending: {:?}",
-                    i,
-                    row_cols,
-                );
-            }
-        }
-    }
-
-    #[test]
-    #[ignore = "requires PLEIADES resolution file `_fts_bl10_0p5meV_1keV_25pts.txt` at repo root (gitignored by policy)"]
-    fn resolution_matrix_grid_mismatch_detected() {
-        let (energies, _plan, matrix) = build_fixture_plan_and_matrix(128);
-        let spec = vec![1.0_f64; matrix.len()];
-
-        // Same grid → passes.
-        let ok = apply_resolution_with_matrix(&energies, &matrix, &spec);
-        assert!(ok.is_ok());
-
-        // Perturb one energy → MatrixGridMismatch with the
-        // offending index.
-        let mut mutated = energies.clone();
-        mutated[37] += 1e-12;
-        let err = apply_resolution_with_matrix(&mutated, &matrix, &spec)
-            .expect_err("grid mismatch must error");
-        assert_eq!(
-            err,
-            ResolutionError::MatrixGridMismatch {
-                first_diff_index: 37,
-            }
-        );
-    }
-
-    #[test]
-    #[ignore = "requires PLEIADES resolution file `_fts_bl10_0p5meV_1keV_25pts.txt` at repo root (gitignored by policy)"]
-    fn resolution_matrix_length_mismatch_detected() {
-        let (energies, _plan, matrix) = build_fixture_plan_and_matrix(64);
-        let short_spec = vec![1.0_f64; matrix.len() - 1];
-        let err = apply_resolution_with_matrix(&energies, &matrix, &short_spec)
-            .expect_err("length mismatch must error");
-        assert!(matches!(err, ResolutionError::LengthMismatch { .. }));
-    }
+    // ---------------------------------------------------------------
+    // Fixture-gated end-to-end VENUS USR equivalence tests moved to
+    // `crates/nereids-physics/tests/venus_usr_resolution.rs`
+    // (`resolution_matrix_is_row_stochastic_on_venus_kernel`,
+    //  `resolution_matrix_apply_equivalent_to_plan_apply_on_venus_kernel`,
+    //  `resolution_matrix_apply_equivalent_at_production_grid`,
+    //  `resolution_matrix_apply_equivalent_across_densities`,
+    //  `resolution_matrix_csr_column_indices_sorted_per_row`,
+    //  `resolution_matrix_grid_mismatch_detected`,
+    //  `resolution_matrix_length_mismatch_detected`) — see issue
+    // #497.  They use the early-return idiom keyed off
+    // `common::venus_usr_resolution_path()` instead of `#[ignore]`.
+    // ---------------------------------------------------------------
 
     #[test]
     fn resolution_matrix_empty_plan() {
@@ -3689,92 +3367,6 @@ mod tests {
         assert_eq!(matrix.len(), 0);
         assert!(matrix.is_empty());
         assert_eq!(matrix.nnz(), 0);
-    }
-
-    /// Microbenchmark: `apply_r` (ResolutionMatrix CSR) vs
-    /// `ResolutionPlan::apply`, 3471-bin VENUS production grid × 100
-    /// spectra. Exercised manually to decide whether the CSR compile +
-    /// CSR matvec beats the plan's two-pointer walk at the
-    /// no-SIMD-no-unsafe baseline promised in #473.
-    ///
-    /// Run manually with:
-    ///
-    /// ```text
-    /// cargo test --release -p nereids-physics \
-    ///   resolution_matrix_apply_microbench -- --ignored --nocapture
-    /// ```
-    #[test]
-    #[ignore = "microbenchmark; requires PLEIADES resolution file `_fts_bl10_0p5meV_1keV_25pts.txt` at repo root"]
-    fn resolution_matrix_apply_microbench() {
-        let res_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join("_fts_bl10_0p5meV_1keV_25pts.txt");
-        let text = std::fs::read_to_string(&res_path).expect(
-            "missing PLEIADES resolution file at repo root (see `#[ignore]` message for details)",
-        );
-        let tab = TabulatedResolution::from_text(&text, 25.0).unwrap();
-
-        let n = 3471_usize;
-        let energies: Vec<f64> = (0..n)
-            .map(|i| 7.0 + i as f64 * ((200.0 - 7.0) / (n - 1) as f64))
-            .collect();
-        let plan = tab.plan(&energies).expect("sorted grid must validate");
-
-        let t_compile = std::time::Instant::now();
-        let matrix = plan.compile_to_matrix();
-        let t_compile = t_compile.elapsed();
-
-        let spec: Vec<f64> = energies
-            .iter()
-            .map(|&e| {
-                let sigma = 50.0 * (-((e - 80.0).powi(2)) / 8.0).exp()
-                    + 10.0 * (-((e - 150.0).powi(2)) / 4.0).exp();
-                (-1.6e-4 * sigma).exp()
-            })
-            .collect();
-
-        let repeats = 100_usize;
-
-        // Warm both paths so the first call's cache-miss latency
-        // does not skew the micro-times.
-        for _ in 0..5 {
-            let _ = plan.apply(&spec);
-            let _ = apply_r(&matrix, &spec);
-        }
-
-        let start = std::time::Instant::now();
-        let mut sink_plan = 0.0f64;
-        for _ in 0..repeats {
-            sink_plan += plan.apply(&spec).iter().sum::<f64>();
-        }
-        let t_plan = start.elapsed();
-
-        let start = std::time::Instant::now();
-        let mut sink_matrix = 0.0f64;
-        for _ in 0..repeats {
-            sink_matrix += apply_r(&matrix, &spec).iter().sum::<f64>();
-        }
-        let t_matrix = start.elapsed();
-
-        let speedup = t_plan.as_secs_f64() / t_matrix.as_secs_f64();
-        println!(
-            "ResolutionMatrix microbench (n_grid={n}, {repeats} spectra):\n\
-             compile (once)       : {:?}  ({} nnz)\n\
-             plan.apply × {repeats} : {:?}\n\
-             apply_r   × {repeats} : {:?}\n\
-             speedup vs plan      : {:.2}x\n\
-             sinks (plan/matrix)  : {:.6e} / {:.6e}",
-            t_compile,
-            matrix.nnz(),
-            t_plan,
-            t_matrix,
-            speedup,
-            sink_plan,
-            sink_matrix,
-        );
     }
 
     /// Hand-construct a `ResolutionPlan` that deliberately exercises

--- a/crates/nereids-physics/src/surrogate.rs
+++ b/crates/nereids-physics/src/surrogate.rs
@@ -1129,7 +1129,7 @@ pub type ScalarSurrogatePlan = ScalarChebyshevPlan;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resolution::{ResolutionPlan, TabulatedResolution};
+    use crate::resolution::ResolutionPlan;
 
     // ---------- Synthetic plan helpers (CI-hermetic) ----------
 
@@ -1676,103 +1676,13 @@ mod tests {
             .fold(0.0_f64, f64::max)
     }
 
-    // ---------- Real-VENUS-kernel tests (#[ignore]-gated) ----------
-    //
-    // Gated on the PLEIADES resolution fixture per the established
-    // pattern in `resolution.rs`.  These exercise the cubature on the
-    // production-scale VENUS kernel at the actual grid size surrogates
-    // will see in the wiring follow-up (PR #474b).
-
-    /// k = 1 grouped case: the cubature should match the exact
-    /// `ResolutionMatrix @ exp(-n σ)` forward output to LP precision
-    /// at the training densities, and produce bounded error at
-    /// held-out densities inside the training box.  Codex04's 20-seed
-    /// KL follow-up showed 1.27× scatter inflation on grouped-Hf k=1
-    /// — this test does not re-measure that; it only checks forward-
-    /// model correctness.
-    #[test]
-    #[ignore = "requires PLEIADES resolution file `_fts_bl10_0p5meV_1keV_25pts.txt` at repo root (gitignored by policy)"]
-    fn cubature_real_venus_k1_forward_equivalence() {
-        let res_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join("_fts_bl10_0p5meV_1keV_25pts.txt");
-        let text = std::fs::read_to_string(&res_path).expect(
-            "missing PLEIADES resolution file at repo root (see `#[ignore]` message for details)",
-        );
-        let tab = TabulatedResolution::from_text(&text, 25.0).expect("parse fixture");
-
-        // Smaller production-ish grid (512 instead of 3471) to keep
-        // LP-per-row cost tractable within a single test — the
-        // cubature structure is grid-independent, so 512 suffices to
-        // show correctness.  Full 3471 sweep lives in the wiring
-        // follow-up.
-        let n_grid = 512_usize;
-        let energies: Vec<f64> = (0..n_grid)
-            .map(|i| 7.0 + (200.0 - 7.0) * (i as f64) / ((n_grid - 1) as f64))
-            .collect();
-        let plan = tab.plan(&energies).expect("build plan on sorted grid");
-        let matrix = plan.compile_to_matrix();
-
-        // Synthetic Gaussian-resonance σ on the real energy grid —
-        // we don't need real ENDF σ to prove the cubature math; a
-        // physically plausible σ shape is sufficient.  The real-
-        // ENDF closed-loop validation belongs in PR #474b.
-        let sigma: Vec<f64> = energies
-            .iter()
-            .map(|&e| {
-                let g = (-((e - 80.0).powi(2)) / 8.0).exp();
-                100.0 * g + 5.0
-            })
-            .collect();
-
-        let train_max = [2e-4_f64];
-        let training = SparseEmpiricalCubaturePlan::default_training_points(&train_max);
-        let anchor = SparseEmpiricalCubaturePlan::default_jacobian_anchor(&train_max);
-        let cub = SparseEmpiricalCubaturePlan::build(&matrix, &sigma, 1, &training, &anchor)
-            .expect("build k=1 cubature on real VENUS kernel");
-
-        // At each training density, cubature = exact.
-        for n_s in training.iter() {
-            let t_cub = cub.forward(n_s);
-            let t_exact = exact_forward(&matrix, &sigma, 1, n_s);
-            let max_err = max_hybrid_err(&t_cub, &t_exact);
-            assert!(
-                max_err < 1e-9,
-                "VENUS k=1 training n={n_s:?} max err = {max_err:.3e}",
-            );
-        }
-
-        // At held-out density (VENUS production ~ 1.6e-4), bounded
-        // error.  Codex04's real-VENUS Hf aggregated fit showed a
-        // density shift of 1.66e-4 relative — which means forward
-        // error at the optimum is at least that small.  Here we
-        // allow 1e-3 max abs error as a generous ceiling; the actual
-        // value on the Beer-Lambert `T ∈ [0, 1]` output is typically
-        // an order of magnitude tighter.
-        let n_venus = vec![1.6e-4];
-        let t_cub = cub.forward(&n_venus);
-        let t_exact = exact_forward(&matrix, &sigma, 1, &n_venus);
-        let max_abs = t_cub
-            .iter()
-            .zip(t_exact.iter())
-            .map(|(a, b)| (a - b).abs())
-            .fold(0.0_f64, f64::max);
-        assert!(
-            max_abs < 1e-3,
-            "VENUS k=1 held-out n=1.6e-4 max abs err = {max_abs:.3e}",
-        );
-
-        // Log compression ratio for diagnostics.
-        let exact_nnz = matrix.nnz();
-        let cub_atoms = cub.n_atoms();
-        eprintln!(
-            "VENUS k=1 cubature compression: {exact_nnz} exact nnz → {cub_atoms} atoms ({:.1}× compression)",
-            exact_nnz as f64 / cub_atoms as f64,
-        );
-    }
+    // ---------------------------------------------------------------
+    // Fixture-gated real-VENUS-kernel cubature regression
+    // (`cubature_real_venus_k1_forward_equivalence`) moved to
+    // `crates/nereids-physics/tests/venus_usr_surrogate.rs` — see
+    // issue #497.  It uses the early-return idiom keyed off
+    // `common::venus_usr_resolution_path()` instead of `#[ignore]`.
+    // ---------------------------------------------------------------
 
     // ── Scalar (k = 1) surrogate tests — PR #475 ───────────────────
 
@@ -1902,111 +1812,11 @@ mod tests {
         ));
     }
 
-    /// Real-VENUS regression test for the Chebyshev scalar
-    /// surrogate on the 3471-bin VENUS production grid with
-    /// synthetic Hf-like σ.  Asserts forward accuracy ≤ 1e-5 at
-    /// VENUS density (issue #475 success criterion) and logs
-    /// per-call wall time.  PR #475 benched this against a
-    /// Lanczos σ-pushforward Gauss quadrature on the same kernel
-    /// and picked Chebyshev — it won on both accuracy
-    /// (≤ 2e-15 vs ≤ 4e-15) and wall-time.  Exact speedup ratios
-    /// are hardware-dependent and intentionally not pinned here;
-    /// the accuracy bound stays portable.
-    #[test]
-    #[ignore = "requires PLEIADES resolution file `_fts_bl10_0p5meV_1keV_25pts.txt` at repo root (gitignored by policy)"]
-    fn scalar_chebyshev_real_venus_k1_regression() {
-        let res_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join("_fts_bl10_0p5meV_1keV_25pts.txt");
-        let text = std::fs::read_to_string(&res_path).expect(
-            "missing PLEIADES resolution file at repo root (see `#[ignore]` message for details)",
-        );
-        let tab = TabulatedResolution::from_text(&text, 25.0).expect("parse fixture");
-
-        // VENUS production grid size.
-        let n_grid = 3471_usize;
-        let energies: Vec<f64> = (0..n_grid)
-            .map(|i| 7.0 + (200.0 - 7.0) * (i as f64) / ((n_grid - 1) as f64))
-            .collect();
-        let plan = std::sync::Arc::new(tab.plan(&energies).expect("build plan on sorted grid"));
-        let matrix = plan.compile_to_matrix();
-        let matrix_nnz = matrix.nnz();
-
-        // Synthetic Hf-like σ: Gaussian resonance peaks + baseline
-        // potential scattering.  Rough ENDF-Hf magnitudes (peaks
-        // up to O(1e3) barns, baseline ~10 barns).
-        let sigma: Vec<f64> = energies
-            .iter()
-            .map(|&e| {
-                let peak_a = 1200.0 * (-((e - 80.0).powi(2)) / 8.0).exp();
-                let peak_b = 600.0 * (-((e - 120.0).powi(2)) / 6.0).exp();
-                let peak_c = 300.0 * (-((e - 160.0).powi(2)) / 10.0).exp();
-                peak_a + peak_b + peak_c + 10.0
-            })
-            .collect();
-
-        // Training box: 2 × VENUS density.  M = 16 Chebyshev nodes
-        // — PR #475 bench showed this achieves 1e-15 forward
-        // accuracy on the whole box.
-        let n_max = 2e-4_f64;
-        let t_build = std::time::Instant::now();
-        let cheb = ScalarChebyshevPlan::build(std::sync::Arc::clone(&plan), &sigma, n_max, 16)
-            .expect("build Chebyshev plan");
-        let t_build = t_build.elapsed();
-
-        // Forward accuracy at VENUS density.
-        let n_venus = 1.6e-4_f64;
-        let t_exact = exact_forward(&matrix, &sigma, 1, &[n_venus]);
-        let t_cheb = cheb.forward_scalar(n_venus);
-        let max_err = max_hybrid_err(&t_cheb, &t_exact);
-
-        // Per-forward timing.
-        let n_iters = 1000;
-        let t0 = std::time::Instant::now();
-        let mut sink = 0.0_f64;
-        for _ in 0..n_iters {
-            sink += cheb.forward_scalar(n_venus)[0];
-        }
-        let t_fwd = t0.elapsed() / n_iters as u32;
-        std::hint::black_box(sink);
-
-        let t_un: Vec<f64> = sigma.iter().map(|&s| (-n_venus * s).exp()).collect();
-        let t0 = std::time::Instant::now();
-        let mut sink = 0.0_f64;
-        for _ in 0..n_iters {
-            sink += crate::resolution::apply_r(&matrix, &t_un)[0];
-        }
-        let t_exact_fwd = t0.elapsed() / n_iters as u32;
-        std::hint::black_box(sink);
-
-        eprintln!();
-        eprintln!(
-            "=== scalar Chebyshev VENUS k=1 regression (n_grid = {n_grid}, matrix nnz = {matrix_nnz}) ==="
-        );
-        eprintln!(
-            "Chebyshev (M=16):  build = {:>9.1?}  n_coeff = {:>7}  fwd = {:>8.2?}  max_err @ VENUS = {:.3e}",
-            t_build,
-            n_grid * 16,
-            t_fwd,
-            max_err,
-        );
-        eprintln!(
-            "Exact apply_r:     build = {:>9}                     fwd = {:>8.2?}  (reference)",
-            "n/a", t_exact_fwd,
-        );
-        eprintln!(
-            "Cheb speedup vs exact: {:.1}×",
-            t_exact_fwd.as_nanos() as f64 / t_fwd.as_nanos() as f64,
-        );
-        eprintln!();
-
-        // Issue #475 success criteria.
-        assert!(
-            max_err < 1e-5,
-            "Chebyshev forward max err {max_err:.3e} exceeds 1e-5 ceiling",
-        );
-    }
+    // ---------------------------------------------------------------
+    // Fixture-gated real-VENUS-kernel scalar Chebyshev regression
+    // (`scalar_chebyshev_real_venus_k1_regression`) moved to
+    // `crates/nereids-physics/tests/venus_usr_surrogate.rs` — see
+    // issue #497.  It uses the early-return idiom keyed off
+    // `common::venus_usr_resolution_path()` instead of `#[ignore]`.
+    // ---------------------------------------------------------------
 }

--- a/crates/nereids-physics/tests/README.md
+++ b/crates/nereids-physics/tests/README.md
@@ -1,0 +1,29 @@
+# Integration tests for `nereids-physics`
+
+## Fixture-gated tests
+
+Some tests require external instrument-characterization data that
+ORNL has not approved for public release. The fixture file is:
+
+- `_fts_bl10_0p5meV_1keV_25pts.txt` — VENUS instrument tabulated
+  resolution kernel (SAMMY USR format).  Place at the workspace root.
+
+These tests use the early-return idiom rather than `#[ignore]`:
+
+```rust
+let Some(path) = common::venus_usr_resolution_path() else { return; };
+```
+
+When the fixture is present, the test exercises real-instrument
+coverage.  When absent (CI, fresh checkouts), the test is a no-op
+and `cargo test` reports it as passed — no "ignored" noise.
+
+## Why not `#[ignore]`?
+
+Historical reason: previous test scaffolding used
+`#[ignore = "requires PLEIADES resolution file ..."]`.  The label
+"PLEIADES" was a misnomer (PLEIADES is a Python wrapper around
+SAMMY; this file is a SAMMY-format kernel for the VENUS
+instrument).  The `#[ignore]` mechanism also conflated
+fixture-gating with broken-on-purpose tests, and didn't enforce
+that fixture-present runs actually executed.  See issue #497.

--- a/crates/nereids-physics/tests/common/mod.rs
+++ b/crates/nereids-physics/tests/common/mod.rs
@@ -1,0 +1,22 @@
+//! Common helpers for fixture-gated integration tests.
+
+use std::path::PathBuf;
+
+/// Locate the VENUS instrument tabulated resolution fixture
+/// (`_fts_bl10_0p5meV_1keV_25pts.txt`, SAMMY USR format) at the
+/// workspace root.  The fixture is gitignored per ORNL release
+/// policy (.gitignore:48 — "Instrument resolution files (not
+/// approved for public release)").
+///
+/// Returns `Some(path)` when the fixture is present (developer
+/// machines with the file at repo root) and `None` otherwise (CI
+/// runners, fresh checkouts).  Callers should early-return on `None`
+/// so the test becomes a no-op without `#[ignore]` noise in
+/// `cargo test` output.
+pub fn venus_usr_resolution_path() -> Option<PathBuf> {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()? // crates/
+        .parent()? // workspace root
+        .join("_fts_bl10_0p5meV_1keV_25pts.txt");
+    if p.exists() { Some(p) } else { None }
+}

--- a/crates/nereids-physics/tests/venus_usr_resolution.rs
+++ b/crates/nereids-physics/tests/venus_usr_resolution.rs
@@ -1,0 +1,367 @@
+//! Fixture-gated regression tests for the VENUS USR resolution
+//! operator and CSR-compiled [`crate::resolution::ResolutionMatrix`].
+//!
+//! These tests load the SAMMY-format tabulated resolution kernel for
+//! the VENUS instrument (SNS Beam Line 10) from a gitignored file at
+//! the workspace root.  When the fixture is absent (CI, fresh
+//! checkouts), each test early-returns and is reported as passing —
+//! no `#[ignore]` noise.  When the fixture is present, the tests
+//! pin bit-exactness (where the test name says so) or hybrid
+//! abs+rel equivalence within `1e-12` against the slow oracle
+//! [`broaden_presorted_reference`].
+//!
+//! See `tests/README.md` for the rationale behind the early-return
+//! idiom and issue #497 for the move from `#[ignore]`'d tests in
+//! `src/resolution.rs`.
+
+mod common;
+
+use nereids_physics::resolution::{
+    ResolutionError, ResolutionMatrix, ResolutionPlan, TabulatedResolution, apply_r,
+    apply_resolution_with_matrix, test_support,
+};
+
+// ── Helpers (duplicated from `src/resolution.rs` tests — keeping
+//    the crate's public surface minimal per issue #497 scope) ─────
+
+fn interp_spectrum(energies: &[f64], spectrum: &[f64], e: f64) -> Option<f64> {
+    use nereids_core::constants::NEAR_ZERO_FLOOR;
+    if e < energies[0] || e > *energies.last().unwrap() {
+        return None;
+    }
+    let lo = match energies
+        .binary_search_by(|x| x.partial_cmp(&e).unwrap_or(std::cmp::Ordering::Equal))
+    {
+        Ok(idx) => return Some(spectrum[idx]),
+        Err(idx) => idx.saturating_sub(1),
+    };
+    let hi = lo + 1;
+    if hi >= energies.len() {
+        return Some(spectrum[lo]);
+    }
+    let span = energies[hi] - energies[lo];
+    if span.abs() < NEAR_ZERO_FLOOR {
+        return Some(spectrum[lo]);
+    }
+    let frac = (e - energies[lo]) / span;
+    Some(spectrum[lo] + frac * (spectrum[hi] - spectrum[lo]))
+}
+
+/// Reference implementation — the pre-optimization
+/// `broaden_presorted`.  Used solely as the equivalence oracle in
+/// the bit-exact test below.  Duplicated from `src/resolution.rs`
+/// rather than promoting the crate-internal helper to `pub`; uses
+/// `test_support::TOF_FACTOR` + `test_support::interpolated_kernel`
+/// so the oracle and SUT share the exact same constants and
+/// interior math.
+fn broaden_presorted_reference(
+    tab: &TabulatedResolution,
+    energies: &[f64],
+    spectrum: &[f64],
+) -> Vec<f64> {
+    use nereids_core::constants::DIVISION_FLOOR;
+    let tof_factor = test_support::TOF_FACTOR;
+
+    let n = energies.len();
+    if n == 0 {
+        return vec![];
+    }
+    let mut result = vec![0.0f64; n];
+    for i in 0..n {
+        let e = energies[i];
+        if e <= 0.0 {
+            result[i] = spectrum[i];
+            continue;
+        }
+        let tof_center = tof_factor * tab.flight_path_m() / e.sqrt();
+        let (offsets, weights) = test_support::interpolated_kernel(tab, e);
+        let mut sum = 0.0;
+        let mut norm = 0.0;
+        for k in 0..offsets.len() {
+            let dt = offsets[k];
+            let w = weights[k];
+            if w <= 0.0 {
+                continue;
+            }
+            let tof_prime = tof_center + dt;
+            if tof_prime <= 0.0 {
+                continue;
+            }
+            let e_prime = (tof_factor * tab.flight_path_m() / tof_prime).powi(2);
+            let s = match interp_spectrum(energies, spectrum, e_prime) {
+                Some(v) => v,
+                None => continue,
+            };
+            let dt_width = if k > 0 && k < offsets.len() - 1 {
+                (offsets[k + 1] - offsets[k - 1]) * 0.5
+            } else if k == 0 && offsets.len() > 1 {
+                offsets[1] - offsets[0]
+            } else if k == offsets.len() - 1 && offsets.len() > 1 {
+                offsets[k] - offsets[k - 1]
+            } else {
+                1.0
+            };
+            let weight = w * dt_width.abs();
+            sum += weight * s;
+            norm += weight;
+        }
+        result[i] = if norm > DIVISION_FLOOR {
+            sum / norm
+        } else {
+            spectrum[i]
+        };
+    }
+    result
+}
+
+fn assert_bit_exact(reference: &[f64], actual: &[f64], label: &str) {
+    assert_eq!(reference.len(), actual.len(), "{label}: length mismatch");
+    for (i, (&a, &b)) in reference.iter().zip(actual.iter()).enumerate() {
+        assert_eq!(
+            a.to_bits(),
+            b.to_bits(),
+            "{label}: element {i} mismatch: reference={a:.17e} actual={b:.17e}"
+        );
+    }
+}
+
+/// Hybrid abs+rel tolerance used across equivalence tests.  Guards
+/// against the `a ≈ 0` trap where `a.abs().max(1e-300)` produces
+/// meaningless relative errors for genuinely-zero reference values.
+fn max_hybrid_err(a: &[f64], b: &[f64]) -> f64 {
+    a.iter()
+        .zip(b)
+        .map(|(x, y)| {
+            let denom = x.abs().max(y.abs()).max(1e-12);
+            (x - y).abs() / denom
+        })
+        .fold(0.0_f64, f64::max)
+}
+
+/// Build a `TabulatedResolution` + plan + matrix on a uniform energy
+/// grid using the VENUS USR fixture kernel.  Helper duplicated from
+/// `src/resolution.rs` rather than promoted to the public API.
+///
+/// Panics if the fixture is missing — callers must early-return via
+/// [`common::venus_usr_resolution_path`] BEFORE invoking this.
+fn build_fixture_plan_and_matrix(
+    fixture_path: &std::path::Path,
+    n_grid: usize,
+) -> (Vec<f64>, ResolutionPlan, ResolutionMatrix) {
+    let text = std::fs::read_to_string(fixture_path).expect("read VENUS USR fixture");
+    let res = TabulatedResolution::from_text(&text, 25.0).expect("parse VENUS USR fixture");
+    let energies: Vec<f64> = (0..n_grid)
+        .map(|i| 7.0 + (200.0 - 7.0) * (i as f64) / ((n_grid - 1) as f64))
+        .collect();
+    let plan = res.plan(&energies).expect("build plan on sorted grid");
+    let matrix = plan.compile_to_matrix();
+    (energies, plan, matrix)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+/// Real VENUS BL10 (SNS) resolution kernel, SAMMY USR format, on a
+/// real Hf-like resonance spectrum over the full VENUS analysis
+/// grid.  This is the closest regression of the production A.1 /
+/// B.2 workload.
+#[test]
+fn test_broaden_presorted_bit_exact_on_venus_usr() {
+    let Some(path) = common::venus_usr_resolution_path() else {
+        return;
+    };
+    let text = std::fs::read_to_string(&path).expect("read VENUS USR fixture");
+    let tab = TabulatedResolution::from_text(&text, 25.0).unwrap();
+
+    // Production-like grid: uniform 7..200 eV with ~3500 bins
+    let n = 3471;
+    let energies: Vec<f64> = (0..n)
+        .map(|i| 7.0 + i as f64 * ((200.0 - 7.0) / (n - 1) as f64))
+        .collect();
+    // Resonance-dip spectrum (toy model, exercises the math regardless
+    // of actual Hf σ, which is what we want for an interp test).
+    let spectrum: Vec<f64> = energies
+        .iter()
+        .map(|&e| {
+            1.0 - 0.8 * (-((e - 7.8).powi(2) / 0.01)).exp()
+                - 0.5 * (-((e - 13.9).powi(2) / 0.04)).exp()
+                - 0.6 * (-((e - 22.4).powi(2) / 0.1)).exp()
+        })
+        .collect();
+
+    let reference = broaden_presorted_reference(&tab, &energies, &spectrum);
+    let actual = test_support::broaden_presorted(&tab, &energies, &spectrum);
+    assert_bit_exact(&reference, &actual, "venus_usr_real_resolution");
+}
+
+/// End-to-end row-stochasticity on the real VENUS kernel,
+/// 512-point grid.  Gated on the VENUS USR resolution fixture
+/// (SAMMY-format).
+#[test]
+fn resolution_matrix_is_row_stochastic_on_venus_kernel() {
+    let Some(path) = common::venus_usr_resolution_path() else {
+        return;
+    };
+    let (_energies, _plan, matrix) = build_fixture_plan_and_matrix(&path, 512);
+    for i in 0..matrix.len() {
+        let start = matrix.row_starts()[i] as usize;
+        let end = matrix.row_starts()[i + 1] as usize;
+        let row_sum: f64 = matrix.values()[start..end].iter().sum();
+        assert!(
+            (row_sum - 1.0).abs() < 1e-13,
+            "row {} sum = {} (expected 1.0 within 1e-13)",
+            i,
+            row_sum,
+        );
+    }
+}
+
+#[test]
+fn resolution_matrix_apply_equivalent_to_plan_apply_on_venus_kernel() {
+    let Some(path) = common::venus_usr_resolution_path() else {
+        return;
+    };
+    let (_energies, plan, matrix) = build_fixture_plan_and_matrix(&path, 512);
+    let n_grid = matrix.len();
+    let spec: Vec<f64> = (0..n_grid)
+        .map(|i| {
+            let e = 7.0 + (200.0 - 7.0) * (i as f64) / ((n_grid - 1) as f64);
+            let sigma = 50.0 * (-((e - 80.0).powi(2)) / 8.0).exp()
+                + 10.0 * (-((e - 150.0).powi(2)) / 4.0).exp();
+            (-1.6e-4 * sigma).exp()
+        })
+        .collect();
+    let plan_out = plan.apply(&spec);
+    let matrix_out = apply_r(&matrix, &spec);
+    let max_err = max_hybrid_err(&plan_out, &matrix_out);
+    assert!(
+        max_err < 1e-12,
+        "apply_r vs plan.apply max hybrid err = {:.3e} (expected < 1e-12)",
+        max_err,
+    );
+}
+
+/// Production-grid guardrail for the `1e-12` tolerance documented
+/// on `ResolutionPlan::compile_to_matrix`.  The 3471-bin VENUS grid
+/// has ~82 entries per row, so accumulation error is an order of
+/// magnitude larger than on the synthetic multi-row tests in
+/// `src/resolution.rs`; this test pins the equivalence bound at
+/// production scale so a future regression in either `apply` or
+/// `apply_r` summation order fails loudly.  Logs the observed
+/// `max_hybrid_err` via `eprintln!` so `-- --nocapture` runs surface
+/// the actual headroom against the 1e-12 ceiling.
+#[test]
+fn resolution_matrix_apply_equivalent_at_production_grid() {
+    let Some(path) = common::venus_usr_resolution_path() else {
+        return;
+    };
+    let (_energies, plan, matrix) = build_fixture_plan_and_matrix(&path, 3471);
+    let n_grid = matrix.len();
+    // Same Beer-Lambert test spectrum as the 512-point test.
+    let spec: Vec<f64> = (0..n_grid)
+        .map(|i| {
+            let e = 7.0 + (200.0 - 7.0) * (i as f64) / ((n_grid - 1) as f64);
+            let sigma = 50.0 * (-((e - 80.0).powi(2)) / 8.0).exp()
+                + 10.0 * (-((e - 150.0).powi(2)) / 4.0).exp();
+            (-1.6e-4 * sigma).exp()
+        })
+        .collect();
+    let plan_out = plan.apply(&spec);
+    let matrix_out = apply_r(&matrix, &spec);
+    let max_err = max_hybrid_err(&plan_out, &matrix_out);
+    eprintln!(
+        "3471-grid apply_r vs plan.apply observed max_hybrid_err = {:.3e} \
+         (ceiling 1e-12; theoretical bound ~1e-13 per row × 82 rows/entry)",
+        max_err,
+    );
+    assert!(
+        max_err < 1e-12,
+        "3471-grid apply_r vs plan.apply max hybrid err = {:.3e} (expected < 1e-12)",
+        max_err,
+    );
+}
+
+#[test]
+fn resolution_matrix_apply_equivalent_across_densities() {
+    let Some(path) = common::venus_usr_resolution_path() else {
+        return;
+    };
+    let (_energies, plan, matrix) = build_fixture_plan_and_matrix(&path, 512);
+    let n_grid = matrix.len();
+    for &n_density in &[1e-5_f64, 1e-4, 1.6e-4, 1e-3] {
+        let spec: Vec<f64> = (0..n_grid)
+            .map(|i| {
+                let e = 7.0 + (200.0 - 7.0) * (i as f64) / ((n_grid - 1) as f64);
+                let sigma = 50.0 * (-((e - 80.0).powi(2)) / 8.0).exp()
+                    + 10.0 * (-((e - 150.0).powi(2)) / 4.0).exp();
+                (-n_density * sigma).exp()
+            })
+            .collect();
+        let plan_out = plan.apply(&spec);
+        let matrix_out = apply_r(&matrix, &spec);
+        let max_err = max_hybrid_err(&plan_out, &matrix_out);
+        assert!(
+            max_err < 1e-12,
+            "density n={:.1e}: max hybrid err {:.3e} (expected < 1e-12)",
+            n_density,
+            max_err,
+        );
+    }
+}
+
+#[test]
+fn resolution_matrix_csr_column_indices_sorted_per_row() {
+    let Some(path) = common::venus_usr_resolution_path() else {
+        return;
+    };
+    let (_energies, _plan, matrix) = build_fixture_plan_and_matrix(&path, 256);
+    for i in 0..matrix.len() {
+        let start = matrix.row_starts()[i] as usize;
+        let end = matrix.row_starts()[i + 1] as usize;
+        let row_cols = &matrix.col_indices()[start..end];
+        for w in row_cols.windows(2) {
+            assert!(
+                w[0] < w[1],
+                "row {} col_indices not strictly ascending: {:?}",
+                i,
+                row_cols,
+            );
+        }
+    }
+}
+
+#[test]
+fn resolution_matrix_grid_mismatch_detected() {
+    let Some(path) = common::venus_usr_resolution_path() else {
+        return;
+    };
+    let (energies, _plan, matrix) = build_fixture_plan_and_matrix(&path, 128);
+    let spec = vec![1.0_f64; matrix.len()];
+
+    // Same grid → passes.
+    let ok = apply_resolution_with_matrix(&energies, &matrix, &spec);
+    assert!(ok.is_ok());
+
+    // Perturb one energy → MatrixGridMismatch with the offending index.
+    let mut mutated = energies.clone();
+    mutated[37] += 1e-12;
+    let err = apply_resolution_with_matrix(&mutated, &matrix, &spec)
+        .expect_err("grid mismatch must error");
+    assert_eq!(
+        err,
+        ResolutionError::MatrixGridMismatch {
+            first_diff_index: 37,
+        }
+    );
+}
+
+#[test]
+fn resolution_matrix_length_mismatch_detected() {
+    let Some(path) = common::venus_usr_resolution_path() else {
+        return;
+    };
+    let (energies, _plan, matrix) = build_fixture_plan_and_matrix(&path, 64);
+    let short_spec = vec![1.0_f64; matrix.len() - 1];
+    let err = apply_resolution_with_matrix(&energies, &matrix, &short_spec)
+        .expect_err("length mismatch must error");
+    assert!(matches!(err, ResolutionError::LengthMismatch { .. }));
+}

--- a/crates/nereids-physics/tests/venus_usr_resolution.rs
+++ b/crates/nereids-physics/tests/venus_usr_resolution.rs
@@ -25,22 +25,35 @@ use nereids_physics::resolution::{
 //    the crate's public surface minimal per issue #497 scope) ─────
 
 fn interp_spectrum(energies: &[f64], spectrum: &[f64], e: f64) -> Option<f64> {
-    use nereids_core::constants::NEAR_ZERO_FLOOR;
-    if e < energies[0] || e > *energies.last().unwrap() {
+    // Verbatim copy of the canonical helper at
+    // crates/nereids-physics/src/resolution.rs:2541 (used by the
+    // in-src `broaden_presorted_reference` oracle).  Codex flagged
+    // an earlier rewritten variant in PR #545 round-1 review as
+    // semantically divergent (binary_search_by + early-return on
+    // exact hits vs upper-bound search + always-interpolate) —
+    // either path of divergence can flip the bit-exact comparison
+    // on exact-grid-hit / duplicate-grid edge cases.  Keep this in
+    // sync with the in-src version verbatim; if the production
+    // helper changes, mirror the change here.
+    let n = energies.len();
+    if n == 0 {
         return None;
     }
-    let lo = match energies
-        .binary_search_by(|x| x.partial_cmp(&e).unwrap_or(std::cmp::Ordering::Equal))
-    {
-        Ok(idx) => return Some(spectrum[idx]),
-        Err(idx) => idx.saturating_sub(1),
-    };
-    let hi = lo + 1;
-    if hi >= energies.len() {
-        return Some(spectrum[lo]);
+    if e < energies[0] || e > energies[n - 1] {
+        return None;
+    }
+    let mut lo = 0;
+    let mut hi = n - 1;
+    while hi - lo > 1 {
+        let mid = (lo + hi) / 2;
+        if energies[mid] <= e {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
     }
     let span = energies[hi] - energies[lo];
-    if span.abs() < NEAR_ZERO_FLOOR {
+    if span.abs() < nereids_core::constants::NEAR_ZERO_FLOOR {
         return Some(spectrum[lo]);
     }
     let frac = (e - energies[lo]) / span;

--- a/crates/nereids-physics/tests/venus_usr_resolution_microbench.rs
+++ b/crates/nereids-physics/tests/venus_usr_resolution_microbench.rs
@@ -65,7 +65,7 @@ fn test_broaden_presorted_bench() {
     let t_new = start.elapsed();
 
     let speedup = t_ref.as_secs_f64() / t_new.as_secs_f64();
-    println!(
+    eprintln!(
         "broaden_presorted microbench (n_grid={n}, repeats={repeats}, 499-pt kernel):\n\
          reference (binary search): {t_ref:?}  (sink={sink_ref:.3})\n\
          two-pointer walk         : {t_new:?}  (sink={sink_new:.3})\n\
@@ -132,7 +132,7 @@ fn test_plan_reuse_bench() {
     let t_apply_total = start.elapsed() - t_build;
 
     let speedup = t_percall.as_secs_f64() / (t_build + t_apply_total).as_secs_f64();
-    println!(
+    eprintln!(
         "plan-reuse microbench (n_grid={n}, {repeats} spectra, 499-pt kernel):\n\
          per-call broaden_presorted : {t_percall:?}  (sink={sink_percall:.3})\n\
          plan build (once)          : {t_build:?}\n\
@@ -200,7 +200,7 @@ fn resolution_matrix_apply_microbench() {
     let t_matrix = start.elapsed();
 
     let speedup = t_plan.as_secs_f64() / t_matrix.as_secs_f64();
-    println!(
+    eprintln!(
         "ResolutionMatrix microbench (n_grid={n}, {repeats} spectra):\n\
          compile (once)       : {:?}  ({} nnz)\n\
          plan.apply × {repeats} : {:?}\n\
@@ -220,22 +220,30 @@ fn resolution_matrix_apply_microbench() {
 // ── Local helper duplicated from `src/resolution.rs` ─────────────
 
 fn interp_spectrum(energies: &[f64], spectrum: &[f64], e: f64) -> Option<f64> {
-    use nereids_core::constants::NEAR_ZERO_FLOOR;
-    if e < energies[0] || e > *energies.last().unwrap() {
+    // Verbatim copy of crates/nereids-physics/src/resolution.rs:2541.
+    // See PR #545 round-1 review (Codex) for why a "modernized"
+    // binary_search variant is wrong here: the oracle must match
+    // the in-src helper byte for byte so the bit-exact comparison
+    // does not silently flip on exact-grid-hit edge cases.
+    let n = energies.len();
+    if n == 0 {
         return None;
     }
-    let lo = match energies
-        .binary_search_by(|x| x.partial_cmp(&e).unwrap_or(std::cmp::Ordering::Equal))
-    {
-        Ok(idx) => return Some(spectrum[idx]),
-        Err(idx) => idx.saturating_sub(1),
-    };
-    let hi = lo + 1;
-    if hi >= energies.len() {
-        return Some(spectrum[lo]);
+    if e < energies[0] || e > energies[n - 1] {
+        return None;
+    }
+    let mut lo = 0;
+    let mut hi = n - 1;
+    while hi - lo > 1 {
+        let mid = (lo + hi) / 2;
+        if energies[mid] <= e {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
     }
     let span = energies[hi] - energies[lo];
-    if span.abs() < NEAR_ZERO_FLOOR {
+    if span.abs() < nereids_core::constants::NEAR_ZERO_FLOOR {
         return Some(spectrum[lo]);
     }
     let frac = (e - energies[lo]) / span;

--- a/crates/nereids-physics/tests/venus_usr_resolution_microbench.rs
+++ b/crates/nereids-physics/tests/venus_usr_resolution_microbench.rs
@@ -1,0 +1,303 @@
+//! Fixture-gated microbenchmarks for the VENUS USR resolution
+//! operator and CSR `ResolutionMatrix` apply paths.
+//!
+//! These are slow tests intentionally separated from the regression
+//! suite in `venus_usr_resolution.rs`: they print timing tables to
+//! stderr and exist to validate optimization-PR claims (two-pointer
+//! walk vs binary search, plan-reuse vs per-call, CSR matvec vs
+//! plan apply).
+//!
+//! When the VENUS USR fixture is absent (CI, fresh checkouts), each
+//! microbench early-returns and is reported as passing — no
+//! `#[ignore]` noise.  See issue #497.
+//!
+//! Run manually with `--nocapture --release`, e.g.:
+//!
+//! ```text
+//! cargo test --release -p nereids-physics --test venus_usr_resolution_microbench \
+//!     -- --nocapture
+//! ```
+
+mod common;
+
+use nereids_physics::resolution::{TabulatedResolution, apply_r, test_support};
+
+/// Two-pointer `broaden_presorted` vs binary-search reference.  Pins
+/// the bit-exact sink equality between the two paths so a future
+/// regression in the two-pointer walk surfaces here as well as in
+/// the bit-exact regression test.
+#[test]
+fn test_broaden_presorted_bench() {
+    let Some(path) = common::venus_usr_resolution_path() else {
+        return;
+    };
+    let text = std::fs::read_to_string(&path).expect("read VENUS USR fixture");
+    let tab = TabulatedResolution::from_text(&text, 25.0).unwrap();
+
+    let n = 3471;
+    let energies: Vec<f64> = (0..n)
+        .map(|i| 7.0 + i as f64 * ((200.0 - 7.0) / (n - 1) as f64))
+        .collect();
+    let spectrum: Vec<f64> = energies
+        .iter()
+        .map(|&e| {
+            1.0 - 0.8 * (-((e - 7.8).powi(2) / 0.01)).exp()
+                - 0.6 * (-((e - 22.4).powi(2) / 0.1)).exp()
+        })
+        .collect();
+
+    let repeats = 30;
+
+    let start = std::time::Instant::now();
+    let mut sink_ref = 0.0f64;
+    for _ in 0..repeats {
+        let r = broaden_presorted_reference(&tab, &energies, &spectrum);
+        sink_ref += r.iter().sum::<f64>();
+    }
+    let t_ref = start.elapsed();
+
+    let start = std::time::Instant::now();
+    let mut sink_new = 0.0f64;
+    for _ in 0..repeats {
+        let r = test_support::broaden_presorted(&tab, &energies, &spectrum);
+        sink_new += r.iter().sum::<f64>();
+    }
+    let t_new = start.elapsed();
+
+    let speedup = t_ref.as_secs_f64() / t_new.as_secs_f64();
+    println!(
+        "broaden_presorted microbench (n_grid={n}, repeats={repeats}, 499-pt kernel):\n\
+         reference (binary search): {t_ref:?}  (sink={sink_ref:.3})\n\
+         two-pointer walk         : {t_new:?}  (sink={sink_new:.3})\n\
+         speedup                  : {speedup:.2}x"
+    );
+    assert_eq!(sink_ref.to_bits(), sink_new.to_bits());
+}
+
+/// Plan-reuse path vs per-call `broaden_presorted`.  The payoff
+/// `plan()` + `ResolutionPlan::apply()` is designed to deliver: when
+/// broadening many spectra on the same target grid (LM iterations
+/// with fixed TZERO, spatial maps with pre-calibrated energies),
+/// building the plan once and applying it N times beats rebuilding
+/// the plan internally on every call.
+#[test]
+fn test_plan_reuse_bench() {
+    let Some(path) = common::venus_usr_resolution_path() else {
+        return;
+    };
+    let text = std::fs::read_to_string(&path).expect("read VENUS USR fixture");
+    let tab = TabulatedResolution::from_text(&text, 25.0).unwrap();
+
+    let n = 3471;
+    let energies: Vec<f64> = (0..n)
+        .map(|i| 7.0 + i as f64 * ((200.0 - 7.0) / (n - 1) as f64))
+        .collect();
+
+    // Many spectra simulating an LM fit's sequence of evaluations.
+    let repeats = 100;
+    let mut state: u64 = 0xA5A5_A5A5_DEAD_BEEF;
+    let spectra: Vec<Vec<f64>> = (0..repeats)
+        .map(|_| {
+            energies
+                .iter()
+                .map(|&e| {
+                    state = state
+                        .wrapping_mul(6364136223846793005)
+                        .wrapping_add(1442695040888963407);
+                    let noise = ((state >> 33) as f64) / (u32::MAX as f64);
+                    1.0 - 0.8 * (-((e - 7.8).powi(2) / 0.01)).exp() + 1e-3 * noise
+                })
+                .collect()
+        })
+        .collect();
+
+    // Per-call path: same pipeline as today.  Build cost paid every call.
+    let start = std::time::Instant::now();
+    let mut sink_percall = 0.0f64;
+    for spec in &spectra {
+        let r = test_support::broaden_presorted(&tab, &energies, spec);
+        sink_percall += r.iter().sum::<f64>();
+    }
+    let t_percall = start.elapsed();
+
+    // Plan-reuse path: one build, many applies.
+    let start = std::time::Instant::now();
+    let plan = tab.plan(&energies).expect("sorted grid must validate");
+    let t_build = start.elapsed();
+    let mut sink_plan = 0.0f64;
+    for spec in &spectra {
+        let r = plan.apply(spec);
+        sink_plan += r.iter().sum::<f64>();
+    }
+    let t_apply_total = start.elapsed() - t_build;
+
+    let speedup = t_percall.as_secs_f64() / (t_build + t_apply_total).as_secs_f64();
+    println!(
+        "plan-reuse microbench (n_grid={n}, {repeats} spectra, 499-pt kernel):\n\
+         per-call broaden_presorted : {t_percall:?}  (sink={sink_percall:.3})\n\
+         plan build (once)          : {t_build:?}\n\
+         apply × {repeats}          : {t_apply_total:?}\n\
+         total plan path            : {:?}  (sink={sink_plan:.3})\n\
+         speedup vs per-call        : {speedup:.2}x",
+        t_build + t_apply_total,
+    );
+    assert_eq!(sink_percall.to_bits(), sink_plan.to_bits());
+}
+
+/// `apply_r` (ResolutionMatrix CSR) vs `ResolutionPlan::apply`,
+/// 3471-bin VENUS production grid × 100 spectra.  Exercised
+/// manually to decide whether the CSR compile + CSR matvec beats
+/// the plan's two-pointer walk at the no-SIMD-no-unsafe baseline
+/// promised in #473.
+#[test]
+fn resolution_matrix_apply_microbench() {
+    let Some(path) = common::venus_usr_resolution_path() else {
+        return;
+    };
+    let text = std::fs::read_to_string(&path).expect("read VENUS USR fixture");
+    let tab = TabulatedResolution::from_text(&text, 25.0).unwrap();
+
+    let n = 3471_usize;
+    let energies: Vec<f64> = (0..n)
+        .map(|i| 7.0 + i as f64 * ((200.0 - 7.0) / (n - 1) as f64))
+        .collect();
+    let plan = tab.plan(&energies).expect("sorted grid must validate");
+
+    let t_compile = std::time::Instant::now();
+    let matrix = plan.compile_to_matrix();
+    let t_compile = t_compile.elapsed();
+
+    let spec: Vec<f64> = energies
+        .iter()
+        .map(|&e| {
+            let sigma = 50.0 * (-((e - 80.0).powi(2)) / 8.0).exp()
+                + 10.0 * (-((e - 150.0).powi(2)) / 4.0).exp();
+            (-1.6e-4 * sigma).exp()
+        })
+        .collect();
+
+    let repeats = 100_usize;
+
+    // Warm both paths so the first call's cache-miss latency does
+    // not skew the micro-times.
+    for _ in 0..5 {
+        let _ = plan.apply(&spec);
+        let _ = apply_r(&matrix, &spec);
+    }
+
+    let start = std::time::Instant::now();
+    let mut sink_plan = 0.0f64;
+    for _ in 0..repeats {
+        sink_plan += plan.apply(&spec).iter().sum::<f64>();
+    }
+    let t_plan = start.elapsed();
+
+    let start = std::time::Instant::now();
+    let mut sink_matrix = 0.0f64;
+    for _ in 0..repeats {
+        sink_matrix += apply_r(&matrix, &spec).iter().sum::<f64>();
+    }
+    let t_matrix = start.elapsed();
+
+    let speedup = t_plan.as_secs_f64() / t_matrix.as_secs_f64();
+    println!(
+        "ResolutionMatrix microbench (n_grid={n}, {repeats} spectra):\n\
+         compile (once)       : {:?}  ({} nnz)\n\
+         plan.apply × {repeats} : {:?}\n\
+         apply_r   × {repeats} : {:?}\n\
+         speedup vs plan      : {:.2}x\n\
+         sinks (plan/matrix)  : {:.6e} / {:.6e}",
+        t_compile,
+        matrix.nnz(),
+        t_plan,
+        t_matrix,
+        speedup,
+        sink_plan,
+        sink_matrix,
+    );
+}
+
+// ── Local helper duplicated from `src/resolution.rs` ─────────────
+
+fn interp_spectrum(energies: &[f64], spectrum: &[f64], e: f64) -> Option<f64> {
+    use nereids_core::constants::NEAR_ZERO_FLOOR;
+    if e < energies[0] || e > *energies.last().unwrap() {
+        return None;
+    }
+    let lo = match energies
+        .binary_search_by(|x| x.partial_cmp(&e).unwrap_or(std::cmp::Ordering::Equal))
+    {
+        Ok(idx) => return Some(spectrum[idx]),
+        Err(idx) => idx.saturating_sub(1),
+    };
+    let hi = lo + 1;
+    if hi >= energies.len() {
+        return Some(spectrum[lo]);
+    }
+    let span = energies[hi] - energies[lo];
+    if span.abs() < NEAR_ZERO_FLOOR {
+        return Some(spectrum[lo]);
+    }
+    let frac = (e - energies[lo]) / span;
+    Some(spectrum[lo] + frac * (spectrum[hi] - spectrum[lo]))
+}
+
+fn broaden_presorted_reference(
+    tab: &TabulatedResolution,
+    energies: &[f64],
+    spectrum: &[f64],
+) -> Vec<f64> {
+    use nereids_core::constants::DIVISION_FLOOR;
+    let tof_factor = test_support::TOF_FACTOR;
+
+    let n = energies.len();
+    if n == 0 {
+        return vec![];
+    }
+    let mut result = vec![0.0f64; n];
+    for i in 0..n {
+        let e = energies[i];
+        if e <= 0.0 {
+            result[i] = spectrum[i];
+            continue;
+        }
+        let tof_center = tof_factor * tab.flight_path_m() / e.sqrt();
+        let (offsets, weights) = test_support::interpolated_kernel(tab, e);
+        let mut sum = 0.0;
+        let mut norm = 0.0;
+        for k in 0..offsets.len() {
+            let dt = offsets[k];
+            let w = weights[k];
+            if w <= 0.0 {
+                continue;
+            }
+            let tof_prime = tof_center + dt;
+            if tof_prime <= 0.0 {
+                continue;
+            }
+            let e_prime = (tof_factor * tab.flight_path_m() / tof_prime).powi(2);
+            let s = match interp_spectrum(energies, spectrum, e_prime) {
+                Some(v) => v,
+                None => continue,
+            };
+            let dt_width = if k > 0 && k < offsets.len() - 1 {
+                (offsets[k + 1] - offsets[k - 1]) * 0.5
+            } else if k == 0 && offsets.len() > 1 {
+                offsets[1] - offsets[0]
+            } else if k == offsets.len() - 1 && offsets.len() > 1 {
+                offsets[k] - offsets[k - 1]
+            } else {
+                1.0
+            };
+            let weight = w * dt_width.abs();
+            sum += weight * s;
+            norm += weight;
+        }
+        result[i] = if norm > DIVISION_FLOOR {
+            sum / norm
+        } else {
+            spectrum[i]
+        };
+    }
+    result
+}

--- a/crates/nereids-physics/tests/venus_usr_surrogate.rs
+++ b/crates/nereids-physics/tests/venus_usr_surrogate.rs
@@ -1,0 +1,223 @@
+//! Fixture-gated regression tests for the surrogate cubature and
+//! scalar-Chebyshev plans on the real VENUS USR resolution kernel
+//! (SAMMY-format).
+//!
+//! When the fixture is absent (CI, fresh checkouts), each test
+//! early-returns and is reported as passing — no `#[ignore]` noise.
+//! See `tests/README.md` and issue #497.
+
+mod common;
+
+use nereids_physics::resolution::{ResolutionMatrix, TabulatedResolution, apply_r};
+use nereids_physics::surrogate::{ScalarChebyshevPlan, SparseEmpiricalCubaturePlan};
+
+// ── Helpers duplicated from `src/surrogate.rs` ───────────────────
+
+fn exact_forward(matrix: &ResolutionMatrix, sigmas: &[f64], k: usize, n: &[f64]) -> Vec<f64> {
+    let n_rows = matrix.len();
+    let mut t_un = vec![0.0_f64; n_rows];
+    for (ell, t) in t_un.iter_mut().enumerate() {
+        let mut dot = 0.0_f64;
+        for j in 0..k {
+            dot += n[j] * sigmas[j * n_rows + ell];
+        }
+        *t = (-dot).exp();
+    }
+    apply_r(matrix, &t_un)
+}
+
+fn max_hybrid_err(a: &[f64], b: &[f64]) -> f64 {
+    a.iter()
+        .zip(b)
+        .map(|(x, y)| {
+            let denom = x.abs().max(y.abs()).max(1e-12);
+            (x - y).abs() / denom
+        })
+        .fold(0.0_f64, f64::max)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+/// k = 1 grouped case: the cubature should match the exact
+/// `ResolutionMatrix @ exp(-n σ)` forward output to LP precision at
+/// the training densities, and produce bounded error at held-out
+/// densities inside the training box.  Codex04's 20-seed KL
+/// follow-up showed 1.27× scatter inflation on grouped-Hf k=1 — this
+/// test does not re-measure that; it only checks forward-model
+/// correctness.
+#[test]
+fn cubature_real_venus_k1_forward_equivalence() {
+    let Some(path) = common::venus_usr_resolution_path() else {
+        return;
+    };
+    let text = std::fs::read_to_string(&path).expect("read VENUS USR fixture");
+    let tab = TabulatedResolution::from_text(&text, 25.0).expect("parse fixture");
+
+    // Smaller production-ish grid (512 instead of 3471) to keep
+    // LP-per-row cost tractable within a single test — the cubature
+    // structure is grid-independent, so 512 suffices to show
+    // correctness.
+    let n_grid = 512_usize;
+    let energies: Vec<f64> = (0..n_grid)
+        .map(|i| 7.0 + (200.0 - 7.0) * (i as f64) / ((n_grid - 1) as f64))
+        .collect();
+    let plan = tab.plan(&energies).expect("build plan on sorted grid");
+    let matrix = plan.compile_to_matrix();
+
+    // Synthetic Gaussian-resonance σ on the real energy grid — we
+    // don't need real ENDF σ to prove the cubature math; a physically
+    // plausible σ shape is sufficient.
+    let sigma: Vec<f64> = energies
+        .iter()
+        .map(|&e| {
+            let g = (-((e - 80.0).powi(2)) / 8.0).exp();
+            100.0 * g + 5.0
+        })
+        .collect();
+
+    let train_max = [2e-4_f64];
+    let training = SparseEmpiricalCubaturePlan::default_training_points(&train_max);
+    let anchor = SparseEmpiricalCubaturePlan::default_jacobian_anchor(&train_max);
+    let cub = SparseEmpiricalCubaturePlan::build(&matrix, &sigma, 1, &training, &anchor)
+        .expect("build k=1 cubature on real VENUS kernel");
+
+    // At each training density, cubature = exact.
+    for n_s in training.iter() {
+        let t_cub = cub.forward(n_s);
+        let t_exact = exact_forward(&matrix, &sigma, 1, n_s);
+        let max_err = max_hybrid_err(&t_cub, &t_exact);
+        assert!(
+            max_err < 1e-9,
+            "VENUS k=1 training n={n_s:?} max err = {max_err:.3e}",
+        );
+    }
+
+    // At held-out density (VENUS production ~ 1.6e-4), bounded
+    // error.  Codex04's real-VENUS Hf aggregated fit showed a density
+    // shift of 1.66e-4 relative — which means forward error at the
+    // optimum is at least that small.  Here we allow 1e-3 max abs
+    // error as a generous ceiling; the actual value on the
+    // Beer-Lambert `T ∈ [0, 1]` output is typically an order of
+    // magnitude tighter.
+    let n_venus = vec![1.6e-4];
+    let t_cub = cub.forward(&n_venus);
+    let t_exact = exact_forward(&matrix, &sigma, 1, &n_venus);
+    let max_abs = t_cub
+        .iter()
+        .zip(t_exact.iter())
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0_f64, f64::max);
+    assert!(
+        max_abs < 1e-3,
+        "VENUS k=1 held-out n=1.6e-4 max abs err = {max_abs:.3e}",
+    );
+
+    // Log compression ratio for diagnostics.
+    let exact_nnz = matrix.nnz();
+    let cub_atoms = cub.n_atoms();
+    eprintln!(
+        "VENUS k=1 cubature compression: {exact_nnz} exact nnz → {cub_atoms} atoms ({:.1}× compression)",
+        exact_nnz as f64 / cub_atoms as f64,
+    );
+}
+
+/// Real-VENUS regression test for the Chebyshev scalar surrogate on
+/// the 3471-bin VENUS production grid with synthetic Hf-like σ.
+/// Asserts forward accuracy ≤ 1e-5 at VENUS density (issue #475
+/// success criterion) and logs per-call wall time.  PR #475 benched
+/// this against a Lanczos σ-pushforward Gauss quadrature on the
+/// same kernel and picked Chebyshev — it won on both accuracy
+/// (≤ 2e-15 vs ≤ 4e-15) and wall-time.  Exact speedup ratios are
+/// hardware-dependent and intentionally not pinned here; the
+/// accuracy bound stays portable.
+#[test]
+fn scalar_chebyshev_real_venus_k1_regression() {
+    let Some(path) = common::venus_usr_resolution_path() else {
+        return;
+    };
+    let text = std::fs::read_to_string(&path).expect("read VENUS USR fixture");
+    let tab = TabulatedResolution::from_text(&text, 25.0).expect("parse fixture");
+
+    // VENUS production grid size.
+    let n_grid = 3471_usize;
+    let energies: Vec<f64> = (0..n_grid)
+        .map(|i| 7.0 + (200.0 - 7.0) * (i as f64) / ((n_grid - 1) as f64))
+        .collect();
+    let plan = std::sync::Arc::new(tab.plan(&energies).expect("build plan on sorted grid"));
+    let matrix = plan.compile_to_matrix();
+    let matrix_nnz = matrix.nnz();
+
+    // Synthetic Hf-like σ: Gaussian resonance peaks + baseline
+    // potential scattering.  Rough ENDF-Hf magnitudes (peaks up to
+    // O(1e3) barns, baseline ~10 barns).
+    let sigma: Vec<f64> = energies
+        .iter()
+        .map(|&e| {
+            let peak_a = 1200.0 * (-((e - 80.0).powi(2)) / 8.0).exp();
+            let peak_b = 600.0 * (-((e - 120.0).powi(2)) / 6.0).exp();
+            let peak_c = 300.0 * (-((e - 160.0).powi(2)) / 10.0).exp();
+            peak_a + peak_b + peak_c + 10.0
+        })
+        .collect();
+
+    // Training box: 2 × VENUS density.  M = 16 Chebyshev nodes —
+    // PR #475 bench showed this achieves 1e-15 forward accuracy on
+    // the whole box.
+    let n_max = 2e-4_f64;
+    let t_build = std::time::Instant::now();
+    let cheb = ScalarChebyshevPlan::build(std::sync::Arc::clone(&plan), &sigma, n_max, 16)
+        .expect("build Chebyshev plan");
+    let t_build = t_build.elapsed();
+
+    // Forward accuracy at VENUS density.
+    let n_venus = 1.6e-4_f64;
+    let t_exact = exact_forward(&matrix, &sigma, 1, &[n_venus]);
+    let t_cheb = cheb.forward_scalar(n_venus);
+    let max_err = max_hybrid_err(&t_cheb, &t_exact);
+
+    // Per-forward timing.
+    let n_iters = 1000;
+    let t0 = std::time::Instant::now();
+    let mut sink = 0.0_f64;
+    for _ in 0..n_iters {
+        sink += cheb.forward_scalar(n_venus)[0];
+    }
+    let t_fwd = t0.elapsed() / n_iters as u32;
+    std::hint::black_box(sink);
+
+    let t_un: Vec<f64> = sigma.iter().map(|&s| (-n_venus * s).exp()).collect();
+    let t0 = std::time::Instant::now();
+    let mut sink = 0.0_f64;
+    for _ in 0..n_iters {
+        sink += apply_r(&matrix, &t_un)[0];
+    }
+    let t_exact_fwd = t0.elapsed() / n_iters as u32;
+    std::hint::black_box(sink);
+
+    eprintln!();
+    eprintln!(
+        "=== scalar Chebyshev VENUS k=1 regression (n_grid = {n_grid}, matrix nnz = {matrix_nnz}) ==="
+    );
+    eprintln!(
+        "Chebyshev (M=16):  build = {:>9.1?}  n_coeff = {:>7}  fwd = {:>8.2?}  max_err @ VENUS = {:.3e}",
+        t_build,
+        n_grid * 16,
+        t_fwd,
+        max_err,
+    );
+    eprintln!(
+        "Exact apply_r:     build = {:>9}                     fwd = {:>8.2?}  (reference)",
+        "n/a", t_exact_fwd,
+    );
+    eprintln!(
+        "Cheb speedup vs exact: {:.1}×",
+        t_exact_fwd.as_nanos() as f64 / t_fwd.as_nanos() as f64,
+    );
+    eprintln!();
+
+    // Issue #475 success criteria.
+    assert!(
+        max_err < 1e-5,
+        "Chebyshev forward max err {max_err:.3e} exceeds 1e-5 ceiling",
+    );
+}


### PR DESCRIPTION
## Summary

Combined refactor PR resolving issue #497.  Two halves that travel together:

1. **Relocate** 13 fixture-gated `#[ignore]`'d tests out of `crates/nereids-physics/src/` into proper integration tests under `tests/`.
2. **Rename** the PLEIADES misnomer in the test scaffolding to the correct VENUS USR (SAMMY-format) label, per [discussion on the issue](https://github.com/ornlneutronimaging/NEREIDS/issues/497).

The fixture file `_fts_bl10_0p5meV_1keV_25pts.txt` is a SAMMY-format tabulated resolution kernel for the VENUS instrument (SNS Beam Line 10), not a "PLEIADES artifact" (PLEIADES is a Python wrapper around SAMMY and does not define resolution formats).  The header in the file confirms: `FTS BL10 case i00dd folded triang FWHM 350 ns PSR`.

PLEIADES references in `crates/nereids-io/` (legitimate algorithm citations for ORNL Method 2 normalization) are untouched.

## Round-1 review fixes (Phase A + Phase B)

- **P1 (Codex)**: the duplicated `interp_spectrum` oracle in `venus_usr_resolution.rs:27` and `venus_usr_resolution_microbench.rs:222` had been rewritten using `binary_search_by` with early-return on exact hits, while the canonical helper at `src/resolution.rs:2541` uses upper-bound search and always interpolates.  On exact-grid-hit / duplicate-grid / rounding edge cases the new variant could flip the bit-exact comparison.  Replaced with a verbatim copy of the in-src helper in both files; added keep-in-sync comments.
- **P1 (Copilot)**: the self dev-dep in `Cargo.toml:33` was path-only without a version, which would break `cargo publish` for crates.io.  Switched to `nereids-physics = { workspace = true, features = ["test-support"] }` so the dep inherits version + path from `[workspace.dependencies]` (kept in sync by `scripts/bump-version.sh`).
- **P2 (Copilot)**: switched three `println!` calls in `venus_usr_resolution_microbench.rs` to `eprintln!` to match the file-header documentation ("prints timing tables to stderr") and keep `cargo test` PASS/FAIL output uncluttered.
- **P2 (Copilot)**: PR body test count corrected below (was double-counting the bit-exact test).

## Tests moved (per file)

| Source location (before) | Destination (after) | Count |
|---|---|---|
| `crates/nereids-physics/src/resolution.rs` (`#[cfg(test)] mod tests`) | `crates/nereids-physics/tests/venus_usr_resolution.rs` | 7 regression + 1 bit-exact = **8** |
| `crates/nereids-physics/src/resolution.rs` (`#[cfg(test)] mod tests`) | `crates/nereids-physics/tests/venus_usr_resolution_microbench.rs` | **3** microbenchmarks |
| `crates/nereids-physics/src/surrogate.rs` (`#[cfg(test)] mod tests`) | `crates/nereids-physics/tests/venus_usr_surrogate.rs` | **2** regressions |
| **Total** | | **13** |

Tests no longer carry `#[ignore]`.  They use an early-return idiom keyed off `common::venus_usr_resolution_path()` — present → execute, absent → no-op pass.  No more `0 passed; N ignored` noise in `cargo test`.

## Public-API promotions

Three thin shims added to the **existing** `resolution::test_support` module (already gated behind the `test-support` Cargo feature).  Feature stays off in release builds.

| New shim in `test_support` | Why |
|---|---|
| `pub fn broaden_presorted(...)` | The bit-exact regression and microbenches call the optimized two-pointer walk directly. |
| `pub fn interpolated_kernel(...)` | Needed by the bit-exact equivalence oracle so the oracle and the SUT share the exact same interior math. |
| `pub const TOF_FACTOR: f64` | Same rationale — bit-exactness requires the oracle and SUT to use the same TOF↔energy conversion constant. |

`build_fixture_plan_and_matrix`, `broaden_presorted_reference`, `assert_bit_exact`, `max_hybrid_err`, `exact_forward`, `interp_spectrum` are **duplicated** into the integration tests rather than promoted — they are short helpers (<25 lines each) and duplication keeps the public surface tight.

`crates/nereids-physics/Cargo.toml` gains a self-dev-dep with the `test-support` feature enabled, so integration tests (which link against the production build of the lib, not the `#[cfg(test)]` build) can see `test_support::*`.

## Naming changes

| Before | After |
|---|---|
| `test_broaden_presorted_bit_exact_on_pleiades_resolution` (fn) | `test_broaden_presorted_bit_exact_on_venus_usr` |
| `assert_bit_exact(..., "pleiades_real_resolution")` (snapshot tag) | `assert_bit_exact(..., "venus_usr_real_resolution")` |
| `#[ignore = "requires PLEIADES resolution file ..."]` | (removed — early-return on `common::venus_usr_resolution_path()`) |
| `"Real PLEIADES bl10 resolution file"` (doc comment) | `"Real VENUS BL10 (SNS) resolution kernel, SAMMY USR format"` |
| `"(a gitignored PLEIADES file)"` (comment) | `"(a SAMMY USR file describing the VENUS instrument, gitignored per ORNL release policy)"` |
| `"Gated on the PLEIADES resolution fixture"` (comment) | `"Gated on the VENUS USR resolution fixture (SAMMY-format)"` |

`grep -rn "pleiades\|PLEIADES" crates/nereids-physics/src/` → 0 hits.  The only remaining PLEIADES reference in `crates/nereids-physics/` is in `tests/README.md`, which intentionally documents the historical misnomer being corrected.

Closes #497.

## Test plan

- [x] \`cargo fmt --all\` — clean
- [x] \`cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings\` — clean
- [x] \`cargo test --workspace --exclude nereids-python\` — 799 passed, 11 ignored (the remaining network-gated tests are out of #497 scope), 20 binaries
- [x] With fixture present: the 13 new integration tests execute fully and pass
- [x] Without fixture: 13 new integration tests pass as no-ops in <1 ms total — no \`#[ignore]\` noise
- [x] Network-gated \`#[ignore]\` tests in \`pipeline\`, \`endf\`, \`rmatrix_limited\` untouched (still reported as ignored)
- [x] \`crates/nereids-io/\` PLEIADES references untouched (algorithm citation for ORNL Method 2 normalization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)