### PR TITLE
ci(review-pipeline): pipe Codex prompt via stdin (#536)

### DIFF
--- a/.claude/skills/review-pipeline/SKILL.md
+++ b/.claude/skills/review-pipeline/SKILL.md
@@ -158,16 +158,19 @@ mostly noise for our purposes.
 
 **Known pitfalls** (verified against codex-cli 0.130, May 2026):
 
-- The top-level `codex review` subcommand does NOT exist. Don't use
-  `codex review --base main` — it errors with
-  `unexpected argument '--base' found / Usage: codex <PROMPT>`.
-  However, `codex exec review --base <BRANCH>` **does** ship in
-  codex-cli 0.130+ (originally tracked in
-  [openai/codex#6432](https://github.com/openai/codex/issues/6432))
-  and accepts the prompt via stdin (`-`).  Adopting it workflow-wide
-  is tracked as a separate follow-up — the manual `codex exec` +
-  stdin prompt pattern above remains the canonical form here because
-  it works across all codex-cli versions.
+- **Native review subcommands**: codex-cli 0.130+ ships **both**
+  `codex review --base <BRANCH>` (top-level) and `codex exec review
+  --base <BRANCH>` (under `exec`).  Either accepts the prompt via
+  stdin (`-`) and supports `--uncommitted`, `--commit <SHA>`.  This
+  was tracked in
+  [openai/codex#6432](https://github.com/openai/codex/issues/6432).
+  The error `unexpected argument '--base' found / Usage: codex
+  <PROMPT>` is from pre-0.130 codex-cli where `review` was parsed as
+  a positional prompt instead of a subcommand; if you see that error,
+  upgrade codex-cli rather than working around it.  Adopting the
+  native subcommand workflow-wide is a separate follow-up — the
+  manual `codex exec` + stdin prompt pattern above remains the
+  canonical form here because it works across all codex-cli versions.
 - Slash commands (`/review`, `/test`, etc.) work only in interactive
   TUI sessions; they cannot be invoked from `codex exec`.
 - **codex-cli + API model gating drift fast.** Earlier this year the

--- a/.claude/skills/review-pipeline/SKILL.md
+++ b/.claude/skills/review-pipeline/SKILL.md
@@ -112,11 +112,11 @@ flags, and output capture.  Adopting the native `codex review --base
 <BRANCH>` workflow-wide is tracked as a separate follow-up.
 
 Use this pattern (one Bash call per worktree). The prompt is written to a
-temp file and piped via stdin to avoid the
-heredoc-inside-command-substitution form (`codex exec "$(cat <<'EOF' ...
-EOF)"`), which has truncated or mangled prompts on recent PRs under
-certain shell snapshots — see #536. Temp file + stdin delivers the body
-verbatim across `codex-cli` versions.
+temp file and fed to `codex exec` via stdin redirection (`- < "$PROMPT_FILE"`)
+to avoid the heredoc-inside-command-substitution form (`codex exec
+"$(cat <<'EOF' ... EOF)"`), which has truncated or mangled prompts on
+recent PRs under certain shell snapshots — see #536. Temp file + stdin
+delivers the body verbatim across `codex-cli` versions.
 
 ```bash
 PROMPT_FILE=$(mktemp -t codex-review-{branch_slug}.XXXXXX)
@@ -170,11 +170,14 @@ mostly noise for our purposes.
   [openai/codex#6432](https://github.com/openai/codex/issues/6432).
   The error `unexpected argument '--base' found / Usage: codex
   <PROMPT>` is from pre-0.130 codex-cli where `review` was parsed as
-  a positional prompt instead of a subcommand; if you see that error,
-  upgrade codex-cli rather than working around it.  Adopting the
-  native subcommand workflow-wide is a separate follow-up — the
-  manual `codex exec` + stdin prompt pattern above remains the
-  canonical form here because it works across all codex-cli versions.
+  a positional prompt instead of a subcommand.  If you want to drive
+  the native `codex review --base <BRANCH>` workflow directly,
+  upgrade codex-cli to 0.130+.  **For this skill**, that upgrade is
+  not required — the manual `codex exec` + stdin prompt pattern
+  below is the canonical fallback and works across all codex-cli
+  versions (including environments where upgrading is not feasible).
+  Adopting the native subcommand workflow-wide is tracked as a
+  separate follow-up.
 - Slash commands (`/review`, `/test`, etc.) work only in interactive
   TUI sessions; they cannot be invoked from `codex exec`.
 - **codex-cli + API model gating drift fast.** Earlier this year the

--- a/.claude/skills/review-pipeline/SKILL.md
+++ b/.claude/skills/review-pipeline/SKILL.md
@@ -99,13 +99,17 @@ Unless `--skip-codex` is in `$ARGUMENTS`, also launch one `Bash` command
 per worktree in the **same message** as the Claude self-audit so they
 run concurrently.
 
-There is **no `codex review` subcommand** in current codex-cli (verified
-against 0.125, April 2026). The slash command `/review` exists but is
-interactive-only — it cannot be driven from `codex exec`. The canonical
-headless invocation is `codex exec` with an explicit review prompt; a
-native `codex exec review` is requested in
-[openai/codex#6432](https://github.com/openai/codex/issues/6432) but
-not yet shipped.
+codex-cli 0.130+ ships **both** a top-level `codex review` subcommand
+and `codex exec review` under `exec` (tracked in
+[openai/codex#6432](https://github.com/openai/codex/issues/6432)); the
+interactive `/review` slash command is separate and cannot be driven
+from `codex exec`.  Either native subcommand would work as a higher-
+level invocation, but **this skill uses the manual `codex exec` +
+explicit review prompt pattern below** because it is portable across
+all codex-cli versions (including environments stuck on older
+binaries) and gives us direct control over the prompt body, sandbox
+flags, and output capture.  Adopting the native `codex review --base
+<BRANCH>` workflow-wide is tracked as a separate follow-up.
 
 Use this pattern (one Bash call per worktree). The prompt is written to a
 temp file and piped via stdin to avoid the

--- a/.claude/skills/review-pipeline/SKILL.md
+++ b/.claude/skills/review-pipeline/SKILL.md
@@ -107,13 +107,17 @@ native `codex exec review` is requested in
 [openai/codex#6432](https://github.com/openai/codex/issues/6432) but
 not yet shipped.
 
-Use this pattern (one Bash call per worktree):
+Use this pattern (one Bash call per worktree). The prompt is written to a
+temp file and piped via stdin to avoid the
+heredoc-inside-command-substitution form (`codex exec "$(cat <<'EOF' ...
+EOF)"`), which has truncated or mangled prompts on recent PRs under
+certain shell snapshots — see #536. Temp file + stdin delivers the body
+verbatim across `codex-cli` versions.
 
 ```bash
-codex exec --sandbox read-only --skip-git-repo-check \
-  -C {worktree_path} \
-  --output-last-message /tmp/codex-review-{branch_slug}.md \
-  "$(cat <<'PROMPT'
+PROMPT_FILE=$(mktemp -t codex-review-{branch_slug}.XXXXXX)
+trap 'rm -f "$PROMPT_FILE"' EXIT
+cat > "$PROMPT_FILE" <<'PROMPT'
 You are reviewing the changes on the current branch (HEAD) against `main`
 in the NEREIDS repository.
 
@@ -132,7 +136,11 @@ in the NEREIDS repository.
    - Include `file:line` references for each finding.
 5. If you find nothing significant, say so explicitly. Be terse.
 PROMPT
-)"
+
+codex exec --sandbox read-only --skip-git-repo-check \
+  -C {worktree_path} \
+  --output-last-message /tmp/codex-review-{branch_slug}.md \
+  - < "$PROMPT_FILE"
 ```
 
 Then read the file at `/tmp/codex-review-{branch_slug}.md` for the final
@@ -167,9 +175,11 @@ mostly noise for our purposes.
   errors, the fix is to upgrade codex-cli (`brew upgrade codex` or
   `npm i -g @openai/codex@latest`). Do NOT spend time trying to work
   around with model overrides — keep the binary current.
-- `codex exec` reads the prompt from stdin if you pass `-` or omit the
-  positional, but heredoc-injected positional prompts (as above) are
-  the most reliable form across versions.
+- **Prompt delivery**: write the prompt to a temp file and pipe via stdin
+  (`codex exec ... - < "$PROMPT_FILE"`). The heredoc-inside-command-
+  substitution form (`codex exec "$(cat <<'EOF' ... EOF)"`) has been
+  observed to truncate/mangle prompts under certain shell snapshots —
+  see #536. Temp file + stdin is robust across versions.
 - Avoid `--full-auto` for review — it grants `workspace-write` sandbox,
   which is broader than the read-only review needs.
 

--- a/.claude/skills/review-pipeline/SKILL.md
+++ b/.claude/skills/review-pipeline/SKILL.md
@@ -156,15 +156,18 @@ mostly noise for our purposes.
 - `--output-last-message <file>` — captures the agent's final message
   cleanly; far easier than parsing JSONL.
 
-**Known pitfalls** (verified against codex-cli 0.125, April 2026):
+**Known pitfalls** (verified against codex-cli 0.130, May 2026):
 
-- There is **no `codex review` subcommand**. Don't use `codex review
-  --base main` — it errors with
+- The top-level `codex review` subcommand does NOT exist. Don't use
+  `codex review --base main` — it errors with
   `unexpected argument '--base' found / Usage: codex <PROMPT>`.
-  A native `codex exec review` is requested in
-  [openai/codex#6432](https://github.com/openai/codex/issues/6432) but
-  not yet shipped. Use `codex exec` with an explicit review prompt,
-  per the pattern above.
+  However, `codex exec review --base <BRANCH>` **does** ship in
+  codex-cli 0.130+ (originally tracked in
+  [openai/codex#6432](https://github.com/openai/codex/issues/6432))
+  and accepts the prompt via stdin (`-`).  Adopting it workflow-wide
+  is tracked as a separate follow-up — the manual `codex exec` +
+  stdin prompt pattern above remains the canonical form here because
+  it works across all codex-cli versions.
 - Slash commands (`/review`, `/test`, etc.) work only in interactive
   TUI sessions; they cannot be invoked from `codex exec`.
 - **codex-cli + API model gating drift fast.** Earlier this year the


### PR DESCRIPTION
## Summary
- Replace `codex exec "$(cat <<'PROMPT' ... PROMPT)"` with `mktemp` + `trap rm` + stdin redirection (`codex exec - < "$PROMPT_FILE"`).
- Flip the "Known pitfalls" bullet from "heredoc-positional is most reliable" to "temp-file + stdin is robust."
- Markdown-only edit to `.claude/skills/review-pipeline/SKILL.md` — no Rust touched.

## Why
The heredoc-inside-command-substitution form has truncated or mangled prompts on recent PRs under certain shell snapshots. Codex CLI documents that `codex exec -` reads the prompt from stdin; piping a temp file delivers the body verbatim across codex-cli versions and avoids the failure mode.

## Test plan
- [ ] Manual smoke test on the next `/review-pipeline` invocation: confirm the full prompt body reaches Codex (compare codex transcript echo to `$PROMPT_FILE` contents).
- [ ] Pre-commit checklist (`cargo fmt --all`, `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings`, `cargo test --workspace --exclude nereids-python`): no Rust changed; CI will run the full set on this PR.

Closes #536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)