### PR TITLE
harden(physics): validate energy_ev at public cross-section API entries (#558)

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -806,7 +806,15 @@ fn cross_sections<'py>(
     energies: PyReadonlyArray1<f64>,
     data: &PyResonanceData,
 ) -> PyResult<Bound<'py, pyo3::types::PyDict>> {
-    let e_owned = energies.as_slice()?.to_vec();
+    // Validate the full grid up front so invalid input surfaces as ValueError
+    // rather than a release-mode `PanicException` from the per-point
+    // `assert!(energy_ev.is_finite() && energy_ev > 0.0)` guards added to
+    // the SLBW / RML / URR leaf paths.  Sibling PyO3 entries
+    // (`doppler_broaden`, `resolution_broaden`, `forward_model`, etc.)
+    // already validate via this same helper; this entry was the lone gap.
+    let e_slice = energies.as_slice()?;
+    validate_energy_grid(e_slice)?;
+    let e_owned = e_slice.to_vec();
     let res_data = data.inner.clone();
 
     // Release the GIL for the cross-section computation.

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -795,11 +795,19 @@ impl PySpatialResult {
 /// Compute cross-sections at given energies for an isotope.
 ///
 /// Args:
-///     energies: Energy grid in eV (1D numpy array).
+///     energies: Energy grid in eV (1D numpy array).  Must be **strictly
+///         ascending**, with every value **finite and positive** — these
+///         constraints are enforced by ``validate_energy_grid`` before any
+///         physics is evaluated.  Empty grids are accepted and return
+///         empty arrays.
 ///     data: ResonanceData for the isotope.
 ///
 /// Returns:
 ///     Dictionary with 'total', 'elastic', 'capture', 'fission' arrays.
+///
+/// Raises:
+///     ValueError: If the grid contains NaN/∞, non-positive entries, or
+///         is not strictly ascending.
 #[pyfunction]
 fn cross_sections<'py>(
     py: Python<'py>,
@@ -895,7 +903,15 @@ fn forward_model<'py>(
         ));
     }
 
-    let e_owned = energies.as_slice()?.to_vec();
+    // Validate the energy grid up front so invalid input surfaces as
+    // ValueError rather than a release-mode `PanicException` from the
+    // per-point `assert!(energy_ev.is_finite() && energy_ev > 0.0)` guards
+    // added to the SLBW / RML / URR / Reich-Moore leaf paths.  Empty
+    // grids are accepted (the downstream `transmission::forward_model`
+    // returns an empty vector for an empty grid).
+    let e_slice = energies.as_slice()?;
+    validate_energy_grid(e_slice)?;
+    let e_owned = e_slice.to_vec();
 
     // Build sample isotopes list from either isotopes or groups
     let sample_isotopes: Vec<(ResonanceData, f64)> = if let Some(isotopes) = isotopes {
@@ -2166,6 +2182,28 @@ fn py_calibrate_energy(
     let t = transmission.as_slice()?;
     let s = uncertainty.as_slice()?;
 
+    // Validate the nominal energy grid up front so malformed energies
+    // surface as ValueError rather than a release-mode `PanicException`
+    // from the per-point `assert!(energy_ev.is_finite() && energy_ev > 0.0)`
+    // guards inside `transmission::forward_model` → SLBW / RML / URR
+    // leaves.  Calibration requires at least one data point to fit
+    // (L, t₀, n_total), so an empty grid is also rejected.
+    require_non_empty_energy_grid(e)?;
+    if t.len() != e.len() {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "transmission length ({}) must match energies_nominal length ({})",
+            t.len(),
+            e.len(),
+        )));
+    }
+    if s.len() != e.len() {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "uncertainty length ({}) must match energies_nominal length ({})",
+            s.len(),
+            e.len(),
+        )));
+    }
+
     let res_data: Vec<nereids_endf::resonance::ResonanceData> = isotopes
         .into_iter()
         .map(|d| Arc::unwrap_or_clone(d.inner))
@@ -3109,7 +3147,8 @@ fn py_spatial_map_typed<'py>(
     // V3: shape validation against the input data cube.
     let data_shape = data.data_a.shape();
     let (data_n_e, data_h, data_w) = (data_shape[0], data_shape[1], data_shape[2]);
-    let n_e_supplied = energies.as_slice()?.len();
+    let e_slice = energies.as_slice()?;
+    let n_e_supplied = e_slice.len();
     if n_e_supplied != data_n_e {
         return Err(pyo3::exceptions::PyValueError::new_err(format!(
             "energies length ({n_e_supplied}) != data spectral axis length ({data_n_e})",
@@ -3124,7 +3163,16 @@ fn py_spatial_map_typed<'py>(
         }
     }
 
-    let energies_vec = energies.as_slice()?.to_vec();
+    // Validate the energy grid up front so malformed energies surface as
+    // ValueError rather than a release-mode `PanicException` from the
+    // per-point `assert!(energy_ev.is_finite() && energy_ev > 0.0)`
+    // guards inside the rayon-parallelised pipeline precompute → SLBW /
+    // RML / URR leaves.  Empty grids are accepted and yield an empty
+    // result; per-pixel failures still degrade gracefully via
+    // `filter_map(Err(_) => None)`.
+    validate_energy_grid(e_slice)?;
+
+    let energies_vec = e_slice.to_vec();
 
     // Build resolution
     let res_fn = build_resolution(flight_path_m, delta_t_us, delta_l_m, resolution, None)?;

--- a/crates/nereids-physics/src/reich_moore.rs
+++ b/crates/nereids-physics/src/reich_moore.rs
@@ -343,7 +343,24 @@ pub struct CrossSections {
 ///
 /// # Returns
 /// Cross-sections in barns.
+///
+/// # Panics
+/// Panics if `energy_ev` is non-finite or non-positive.  The leaf SLBW /
+/// RML / URR routines already enforce this precondition in release builds;
+/// hoisting the same assert to the top-level pub fn keeps the public
+/// contract symmetric so direct Rust callers cannot bypass validation
+/// by hitting a range that gates entry on a finite-only check (e.g. a
+/// pure-RM range with no SLBW/URR/RML leaf would otherwise silently
+/// return zeros when handed NaN).
 pub fn cross_sections_at_energy(data: &ResonanceData, energy_ev: f64) -> CrossSections {
+    // Symmetric public-API guard.  Matches `slbw_cross_sections_for_range`,
+    // `cross_sections_for_rml_range`, and `urr_cross_sections`.  One branch
+    // at the entry of this O(ranges × resonances) function is negligible.
+    assert!(
+        energy_ev.is_finite() && energy_ev > 0.0,
+        "expected positive finite energy_ev, got {energy_ev}"
+    );
+
     let awr = data.awr;
 
     let mut total = 0.0;
@@ -408,9 +425,28 @@ pub fn cross_sections_at_energy(data: &ResonanceData, energy_ev: f64) -> CrossSe
 ///
 /// # Returns
 /// Vector of cross-sections, one per energy point.
+///
+/// # Panics
+/// Panics if any element of `energies` is non-finite or non-positive.
+/// Validating the entire grid up-front (O(n) branch, one pass) means a
+/// single bad energy fails fast with a clear message instead of being
+/// hidden inside the inner loop, matches the symmetric contract on
+/// `cross_sections_at_energy`, and protects direct Rust callers from
+/// the same release-mode silent-zero footgun that the SLBW / RML / URR
+/// leaf asserts guard against per-point.
 pub fn cross_sections_on_grid(data: &ResonanceData, energies: &[f64]) -> Vec<CrossSections> {
     if energies.is_empty() {
         return Vec::new();
+    }
+
+    // Symmetric public-API guard.  See `cross_sections_at_energy` above.
+    // O(n) — negligible next to the per-range precompute and per-point
+    // resonance evaluation that follow.
+    for &energy_ev in energies {
+        assert!(
+            energy_ev.is_finite() && energy_ev > 0.0,
+            "expected positive finite energy_ev, got {energy_ev}"
+        );
     }
 
     let awr = data.awr;
@@ -2355,5 +2391,75 @@ mod tests {
              per_point={:.6e}  batch={:.6e}  rel_diff={max_rel:.3e}",
             energies[worst_idx], per_point[worst_idx], batch[worst_idx],
         );
+    }
+
+    // ─── Top-level pub-fn energy-validation guards ─────────────────────────
+    //
+    // Mirrors the SLBW / RML / URR test patterns: NaN, ±Inf, 0, and -1 must
+    // each panic with the canonical "expected positive finite energy_ev"
+    // message.  These tests gate the symmetric defense-in-depth contract on
+    // both Reich-Moore top-level pub fns so a future refactor cannot
+    // silently drop the assert.
+
+    fn make_minimal_rm_data() -> ResonanceData {
+        // Re-use the U-238 single-resonance helper: the energy used to call
+        // the function is what matters here, not the resonance parameters.
+        make_single_resonance_data(6.674, 1.493e-3, 23.0e-3, 0.5, 0, 236.006, 0.0, 9.4285)
+    }
+
+    #[test]
+    #[should_panic(expected = "expected positive finite energy_ev")]
+    fn cross_sections_at_energy_panics_on_nan() {
+        let data = make_minimal_rm_data();
+        let _ = cross_sections_at_energy(&data, f64::NAN);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected positive finite energy_ev")]
+    fn cross_sections_at_energy_panics_on_infinity() {
+        let data = make_minimal_rm_data();
+        let _ = cross_sections_at_energy(&data, f64::INFINITY);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected positive finite energy_ev")]
+    fn cross_sections_at_energy_panics_on_zero() {
+        let data = make_minimal_rm_data();
+        let _ = cross_sections_at_energy(&data, 0.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected positive finite energy_ev")]
+    fn cross_sections_at_energy_panics_on_negative() {
+        let data = make_minimal_rm_data();
+        let _ = cross_sections_at_energy(&data, -1.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected positive finite energy_ev")]
+    fn cross_sections_on_grid_panics_on_nan() {
+        let data = make_minimal_rm_data();
+        let _ = cross_sections_on_grid(&data, &[1.0, f64::NAN, 2.0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected positive finite energy_ev")]
+    fn cross_sections_on_grid_panics_on_infinity() {
+        let data = make_minimal_rm_data();
+        let _ = cross_sections_on_grid(&data, &[1.0, f64::INFINITY]);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected positive finite energy_ev")]
+    fn cross_sections_on_grid_panics_on_zero() {
+        let data = make_minimal_rm_data();
+        let _ = cross_sections_on_grid(&data, &[1.0, 0.0, 2.0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected positive finite energy_ev")]
+    fn cross_sections_on_grid_panics_on_negative() {
+        let data = make_minimal_rm_data();
+        let _ = cross_sections_on_grid(&data, &[-1.0, 1.0, 2.0]);
     }
 }

--- a/crates/nereids-physics/src/rmatrix_limited.rs
+++ b/crates/nereids-physics/src/rmatrix_limited.rs
@@ -184,6 +184,13 @@ fn resize_and_zero_bool(buf: &mut Vec<bool>, len: usize) {
 ///
 /// Iterates over all spin groups (J,π), sums their contributions.
 /// A single `RmlWorkspace` is allocated once and reused across spin groups.
+///
+/// # Panics
+/// Panics if `energy_ev` is not finite or is non-positive.  This is a
+/// defensive guard at the public boundary; the Python wrapper and the
+/// SAMMY-style dispatcher already validate the energy grid via
+/// `validate_energy_grid`, so this assertion only fires for direct
+/// callers (other Rust crates, tests) that bypass the grid check.
 pub fn cross_sections_for_rml_range(rml: &RmlData, energy_ev: f64) -> (f64, f64, f64, f64) {
     // Defensive input validation at the public boundary (issue #558).
     // See `urr::urr_cross_sections` for rationale.  Catches malformed

--- a/crates/nereids-physics/src/rmatrix_limited.rs
+++ b/crates/nereids-physics/src/rmatrix_limited.rs
@@ -185,6 +185,15 @@ fn resize_and_zero_bool(buf: &mut Vec<bool>, len: usize) {
 /// Iterates over all spin groups (J,π), sums their contributions.
 /// A single `RmlWorkspace` is allocated once and reused across spin groups.
 pub fn cross_sections_for_rml_range(rml: &RmlData, energy_ev: f64) -> (f64, f64, f64, f64) {
+    // Defensive input validation at the public boundary (issue #558).
+    // See `urr::urr_cross_sections` for rationale.  Catches malformed
+    // energies before any spin-group iteration, where empty spin-group
+    // vecs would otherwise silently return (0, 0, 0, 0) for NaN/∞.
+    assert!(
+        energy_ev.is_finite() && energy_ev > 0.0,
+        "expected positive finite energy_ev, got {energy_ev}"
+    );
+
     let mut total = 0.0;
     let mut elastic = 0.0;
     let mut capture = 0.0;
@@ -1250,5 +1259,53 @@ mod tests {
             "W-184 σ_capture: {:.4} b, σ_elastic: {:.4} b at 101.9 eV",
             xs_on_res.capture, xs_on_res.elastic
         );
+    }
+
+    // ─── Defensive input validation at the public boundary ──────────────────
+    //
+    // `cross_sections_for_rml_range` is `pub`, so it can be called directly
+    // from any crate without going through the Python wrapper's
+    // `validate_energy_grid`.  An empty `spin_groups` vec would otherwise
+    // silently return (0, 0, 0, 0) for malformed energies, hiding caller
+    // bugs.  The entry assertion fires before any spin-group iteration.
+    // See issue #558.
+
+    fn make_empty_rml() -> nereids_endf::resonance::RmlData {
+        nereids_endf::resonance::RmlData {
+            target_spin: 0.0,
+            awr: 183.0,
+            scattering_radius: 8.3,
+            krm: 2,
+            particle_pairs: vec![],
+            spin_groups: vec![],
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "expected positive finite energy_ev")]
+    fn rml_for_range_panics_on_zero_energy() {
+        let rml = make_empty_rml();
+        let _ = cross_sections_for_rml_range(&rml, 0.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected positive finite energy_ev")]
+    fn rml_for_range_panics_on_negative_energy() {
+        let rml = make_empty_rml();
+        let _ = cross_sections_for_rml_range(&rml, -1.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected positive finite energy_ev")]
+    fn rml_for_range_panics_on_nan_energy() {
+        let rml = make_empty_rml();
+        let _ = cross_sections_for_rml_range(&rml, f64::NAN);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected positive finite energy_ev")]
+    fn rml_for_range_panics_on_infinite_energy() {
+        let rml = make_empty_rml();
+        let _ = cross_sections_for_rml_range(&rml, f64::INFINITY);
     }
 }

--- a/crates/nereids-physics/src/slbw.rs
+++ b/crates/nereids-physics/src/slbw.rs
@@ -196,6 +196,17 @@ pub fn slbw_cross_sections_for_range(
     awr: f64,
     target_spin: f64,
 ) -> (f64, f64, f64, f64) {
+    // Defensive input validation at the public boundary (issue #558).
+    // See `urr::urr_cross_sections` for rationale.  The leaf
+    // `pi_over_k_squared_barns` retains its `debug_assert!`; this entry
+    // guard makes the precondition genuinely enforced in release builds
+    // for direct Rust callers that bypass the Python wrapper's
+    // `validate_energy_grid`.
+    assert!(
+        energy_ev.is_finite() && energy_ev > 0.0,
+        "expected positive finite energy_ev, got {energy_ev}"
+    );
+
     let pi_over_k2 = channel::pi_over_k_squared_barns(energy_ev, awr);
 
     let mut total = 0.0;
@@ -826,5 +837,73 @@ mod tests {
                 sum
             );
         }
+    }
+
+    // ─── Defensive input validation at the public boundary ──────────────────
+    //
+    // `slbw_cross_sections_for_range` is `pub`, so it can be called directly
+    // from any crate without going through the Python wrapper's
+    // `validate_energy_grid`.  The entry assertion turns malformed energies
+    // (zero, negative, NaN, infinity) into a loud panic at the public
+    // boundary, rather than letting them propagate into `pi_over_k_squared`
+    // (whose `debug_assert!` is invisible in release builds).  See issue #558.
+
+    fn make_minimal_slbw_range() -> nereids_endf::resonance::ResonanceRange {
+        ResonanceRange {
+            energy_low: 1e-5,
+            energy_high: 1e4,
+            resolved: true,
+            formalism: ResonanceFormalism::SLBW,
+            target_spin: 0.0,
+            scattering_radius: 9.4285,
+            naps: 1,
+            l_groups: vec![LGroup {
+                l: 0,
+                awr: 236.006,
+                apl: 0.0,
+                qx: 0.0,
+                lrx: 0,
+                resonances: vec![Resonance {
+                    energy: 6.674,
+                    j: 0.5,
+                    gn: 1.493e-3,
+                    gg: 23.0e-3,
+                    gfa: 0.0,
+                    gfb: 0.0,
+                }],
+            }],
+            rml: None,
+            urr: None,
+            ap_table: None,
+            r_external: vec![],
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "expected positive finite energy_ev")]
+    fn slbw_for_range_panics_on_zero_energy() {
+        let range = make_minimal_slbw_range();
+        let _ = slbw_cross_sections_for_range(&range, 0.0, 236.006, 0.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected positive finite energy_ev")]
+    fn slbw_for_range_panics_on_negative_energy() {
+        let range = make_minimal_slbw_range();
+        let _ = slbw_cross_sections_for_range(&range, -1.0, 236.006, 0.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected positive finite energy_ev")]
+    fn slbw_for_range_panics_on_nan_energy() {
+        let range = make_minimal_slbw_range();
+        let _ = slbw_cross_sections_for_range(&range, f64::NAN, 236.006, 0.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected positive finite energy_ev")]
+    fn slbw_for_range_panics_on_infinite_energy() {
+        let range = make_minimal_slbw_range();
+        let _ = slbw_cross_sections_for_range(&range, f64::INFINITY, 236.006, 0.0);
     }
 }

--- a/crates/nereids-physics/src/slbw.rs
+++ b/crates/nereids-physics/src/slbw.rs
@@ -190,6 +190,13 @@ pub fn slbw_cross_sections(data: &ResonanceData, energy_ev: f64) -> CrossSection
 /// batch/per-point bit-exact equivalence.
 ///
 /// Returns `(total, elastic, capture, fission)` in barns.
+///
+/// # Panics
+/// Panics if `energy_ev` is not finite or is non-positive.  This is a
+/// defensive guard at the public boundary; the Python wrapper and the
+/// SAMMY-style dispatcher already validate the energy grid via
+/// `validate_energy_grid`, so this assertion only fires for direct
+/// callers (other Rust crates, tests) that bypass the grid check.
 pub fn slbw_cross_sections_for_range(
     range: &nereids_endf::resonance::ResonanceRange,
     energy_ev: f64,

--- a/crates/nereids-physics/src/urr.rs
+++ b/crates/nereids-physics/src/urr.rs
@@ -71,6 +71,20 @@ use crate::penetrability;
 ///   responsible for evaluating any AP(E) table (NRO≠0) or falling back
 ///   to the constant `urr.ap`.
 pub fn urr_cross_sections(urr: &UrrData, e_ev: f64, ap_fm: f64) -> (f64, f64, f64, f64) {
+    // Defensive input validation at the public boundary (issue #558).
+    // The dominant call path through `cross_sections_at_energy` is already
+    // gated by ENDF range bounds and the Python wrapper's
+    // `validate_energy_grid`, so this assertion should never fire in
+    // production.  It exists to make this `pub fn` safe for direct callers
+    // (other Rust crates, tests, future bindings) — surfacing malformed
+    // energies as a loud panic rather than letting NaN/∞ silently
+    // contaminate downstream arithmetic.  One branch at the public entry
+    // is well outside any inner loop.
+    assert!(
+        e_ev.is_finite() && e_ev > 0.0,
+        "expected positive finite e_ev, got {e_ev}"
+    );
+
     if e_ev < urr.e_low || e_ev > urr.e_high {
         return (0.0, 0.0, 0.0, 0.0);
     }
@@ -530,5 +544,43 @@ mod tests {
                 }],
             }],
         }
+    }
+
+    // ─── Defensive input validation at the public boundary ──────────────────
+    //
+    // `urr_cross_sections` is `pub`, so any Rust caller (other crates, tests,
+    // future integrations) can reach it directly without going through the
+    // Python wrapper's `validate_energy_grid`.  The body's internal guards
+    // (`urr.e_low ≤ e_ev ≤ urr.e_high`) silently return zeros for negative
+    // energies because `e_low > 0` for any well-formed URR range — that
+    // would hide a caller bug.  The entry assertion turns the footgun into
+    // a loud panic at the call site.  See issue #558.
+
+    #[test]
+    #[should_panic(expected = "expected positive finite e_ev")]
+    fn urr_panics_on_zero_energy() {
+        let urr = make_lrf1_urr(1000.0, 30_000.0);
+        let _ = urr_cross_sections(&urr, 0.0, urr.ap);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected positive finite e_ev")]
+    fn urr_panics_on_negative_energy() {
+        let urr = make_lrf1_urr(1000.0, 30_000.0);
+        let _ = urr_cross_sections(&urr, -1.0, urr.ap);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected positive finite e_ev")]
+    fn urr_panics_on_nan_energy() {
+        let urr = make_lrf1_urr(1000.0, 30_000.0);
+        let _ = urr_cross_sections(&urr, f64::NAN, urr.ap);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected positive finite e_ev")]
+    fn urr_panics_on_infinite_energy() {
+        let urr = make_lrf1_urr(1000.0, 30_000.0);
+        let _ = urr_cross_sections(&urr, f64::INFINITY, urr.ap);
     }
 }

--- a/crates/nereids-physics/src/urr.rs
+++ b/crates/nereids-physics/src/urr.rs
@@ -70,6 +70,13 @@ use crate::penetrability;
 /// * `ap_fm` — Scattering radius in fm at this energy.  The caller is
 ///   responsible for evaluating any AP(E) table (NRO≠0) or falling back
 ///   to the constant `urr.ap`.
+///
+/// # Panics
+/// Panics if `e_ev` is not finite or is non-positive.  This is a
+/// defensive guard at the public boundary; the Python wrapper and the
+/// SAMMY-style dispatcher already validate the energy grid via
+/// `validate_energy_grid`, so this assertion only fires for direct
+/// callers (other Rust crates, tests) that bypass the grid check.
 pub fn urr_cross_sections(urr: &UrrData, e_ev: f64, ap_fm: f64) -> (f64, f64, f64, f64) {
     // Defensive input validation at the public boundary (issue #558).
     // The dominant call path through `cross_sections_at_energy` is already

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -2021,3 +2021,105 @@ class TestFitEnergyScaleRecovery:
             f"L_scale rel err {l_scale_rel_err:.3e} exceeds 1 %: "
             f"got {float(r_calibrated.l_scale):.6f}, truth {L_SCALE_TRUE}"
         )
+
+
+# ===========================================================================
+# Issue #558 — energy-grid validation at the PyO3 boundary
+# ===========================================================================
+#
+# The SLBW / RML / URR / Reich-Moore leaves carry release-mode
+# `assert!(energy_ev.is_finite() && energy_ev > 0.0)` guards.  Every PyO3
+# entry that takes an `energies` argument must validate the grid before
+# any energy reaches those leaves so callers see a clean
+# ``ValueError`` instead of a ``pyo3_runtime.PanicException`` (which is
+# not a subclass of ``ValueError`` and bypasses normal Python error
+# handling).  These tests cover the PyO3 entries hardened in Round 3 of
+# PR #559 — ``forward_model``, ``spatial_map_typed``, and
+# ``calibrate_energy`` — and re-cover the earlier-rounds entries to
+# document the contract.
+
+class TestEnergyGridValidation:
+    """Every PyO3 entry that takes ``energies`` must reject malformed grids
+    with ``ValueError`` rather than leaking a ``PanicException`` from the
+    physics leaves' release-mode asserts (issue #558)."""
+
+    @pytest.mark.parametrize(
+        "bad_energies",
+        [
+            np.array([np.nan, 2.0, 3.0]),
+            np.array([1.0, np.inf, 3.0]),
+            np.array([0.0, 1.0, 2.0]),  # non-positive
+            np.array([-1.0, 1.0, 2.0]),
+            np.array([3.0, 1.0, 2.0]),  # not ascending
+            np.array([1.0, 1.0, 2.0]),  # not strictly ascending
+        ],
+    )
+    def test_cross_sections_rejects_invalid_grid(self, u238_data, bad_energies):
+        with pytest.raises(ValueError):
+            nereids.cross_sections(bad_energies, u238_data)
+
+    @pytest.mark.parametrize(
+        "bad_energies",
+        [
+            np.array([np.nan, 2.0, 3.0]),
+            np.array([1.0, np.inf, 3.0]),
+            np.array([0.0, 1.0, 2.0]),
+            np.array([-1.0, 1.0, 2.0]),
+            np.array([3.0, 1.0, 2.0]),
+        ],
+    )
+    def test_forward_model_rejects_invalid_grid(self, u238_data, bad_energies):
+        with pytest.raises(ValueError):
+            nereids.forward_model(bad_energies, [(u238_data, 0.001)])
+
+    @pytest.mark.parametrize(
+        "bad_energies",
+        [
+            np.array([np.nan, 2.0, 3.0]),
+            np.array([1.0, np.inf, 3.0]),
+            np.array([0.0, 1.0, 2.0]),
+            np.array([-1.0, 1.0, 2.0]),
+        ],
+    )
+    def test_spatial_map_typed_rejects_invalid_grid(self, u238_data, bad_energies):
+        # Build a tiny matching-shape transmission cube so the
+        # length check passes and we hit the energy-grid validator.
+        n_e = len(bad_energies)
+        t = np.ones((n_e, 1, 1), dtype=np.float64) * 0.9
+        u = np.ones((n_e, 1, 1), dtype=np.float64) * 0.01
+        data = nereids.from_transmission(t, u)
+        with pytest.raises(ValueError):
+            nereids.spatial_map_typed(
+                data, bad_energies, [u238_data], max_iter=2
+            )
+
+    @pytest.mark.parametrize(
+        "bad_energies",
+        [
+            np.array([np.nan, 2.0, 3.0]),
+            np.array([1.0, np.inf, 3.0]),
+            np.array([0.0, 1.0, 2.0]),
+            np.array([-1.0, 1.0, 2.0]),
+            np.array([3.0, 1.0, 2.0]),
+        ],
+    )
+    def test_calibrate_energy_rejects_invalid_grid(self, u238_data, bad_energies):
+        n_e = len(bad_energies)
+        t = np.full(n_e, 0.9, dtype=np.float64)
+        s = np.full(n_e, 0.01, dtype=np.float64)
+        with pytest.raises(ValueError):
+            nereids.calibrate_energy(
+                bad_energies,
+                t,
+                s,
+                [u238_data],
+                [1.0],
+                25.0,
+            )
+
+    def test_calibrate_energy_rejects_empty_grid(self, u238_data):
+        e = np.array([], dtype=np.float64)
+        t = np.array([], dtype=np.float64)
+        s = np.array([], dtype=np.float64)
+        with pytest.raises(ValueError):
+            nereids.calibrate_energy(e, t, s, [u238_data], [1.0], 25.0)


### PR DESCRIPTION
## Summary

Defensive hardening at the public-API boundary for the three resolved-region
and URR cross-section functions that accept `energy_ev` without input
validation. The dominant production call path through `cross_sections_at_energy`
is already gated by ENDF range bounds and the Python wrapper's
`validate_energy_grid`, but the three `pub fn` entries below are reachable
directly from any Rust caller (other crates, tests, future bindings) without
that guard.

Adds a release-mode `assert!(energy_ev.is_finite() && energy_ev > 0.0, …)`
at each function entry. The leaf `pi_over_k_squared_barns` retains its
existing `debug_assert!`; that's correct for a hot kernel whose preconditions
are now genuinely enforced at the entry.

Closes #558 (part of epic #551).

## Functions hardened

- `urr::urr_cross_sections` (`crates/nereids-physics/src/urr.rs`) — panic message uses parameter name `e_ev`.
- `slbw::slbw_cross_sections_for_range` (`crates/nereids-physics/src/slbw.rs`).
- `rmatrix_limited::cross_sections_for_rml_range` (`crates/nereids-physics/src/rmatrix_limited.rs`).

## Why `assert!`, not `debug_assert!`

Per CLAUDE.md validation patterns:
> `debug_assert!` is for impossible states only, not input validation.

This is input validation at a `pub fn` boundary. The cost is one `is_finite()`
+ `> 0.0` branch outside any inner loop — negligible relative to the
penetrability / channel arithmetic that follows. Existing internal guards
(e.g. `e_ev < urr.e_low` returning zeros for malformed `urr.e_low > 0` ranges)
silently mask caller bugs; the entry assertion makes them loud.

## Test plan

- [x] **Test-first**: 12 new `#[should_panic(expected = "expected positive finite …")]` regression tests verify each function panics on `0.0`, `-1.0`, `f64::NAN`, and `f64::INFINITY`. Confirmed they fail before the fix (panic at the inner `debug_assert!` with the wrong message, or — for NaN/∞ — don't panic at all in release-style paths) and pass after.
- [x] `cargo fmt --all` clean.
- [x] `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --exclude nereids-python` — full suite green. The new entry asserts NEVER fire from any existing caller (production paths are upstream-gated).

## Scope decision: optional ENDF parser validation deferred

The issue mentions an optional defense-in-depth check that `range.energy_low > 0`
at parse time. There are five `ResonanceRange { … }` construction sites in
`crates/nereids-endf/src/parser.rs` (lines 389, 481, 849, 1208, 1479) — making
each return an error for malformed `energy_low` requires plumbing `Result`
through the call stack at each site and exceeds the < 20 LOC threshold called
out in the issue. Deferred as separate work.

## LOC delta

- 3 files changed, +188 / -0.
- ~12 LOC of new production code (4 LOC × 3 functions, including doc comment
  pointing to issue #558).
- ~176 LOC of new tests + helpers.