### PR TITLE
feat(spatial): expose per-pixel back_d_map and back_f_map (#538)

### DIFF
--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -1132,12 +1132,16 @@ fn selected_pixel_fit_result_for_overlay(
             .map(|map| map[[y, x]]),
         anorm: result.anorm_map.as_ref().map_or(1.0, |map| map[[y, x]]),
         background,
-        // Issue #538: when the spatial pipeline fit BackD/BackF
-        // per pixel, surface the value at (y, x); otherwise fall
-        // back to the sentinel `0.0` that `SpectrumFitResult.back_d`
-        // / `back_f` carry when the exponential tail was not fit.
-        back_d: result.back_d_map.as_ref().map_or(0.0, |map| map[[y, x]]),
-        back_f: result.back_f_map.as_ref().map_or(0.0, |map| map[[y, x]]),
+        // Issue #538 (PR #548 round-2 review): `SpectrumFitResult.back_d`
+        // / `back_f` are `Option<f64>` (None = "not fit").  Mapping
+        // `back_d_map` / `back_f_map` to `Option<f64>` here preserves
+        // the distinction across snapshot reload: when the maps are
+        // `None` (reload, or fit_back_d=false), the overlay carries
+        // `None`, and the curve renderer in `widgets::design::build_fit_line`
+        // drops the exponential-tail term rather than rendering a
+        // misleading 0.0-sentinel contribution.
+        back_d: result.back_d_map.as_ref().map(|map| map[[y, x]]),
+        back_f: result.back_f_map.as_ref().map(|map| map[[y, x]]),
         t0_us: result.t0_us_map.as_ref().map(|map| map[[y, x]]),
         l_scale: result.l_scale_map.as_ref().map(|map| map[[y, x]]),
         deviance_per_dof: result.deviance_per_dof_map.as_ref().map(|map| map[[y, x]]),

--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -1132,13 +1132,13 @@ fn selected_pixel_fit_result_for_overlay(
             .map(|map| map[[y, x]]),
         anorm: result.anorm_map.as_ref().map_or(1.0, |map| map[[y, x]]),
         background,
-        // Issue #538 (PR #548 round-2 review): `SpectrumFitResult.back_d`
-        // / `back_f` are `Option<f64>` (None = "not fit").  Mapping
-        // `back_d_map` / `back_f_map` to `Option<f64>` here preserves
-        // the distinction across snapshot reload: when the maps are
-        // `None` (reload, or fit_back_d=false), the overlay carries
-        // `None`, and the curve renderer in `widgets::design::build_fit_line`
-        // drops the exponential-tail term rather than rendering a
+        // `SpectrumFitResult.back_d` / `back_f` are `Option<f64>`
+        // (`None` = "not fit").  Mapping the spatial `back_d_map` /
+        // `back_f_map` to `Option<f64>` here preserves the
+        // distinction across snapshot reload: when the spatial maps
+        // are `None` (reload, or `fit_back_d=false`), the overlay
+        // carries `None` and `widgets::design::build_fit_line` drops
+        // the exponential-tail term rather than rendering a
         // misleading 0.0-sentinel contribution.
         back_d: result.back_d_map.as_ref().map(|map| map[[y, x]]),
         back_f: result.back_f_map.as_ref().map(|map| map[[y, x]]),

--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -1132,8 +1132,12 @@ fn selected_pixel_fit_result_for_overlay(
             .map(|map| map[[y, x]]),
         anorm: result.anorm_map.as_ref().map_or(1.0, |map| map[[y, x]]),
         background,
-        back_d: 0.0,
-        back_f: 0.0,
+        // Issue #538: when the spatial pipeline fit BackD/BackF
+        // per pixel, surface the value at (y, x); otherwise fall
+        // back to the sentinel `0.0` that `SpectrumFitResult.back_d`
+        // / `back_f` carry when the exponential tail was not fit.
+        back_d: result.back_d_map.as_ref().map_or(0.0, |map| map[[y, x]]),
+        back_f: result.back_f_map.as_ref().map_or(0.0, |map| map[[y, x]]),
         t0_us: result.t0_us_map.as_ref().map(|map| map[[y, x]]),
         l_scale: result.l_scale_map.as_ref().map(|map| map[[y, x]]),
         deviance_per_dof: result.deviance_per_dof_map.as_ref().map(|map| map[[y, x]]),

--- a/apps/gui/src/project.rs
+++ b/apps/gui/src/project.rs
@@ -1094,8 +1094,14 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
             temperature_k_unc: snap.single_fit_temperature_unc,
             anorm: snap.single_fit_anorm.unwrap_or(1.0),
             background: snap.single_fit_background.unwrap_or([0.0, 0.0, 0.0]),
-            back_d: 0.0,
-            back_f: 0.0,
+            // Issue #538 (PR #548 round-2 review): `back_d` / `back_f`
+            // are now `Option<f64>` (None = "exponential tail not fit").
+            // The single-pixel snapshot fields don't yet persist these,
+            // so None on reload is the correct "not fit" signal — the
+            // curve renderer drops the exponential term, no misleading
+            // 0.0 sentinel.
+            back_d: None,
+            back_f: None,
             t0_us: None,
             l_scale: None,
             deviance_per_dof: None,

--- a/apps/gui/src/project.rs
+++ b/apps/gui/src/project.rs
@@ -1063,10 +1063,9 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
             // D-11/D-21: Now persisted; None for old project files.
             anorm_map: snap.anorm_map,
             background_maps: snap.background_maps,
-            // Issue #538: per-pixel BackD/BackF maps are not yet
-            // persisted in project files (same precedent as the TZERO
-            // maps below).  Re-running spatial_map_typed regenerates
-            // them.
+            // Per-pixel BackD/BackF maps are not yet persisted in
+            // project files (same precedent as the TZERO maps below).
+            // Re-running `spatial_map_typed` regenerates them.
             back_d_map: None,
             back_f_map: None,
             // TZERO maps are not yet persisted in project files — None on
@@ -1094,12 +1093,11 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
             temperature_k_unc: snap.single_fit_temperature_unc,
             anorm: snap.single_fit_anorm.unwrap_or(1.0),
             background: snap.single_fit_background.unwrap_or([0.0, 0.0, 0.0]),
-            // Issue #538 (PR #548 round-2 review): `back_d` / `back_f`
-            // are now `Option<f64>` (None = "exponential tail not fit").
-            // The single-pixel snapshot fields don't yet persist these,
-            // so None on reload is the correct "not fit" signal — the
-            // curve renderer drops the exponential term, no misleading
-            // 0.0 sentinel.
+            // `back_d` / `back_f` are `Option<f64>` (`None` =
+            // exponential tail not fit).  The single-pixel snapshot
+            // fields don't yet persist these, so `None` on reload is
+            // the correct "not fit" signal — the curve renderer drops
+            // the exponential term, no misleading 0.0 sentinel.
             back_d: None,
             back_f: None,
             t0_us: None,

--- a/apps/gui/src/project.rs
+++ b/apps/gui/src/project.rs
@@ -1081,6 +1081,20 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
         state.spatial_result = Some(result);
     }
 
+    // Issue #538 / PR #548 review: per-pixel `back_d_map` / `back_f_map`
+    // are not yet persisted in project files, but the analyze overlay
+    // reads them via `map_or(0.0, …)` — so a reload would surface the
+    // unfit-sentinel `0.0` for back_d/back_f even when the original fit
+    // produced legitimate non-zero values.  To avoid the misleading
+    // sentinel, drop the restored in-memory `spatial_result` on reload
+    // so the user must re-run `spatial_map_typed` for a fresh fit.  The
+    // serialized snapshot fields (`density_maps`, `anorm_map`, …)
+    // remain on disk and are not affected; only the in-memory
+    // representation is cleared.  Note: until the user re-runs, an
+    // immediate save will serialize an empty spatial result — the user
+    // is expected to re-fit before saving over their data.
+    state.spatial_result = None;
+
     // 16b. Restore single-pixel fit results
     if let Some(densities) = snap.single_fit_densities {
         let uncertainties = snap.single_fit_uncertainties;

--- a/apps/gui/src/project.rs
+++ b/apps/gui/src/project.rs
@@ -1081,20 +1081,6 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
         state.spatial_result = Some(result);
     }
 
-    // Issue #538 / PR #548 review: per-pixel `back_d_map` / `back_f_map`
-    // are not yet persisted in project files, but the analyze overlay
-    // reads them via `map_or(0.0, …)` — so a reload would surface the
-    // unfit-sentinel `0.0` for back_d/back_f even when the original fit
-    // produced legitimate non-zero values.  To avoid the misleading
-    // sentinel, drop the restored in-memory `spatial_result` on reload
-    // so the user must re-run `spatial_map_typed` for a fresh fit.  The
-    // serialized snapshot fields (`density_maps`, `anorm_map`, …)
-    // remain on disk and are not affected; only the in-memory
-    // representation is cleared.  Note: until the user re-runs, an
-    // immediate save will serialize an empty spatial result — the user
-    // is expected to re-fit before saving over their data.
-    state.spatial_result = None;
-
     // 16b. Restore single-pixel fit results
     if let Some(densities) = snap.single_fit_densities {
         let uncertainties = snap.single_fit_uncertainties;

--- a/apps/gui/src/project.rs
+++ b/apps/gui/src/project.rs
@@ -1063,6 +1063,12 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
             // D-11/D-21: Now persisted; None for old project files.
             anorm_map: snap.anorm_map,
             background_maps: snap.background_maps,
+            // Issue #538: per-pixel BackD/BackF maps are not yet
+            // persisted in project files (same precedent as the TZERO
+            // maps below).  Re-running spatial_map_typed regenerates
+            // them.
+            back_d_map: None,
+            back_f_map: None,
             // TZERO maps are not yet persisted in project files — None on
             // restore.  Re-running spatial_map_typed regenerates them.
             t0_us_map: None,

--- a/apps/gui/src/widgets/design.rs
+++ b/apps/gui/src/widgets/design.rs
@@ -1097,10 +1097,25 @@ pub(crate) fn build_fit_line(p: &FitLineParams<'_>) -> Option<Line<'static>> {
             let e = p.energies.get(i).copied().unwrap_or(f64::NAN);
             let bg_poly = if e > 0.0 && e.is_finite() {
                 let sqrt_e = e.sqrt();
+                // Issue #538 (PR #548 round-2 review): SpectrumFitResult
+                // `back_d` / `back_f` are now `Option<f64>` — `None`
+                // means "exponential tail not fit" (e.g., counts-KL
+                // path, LM with `fit_back_d=false`, or a project-reload
+                // dropping the unpersisted maps).  Drop the tail term
+                // in that case so the rendered curve does not include a
+                // misleading nonzero contribution from a stale 0.0
+                // sentinel.  SAMMY pairs BackD/BackF (see
+                // `validate_transmission_background`), so the
+                // `(Some, Some)` arm is the only one that materialises
+                // a non-zero contribution in practice.
+                let exp_tail = match (p.result.back_d, p.result.back_f) {
+                    (Some(bd), Some(bf)) => bd * (-bf / sqrt_e).exp(),
+                    _ => 0.0,
+                };
                 p.result.background[0]
                     + p.result.background[1] / sqrt_e
                     + p.result.background[2] * sqrt_e
-                    + p.result.back_d * (-p.result.back_f / sqrt_e).exp()
+                    + exp_tail
             } else {
                 // Non-positive or non-finite energy: skip the polynomial.
                 // BackB/√E and BackD·exp(-BackF/√E) blow up at E ≤ 0, and

--- a/apps/gui/src/widgets/design.rs
+++ b/apps/gui/src/widgets/design.rs
@@ -1097,17 +1097,13 @@ pub(crate) fn build_fit_line(p: &FitLineParams<'_>) -> Option<Line<'static>> {
             let e = p.energies.get(i).copied().unwrap_or(f64::NAN);
             let bg_poly = if e > 0.0 && e.is_finite() {
                 let sqrt_e = e.sqrt();
-                // Issue #538 (PR #548 round-2 review): SpectrumFitResult
-                // `back_d` / `back_f` are now `Option<f64>` — `None`
-                // means "exponential tail not fit" (e.g., counts-KL
-                // path, LM with `fit_back_d=false`, or a project-reload
-                // dropping the unpersisted maps).  Drop the tail term
-                // in that case so the rendered curve does not include a
-                // misleading nonzero contribution from a stale 0.0
-                // sentinel.  SAMMY pairs BackD/BackF (see
-                // `validate_transmission_background`), so the
-                // `(Some, Some)` arm is the only one that materialises
-                // a non-zero contribution in practice.
+                // `back_d` / `back_f` are `Option<f64>`: `None` means
+                // "exponential tail not fit" (counts-KL path, LM with
+                // `fit_back_d=false`, or a project reload that dropped
+                // the unpersisted maps).  Drop the tail term entirely
+                // in that case.  SAMMY pairs BackD/BackF, so
+                // `(Some, Some)` is the only arm that fires in
+                // practice.
                 let exp_tail = match (p.result.back_d, p.result.back_f) {
                     (Some(bd), Some(bf)) => bd * (-bf / sqrt_e).exp(),
                     _ => 0.0,

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -297,6 +297,24 @@ class SpatialResult:
         ...
 
     @property
+    def back_d_map(self) -> NDArray[np.float64] | None:
+        """Per-pixel SAMMY exponential background amplitude (BackD) map.
+
+        ``None`` whenever the LM transmission background was not active
+        (``background=False``) OR the exponential tail was not fit
+        (``fit_back_d=False``).  Counts-KL runs are always ``None``
+        because the joint-Poisson dispatch never fits BackD/BackF.
+        See issue #538."""
+        ...
+
+    @property
+    def back_f_map(self) -> NDArray[np.float64] | None:
+        """Per-pixel SAMMY exponential background decay constant (BackF) map.
+
+        ``None`` under the same conditions as :py:attr:`back_d_map`."""
+        ...
+
+    @property
     def t0_us_map(self) -> NDArray[np.float64] | None:
         """Per-pixel SAMMY TZERO offset t0 (µs) map.
         ``None`` when the run did not use ``fit_energy_scale=True``."""
@@ -768,6 +786,10 @@ def spatial_map_typed(
     max_iter: int = 200,
     solver: str = "auto",
     background: bool = False,
+    fit_back_d: bool = False,
+    fit_back_f: bool = False,
+    back_d_init: float = 0.01,
+    back_f_init: float = 1.0,
     fit_alpha_1: bool = False,
     fit_alpha_2: bool = False,
     alpha_1_init: float = 1.0,
@@ -802,6 +824,17 @@ def spatial_map_typed(
     Args:
         data: InputData from `from_counts()`, `from_counts_with_nuisance()`,
             or `from_transmission()`.
+        fit_back_d, fit_back_f: When ``background=True``, fit the
+            optional SAMMY exponential background tail
+            ``BackD * exp(-BackF / √E)``.  SAMMY pairs the two — fitting
+            only one is rejected.  Materialises
+            :py:attr:`SpatialResult.back_d_map` /
+            :py:attr:`SpatialResult.back_f_map` per-pixel (issue #538).
+        back_d_init, back_f_init: Initial values for the exponential
+            tail.  Both must be strictly positive when their fit flags
+            are set (BackF's Jacobian column zeros out at BackD ≈ 0,
+            and BackD becomes a constant duplicate of BackA at
+            BackF ≈ 0).
         c: Proton-charge ratio ``Q_s / Q_ob`` for the counts-KL dispatch
             (memo 35 §P1.3).  Default 1.0 (assumes caller PC-normalized
             the flux already).  Ignored for LM / transmission-KL paths.
@@ -821,7 +854,9 @@ def spatial_map_typed(
     Always returns SpatialResult.  For counts-KL runs,
     ``SpatialResult.deviance_per_dof_map`` is populated as the primary GOF.
     When ``fit_energy_scale=True``, per-pixel ``t0_us_map`` and
-    ``l_scale_map`` are populated on the returned SpatialResult.
+    ``l_scale_map`` are populated on the returned SpatialResult.  When
+    ``background=True`` with ``fit_back_d=True`` / ``fit_back_f=True``,
+    per-pixel ``back_d_map`` / ``back_f_map`` are populated (issue #538).
     """
     ...
 

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -305,7 +305,7 @@ class SpatialResult:
         not fit (``fit_back_d=False``).  For counts inputs the map is
         always ``None`` — the joint-Poisson dispatch (counts-KL) never
         fits BackD/BackF, and the spatial pipeline rejects counts +
-        ``fit_back_d=True`` up-front (issue #538).  See issue #538."""
+        ``fit_back_d=True`` up-front."""
         ...
 
     @property
@@ -830,7 +830,7 @@ def spatial_map_typed(
             ``BackD * exp(-BackF / √E)``.  SAMMY pairs the two — fitting
             only one is rejected.  Materialises
             :py:attr:`SpatialResult.back_d_map` /
-            :py:attr:`SpatialResult.back_f_map` per-pixel (issue #538).
+            :py:attr:`SpatialResult.back_f_map` per-pixel.
         back_d_init, back_f_init: Initial values for the exponential
             tail.  Both must be strictly positive when their fit flags
             are set (BackF's Jacobian column zeros out at BackD ≈ 0,
@@ -857,7 +857,7 @@ def spatial_map_typed(
     When ``fit_energy_scale=True``, per-pixel ``t0_us_map`` and
     ``l_scale_map`` are populated on the returned SpatialResult.  When
     ``background=True`` with ``fit_back_d=True`` / ``fit_back_f=True``,
-    per-pixel ``back_d_map`` / ``back_f_map`` are populated (issue #538).
+    per-pixel ``back_d_map`` / ``back_f_map`` are populated.
     """
     ...
 

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -300,11 +300,12 @@ class SpatialResult:
     def back_d_map(self) -> NDArray[np.float64] | None:
         """Per-pixel SAMMY exponential background amplitude (BackD) map.
 
-        ``None`` whenever the LM transmission background was not active
-        (``background=False``) OR the exponential tail was not fit
-        (``fit_back_d=False``).  Counts-KL runs are always ``None``
-        because the joint-Poisson dispatch never fits BackD/BackF.
-        See issue #538."""
+        ``None`` whenever the polynomial transmission background was
+        not active (``background=False``) OR the exponential tail was
+        not fit (``fit_back_d=False``).  For counts inputs the map is
+        always ``None`` — the joint-Poisson dispatch (counts-KL) never
+        fits BackD/BackF, and the spatial pipeline rejects counts +
+        ``fit_back_d=True`` up-front (issue #538).  See issue #538."""
         ...
 
     @property

--- a/bindings/python/python/nereids/mcp/server.py
+++ b/bindings/python/python/nereids/mcp/server.py
@@ -525,8 +525,8 @@ def _spatial_fit_kwargs(
         "max_iter",
         "solver",
         "background",
-        # Issue #538: surface the SAMMY exponential background tail
-        # (`BackD`/`BackF`) at the MCP boundary so callers can request
+        # Surface the SAMMY exponential background tail
+        # (`BackD` / `BackF`) at the MCP boundary so callers can request
         # per-pixel `back_d_map` / `back_f_map`.
         "fit_back_d",
         "fit_back_f",
@@ -982,9 +982,9 @@ def _process_density_map(
     # reconstruct the model curve per-pixel) and surface aggregate
     # stats in the JSON summary.  Per-pixel ``back_d_map`` / ``back_f_map``
     # require ``background=True`` AND ``fit_back_d=True`` /
-    # ``fit_back_f=True`` (issue #538) — counts-KL runs always have them
-    # as ``None`` because the joint-Poisson dispatch never fits the
-    # SAMMY exponential tail.
+    # ``fit_back_f=True`` — counts-KL runs always have them as ``None``
+    # because the joint-Poisson dispatch never fits the SAMMY
+    # exponential tail.
     fit_param_stats: dict[str, Any] = {}
     anorm_map = getattr(result, "anorm_map", None)
     if anorm_map is not None:

--- a/bindings/python/python/nereids/mcp/server.py
+++ b/bindings/python/python/nereids/mcp/server.py
@@ -525,6 +525,13 @@ def _spatial_fit_kwargs(
         "max_iter",
         "solver",
         "background",
+        # Issue #538: surface the SAMMY exponential background tail
+        # (`BackD`/`BackF`) at the MCP boundary so callers can request
+        # per-pixel `back_d_map` / `back_f_map`.
+        "fit_back_d",
+        "fit_back_f",
+        "back_d_init",
+        "back_f_init",
         "fit_alpha_1",
         "fit_alpha_2",
         "alpha_1_init",
@@ -965,16 +972,19 @@ def _process_density_map(
             }
         )
 
-    # SpatialResult exposes per-pixel anorm / background / t0 / l_scale maps
-    # whenever the spatial pipeline ran with the corresponding *feature*
-    # enabled (e.g. `background=True` materialises all three terms of
-    # `background_maps` — including NaN-per-pixel entries for terms that
-    # were not actually fit — and `fit_energy_scale=True` materialises
-    # both t0/L scale maps).  Save the raw arrays into the NPZ (so
-    # downstream consumers can reconstruct the model curve per-pixel) and
-    # surface aggregate stats in the JSON summary.  Per-pixel
-    # back_d_map / back_f_map are not yet exposed on SpatialResult;
-    # tracked as a Rust-side follow-up (#538).
+    # SpatialResult exposes per-pixel anorm / background / back_d /
+    # back_f / t0 / l_scale maps whenever the spatial pipeline ran with
+    # the corresponding *feature* enabled (e.g. `background=True`
+    # materialises all three terms of `background_maps` — including
+    # NaN-per-pixel entries for terms that were not actually fit — and
+    # `fit_energy_scale=True` materialises both t0/L scale maps).  Save
+    # the raw arrays into the NPZ (so downstream consumers can
+    # reconstruct the model curve per-pixel) and surface aggregate
+    # stats in the JSON summary.  Per-pixel ``back_d_map`` / ``back_f_map``
+    # require ``background=True`` AND ``fit_back_d=True`` /
+    # ``fit_back_f=True`` (issue #538) — counts-KL runs always have them
+    # as ``None`` because the joint-Poisson dispatch never fits the
+    # SAMMY exponential tail.
     fit_param_stats: dict[str, Any] = {}
     anorm_map = getattr(result, "anorm_map", None)
     if anorm_map is not None:
@@ -989,6 +999,16 @@ def _process_density_map(
             arrays_to_save[f"background_term_{term_idx}_map"] = bm_arr
             bm_stats.append(_array_stats(bm_arr))
         fit_param_stats["background"] = bm_stats
+    back_d_map = getattr(result, "back_d_map", None)
+    if back_d_map is not None:
+        back_d_arr = np.asarray(back_d_map)
+        arrays_to_save["back_d_map"] = back_d_arr
+        fit_param_stats["back_d"] = _array_stats(back_d_arr)
+    back_f_map = getattr(result, "back_f_map", None)
+    if back_f_map is not None:
+        back_f_arr = np.asarray(back_f_map)
+        arrays_to_save["back_f_map"] = back_f_arr
+        fit_param_stats["back_f"] = _array_stats(back_f_arr)
     t0_us_map = getattr(result, "t0_us_map", None)
     if t0_us_map is not None:
         t0_arr = np.asarray(t0_us_map)

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -632,6 +632,12 @@ struct PySpatialResult {
     anorm_map: Option<Py<PyArray2<f64>>>,
     /// Per-pixel background parameter maps (None when background=False).
     background_maps: Option<[Py<PyArray2<f64>>; 3]>,
+    /// Per-pixel SAMMY BackD exponential-amplitude map
+    /// (None unless ``background=True`` AND ``fit_back_d=True``).
+    back_d_map: Option<Py<PyArray2<f64>>>,
+    /// Per-pixel SAMMY BackF exponential-decay-constant map
+    /// (None unless ``background=True`` AND ``fit_back_f=True``).
+    back_f_map: Option<Py<PyArray2<f64>>>,
     /// Per-pixel fitted TZERO t0 (µs) map (None when fit_energy_scale=False).
     t0_us_map: Option<Py<PyArray2<f64>>>,
     /// Per-pixel fitted TZERO L_scale map (None when fit_energy_scale=False).
@@ -739,6 +745,25 @@ impl PySpatialResult {
         self.background_maps
             .as_ref()
             .map(|maps| maps.iter().map(|m| m.bind(py).clone()).collect())
+    }
+
+    /// Per-pixel SAMMY exponential background amplitude (``BackD``) map.
+    /// ``None`` whenever the LM transmission background was not active
+    /// (``background=False``) OR the exponential tail was not fit
+    /// (``fit_back_d=False``).  Counts-KL runs are always ``None``
+    /// because the joint-Poisson dispatch never fits ``BackD``/``BackF``.
+    /// Mirrors the per-spectrum ``FitResult.back_d`` convention from
+    /// issue #537.
+    #[getter]
+    fn back_d_map<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyArray2<f64>>> {
+        self.back_d_map.as_ref().map(|m| m.bind(py).clone())
+    }
+
+    /// Per-pixel SAMMY exponential background decay constant (``BackF``) map.
+    /// ``None`` under the same conditions as :py:attr:`back_d_map`.
+    #[getter]
+    fn back_f_map<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyArray2<f64>>> {
+        self.back_f_map.as_ref().map(|m| m.bind(py).clone())
     }
 
     /// Per-pixel SAMMY TZERO offset t0 (µs) map.
@@ -2866,6 +2891,14 @@ fn spatial_result_to_py(
             PyArray2::from_array(py, &maps[2]).into(),
         ]
     });
+    let back_d_map = result
+        .back_d_map
+        .as_ref()
+        .map(|m| PyArray2::from_array(py, m).into());
+    let back_f_map = result
+        .back_f_map
+        .as_ref()
+        .map(|m| PyArray2::from_array(py, m).into());
     let temperature_map = result
         .temperature_map
         .as_ref()
@@ -2902,6 +2935,8 @@ fn spatial_result_to_py(
         temperature_uncertainty_map,
         anorm_map,
         background_maps,
+        back_d_map,
+        back_f_map,
         t0_us_map,
         l_scale_map,
     }
@@ -2960,6 +2995,10 @@ fn spatial_result_to_py(
     max_iter = 200,
     solver = "auto",
     background = false,
+    fit_back_d = false,
+    fit_back_f = false,
+    back_d_init = 0.01,
+    back_f_init = 1.0,
     fit_alpha_1 = false,
     fit_alpha_2 = false,
     alpha_1_init = 1.0,
@@ -2991,6 +3030,10 @@ fn py_spatial_map_typed<'py>(
     max_iter: usize,
     solver: &str,
     background: bool,
+    fit_back_d: bool,
+    fit_back_f: bool,
+    back_d_init: f64,
+    back_f_init: f64,
     fit_alpha_1: bool,
     fit_alpha_2: bool,
     alpha_1_init: f64,
@@ -3137,8 +3180,32 @@ fn py_spatial_map_typed<'py>(
 
     // Background
     if background {
-        config = config
-            .with_transmission_background(nereids_pipeline::pipeline::BackgroundConfig::default());
+        // Issue #538: plumb fit_back_d / fit_back_f / back_d_init /
+        // back_f_init through to `BackgroundConfig` so the LM
+        // transmission per-pixel fit can actually fit the exponential
+        // tail (BackD/BackF).  Without this, the spatial pipeline
+        // attached only the default config (both `fit_back_d` /
+        // `fit_back_f` = false) and the exposed `back_d_map` /
+        // `back_f_map` would never be `Some`.  Mirrors the single-
+        // spectrum `py_fit_spectrum_typed` wiring above.
+        let bg = nereids_pipeline::pipeline::BackgroundConfig {
+            fit_back_d,
+            fit_back_f,
+            back_d_init,
+            back_f_init,
+            ..nereids_pipeline::pipeline::BackgroundConfig::default()
+        };
+        config = config.with_transmission_background(bg);
+    } else if fit_back_d || fit_back_f {
+        // The exponential tail can only be fit when the background
+        // model is active.  Reject the silent-noop combination at the
+        // binding boundary so the user gets a clear error rather than
+        // a `back_d_map` / `back_f_map` of all None.
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "fit_back_d / fit_back_f require background=True \
+             (issue #538): the exponential tail of the SAMMY background \
+             only exists when the polynomial background model is attached.",
+        ));
     }
     if fit_alpha_1 || fit_alpha_2 || alpha_1_init != 1.0 || alpha_2_init != 1.0 {
         if data.kind != "counts_with_nuisance" {

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -3287,8 +3287,25 @@ fn py_spatial_map_typed<'py>(
     // which are not Send, so we cannot use py.allow_threads().  The existing
     // py_spatial_map has the same limitation.  Rayon still parallelizes the
     // per-pixel fitting within the GIL.
-    let result = spatial_map_typed(&input, &config, dead_arr.as_ref(), None, None)
-        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+    // Issue #538 (PR #548 round-3 review): map user-input
+    // configuration errors (unpaired fit_back_d/fit_back_f,
+    // non-finite/non-positive back_*_init, counts-KL + exponential
+    // tail) to `PyValueError`, matching the up-front PyValueError at
+    // the `background=False + fit_back_d=True` boundary above (line
+    // ~289).  Other PipelineError variants stay as PyRuntimeError —
+    // they signal solver / numeric failures, not bad input.
+    let result =
+        spatial_map_typed(&input, &config, dead_arr.as_ref(), None, None).map_err(|e| {
+            let msg = e.to_string();
+            if matches!(
+                e,
+                nereids_pipeline::error::PipelineError::InvalidParameter(_)
+            ) {
+                pyo3::exceptions::PyValueError::new_err(msg)
+            } else {
+                pyo3::exceptions::PyRuntimeError::new_err(msg)
+            }
+        })?;
 
     Ok(spatial_result_to_py(py, &result))
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -3609,19 +3609,19 @@ fn py_fit_counts_spectrum_typed<'py>(
         anorm: result.anorm,
         background: result.background,
         // BackD / BackF are only meaningful when the polynomial background
-        // model was actually attached (the `if background { ... }` block
-        // above never runs when `background=False`, so `result.back_d` and
-        // `result.back_f` are sentinel zeros from the inner Rust
-        // `FitResult`).  Reporting them in that case falsely tells MCP
-        // consumers the exponential tail was fitted, so we gate on both
-        // `background` AND the per-term flag.
+        // model was actually attached.  Issue #538 (PR #548 round-2 review):
+        // `result.back_d` / `result.back_f` are now `Option<f64>` (None when
+        // the inner Rust fit didn't fit the exponential tail).  The outer
+        // gate on `background && fit_back_d` is defensive — it ensures
+        // PyFitResult.back_d is None whenever the caller didn't request the
+        // tail, regardless of any future change to the inner Rust contract.
         back_d: if background && fit_back_d {
-            Some(result.back_d)
+            result.back_d
         } else {
             None
         },
         back_f: if background && fit_back_f {
-            Some(result.back_f)
+            result.back_f
         } else {
             None
         },
@@ -4117,19 +4117,19 @@ fn py_fit_spectrum_typed<'py>(
         anorm: result.anorm,
         background: result.background,
         // BackD / BackF are only meaningful when the polynomial background
-        // model was actually attached (the `if background { ... }` block
-        // above never runs when `background=False`, so `result.back_d` and
-        // `result.back_f` are sentinel zeros from the inner Rust
-        // `FitResult`).  Reporting them in that case falsely tells MCP
-        // consumers the exponential tail was fitted, so we gate on both
-        // `background` AND the per-term flag.
+        // model was actually attached.  Issue #538 (PR #548 round-2 review):
+        // `result.back_d` / `result.back_f` are now `Option<f64>` (None when
+        // the inner Rust fit didn't fit the exponential tail).  The outer
+        // gate on `background && fit_back_d` is defensive — it ensures
+        // PyFitResult.back_d is None whenever the caller didn't request the
+        // tail, regardless of any future change to the inner Rust contract.
         back_d: if background && fit_back_d {
-            Some(result.back_d)
+            result.back_d
         } else {
             None
         },
         back_f: if background && fit_back_f {
-            Some(result.back_f)
+            result.back_f
         } else {
             None
         },

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -3180,14 +3180,13 @@ fn py_spatial_map_typed<'py>(
 
     // Background
     if background {
-        // Issue #538: plumb fit_back_d / fit_back_f / back_d_init /
-        // back_f_init through to `BackgroundConfig` so the LM
+        // Plumb `fit_back_d` / `fit_back_f` / `back_d_init` /
+        // `back_f_init` through to `BackgroundConfig` so the LM
         // transmission per-pixel fit can actually fit the exponential
-        // tail (BackD/BackF).  Without this, the spatial pipeline
-        // attached only the default config (both `fit_back_d` /
-        // `fit_back_f` = false) and the exposed `back_d_map` /
-        // `back_f_map` would never be `Some`.  Mirrors the single-
-        // spectrum `py_fit_spectrum_typed` wiring above.
+        // tail.  Without this, the spatial pipeline would attach only
+        // the default config (both flags `false`) and the exposed
+        // `back_d_map` / `back_f_map` would never be `Some`.  Mirrors
+        // the single-spectrum `py_fit_spectrum_typed` wiring above.
         let bg = nereids_pipeline::pipeline::BackgroundConfig {
             fit_back_d,
             fit_back_f,
@@ -3202,9 +3201,9 @@ fn py_spatial_map_typed<'py>(
         // binding boundary so the user gets a clear error rather than
         // a `back_d_map` / `back_f_map` of all None.
         return Err(pyo3::exceptions::PyValueError::new_err(
-            "fit_back_d / fit_back_f require background=True \
-             (issue #538): the exponential tail of the SAMMY background \
-             only exists when the polynomial background model is attached.",
+            "fit_back_d / fit_back_f require background=True: the \
+             exponential tail of the SAMMY background only exists when \
+             the polynomial background model is attached.",
         ));
     }
     if fit_alpha_1 || fit_alpha_2 || alpha_1_init != 1.0 || alpha_2_init != 1.0 {
@@ -3287,13 +3286,13 @@ fn py_spatial_map_typed<'py>(
     // which are not Send, so we cannot use py.allow_threads().  The existing
     // py_spatial_map has the same limitation.  Rayon still parallelizes the
     // per-pixel fitting within the GIL.
-    // Issue #538 (PR #548 round-3 review): map user-input
-    // configuration errors (unpaired fit_back_d/fit_back_f,
-    // non-finite/non-positive back_*_init, counts-KL + exponential
-    // tail) to `PyValueError`, matching the up-front PyValueError at
-    // the `background=False + fit_back_d=True` boundary above (line
-    // ~289).  Other PipelineError variants stay as PyRuntimeError —
-    // they signal solver / numeric failures, not bad input.
+    // Map user-input configuration errors (unpaired
+    // `fit_back_d`/`fit_back_f`, non-finite/non-positive `back_*_init`,
+    // counts-KL + exponential tail) to `PyValueError`, matching the
+    // up-front `PyValueError` at the `background=False +
+    // fit_back_d=True` boundary above.  Other `PipelineError`
+    // variants stay as `PyRuntimeError` — they signal solver /
+    // numeric failures, not bad input.
     let result =
         spatial_map_typed(&input, &config, dead_arr.as_ref(), None, None).map_err(|e| {
             let msg = e.to_string();
@@ -3625,13 +3624,14 @@ fn py_fit_counts_spectrum_typed<'py>(
         temperature_k_unc: result.temperature_k_unc,
         anorm: result.anorm,
         background: result.background,
-        // BackD / BackF are only meaningful when the polynomial background
-        // model was actually attached.  Issue #538 (PR #548 round-2 review):
-        // `result.back_d` / `result.back_f` are now `Option<f64>` (None when
-        // the inner Rust fit didn't fit the exponential tail).  The outer
-        // gate on `background && fit_back_d` is defensive — it ensures
-        // PyFitResult.back_d is None whenever the caller didn't request the
-        // tail, regardless of any future change to the inner Rust contract.
+        // BackD / BackF are only meaningful when the polynomial
+        // background model was actually attached.  `result.back_d` /
+        // `result.back_f` are `Option<f64>` (None when the inner
+        // Rust fit didn't fit the exponential tail).  The outer gate
+        // on `background && fit_back_d` is defensive — it ensures
+        // PyFitResult.back_d is None whenever the caller didn't
+        // request the tail, regardless of any future change to the
+        // inner Rust contract.
         back_d: if background && fit_back_d {
             result.back_d
         } else {
@@ -4133,13 +4133,14 @@ fn py_fit_spectrum_typed<'py>(
         temperature_k_unc: result.temperature_k_unc,
         anorm: result.anorm,
         background: result.background,
-        // BackD / BackF are only meaningful when the polynomial background
-        // model was actually attached.  Issue #538 (PR #548 round-2 review):
-        // `result.back_d` / `result.back_f` are now `Option<f64>` (None when
-        // the inner Rust fit didn't fit the exponential tail).  The outer
-        // gate on `background && fit_back_d` is defensive — it ensures
-        // PyFitResult.back_d is None whenever the caller didn't request the
-        // tail, regardless of any future change to the inner Rust contract.
+        // BackD / BackF are only meaningful when the polynomial
+        // background model was actually attached.  `result.back_d` /
+        // `result.back_f` are `Option<f64>` (None when the inner
+        // Rust fit didn't fit the exponential tail).  The outer gate
+        // on `background && fit_back_d` is defensive — it ensures
+        // PyFitResult.back_d is None whenever the caller didn't
+        // request the tail, regardless of any future change to the
+        // inner Rust contract.
         back_d: if background && fit_back_d {
             result.back_d
         } else {

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -1653,8 +1653,12 @@ fn fit_counts_joint_poisson(
         temperature_k_unc,
         anorm: anorm_out,
         background: bg_abc_out,
-        back_d: 0.0,
-        back_f: 0.0,
+        // Issue #538 (PR #548 round-2 review): joint-Poisson never fits
+        // the exponential tail.  `None` signals "tail not fit" to
+        // downstream consumers (GUI overlay curve drops the exponential
+        // term; PyO3 conversion passes through to Python as `None`).
+        back_d: None,
+        back_f: None,
         t0_us: energy_scale_indices.map(|(t0_idx, _)| result.params[t0_idx]),
         l_scale: energy_scale_indices.map(|(_, ls_idx)| result.params[ls_idx]),
         deviance_per_dof: Some(result.deviance_per_dof),
@@ -2021,22 +2025,26 @@ fn extract_result(
 ) -> Result<SpectrumFitResult, PipelineError> {
     let densities: Vec<f64> = (0..n_density_params).map(|i| result.params[i]).collect();
 
-    let (anorm, background, back_d, back_f) = if let Some(bi) = bg_indices {
-        let bd = bi.back_d.map_or(0.0, |i| result.params[i]);
-        let bf = bi.back_f.map_or(0.0, |i| result.params[i]);
-        (
-            result.params[bi.anorm],
-            [
-                result.params[bi.back_a],
-                result.params[bi.back_b],
-                result.params[bi.back_c],
-            ],
-            bd,
-            bf,
-        )
-    } else {
-        (1.0, [0.0, 0.0, 0.0], 0.0, 0.0)
-    };
+    let (anorm, background, back_d, back_f): (f64, [f64; 3], Option<f64>, Option<f64>) =
+        if let Some(bi) = bg_indices {
+            // Issue #538 (PR #548 round-2 review): `Option<f64>`
+            // distinguishes "exponential tail not fit" (None) from
+            // "fit produced zero" (Some(0.0)) — was a 0.0 sentinel.
+            let bd = bi.back_d.map(|i| result.params[i]);
+            let bf = bi.back_f.map(|i| result.params[i]);
+            (
+                result.params[bi.anorm],
+                [
+                    result.params[bi.back_a],
+                    result.params[bi.back_b],
+                    result.params[bi.back_c],
+                ],
+                bd,
+                bf,
+            )
+        } else {
+            (1.0, [0.0, 0.0, 0.0], None, None)
+        };
 
     let (uncertainties, temperature_k, temperature_k_unc) = if result.converged {
         match &result.uncertainties {
@@ -2463,11 +2471,20 @@ pub struct SpectrumFitResult {
     /// pipeline emits `[0.0, 0.0, 0.0]`.
     pub background: [f64; 3],
     /// Fitted exponential background amplitude (SAMMY BackD).
-    /// Zero when the exponential tail is not fitted.
-    pub back_d: f64,
+    /// `None` when the exponential tail is not fitted; `Some(value)`
+    /// when the LM transmission background was active with
+    /// `fit_back_d=true`.  Mirrors [`Self::t0_us`] /
+    /// [`Self::l_scale`] semantics so the GUI overlay can
+    /// distinguish "unfit" from "fitted to zero" without an ambiguous
+    /// `0.0` sentinel (issue #538, PR #548 round-2 review).
+    pub back_d: Option<f64>,
     /// Fitted exponential background decay constant (SAMMY BackF).
-    /// Zero when the exponential tail is not fitted.
-    pub back_f: f64,
+    /// `None` when the exponential tail is not fitted; `Some(value)`
+    /// when the LM transmission background was active with
+    /// `fit_back_f=true`.  Paired with [`Self::back_d`] — SAMMY
+    /// requires both flags toggled together (see
+    /// `validate_transmission_background`).
+    pub back_f: Option<f64>,
     /// Fitted TOF offset in microseconds (SAMMY TZERO t₀).
     /// `None` when energy-scale fitting is not enabled.
     pub t0_us: Option<f64>,

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -1653,10 +1653,10 @@ fn fit_counts_joint_poisson(
         temperature_k_unc,
         anorm: anorm_out,
         background: bg_abc_out,
-        // Issue #538 (PR #548 round-2 review): joint-Poisson never fits
-        // the exponential tail.  `None` signals "tail not fit" to
-        // downstream consumers (GUI overlay curve drops the exponential
-        // term; PyO3 conversion passes through to Python as `None`).
+        // Joint-Poisson never fits the exponential tail.  `None`
+        // signals "tail not fit" to downstream consumers (GUI overlay
+        // curve drops the exponential term; PyO3 conversion passes
+        // through to Python as `None`).
         back_d: None,
         back_f: None,
         t0_us: energy_scale_indices.map(|(t0_idx, _)| result.params[t0_idx]),
@@ -2027,9 +2027,8 @@ fn extract_result(
 
     let (anorm, background, back_d, back_f): (f64, [f64; 3], Option<f64>, Option<f64>) =
         if let Some(bi) = bg_indices {
-            // Issue #538 (PR #548 round-2 review): `Option<f64>`
-            // distinguishes "exponential tail not fit" (None) from
-            // "fit produced zero" (Some(0.0)) — was a 0.0 sentinel.
+            // `Option<f64>` distinguishes "exponential tail not fit"
+            // (`None`) from "fit produced zero" (`Some(0.0)`).
             let bd = bi.back_d.map(|i| result.params[i]);
             let bf = bi.back_f.map(|i| result.params[i]);
             (
@@ -2476,7 +2475,7 @@ pub struct SpectrumFitResult {
     /// `fit_back_d=true`.  Mirrors [`Self::t0_us`] /
     /// [`Self::l_scale`] semantics so the GUI overlay can
     /// distinguish "unfit" from "fitted to zero" without an ambiguous
-    /// `0.0` sentinel (issue #538, PR #548 round-2 review).
+    /// `0.0` sentinel.
     pub back_d: Option<f64>,
     /// Fitted exponential background decay constant (SAMMY BackF).
     /// `None` when the exponential tail is not fitted; `Some(value)`

--- a/crates/nereids-pipeline/src/spatial.rs
+++ b/crates/nereids-pipeline/src/spatial.rs
@@ -320,6 +320,26 @@ pub fn spatial_map_typed(
         ));
     }
 
+    // PR #548 Copilot review: `fit_spectrum_typed` rejects
+    // `CountsWithNuisance + LM` per-pixel (see pipeline.rs:950 —
+    // "CountsWithNuisance requires a counts-domain solver"), but
+    // `spatial_map_typed` swallows the per-pixel errors as `n_failed`
+    // and returns `Ok(SpatialResult)` with all-NaN maps.  Hoist the
+    // same rejection up-front so callers get a clear diagnostic
+    // instead of a silently-failed spatial result.
+    if matches!(input, InputData3D::CountsWithNuisance { .. })
+        && matches!(config.solver(), SolverConfig::LevenbergMarquardt(_))
+    {
+        return Err(PipelineError::InvalidParameter(
+            "spatial_map_typed: InputData3D::CountsWithNuisance requires a counts-domain \
+             solver (joint-Poisson via SolverConfig::PoissonKL or SolverConfig::Auto); \
+             SolverConfig::LevenbergMarquardt cannot use the user-supplied nuisance \
+             parameters (alpha_1, alpha_2).  Choose a counts-domain solver, or drop the \
+             nuisance arm by passing `InputData3D::Counts` instead."
+                .into(),
+        ));
+    }
+
     // Issue #538 (#548 review): hoist transmission-background BackD/BackF
     // validation from the per-pixel solver up to the spatial dispatch.
     // Without this, invalid configs (unpaired `fit_back_d`/`fit_back_f`,
@@ -2383,6 +2403,47 @@ mod tests {
         assert!(
             msg.contains("counts-KL") || msg.contains("joint-Poisson"),
             "error must reference the counts-KL incompatibility, got: {msg}"
+        );
+    }
+
+    /// PR #548 Copilot review: `CountsWithNuisance + LM` is rejected
+    /// up-front so the caller does not get an all-NaN spatial result
+    /// from per-pixel `n_failed` swallowing.  `fit_spectrum_typed`
+    /// rejects this combo per-pixel (pipeline.rs:950); the hoisted
+    /// spatial-level rejection surfaces the same diagnostic at the
+    /// boundary instead of pretending the fit ran.
+    #[test]
+    fn test_spatial_map_counts_with_nuisance_plus_lm_rejected_up_front() {
+        use ndarray::Array3;
+        let rd = u238_single_resonance();
+        let energies: Vec<f64> = (0..51).map(|i| 1.0 + (i as f64) * 0.2).collect();
+        let (sample, _ob) = synthetic_4x4_counts(&rd, 0.0005, &energies, 1000.0);
+        // `CountsWithNuisance` carries (sample, flux, background) per
+        // pixel.  The validation under test fires before any field is
+        // consumed, so synthetic flat 4x4 arrays suffice.
+        let flux: Array3<f64> = Array3::from_elem((energies.len(), 4, 4), 1000.0);
+        let background: Array3<f64> = Array3::from_elem((energies.len(), 4, 4), 0.0);
+        let data = InputData3D::CountsWithNuisance {
+            sample_counts: sample.view(),
+            flux: flux.view(),
+            background: background.view(),
+        };
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![rd],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.001],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig::default()));
+        let err = spatial_map_typed(&data, &config, None, None, None)
+            .expect_err("CountsWithNuisance + LM must be rejected up-front");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("CountsWithNuisance") && msg.contains("counts-domain"),
+            "error must mention CountsWithNuisance + counts-domain requirement, got: {msg}"
         );
     }
 

--- a/crates/nereids-pipeline/src/spatial.rs
+++ b/crates/nereids-pipeline/src/spatial.rs
@@ -120,7 +120,9 @@ pub struct SpatialResult {
 
 // ── Phase 3: InputData3D + spatial_map_typed ─────────────────────────────
 
-use crate::pipeline::{InputData, SolverConfig, UnifiedFitConfig, fit_spectrum_typed};
+use crate::pipeline::{
+    InputData, SolverConfig, UnifiedFitConfig, fit_spectrum_typed, validate_transmission_background,
+};
 
 /// 3D input data for spatial mapping.
 ///
@@ -316,6 +318,59 @@ pub fn spatial_map_typed(
              fit temperature on the nominal energy grid."
                 .into(),
         ));
+    }
+
+    // Issue #538 (#548 review): hoist transmission-background BackD/BackF
+    // validation from the per-pixel solver up to the spatial dispatch.
+    // Without this, invalid configs (unpaired `fit_back_d`/`fit_back_f`,
+    // non-positive `back_*_init`, counts-KL plus exponential tail) get
+    // swallowed as `n_failed` per pixel and `spatial_map_typed` still
+    // returns `Ok(SpatialResult)` with all-NaN maps — silently failing
+    // is worse than a clear validation error.
+    if let Some(bg) = config.transmission_background() {
+        // SAMMY pairs BackD/BackF — enabling only one leaves the other
+        // registered but unused.  Already enforced per-pixel in the LM
+        // solver; surface up-front for the spatial dispatch.
+        validate_transmission_background(bg)?;
+        // BackF's Jacobian column zeros out at BackD ≈ 0 (and BackD
+        // becomes a constant duplicate of BackA at BackF ≈ 0).  Reject
+        // non-positive initial values so the LM solver does not silently
+        // produce all-NaN maps via a degenerate Jacobian.
+        if bg.fit_back_d && bg.back_d_init <= 0.0 {
+            return Err(PipelineError::InvalidParameter(format!(
+                "transmission_background.back_d_init must be strictly positive when \
+                 fit_back_d=true (got {}). BackF's Jacobian column zeros out at \
+                 BackD ≈ 0; non-positive initial values produce a degenerate fit that \
+                 LM cannot recover.",
+                bg.back_d_init,
+            )));
+        }
+        if bg.fit_back_f && bg.back_f_init <= 0.0 {
+            return Err(PipelineError::InvalidParameter(format!(
+                "transmission_background.back_f_init must be strictly positive when \
+                 fit_back_f=true (got {}). BackD becomes a constant duplicate of BackA \
+                 at BackF ≈ 0; non-positive initial values produce a degenerate fit \
+                 that LM cannot recover.",
+                bg.back_f_init,
+            )));
+        }
+        // The joint-Poisson (counts-KL) dispatch never fits the SAMMY
+        // exponential tail — `fit_counts_joint_poisson` rejects
+        // `fit_back_d || fit_back_f` per pixel.  Surface up-front so the
+        // user gets a clear diagnostic instead of an all-NaN map.
+        if (bg.fit_back_d || bg.fit_back_f)
+            && input.is_counts()
+            && !matches!(config.solver(), SolverConfig::LevenbergMarquardt(_))
+        {
+            return Err(PipelineError::InvalidParameter(
+                "spatial_map_typed: transmission_background with fit_back_d=true / \
+                 fit_back_f=true cannot be combined with the counts-KL (joint-Poisson) \
+                 dispatch. The joint-Poisson solver does not fit the SAMMY exponential \
+                 tail. Either switch to SolverConfig::LevenbergMarquardt or disable the \
+                 exponential tail (fit_back_d=false, fit_back_f=false)."
+                    .into(),
+            ));
+        }
     }
 
     // Collect live pixel coordinates
@@ -2088,6 +2143,160 @@ mod tests {
         assert!(
             result.back_f_map.is_none(),
             "back_f_map must be None on the counts-KL path"
+        );
+    }
+
+    /// Issue #538 P1 (#548 review): unpaired `fit_back_d` /
+    /// `fit_back_f` must be rejected up-front by `spatial_map_typed`,
+    /// not just per-pixel.  Without this guard the per-pixel solver
+    /// errors are swallowed as `n_failed` and the caller sees an
+    /// all-NaN map with no diagnostic.
+    #[test]
+    fn test_spatial_map_back_d_f_unpaired_rejected_up_front() {
+        let rd = u238_single_resonance();
+        let energies: Vec<f64> = (0..51).map(|i| 1.0 + (i as f64) * 0.2).collect();
+        let (t_3d, u_3d) = synthetic_4x4_transmission(&rd, 0.001, &energies);
+        let data = InputData3D::Transmission {
+            transmission: t_3d.view(),
+            uncertainty: u_3d.view(),
+        };
+        let bg = crate::pipeline::BackgroundConfig {
+            fit_back_d: true,
+            fit_back_f: false, // unpaired — must be rejected
+            back_d_init: 0.01,
+            back_f_init: 1.0,
+            ..crate::pipeline::BackgroundConfig::default()
+        };
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![rd],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.001],
+        )
+        .unwrap()
+        .with_transmission_background(bg);
+        let err = spatial_map_typed(&data, &config, None, None, None)
+            .expect_err("unpaired fit_back_d/fit_back_f must be rejected up-front");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("fit_back_d") && msg.contains("fit_back_f"),
+            "error message must reference both fit flags, got: {msg}"
+        );
+    }
+
+    /// Issue #538 P1 (#548 review): non-positive `back_d_init` /
+    /// `back_f_init` is rejected up-front so the LM solver does not
+    /// silently produce a degenerate Jacobian.
+    #[test]
+    fn test_spatial_map_back_d_init_non_positive_rejected() {
+        let rd = u238_single_resonance();
+        let energies: Vec<f64> = (0..51).map(|i| 1.0 + (i as f64) * 0.2).collect();
+        let (t_3d, u_3d) = synthetic_4x4_transmission(&rd, 0.001, &energies);
+        let data = InputData3D::Transmission {
+            transmission: t_3d.view(),
+            uncertainty: u_3d.view(),
+        };
+        let bg = crate::pipeline::BackgroundConfig {
+            fit_back_d: true,
+            fit_back_f: true,
+            back_d_init: 0.0, // non-positive — must be rejected
+            back_f_init: 1.0,
+            ..crate::pipeline::BackgroundConfig::default()
+        };
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![rd],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.001],
+        )
+        .unwrap()
+        .with_transmission_background(bg);
+        let err = spatial_map_typed(&data, &config, None, None, None)
+            .expect_err("back_d_init=0.0 with fit_back_d=true must be rejected up-front");
+        assert!(
+            err.to_string().contains("back_d_init"),
+            "error must reference back_d_init, got: {err}"
+        );
+    }
+
+    /// Issue #538 P1 (#548 review): non-positive `back_f_init` is
+    /// rejected up-front for the same reason as `back_d_init`.
+    #[test]
+    fn test_spatial_map_back_f_init_non_positive_rejected() {
+        let rd = u238_single_resonance();
+        let energies: Vec<f64> = (0..51).map(|i| 1.0 + (i as f64) * 0.2).collect();
+        let (t_3d, u_3d) = synthetic_4x4_transmission(&rd, 0.001, &energies);
+        let data = InputData3D::Transmission {
+            transmission: t_3d.view(),
+            uncertainty: u_3d.view(),
+        };
+        let bg = crate::pipeline::BackgroundConfig {
+            fit_back_d: true,
+            fit_back_f: true,
+            back_d_init: 0.01,
+            back_f_init: -1.0, // negative — must be rejected
+            ..crate::pipeline::BackgroundConfig::default()
+        };
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![rd],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.001],
+        )
+        .unwrap()
+        .with_transmission_background(bg);
+        let err = spatial_map_typed(&data, &config, None, None, None)
+            .expect_err("back_f_init=-1.0 with fit_back_f=true must be rejected up-front");
+        assert!(
+            err.to_string().contains("back_f_init"),
+            "error must reference back_f_init, got: {err}"
+        );
+    }
+
+    /// Issue #538 P1 (#548 review): the joint-Poisson (counts-KL)
+    /// dispatch combined with a `transmission_background` carrying
+    /// `fit_back_d=true` / `fit_back_f=true` is rejected up-front so
+    /// the user gets a clear diagnostic instead of an all-NaN map
+    /// from per-pixel `n_failed` swallowing.
+    #[test]
+    fn test_spatial_map_counts_kl_plus_back_d_rejected_up_front() {
+        let rd = u238_single_resonance();
+        let energies: Vec<f64> = (0..51).map(|i| 1.0 + (i as f64) * 0.2).collect();
+        let (sample, ob) = synthetic_4x4_counts(&rd, 0.0005, &energies, 1000.0);
+        let data = InputData3D::Counts {
+            sample_counts: sample.view(),
+            open_beam_counts: ob.view(),
+        };
+        let bg = crate::pipeline::BackgroundConfig {
+            fit_back_d: true,
+            fit_back_f: true,
+            back_d_init: 0.01,
+            back_f_init: 1.0,
+            ..crate::pipeline::BackgroundConfig::default()
+        };
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![rd],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.001],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::PoissonKL(PoissonConfig::default()))
+        .with_transmission_background(bg);
+        let err = spatial_map_typed(&data, &config, None, None, None)
+            .expect_err("counts-KL + fit_back_d/fit_back_f must be rejected up-front");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("counts-KL") || msg.contains("joint-Poisson"),
+            "error must reference the counts-KL incompatibility, got: {msg}"
         );
     }
 

--- a/crates/nereids-pipeline/src/spatial.rs
+++ b/crates/nereids-pipeline/src/spatial.rs
@@ -23,7 +23,8 @@ use crate::pipeline::SpectrumFitResult;
 /// (`density_maps`, `uncertainty_maps`, `chi_squared_map`,
 /// `deviance_per_dof_map`, `temperature_map`,
 /// `temperature_uncertainty_map`, `anorm_map`, `background_maps`,
-/// `t0_us_map`, `l_scale_map`) contains `NaN` at every pixel where
+/// `back_d_map`, `back_f_map`, `t0_us_map`, `l_scale_map`)
+/// contains `NaN` at every pixel where
 /// `converged_map` is `false`.  The only map written unconditionally
 /// is `converged_map` itself — it is how callers discover that a
 /// pixel failed.  Callers rendering numeric values should gate on
@@ -74,16 +75,31 @@ pub struct SpatialResult {
     /// (legacy alpha-fitting `[b0, b1, alpha_2]` layout was retired with
     /// `fit_counts_poisson` in PR #450).
     ///
-    /// **Limitation:** the exponential `BackD`/`BackF` terms are NOT
-    /// surfaced per-pixel.  Counts-KL never fits them (always 0); LM
-    /// transmission can fit them at the per-pixel level but the
-    /// resulting `back_d`/`back_f` are dropped when collating spatial
-    /// outputs.  If a downstream consumer needs the full 6-term
-    /// background reconstruction per-pixel, extend `SpatialResult`
-    /// with `back_d_map`/`back_f_map` (filed as a follow-up if needed).
+    /// The exponential `BackD`/`BackF` terms are surfaced separately
+    /// in [`Self::back_d_map`] / [`Self::back_f_map`] — both `None`
+    /// for counts-KL runs (the joint-Poisson dispatch never fits the
+    /// exponential tail) and for LM transmission runs that left
+    /// `fit_back_d` / `fit_back_f` at their default `false`.
     ///
     /// NaN at pixels where `converged_map` is `false`.
     pub background_maps: Option<[Array2<f64>; 3]>,
+    /// Per-pixel fitted SAMMY exponential background amplitude
+    /// `BackD` (issue #538).  `Some` only when the LM transmission
+    /// background path was active AND `fit_back_d=true`; `None`
+    /// otherwise (counts-KL runs, LM runs without a background model,
+    /// and LM runs that fit the polynomial terms but left the
+    /// exponential tail at its initial value).
+    /// NaN at pixels where `converged_map` is `false`.
+    pub back_d_map: Option<Array2<f64>>,
+    /// Per-pixel fitted SAMMY exponential background decay constant
+    /// `BackF` (issue #538).  `Some` only when the LM transmission
+    /// background path was active AND `fit_back_f=true`; `None`
+    /// otherwise.  Mirrors [`Self::back_d_map`]'s gating because
+    /// `BackD` and `BackF` are required to fit together (see
+    /// `validate_transmission_background` in
+    /// `crate::pipeline`).
+    /// NaN at pixels where `converged_map` is `false`.
+    pub back_f_map: Option<Array2<f64>>,
     /// Per-pixel fitted SAMMY TZERO offset (µs) map.
     /// `Some` when `config.fit_energy_scale` is true; `None` otherwise.
     /// NaN at pixels where `converged_map` is `false`.
@@ -316,6 +332,21 @@ pub fn spatial_map_typed(
     let isotope_labels = config.isotope_names().to_vec();
     let has_background_outputs =
         config.transmission_background().is_some() || config.counts_background().is_some();
+    // Issue #538: the exponential `BackD`/`BackF` terms are LM-transmission-
+    // only.  The joint-Poisson (counts-KL) path never fits them — see
+    // `pipeline::fit_counts_joint_poisson` validation rejecting
+    // `fit_back_d || fit_back_f` and the surrounding inline note.  Gate
+    // both maps on the transmission-background config carrying the
+    // per-term `fit_back_d` / `fit_back_f` flags so callers can tell the
+    // difference between "map is full of NaN because no pixel converged"
+    // (`Some([NaN, ...])`) and "the exponential tail was never engaged"
+    // (`None`).
+    let has_back_d_map = config
+        .transmission_background()
+        .is_some_and(|bg| bg.fit_back_d);
+    let has_back_f_map = config
+        .transmission_background()
+        .is_some_and(|bg| bg.fit_back_f);
 
     // Whether the per-pixel dispatch routes through the counts-KL
     // (joint-Poisson) solver.  True iff the input is counts AND the
@@ -375,6 +406,16 @@ pub fn spatial_map_typed(
                     Array2::from_elem((height, width), f64::NAN),
                     Array2::from_elem((height, width), f64::NAN),
                 ])
+            } else {
+                None
+            },
+            back_d_map: if has_back_d_map {
+                Some(Array2::from_elem((height, width), f64::NAN))
+            } else {
+                None
+            },
+            back_f_map: if has_back_f_map {
+                Some(Array2::from_elem((height, width), f64::NAN))
             } else {
                 None
             },
@@ -971,6 +1012,16 @@ pub fn spatial_map_typed(
     } else {
         None
     };
+    let mut back_d_map: Option<Array2<f64>> = if has_back_d_map {
+        Some(Array2::from_elem((height, width), f64::NAN))
+    } else {
+        None
+    };
+    let mut back_f_map: Option<Array2<f64>> = if has_back_f_map {
+        Some(Array2::from_elem((height, width), f64::NAN))
+    } else {
+        None
+    };
     let mut t0_us_map: Option<Array2<f64>> = if config.fit_energy_scale() {
         Some(Array2::from_elem((height, width), f64::NAN))
     } else {
@@ -1052,6 +1103,19 @@ pub fn spatial_map_typed(
             bg_maps[1][[*y, *x]] = result.background[1];
             bg_maps[2][[*y, *x]] = result.background[2];
         }
+        // Issue #538: the per-pixel `SpectrumFitResult` always carries
+        // `back_d`/`back_f` as `f64` (sentinel `0.0` when the bg model
+        // never fit them); the spatial result only materialises the
+        // maps when the LM transmission background actually fit them,
+        // matching the gating already enforced for `has_back_d_map` /
+        // `has_back_f_map` above.  No further `is_some`-style gate on
+        // the per-pixel result is needed.
+        if let Some(ref mut map) = back_d_map {
+            map[[*y, *x]] = result.back_d;
+        }
+        if let Some(ref mut map) = back_f_map {
+            map[[*y, *x]] = result.back_f;
+        }
         if let (Some(map), Some(v)) = (&mut t0_us_map, result.t0_us) {
             map[[*y, *x]] = v;
         }
@@ -1071,6 +1135,8 @@ pub fn spatial_map_typed(
         isotope_labels,
         anorm_map,
         background_maps,
+        back_d_map,
+        back_f_map,
         t0_us_map,
         l_scale_map,
         n_converged,
@@ -1815,6 +1881,214 @@ mod tests {
                 );
             }
         }
+        if let Some(ref m) = result.back_d_map {
+            let v = m[[uy, ux]];
+            assert!(
+                v.is_nan(),
+                "back_d_map at unconverged pixel ({uy},{ux}) must be NaN, got {v}"
+            );
+        }
+        if let Some(ref m) = result.back_f_map {
+            let v = m[[uy, ux]];
+            assert!(
+                v.is_nan(),
+                "back_f_map at unconverged pixel ({uy},{ux}) must be NaN, got {v}"
+            );
+        }
+    }
+
+    /// Issue #538: `back_d_map` / `back_f_map` stay `None` whenever
+    /// `fit_back_d` / `fit_back_f` are left at their defaults, even
+    /// when a transmission background config is attached.  This is the
+    /// "exponential tail never engaged" arm of the gating contract.
+    #[test]
+    fn test_spatial_map_back_d_f_maps_none_when_fit_disabled() {
+        let rd = u238_single_resonance();
+        let energies: Vec<f64> = (0..51).map(|i| 1.0 + (i as f64) * 0.2).collect();
+        let (t_3d, u_3d) = synthetic_4x4_transmission(&rd, 0.001, &energies);
+        let data = InputData3D::Transmission {
+            transmission: t_3d.view(),
+            uncertainty: u_3d.view(),
+        };
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![rd],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.001],
+        )
+        .unwrap()
+        // background=true but fit_back_d/fit_back_f are left at their
+        // default `false` — back_*_map must remain None.
+        .with_transmission_background(crate::pipeline::BackgroundConfig::default());
+
+        let result = spatial_map_typed(&data, &config, None, None, None).unwrap();
+        assert!(
+            result.background_maps.is_some(),
+            "background_maps should be Some when transmission_background is attached"
+        );
+        assert!(
+            result.back_d_map.is_none(),
+            "back_d_map must be None when fit_back_d=false"
+        );
+        assert!(
+            result.back_f_map.is_none(),
+            "back_f_map must be None when fit_back_f=false"
+        );
+    }
+
+    /// Issue #538: `back_d_map` / `back_f_map` are `Some` (and carry
+    /// finite values at converged pixels) when the LM transmission
+    /// background is fit with both exponential-tail flags set.
+    /// Synthesises a 4×4 cube with a known exponential tail on top of
+    /// U-238 absorption so the BackD/BackF Jacobian columns are not
+    /// degenerate (a smooth resonance-only model is unidentifiable in
+    /// BackD/BackF — `anorm` absorbs them — so the fitter stagnates
+    /// and converges = false on every pixel).  This mirrors the
+    /// single-spectrum coverage in
+    /// `fitting::transmission_model::tests::exponential_fit_recovers_all_params`
+    /// while exercising the spatial aggregation path that issue #538
+    /// adds.
+    #[test]
+    fn test_spatial_map_back_d_f_maps_some_when_fit_enabled() {
+        let rd = u238_single_resonance();
+        // 101-bin grid (matches `test_spatial_map_typed_transmission_lm`).
+        let energies: Vec<f64> = (0..101).map(|i| 1.0 + (i as f64) * 0.1).collect();
+        let true_density = 0.0005;
+        let true_back_d = 0.03;
+        let true_back_f = 2.0;
+        // Build the resonance-only transmission first, then add the
+        // exponential tail in-place so the fitter sees a model whose
+        // BackD/BackF columns carry non-degenerate signal.  The 1/√E
+        // factor (NormalizedTransmissionModel exponential wrapper)
+        // makes BackD/BackF identifiable across the [1, 11] eV range.
+        let (mut t_3d, u_3d) = synthetic_4x4_transmission(&rd, true_density, &energies);
+        for (i, &e) in energies.iter().enumerate() {
+            let inv_sqrt_e = 1.0 / e.sqrt();
+            let tail = true_back_d * (-true_back_f * inv_sqrt_e).exp();
+            for y in 0..4 {
+                for x in 0..4 {
+                    t_3d[[i, y, x]] += tail;
+                }
+            }
+        }
+        let data = InputData3D::Transmission {
+            transmission: t_3d.view(),
+            uncertainty: u_3d.view(),
+        };
+        // SAMMY pairs BackD/BackF — `validate_transmission_background`
+        // rejects fitting only one.  Both initial values must stay
+        // strictly positive (the BackF Jacobian column zeros out when
+        // BackD ≈ 0; see BackgroundConfig docstring).
+        let bg = crate::pipeline::BackgroundConfig {
+            fit_back_d: true,
+            fit_back_f: true,
+            back_d_init: 0.01,
+            back_f_init: 1.0,
+            ..crate::pipeline::BackgroundConfig::default()
+        };
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![rd],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![true_density],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig {
+            max_iter: 500,
+            ..LmConfig::default()
+        }))
+        .with_transmission_background(bg);
+
+        let result = spatial_map_typed(&data, &config, None, None, None).unwrap();
+        let bd = result
+            .back_d_map
+            .as_ref()
+            .expect("back_d_map should be Some when fit_back_d=true");
+        let bf = result
+            .back_f_map
+            .as_ref()
+            .expect("back_f_map should be Some when fit_back_f=true");
+        assert_eq!(bd.shape(), [4, 4]);
+        assert_eq!(bf.shape(), [4, 4]);
+        assert!(
+            result.n_converged > 0,
+            "no pixels converged with LM + 7-param transmission background \
+             on synthetic data carrying an exponential tail — test fixture \
+             is no longer exercising the gating contract"
+        );
+        // At converged pixels both must be finite; at unconverged pixels
+        // the NaN-on-failure contract leaves them NaN.
+        let mut n_finite_d = 0;
+        let mut n_finite_f = 0;
+        for y in 0..4 {
+            for x in 0..4 {
+                if result.converged_map[[y, x]] {
+                    if bd[[y, x]].is_finite() {
+                        n_finite_d += 1;
+                    }
+                    if bf[[y, x]].is_finite() {
+                        n_finite_f += 1;
+                    }
+                } else {
+                    assert!(
+                        bd[[y, x]].is_nan(),
+                        "back_d_map at unconverged ({y},{x}) must be NaN"
+                    );
+                    assert!(
+                        bf[[y, x]].is_nan(),
+                        "back_f_map at unconverged ({y},{x}) must be NaN"
+                    );
+                }
+            }
+        }
+        // At least one converged pixel must populate finite back_d/back_f
+        // — otherwise the gating is vacuous.
+        assert!(
+            n_finite_d > 0 && n_finite_f > 0,
+            "at least one converged pixel must produce finite back_d/back_f \
+             (n_converged={}, n_finite_d={n_finite_d}, n_finite_f={n_finite_f})",
+            result.n_converged
+        );
+    }
+
+    /// Issue #538: counts-KL never fits the exponential tail, so the
+    /// `back_d_map` / `back_f_map` fields must remain `None` even when
+    /// the counts-KL background is attached.  This is the gate that
+    /// keeps the joint-Poisson dispatch from accidentally surfacing a
+    /// map of sentinel zeros.
+    #[test]
+    fn test_spatial_map_counts_kl_back_d_f_maps_are_none() {
+        let rd = u238_single_resonance();
+        let energies: Vec<f64> = (0..101).map(|i| 1.0 + (i as f64) * 0.1).collect();
+        let (sample, ob) = synthetic_4x4_counts(&rd, 0.0005, &energies, 1000.0);
+        let data = InputData3D::Counts {
+            sample_counts: sample.view(),
+            open_beam_counts: ob.view(),
+        };
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![rd],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.001],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::PoissonKL(PoissonConfig::default()))
+        .with_counts_background(crate::pipeline::CountsBackgroundConfig::default());
+        let result = spatial_map_typed(&data, &config, None, None, None).unwrap();
+        assert!(
+            result.back_d_map.is_none(),
+            "back_d_map must be None on the counts-KL path"
+        );
+        assert!(
+            result.back_f_map.is_none(),
+            "back_f_map must be None on the counts-KL path"
+        );
     }
 
     // ── Counts-KL spatial path (post-collapse) ────────────────────────

--- a/crates/nereids-pipeline/src/spatial.rs
+++ b/crates/nereids-pipeline/src/spatial.rs
@@ -335,22 +335,26 @@ pub fn spatial_map_typed(
         // BackF's Jacobian column zeros out at BackD ≈ 0 (and BackD
         // becomes a constant duplicate of BackA at BackF ≈ 0).  Reject
         // non-positive initial values so the LM solver does not silently
-        // produce all-NaN maps via a degenerate Jacobian.
-        if bg.fit_back_d && bg.back_d_init <= 0.0 {
+        // produce all-NaN maps via a degenerate Jacobian.  Round-2
+        // Codex review: also reject `NaN` / `+inf` — both pass `<= 0.0`
+        // checks (NaN comparisons are always false; +inf is > 0) but
+        // propagate into the fit parameters and silently corrupt the
+        // result.
+        if bg.fit_back_d && (!bg.back_d_init.is_finite() || bg.back_d_init <= 0.0) {
             return Err(PipelineError::InvalidParameter(format!(
-                "transmission_background.back_d_init must be strictly positive when \
-                 fit_back_d=true (got {}). BackF's Jacobian column zeros out at \
-                 BackD ≈ 0; non-positive initial values produce a degenerate fit that \
-                 LM cannot recover.",
+                "transmission_background.back_d_init must be finite and strictly \
+                 positive when fit_back_d=true (got {}). BackF's Jacobian column \
+                 zeros out at BackD ≈ 0; non-finite or non-positive initial values \
+                 produce a degenerate fit that LM cannot recover.",
                 bg.back_d_init,
             )));
         }
-        if bg.fit_back_f && bg.back_f_init <= 0.0 {
+        if bg.fit_back_f && (!bg.back_f_init.is_finite() || bg.back_f_init <= 0.0) {
             return Err(PipelineError::InvalidParameter(format!(
-                "transmission_background.back_f_init must be strictly positive when \
-                 fit_back_f=true (got {}). BackD becomes a constant duplicate of BackA \
-                 at BackF ≈ 0; non-positive initial values produce a degenerate fit \
-                 that LM cannot recover.",
+                "transmission_background.back_f_init must be finite and strictly \
+                 positive when fit_back_f=true (got {}). BackD becomes a constant \
+                 duplicate of BackA at BackF ≈ 0; non-finite or non-positive initial \
+                 values produce a degenerate fit that LM cannot recover.",
                 bg.back_f_init,
             )));
         }
@@ -1158,18 +1162,22 @@ pub fn spatial_map_typed(
             bg_maps[1][[*y, *x]] = result.background[1];
             bg_maps[2][[*y, *x]] = result.background[2];
         }
-        // Issue #538: the per-pixel `SpectrumFitResult` always carries
-        // `back_d`/`back_f` as `f64` (sentinel `0.0` when the bg model
-        // never fit them); the spatial result only materialises the
-        // maps when the LM transmission background actually fit them,
-        // matching the gating already enforced for `has_back_d_map` /
-        // `has_back_f_map` above.  No further `is_some`-style gate on
-        // the per-pixel result is needed.
+        // Issue #538 (PR #548 round-2 review): per-pixel
+        // `SpectrumFitResult` carries `back_d` / `back_f` as
+        // `Option<f64>` (None when the bg model never fit the
+        // exponential tail).  The spatial result only materialises the
+        // maps when the LM transmission background actually fit them
+        // (gated above via `has_back_d_map` / `has_back_f_map`), so a
+        // converged pixel here should always carry `Some(value)`.
+        // Fall back to NaN for the rare case of None at a converged
+        // pixel — that surfaces an upstream bug via the
+        // NaN-on-failure contract rather than a misleading sentinel
+        // `0.0`.
         if let Some(ref mut map) = back_d_map {
-            map[[*y, *x]] = result.back_d;
+            map[[*y, *x]] = result.back_d.unwrap_or(f64::NAN);
         }
         if let Some(ref mut map) = back_f_map {
-            map[[*y, *x]] = result.back_f;
+            map[[*y, *x]] = result.back_f.unwrap_or(f64::NAN);
         }
         if let (Some(map), Some(v)) = (&mut t0_us_map, result.t0_us) {
             map[[*y, *x]] = v;
@@ -2256,6 +2264,84 @@ mod tests {
         assert!(
             err.to_string().contains("back_f_init"),
             "error must reference back_f_init, got: {err}"
+        );
+    }
+
+    /// Issue #538 P1 (#548 round-2 review): NaN `back_d_init` is
+    /// rejected up-front.  Without the `is_finite()` guard, NaN passes
+    /// the `<= 0.0` check (NaN comparisons are always false) and
+    /// propagates into the fit parameters.
+    #[test]
+    fn test_spatial_map_back_d_init_nan_rejected() {
+        let rd = u238_single_resonance();
+        let energies: Vec<f64> = (0..51).map(|i| 1.0 + (i as f64) * 0.2).collect();
+        let (t_3d, u_3d) = synthetic_4x4_transmission(&rd, 0.001, &energies);
+        let data = InputData3D::Transmission {
+            transmission: t_3d.view(),
+            uncertainty: u_3d.view(),
+        };
+        let bg = crate::pipeline::BackgroundConfig {
+            fit_back_d: true,
+            fit_back_f: true,
+            back_d_init: f64::NAN, // NaN — must be rejected
+            back_f_init: 1.0,
+            ..crate::pipeline::BackgroundConfig::default()
+        };
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![rd],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.001],
+        )
+        .unwrap()
+        .with_transmission_background(bg);
+        let err = spatial_map_typed(&data, &config, None, None, None)
+            .expect_err("NaN back_d_init must be rejected up-front");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("back_d_init") && (msg.contains("finite") || msg.contains("NaN")),
+            "error must mention finite/NaN for back_d_init, got: {msg}"
+        );
+    }
+
+    /// Issue #538 P1 (#548 round-2 review): +inf `back_f_init` is
+    /// rejected up-front.  Without the `is_finite()` guard, +inf
+    /// passes the `<= 0.0` check (positive infinity is > 0) and
+    /// propagates into the fit parameters.
+    #[test]
+    fn test_spatial_map_back_f_init_inf_rejected() {
+        let rd = u238_single_resonance();
+        let energies: Vec<f64> = (0..51).map(|i| 1.0 + (i as f64) * 0.2).collect();
+        let (t_3d, u_3d) = synthetic_4x4_transmission(&rd, 0.001, &energies);
+        let data = InputData3D::Transmission {
+            transmission: t_3d.view(),
+            uncertainty: u_3d.view(),
+        };
+        let bg = crate::pipeline::BackgroundConfig {
+            fit_back_d: true,
+            fit_back_f: true,
+            back_d_init: 0.01,
+            back_f_init: f64::INFINITY, // +inf — must be rejected
+            ..crate::pipeline::BackgroundConfig::default()
+        };
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![rd],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.001],
+        )
+        .unwrap()
+        .with_transmission_background(bg);
+        let err = spatial_map_typed(&data, &config, None, None, None)
+            .expect_err("+inf back_f_init must be rejected up-front");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("back_f_init") && (msg.contains("finite") || msg.contains("inf")),
+            "error must mention finite/inf for back_f_init, got: {msg}"
         );
     }
 

--- a/crates/nereids-pipeline/src/spatial.rs
+++ b/crates/nereids-pipeline/src/spatial.rs
@@ -83,21 +83,20 @@ pub struct SpatialResult {
     ///
     /// NaN at pixels where `converged_map` is `false`.
     pub background_maps: Option<[Array2<f64>; 3]>,
-    /// Per-pixel fitted SAMMY exponential background amplitude
-    /// `BackD` (issue #538).  `Some` only when the LM transmission
-    /// background path was active AND `fit_back_d=true`; `None`
-    /// otherwise (counts-KL runs, LM runs without a background model,
-    /// and LM runs that fit the polynomial terms but left the
-    /// exponential tail at its initial value).
+    /// Per-pixel fitted SAMMY exponential background amplitude `BackD`.
+    /// `Some` only when the LM transmission background path was active
+    /// AND `fit_back_d=true`; `None` otherwise (counts-KL runs, LM
+    /// runs without a background model, and LM runs that fit the
+    /// polynomial terms but left the exponential tail at its initial
+    /// value).
     /// NaN at pixels where `converged_map` is `false`.
     pub back_d_map: Option<Array2<f64>>,
     /// Per-pixel fitted SAMMY exponential background decay constant
-    /// `BackF` (issue #538).  `Some` only when the LM transmission
-    /// background path was active AND `fit_back_f=true`; `None`
-    /// otherwise.  Mirrors [`Self::back_d_map`]'s gating because
-    /// `BackD` and `BackF` are required to fit together (see
-    /// `validate_transmission_background` in
-    /// `crate::pipeline`).
+    /// `BackF`.  `Some` only when the LM transmission background path
+    /// was active AND `fit_back_f=true`; `None` otherwise.  Mirrors
+    /// [`Self::back_d_map`]'s gating because `BackD` and `BackF` are
+    /// required to fit together (see `validate_transmission_background`
+    /// in `crate::pipeline`).
     /// NaN at pixels where `converged_map` is `false`.
     pub back_f_map: Option<Array2<f64>>,
     /// Per-pixel fitted SAMMY TZERO offset (µs) map.
@@ -320,13 +319,13 @@ pub fn spatial_map_typed(
         ));
     }
 
-    // PR #548 Copilot review: `fit_spectrum_typed` rejects
-    // `CountsWithNuisance + LM` per-pixel (see pipeline.rs:950 —
-    // "CountsWithNuisance requires a counts-domain solver"), but
-    // `spatial_map_typed` swallows the per-pixel errors as `n_failed`
-    // and returns `Ok(SpatialResult)` with all-NaN maps.  Hoist the
-    // same rejection up-front so callers get a clear diagnostic
-    // instead of a silently-failed spatial result.
+    // `fit_spectrum_typed` rejects `CountsWithNuisance + LM` per-pixel
+    // (see `validate_input_solver` in `pipeline.rs` — "CountsWithNuisance
+    // requires a counts-domain solver"), but per-pixel errors here are
+    // swallowed as `n_failed` and `spatial_map_typed` returns
+    // `Ok(SpatialResult)` with all-NaN maps.  Hoist the rejection so
+    // callers get a clear diagnostic instead of a silently-failed
+    // spatial result.
     if matches!(input, InputData3D::CountsWithNuisance { .. })
         && matches!(config.solver(), SolverConfig::LevenbergMarquardt(_))
     {
@@ -340,13 +339,11 @@ pub fn spatial_map_typed(
         ));
     }
 
-    // Issue #538 (#548 review): hoist transmission-background BackD/BackF
-    // validation from the per-pixel solver up to the spatial dispatch.
-    // Without this, invalid configs (unpaired `fit_back_d`/`fit_back_f`,
-    // non-positive `back_*_init`, counts-KL plus exponential tail) get
-    // swallowed as `n_failed` per pixel and `spatial_map_typed` still
-    // returns `Ok(SpatialResult)` with all-NaN maps — silently failing
-    // is worse than a clear validation error.
+    // Validate `transmission_background` BackD/BackF here rather than
+    // per-pixel.  Invalid configs (unpaired flags, non-finite or non-
+    // positive init values, counts-KL plus exponential tail) would
+    // otherwise be swallowed as `n_failed` per pixel and produce an
+    // all-NaN map with no diagnostic.
     if let Some(bg) = config.transmission_background() {
         // SAMMY pairs BackD/BackF — enabling only one leaves the other
         // registered but unused.  Already enforced per-pixel in the LM
@@ -355,11 +352,10 @@ pub fn spatial_map_typed(
         // BackF's Jacobian column zeros out at BackD ≈ 0 (and BackD
         // becomes a constant duplicate of BackA at BackF ≈ 0).  Reject
         // non-positive initial values so the LM solver does not silently
-        // produce all-NaN maps via a degenerate Jacobian.  Round-2
-        // Codex review: also reject `NaN` / `+inf` — both pass `<= 0.0`
-        // checks (NaN comparisons are always false; +inf is > 0) but
-        // propagate into the fit parameters and silently corrupt the
-        // result.
+        // produce all-NaN maps via a degenerate Jacobian.  Also reject
+        // `NaN` / `+inf` — both pass `<= 0.0` (NaN comparisons are
+        // always false; +inf is > 0) but propagate into the fit
+        // parameters and silently corrupt the result.
         if bg.fit_back_d && (!bg.back_d_init.is_finite() || bg.back_d_init <= 0.0) {
             return Err(PipelineError::InvalidParameter(format!(
                 "transmission_background.back_d_init must be finite and strictly \
@@ -411,15 +407,13 @@ pub fn spatial_map_typed(
     let isotope_labels = config.isotope_names().to_vec();
     let has_background_outputs =
         config.transmission_background().is_some() || config.counts_background().is_some();
-    // Issue #538: the exponential `BackD`/`BackF` terms are LM-transmission-
-    // only.  The joint-Poisson (counts-KL) path never fits them — see
-    // `pipeline::fit_counts_joint_poisson` validation rejecting
-    // `fit_back_d || fit_back_f` and the surrounding inline note.  Gate
-    // both maps on the transmission-background config carrying the
-    // per-term `fit_back_d` / `fit_back_f` flags so callers can tell the
-    // difference between "map is full of NaN because no pixel converged"
-    // (`Some([NaN, ...])`) and "the exponential tail was never engaged"
-    // (`None`).
+    // The exponential `BackD` / `BackF` terms are LM-transmission-only:
+    // `fit_counts_joint_poisson` rejects `fit_back_d || fit_back_f` for
+    // the counts-KL path.  Gate both maps on the transmission-background
+    // config carrying the per-term `fit_back_d` / `fit_back_f` flags so
+    // callers can distinguish "map full of NaN because no pixel
+    // converged" (`Some([NaN, ...])`) from "the exponential tail was
+    // never engaged" (`None`).
     let has_back_d_map = config
         .transmission_background()
         .is_some_and(|bg| bg.fit_back_d);
@@ -1182,15 +1176,13 @@ pub fn spatial_map_typed(
             bg_maps[1][[*y, *x]] = result.background[1];
             bg_maps[2][[*y, *x]] = result.background[2];
         }
-        // Issue #538 (PR #548 round-2 review): per-pixel
         // `SpectrumFitResult` carries `back_d` / `back_f` as
-        // `Option<f64>` (None when the bg model never fit the
-        // exponential tail).  The spatial result only materialises the
-        // maps when the LM transmission background actually fit them
-        // (gated above via `has_back_d_map` / `has_back_f_map`), so a
-        // converged pixel here should always carry `Some(value)`.
-        // Fall back to NaN for the rare case of None at a converged
-        // pixel — that surfaces an upstream bug via the
+        // `Option<f64>` — `None` when the bg model never fit the
+        // exponential tail.  Maps here are only materialised when LM
+        // actually fit them (gated via `has_back_d_map` /
+        // `has_back_f_map`), so a converged pixel should always carry
+        // `Some(value)`.  Fall back to NaN for the rare case of `None`
+        // at a converged pixel — that surfaces an upstream bug via the
         // NaN-on-failure contract rather than a misleading sentinel
         // `0.0`.
         if let Some(ref mut map) = back_d_map {
@@ -1980,9 +1972,9 @@ mod tests {
         }
     }
 
-    /// Issue #538: `back_d_map` / `back_f_map` stay `None` whenever
-    /// `fit_back_d` / `fit_back_f` are left at their defaults, even
-    /// when a transmission background config is attached.  This is the
+    /// `back_d_map` / `back_f_map` stay `None` whenever `fit_back_d` /
+    /// `fit_back_f` are left at their defaults, even when a
+    /// transmission background config is attached.  This is the
     /// "exponential tail never engaged" arm of the gating contract.
     #[test]
     fn test_spatial_map_back_d_f_maps_none_when_fit_disabled() {
@@ -2021,18 +2013,16 @@ mod tests {
         );
     }
 
-    /// Issue #538: `back_d_map` / `back_f_map` are `Some` (and carry
-    /// finite values at converged pixels) when the LM transmission
-    /// background is fit with both exponential-tail flags set.
-    /// Synthesises a 4×4 cube with a known exponential tail on top of
-    /// U-238 absorption so the BackD/BackF Jacobian columns are not
-    /// degenerate (a smooth resonance-only model is unidentifiable in
-    /// BackD/BackF — `anorm` absorbs them — so the fitter stagnates
-    /// and converges = false on every pixel).  This mirrors the
-    /// single-spectrum coverage in
+    /// `back_d_map` / `back_f_map` are `Some` (and carry finite values
+    /// at converged pixels) when the LM transmission background is fit
+    /// with both exponential-tail flags set.  Synthesises a 4×4 cube
+    /// with a known exponential tail on top of U-238 absorption so the
+    /// BackD/BackF Jacobian columns are not degenerate (a smooth
+    /// resonance-only model is unidentifiable in BackD/BackF — `anorm`
+    /// absorbs them — so the fitter stagnates and converges = false on
+    /// every pixel).  Mirrors the single-spectrum coverage in
     /// `fitting::transmission_model::tests::exponential_fit_recovers_all_params`
-    /// while exercising the spatial aggregation path that issue #538
-    /// adds.
+    /// while exercising the spatial aggregation path.
     #[test]
     fn test_spatial_map_back_d_f_maps_some_when_fit_enabled() {
         let rd = u238_single_resonance();
@@ -2138,11 +2128,10 @@ mod tests {
         );
     }
 
-    /// Issue #538: counts-KL never fits the exponential tail, so the
-    /// `back_d_map` / `back_f_map` fields must remain `None` even when
-    /// the counts-KL background is attached.  This is the gate that
-    /// keeps the joint-Poisson dispatch from accidentally surfacing a
-    /// map of sentinel zeros.
+    /// Counts-KL never fits the exponential tail, so `back_d_map` /
+    /// `back_f_map` must remain `None` even when the counts-KL
+    /// background is attached.  Keeps the joint-Poisson dispatch from
+    /// accidentally surfacing a map of sentinel zeros.
     #[test]
     fn test_spatial_map_counts_kl_back_d_f_maps_are_none() {
         let rd = u238_single_resonance();
@@ -2174,11 +2163,10 @@ mod tests {
         );
     }
 
-    /// Issue #538 P1 (#548 review): unpaired `fit_back_d` /
-    /// `fit_back_f` must be rejected up-front by `spatial_map_typed`,
-    /// not just per-pixel.  Without this guard the per-pixel solver
-    /// errors are swallowed as `n_failed` and the caller sees an
-    /// all-NaN map with no diagnostic.
+    /// Unpaired `fit_back_d` / `fit_back_f` must be rejected up-front
+    /// by `spatial_map_typed`, not just per-pixel.  Without this guard
+    /// the per-pixel solver errors are swallowed as `n_failed` and the
+    /// caller sees an all-NaN map with no diagnostic.
     #[test]
     fn test_spatial_map_back_d_f_unpaired_rejected_up_front() {
         let rd = u238_single_resonance();
@@ -2214,9 +2202,9 @@ mod tests {
         );
     }
 
-    /// Issue #538 P1 (#548 review): non-positive `back_d_init` /
-    /// `back_f_init` is rejected up-front so the LM solver does not
-    /// silently produce a degenerate Jacobian.
+    /// Non-positive `back_d_init` is rejected up-front so the LM
+    /// solver does not silently produce a degenerate Jacobian (BackF's
+    /// column zeros out at BackD ≈ 0).
     #[test]
     fn test_spatial_map_back_d_init_non_positive_rejected() {
         let rd = u238_single_resonance();
@@ -2251,8 +2239,9 @@ mod tests {
         );
     }
 
-    /// Issue #538 P1 (#548 review): non-positive `back_f_init` is
-    /// rejected up-front for the same reason as `back_d_init`.
+    /// Non-positive `back_f_init` is rejected up-front for the same
+    /// reason as `back_d_init` (BackD becomes a duplicate of BackA at
+    /// BackF ≈ 0).
     #[test]
     fn test_spatial_map_back_f_init_non_positive_rejected() {
         let rd = u238_single_resonance();
@@ -2287,10 +2276,10 @@ mod tests {
         );
     }
 
-    /// Issue #538 P1 (#548 round-2 review): NaN `back_d_init` is
-    /// rejected up-front.  Without the `is_finite()` guard, NaN passes
-    /// the `<= 0.0` check (NaN comparisons are always false) and
-    /// propagates into the fit parameters.
+    /// NaN `back_d_init` is rejected up-front.  Without the
+    /// `is_finite()` guard, NaN passes the `<= 0.0` check (NaN
+    /// comparisons are always false) and propagates into the fit
+    /// parameters.
     #[test]
     fn test_spatial_map_back_d_init_nan_rejected() {
         let rd = u238_single_resonance();
@@ -2326,10 +2315,9 @@ mod tests {
         );
     }
 
-    /// Issue #538 P1 (#548 round-2 review): +inf `back_f_init` is
-    /// rejected up-front.  Without the `is_finite()` guard, +inf
-    /// passes the `<= 0.0` check (positive infinity is > 0) and
-    /// propagates into the fit parameters.
+    /// +inf `back_f_init` is rejected up-front.  Without the
+    /// `is_finite()` guard, +inf passes the `<= 0.0` check (positive
+    /// infinity is > 0) and propagates into the fit parameters.
     #[test]
     fn test_spatial_map_back_f_init_inf_rejected() {
         let rd = u238_single_resonance();
@@ -2365,11 +2353,11 @@ mod tests {
         );
     }
 
-    /// Issue #538 P1 (#548 review): the joint-Poisson (counts-KL)
-    /// dispatch combined with a `transmission_background` carrying
-    /// `fit_back_d=true` / `fit_back_f=true` is rejected up-front so
-    /// the user gets a clear diagnostic instead of an all-NaN map
-    /// from per-pixel `n_failed` swallowing.
+    /// The joint-Poisson (counts-KL) dispatch combined with a
+    /// `transmission_background` carrying `fit_back_d=true` /
+    /// `fit_back_f=true` is rejected up-front so the user gets a clear
+    /// diagnostic instead of an all-NaN map from per-pixel `n_failed`
+    /// swallowing.
     #[test]
     fn test_spatial_map_counts_kl_plus_back_d_rejected_up_front() {
         let rd = u238_single_resonance();
@@ -2406,12 +2394,11 @@ mod tests {
         );
     }
 
-    /// PR #548 Copilot review: `CountsWithNuisance + LM` is rejected
-    /// up-front so the caller does not get an all-NaN spatial result
-    /// from per-pixel `n_failed` swallowing.  `fit_spectrum_typed`
-    /// rejects this combo per-pixel (pipeline.rs:950); the hoisted
-    /// spatial-level rejection surfaces the same diagnostic at the
-    /// boundary instead of pretending the fit ran.
+    /// `CountsWithNuisance + LM` is rejected up-front so the caller
+    /// does not get an all-NaN spatial result from per-pixel `n_failed`
+    /// swallowing.  `fit_spectrum_typed` rejects this combo per-pixel;
+    /// the hoisted spatial-level rejection surfaces the same diagnostic
+    /// at the boundary instead of pretending the fit ran.
     #[test]
     fn test_spatial_map_counts_with_nuisance_plus_lm_rejected_up_front() {
         use ndarray::Array3;

--- a/docs/guide/src/python-api.md
+++ b/docs/guide/src/python-api.md
@@ -82,6 +82,8 @@ Returned by `spatial_map_typed(...)`.
 | `converged_map` | `NDArray[bool_]` | Per-pixel convergence flags. |
 | `n_converged`, `n_failed`, `n_total` | `int` | Pixel fit counts. |
 | `temperature_map` | `NDArray[float64] or None` | Fitted temperature map when enabled. |
+| `anorm_map`, `background_maps` | `NDArray[float64] / list[...] or None` | SAMMY `Anorm` and the polynomial background `[BackA, BackB, BackC]` per pixel when `background=True`. |
+| `back_d_map`, `back_f_map` | `NDArray[float64] or None` | SAMMY exponential background `BackD` / `BackF` per pixel when `background=True` and `fit_back_d=True` / `fit_back_f=True`. Counts-KL spatial runs always return `None` for both (the joint-Poisson dispatch never fits the exponential tail). |
 | `t0_us_map`, `l_scale_map` | `NDArray[float64] or None` | Energy-scale maps when enabled. |
 
 ### `NexusData`
@@ -264,6 +266,8 @@ Keyword arguments:
 | `max_iter=200` | Maximum per-pixel optimizer iterations. |
 | `solver="auto"` | Dispatch from input type unless explicitly set. |
 | `background=False` | Enable SAMMY-style background for LM/transmission paths. |
+| `fit_back_d=False`, `fit_back_f=False` | Fit the SAMMY exponential background tail (`BackD * exp(-BackF / √E)`).  Requires `background=True`.  Per-pixel `back_d_map` / `back_f_map` are populated on the returned `SpatialResult` (issue #538). |
+| `back_d_init=0.01`, `back_f_init=1.0` | Initial values for the exponential tail. |
 | `fit_alpha_1=False`, `fit_alpha_2=False` | Fit counts-domain nuisance/background terms. |
 | `alpha_1_init=1.0`, `alpha_2_init=1.0` | Initial nuisance/background values. |
 | `c=1.0` | Proton-charge ratio for counts-KL spatial fitting. |

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -534,6 +534,107 @@ class TestSpatialMapTransmission:
         r = repr(result)
         assert "SpatialResult" in r
 
+    def test_spatial_map_back_d_f_maps_none_when_disabled(self, u238_data):
+        """Issue #538: ``back_d_map`` / ``back_f_map`` must be ``None``
+        whenever ``fit_back_d`` / ``fit_back_f`` are left at their
+        defaults — even when ``background=True`` attaches the polynomial
+        terms.  This is the "exponential tail never engaged" gate."""
+        energies = np.linspace(1.0, 30.0, 200)
+        t_1d = np.asarray(nereids.forward_model(energies, [(u238_data, 0.001)]))
+        trans = np.tile(t_1d[:, None, None], (1, 2, 2))
+        unc = np.full_like(trans, 0.01)
+
+        data = nereids.from_transmission(trans, unc)
+        result = nereids.spatial_map_typed(
+            data,
+            energies,
+            [u238_data],
+            max_iter=30,
+            background=True,
+            # fit_back_d / fit_back_f left at False (default).
+        )
+        # Polynomial background maps materialise.
+        assert result.anorm_map is not None
+        assert result.background_maps is not None
+        # Exponential tail maps stay None when not requested.
+        assert result.back_d_map is None, (
+            f"back_d_map must be None when fit_back_d=False, got "
+            f"{result.back_d_map!r}"
+        )
+        assert result.back_f_map is None, (
+            f"back_f_map must be None when fit_back_f=False, got "
+            f"{result.back_f_map!r}"
+        )
+
+    def test_spatial_map_back_d_f_maps_some_when_enabled(self, u238_data):
+        """Issue #538: ``back_d_map`` / ``back_f_map`` are 2-D float64
+        arrays when ``background=True`` and both ``fit_back_d`` /
+        ``fit_back_f`` are set.  Uses the *real* PyO3 binding (not a
+        SimpleNamespace stub) per the project's PyO3-contract testing
+        convention."""
+        energies = np.linspace(1.0, 30.0, 200)
+        t_1d = np.asarray(nereids.forward_model(energies, [(u238_data, 0.001)]))
+        ny, nx = 2, 2
+        trans = np.tile(t_1d[:, None, None], (1, ny, nx))
+        unc = np.full_like(trans, 0.01)
+
+        data = nereids.from_transmission(trans, unc)
+        result = nereids.spatial_map_typed(
+            data,
+            energies,
+            [u238_data],
+            max_iter=80,
+            background=True,
+            fit_back_d=True,
+            fit_back_f=True,
+            back_d_init=0.01,
+            back_f_init=1.0,
+        )
+        assert result.back_d_map is not None, (
+            "back_d_map must be populated when fit_back_d=True"
+        )
+        assert result.back_f_map is not None, (
+            "back_f_map must be populated when fit_back_f=True"
+        )
+        bd = np.asarray(result.back_d_map)
+        bf = np.asarray(result.back_f_map)
+        assert bd.shape == (ny, nx)
+        assert bf.shape == (ny, nx)
+        assert bd.dtype == np.float64
+        assert bf.dtype == np.float64
+        # At least one converged pixel must populate a finite back_d/back_f
+        # value, otherwise the gating is vacuous.
+        converged = np.asarray(result.converged_map)
+        assert converged.any(), "test fixture produced zero converged pixels"
+        finite_bd = np.isfinite(bd[converged])
+        finite_bf = np.isfinite(bf[converged])
+        assert finite_bd.any() and finite_bf.any(), (
+            f"at least one converged pixel must produce a finite back_d/back_f "
+            f"(finite_bd={finite_bd.sum()}, finite_bf={finite_bf.sum()})"
+        )
+
+    def test_spatial_map_back_d_f_requires_background_kwarg(self, u238_data):
+        """Issue #538: ``fit_back_d`` / ``fit_back_f`` with
+        ``background=False`` is rejected at the binding boundary —
+        the exponential tail of the SAMMY background only exists when
+        the polynomial background is attached, so silently producing
+        ``back_d_map=None`` would be misleading."""
+        energies = np.linspace(1.0, 30.0, 100)
+        t_1d = np.asarray(nereids.forward_model(energies, [(u238_data, 0.001)]))
+        trans = np.tile(t_1d[:, None, None], (1, 2, 2))
+        unc = np.full_like(trans, 0.01)
+        data = nereids.from_transmission(trans, unc)
+        with pytest.raises(ValueError, match="background=True"):
+            nereids.spatial_map_typed(
+                data,
+                energies,
+                [u238_data],
+                max_iter=10,
+                background=False,
+                fit_back_d=True,
+                fit_back_f=True,
+            )
+
 
 # ===========================================================================
 # Spatial mapping (Poisson)

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -571,9 +571,28 @@ class TestSpatialMapTransmission:
         arrays when ``background=True`` and both ``fit_back_d`` /
         ``fit_back_f`` are set.  Uses the *real* PyO3 binding (not a
         SimpleNamespace stub) per the project's PyO3-contract testing
-        convention."""
-        energies = np.linspace(1.0, 30.0, 200)
+        convention.
+
+        Round-2 review (Codex): the original fixture was resonance-only
+        (no exponential tail injected), which made BackD/BackF
+        unidentifiable — ``anorm`` absorbed them and LM stalled at
+        ``back_d ≈ 0`` with `converged = false` per pixel, so the
+        finite-value assertion was vacuous or flaky.  Mirror the Rust
+        coverage in
+        ``test_spatial_map_back_d_f_maps_some_when_fit_enabled`` by
+        injecting a known ``BackD * exp(-BackF / √E)`` tail on top of
+        the resonance-only transmission so the BackD/BackF Jacobian
+        columns carry non-degenerate signal."""
+        # 1.0 to 11.0 eV (101 bins) matches the Rust fixture and keeps
+        # the 1/√E factor identifiable across the range.
+        energies = np.linspace(1.0, 11.0, 101)
         t_1d = np.asarray(nereids.forward_model(energies, [(u238_data, 0.001)]))
+        # Inject a known exponential tail so the BackD/BackF columns
+        # are not degenerate.  Values mirror the Rust test.
+        true_back_d = 0.03
+        true_back_f = 2.0
+        tail = true_back_d * np.exp(-true_back_f / np.sqrt(energies))
+        t_1d = t_1d + tail
         ny, nx = 2, 2
         trans = np.tile(t_1d[:, None, None], (1, ny, nx))
         unc = np.full_like(trans, 0.01)
@@ -583,7 +602,7 @@ class TestSpatialMapTransmission:
             data,
             energies,
             [u238_data],
-            max_iter=80,
+            max_iter=500,
             background=True,
             fit_back_d=True,
             fit_back_f=True,
@@ -603,9 +622,14 @@ class TestSpatialMapTransmission:
         assert bd.dtype == np.float64
         assert bf.dtype == np.float64
         # At least one converged pixel must populate a finite back_d/back_f
-        # value, otherwise the gating is vacuous.
+        # value, otherwise the gating is vacuous (matches the Rust
+        # `n_converged > 0` precondition).
         converged = np.asarray(result.converged_map)
-        assert converged.any(), "test fixture produced zero converged pixels"
+        assert converged.any(), (
+            "test fixture produced zero converged pixels — the LM fit failed "
+            "to recover BackD/BackF on the injected tail; the test fixture "
+            "is no longer exercising the gating contract"
+        )
         finite_bd = np.isfinite(bd[converged])
         finite_bf = np.isfinite(bf[converged])
         assert finite_bd.any() and finite_bf.any(), (


### PR DESCRIPTION
## Summary

- Adds `SpatialResult.back_d_map` / `back_f_map` (`Option<Array2<f64>>`) and mirror PyO3 + MCP accessors so the per-pixel SAMMY exponential background `BackD * exp(-BackF / √E)` is no longer dropped when collating spatial outputs.
- Threads `fit_back_d` / `fit_back_f` / `back_d_init` / `back_f_init` kwargs through `py_spatial_map_typed` (previously absent from the spatial signature even though the single-spectrum `fit_spectrum_typed` exposed them).
- Gating mirrors PR #537's "absent when unset" contract: maps are `None` unless the LM transmission background was attached **and** the corresponding `fit_back_*` flag is `true`; counts-KL is always `None` because `fit_counts_joint_poisson` rejects `fit_back_d || fit_back_f`.

Closes #538.  Follows on from #537 (single-spectrum side of the same contract).

## What was exposed and how it gates

| `transmission_background` attached | `fit_back_d` | `back_d_map` |
|------------------------------------|--------------|--------------|
| No                                 | (irrelevant) | `None`       |
| Yes                                | `false`      | `None`       |
| Yes                                | `true`       | `Some(...)`  |

`back_f_map` follows the same table; SAMMY pairs BackD/BackF and `validate_transmission_background` rejects fitting only one.

Asking for `fit_back_d=True` with `background=False` is rejected at the Python binding boundary (clear `ValueError`) so callers cannot silently end up with `None` maps.

## Files touched

- `crates/nereids-pipeline/src/spatial.rs` — `SpatialResult` fields, gating, population, NaN-on-failure regression, 3 new tests.
- `bindings/python/src/lib.rs` — `PySpatialResult` fields + accessors, conversion in `spatial_result_to_py`, new kwargs in `py_spatial_map_typed`.
- `bindings/python/python/nereids/__init__.pyi` — property stubs + `spatial_map_typed` signature (drift gate passes).
- `bindings/python/python/nereids/mcp/server.py` — surfaces both maps in `density_map` NPZ + `fit_param_stats`; accepts the 4 new kwargs in `_spatial_fit_kwargs`.
- `apps/gui/src/guided/analyze.rs` — `analyze_pixel_fit_from_map` now reads per-pixel `back_d`/`back_f` when available.
- `apps/gui/src/project.rs` — restoration sets new fields to `None` (matches existing TZERO-map precedent).
- `docs/guide/src/python-api.md` — `SpatialResult` table + `spatial_map_typed` kwarg list.
- `tests/test_nereids.py` — 3 real-PyO3-binding tests (`None` when disabled, `Some` + shape when enabled, `ValueError` when `fit_back_d=True` without `background=True`).

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings` (clean — no `#[allow(...)]` suppressions; first attempt caught a `field_reassign_with_default` and was fixed by switching to the struct-update syntax).
- [x] `cargo test --workspace --exclude nereids-python` — 75 spatial/pipeline + all other tests passing locally.
- [x] `pixi run build && pixi run python -m pytest tests/` — 91 passed, 1 skipped (MCP test guarded by `fastmcp` importorskip).
- [x] `pixi run python scripts/check_python_api_drift.py` — drift gate passes (`__init__.pyi` <-> `python-api.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)