### PR TITLE
fix(python): __init__.pyi stub drift + calibrate_energy py.detach borrow (#555)

### DIFF
--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -720,6 +720,7 @@ def calibrate_energy(
     abundances: list[float],
     assumed_flight_path_m: float,
     temperature_k: float = 293.6,
+    resolution: TabulatedResolution | None = None,
 ) -> CalibrationResult:
     """Calibrate the energy axis by fitting flight path and TOF delay.
 
@@ -773,8 +774,11 @@ def from_counts_with_nuisance(
     Use this when the detector/counts background spectrum has been
     estimated outside NEREIDS and should be supplied explicitly
     alongside the open-beam flux.  Routes through the counts-KL
-    (joint-Poisson) dispatch when passed to ``spatial_map_typed`` /
-    ``fit_counts_spectrum_typed`` with ``solver="auto"`` / ``"kl"``.
+    (joint-Poisson) dispatch when passed to ``spatial_map_typed``
+    with ``solver="auto"`` / ``"kl"``.  (Per-spectrum counts fitting
+    uses ``fit_counts_spectrum_typed``, which takes the raw 1D
+    ``sample_counts`` / ``open_beam_counts`` / ``detector_background``
+    arrays directly rather than an ``InputData`` wrapper.)
 
     Args:
         sample_counts: 3D float64 array (n_energies, height, width).

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -763,6 +763,31 @@ def from_counts(
     ...
 
 
+def from_counts_with_nuisance(
+    sample_counts: NDArray[np.float64],
+    flux: NDArray[np.float64],
+    background: NDArray[np.float64],
+) -> InputData:
+    """Create InputData from raw detector counts plus explicit nuisance spectra.
+
+    Use this when the detector/counts background spectrum has been
+    estimated outside NEREIDS and should be supplied explicitly
+    alongside the open-beam flux.  Routes through the counts-KL
+    (joint-Poisson) dispatch when passed to ``spatial_map_typed`` /
+    ``fit_counts_spectrum_typed`` with ``solver="auto"`` / ``"kl"``.
+
+    Args:
+        sample_counts: 3D float64 array (n_energies, height, width).
+        flux: 3D float64 array (n_energies, height, width) of open-beam flux.
+        background: 3D float64 array (n_energies, height, width) of
+            detector/counts background.
+
+    Returns:
+        InputData object to pass to ``spatial_map_typed()``.
+    """
+    ...
+
+
 def from_transmission(
     transmission: NDArray[np.float64],
     uncertainty: NDArray[np.float64],

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -2195,19 +2195,19 @@ fn py_calibrate_energy(
     // guards inside `transmission::forward_model` → SLBW / RML / URR
     // leaves.  Calibration requires at least one data point to fit
     // (L, t₀, n_total), so an empty grid is also rejected.
-    require_non_empty_energy_grid(e)?;
-    if t.len() != e.len() {
+    require_non_empty_energy_grid(&e_owned)?;
+    if t_owned.len() != e_owned.len() {
         return Err(pyo3::exceptions::PyValueError::new_err(format!(
             "transmission length ({}) must match energies_nominal length ({})",
-            t.len(),
-            e.len(),
+            t_owned.len(),
+            e_owned.len(),
         )));
     }
-    if s.len() != e.len() {
+    if s_owned.len() != e_owned.len() {
         return Err(pyo3::exceptions::PyValueError::new_err(format!(
             "uncertainty length ({}) must match energies_nominal length ({})",
-            s.len(),
-            e.len(),
+            s_owned.len(),
+            e_owned.len(),
         )));
     }
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -2178,9 +2178,16 @@ fn py_calibrate_energy(
     temperature_k: f64,
     resolution: Option<PyTabulatedResolution>,
 ) -> PyResult<PyCalibrationResult> {
-    let e = energies_nominal.as_slice()?;
-    let t = transmission.as_slice()?;
-    let s = uncertainty.as_slice()?;
+    // Copy NumPy slices to owned `Vec<f64>` *before* `py.detach` so the
+    // closure does not hold borrows into NumPy-owned memory across the GIL
+    // release.  rust-numpy 0.28 only guards borrows while the GIL is held;
+    // once detached another Python thread could mutate/reallocate the
+    // arrays and the inner Rust slices would dangle.  Every other
+    // `py.detach` site in this file follows the same `.as_slice()?.to_vec()`
+    // pattern — `calibrate_energy` was the lone outlier.
+    let e_owned = energies_nominal.as_slice()?.to_vec();
+    let t_owned = transmission.as_slice()?.to_vec();
+    let s_owned = uncertainty.as_slice()?.to_vec();
 
     // Validate the nominal energy grid up front so malformed energies
     // surface as ValueError rather than a release-mode `PanicException`
@@ -2215,9 +2222,9 @@ fn py_calibrate_energy(
 
     let result = py.detach(move || {
         nereids_pipeline::calibration::calibrate_energy(
-            e,
-            t,
-            s,
+            &e_owned,
+            &t_owned,
+            &s_owned,
             &res_data,
             &abundances,
             assumed_flight_path_m,

--- a/scripts/python_api_allowlist.txt
+++ b/scripts/python_api_allowlist.txt
@@ -68,3 +68,14 @@ detect_dead_pixels
 # ---------------------------------------------------------------------------
 compute_model_jacobian
 ModelJacobianResult
+
+# ---------------------------------------------------------------------------
+# Typed-API counts+nuisance constructor (issue #555 M5).  ``from_counts``
+# and ``from_transmission`` are exercised in the curated narrative; the
+# nuisance variant is the explicit-background sibling and follows the
+# same shape, so it's covered by the surrounding section without a
+# dedicated heading.  Move OUT of the allowlist once
+# ``docs/guide/src/python-api.md`` gains an explicit "Counts with
+# explicit background" subsection.
+# ---------------------------------------------------------------------------
+from_counts_with_nuisance

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -2144,8 +2144,17 @@ class TestStubConformance:
     def test_from_counts_with_nuisance_importable_and_introspectable(self):
         """M5 regression: the symbol must be importable from ``nereids``,
         callable, AND its signature must be introspectable via
-        ``inspect.signature`` — the latter is what static type checkers
-        relied on before the stub fix landed."""
+        ``inspect.signature``.
+
+        Tooling and users that rely on runtime signature introspection
+        (``inspect.signature``) — e.g. IDE REPL completions, Sphinx
+        ``autodoc``, ``help()`` — need the runtime signature to stay
+        consistent with the stub.  Static type checkers (mypy / pyright)
+        read the ``.pyi`` directly and don't use runtime introspection,
+        but a divergence between the stub and the compiled extension
+        still misleads either audience.  This test catches stub/runtime
+        drift in both directions.
+        """
         import inspect
 
         from nereids import from_counts_with_nuisance  # noqa: F401

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -2196,13 +2196,19 @@ class TestStubConformance:
         # re-exports the inner ``nereids.nereids`` extension module
         # itself as an attribute on the outer package) because those
         # are package plumbing, not typed-surface exports.
+        #
+        # No ``Py*``-prefix filter: every current PyO3 export carries
+        # a ``#[pyclass(name = "...")]`` / ``#[pyo3(name = "...")]``
+        # attribute that strips the prefix on the Python side, so a
+        # runtime symbol that *did* start with ``Py`` would be a real
+        # surface (e.g. an unrenamed ``#[pyclass]``) and should be
+        # gated, not silently skipped.
         import types
 
         runtime_names = {
             name
             for name in dir(nereids)
             if not name.startswith("_")
-            and not name.startswith("Py")
             and not isinstance(getattr(nereids, name), types.ModuleType)
         }
 
@@ -2216,6 +2222,92 @@ class TestStubConformance:
             f"runtime symbols missing from __init__.pyi: {sorted(missing)!r}. "
             "Either add a `def`/`class` to the stub OR justify the omission "
             "in `intentional_omissions`."
+        )
+
+    def test_runtime_function_parameter_names_match_stub(self):
+        """Every top-level callable exported by the compiled ``nereids``
+        module must have parameter NAMES that match the stub signature
+        in ``__init__.pyi``.
+
+        This is the sibling drift gate to
+        ``test_runtime_exports_present_in_stub``: that test ensures the
+        *name* of every export is present; this one ensures the
+        *parameter names* of every function-shaped export are present.
+
+        Class methods are out of scope (PyO3 ``#[getter]`` /
+        ``#[pymethods]`` introspection is noisier and rarely drifts the
+        same way).  This guards against the M5/P2-1 failure mode where
+        a kwarg like ``resolution=`` was added to the PyO3 export but
+        not to the stub, so static type checkers rejected valid
+        runtime calls.
+        """
+        import ast
+        import inspect
+        from pathlib import Path
+
+        nereids_dir = Path(nereids.__file__).resolve().parent
+        stub_path = nereids_dir / "__init__.pyi"
+        tree = ast.parse(stub_path.read_text(encoding="utf-8"))
+
+        # Map of top-level function name -> ordered list of parameter
+        # names as declared in the stub.  We include positional-only,
+        # positional-or-keyword, the ``*`` marker is skipped, and
+        # keyword-only parameters are appended in declaration order.
+        # ``self`` / ``cls`` cannot appear at module scope; ignore
+        # ``*args`` / ``**kwargs`` because none of our exports use them
+        # and including them would only weaken the comparison.
+        stub_params: dict[str, list[str]] = {}
+        for node in tree.body:
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            if node.name.startswith("_"):
+                continue
+            names: list[str] = []
+            args = node.args
+            for arg in args.posonlyargs:
+                names.append(arg.arg)
+            for arg in args.args:
+                names.append(arg.arg)
+            for arg in args.kwonlyargs:
+                names.append(arg.arg)
+            stub_params[node.name] = names
+
+        mismatches: list[str] = []
+        for name, expected in stub_params.items():
+            rt_obj = getattr(nereids, name, None)
+            if rt_obj is None or not callable(rt_obj):
+                # Stub declares a function but runtime export is
+                # missing or non-callable: that is a different drift
+                # class, covered by the test above.
+                continue
+            try:
+                sig = inspect.signature(rt_obj)
+            except (TypeError, ValueError):
+                # PyO3 builtins can refuse signature introspection on
+                # rare overload shapes.  Skip rather than fail — the
+                # name-presence gate above still applies.
+                continue
+            # Drop *args / **kwargs entries on the runtime side too;
+            # we compare the named-parameter spine only.
+            actual = [
+                p.name
+                for p in sig.parameters.values()
+                if p.kind
+                not in (
+                    inspect.Parameter.VAR_POSITIONAL,
+                    inspect.Parameter.VAR_KEYWORD,
+                )
+            ]
+            if actual != expected:
+                mismatches.append(
+                    f"  {name}:\n"
+                    f"    stub:    {expected!r}\n"
+                    f"    runtime: {actual!r}"
+                )
+
+        assert not mismatches, (
+            "parameter-name drift between PyO3 runtime exports and "
+            "__init__.pyi:\n" + "\n".join(mismatches)
         )
 
 

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -2123,3 +2123,182 @@ class TestEnergyGridValidation:
         s = np.array([], dtype=np.float64)
         with pytest.raises(ValueError):
             nereids.calibrate_energy(e, t, s, [u238_data], [1.0], 25.0)
+
+
+# ===========================================================================
+# Type-stub conformance — regression for issue #555 (M5)
+# ===========================================================================
+
+
+class TestStubConformance:
+    """Sanity checks that the runtime PyO3 export surface is reflected in
+    ``bindings/python/python/nereids/__init__.pyi``.
+
+    The original M5 drift (``from_counts_with_nuisance`` exported by Rust
+    but missing from the stub) slipped past ``scripts/check_python_api_drift.py``
+    because that checker compares stub vs the curated narrative docs, not
+    stub vs the compiled extension.  These tests close that gap on the
+    runtime side.
+    """
+
+    def test_from_counts_with_nuisance_importable_and_introspectable(self):
+        """M5 regression: the symbol must be importable from ``nereids``,
+        callable, AND its signature must be introspectable via
+        ``inspect.signature`` — the latter is what static type checkers
+        relied on before the stub fix landed."""
+        import inspect
+
+        from nereids import from_counts_with_nuisance  # noqa: F401
+
+        # Stub fix means a static type-checker would now accept this
+        # `getattr` path too; the runtime check below is the regression
+        # gate against future re-drift.
+        assert callable(nereids.from_counts_with_nuisance)
+        sig = inspect.signature(nereids.from_counts_with_nuisance)
+        params = list(sig.parameters.keys())
+        # Parameter names must match the PyO3 binding signature so the
+        # stub stays in lock-step with runtime introspection.
+        assert params == ["sample_counts", "flux", "background"], (
+            f"from_counts_with_nuisance signature drifted from stub: "
+            f"got {params!r}"
+        )
+
+    def test_runtime_exports_present_in_stub(self):
+        """Every public (non-underscore) attribute on the compiled
+        ``nereids`` module must be either defined in ``__init__.pyi`` OR
+        documented as an intentional omission below.
+
+        This catches the inverse of the python-api.md drift check: a
+        PyO3 export that was never added to the stub at all.  Failure
+        mode prior to this regression: `from_counts_with_nuisance`
+        worked at runtime but was rejected by mypy / pyright.
+        """
+        import ast
+        from pathlib import Path
+
+        # Resolve the stub relative to the installed package (works
+        # whether nereids is installed editable from the source tree
+        # or as a wheel that carries the .pyi alongside the .so).
+        nereids_dir = Path(nereids.__file__).resolve().parent
+        stub_path = nereids_dir / "__init__.pyi"
+        assert stub_path.exists(), f"missing type stub: {stub_path}"
+
+        tree = ast.parse(stub_path.read_text(encoding="utf-8"))
+        stub_names: set[str] = set()
+        for node in tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                if not node.name.startswith("_"):
+                    stub_names.add(node.name)
+
+        # Dunders + the ``__version__`` style attributes don't belong
+        # in the stub; pyo3's auto-injected ``annotations`` import isn't
+        # an export either.  We also exclude submodules (e.g. PyO3
+        # re-exports the inner ``nereids.nereids`` extension module
+        # itself as an attribute on the outer package) because those
+        # are package plumbing, not typed-surface exports.
+        import types
+
+        runtime_names = {
+            name
+            for name in dir(nereids)
+            if not name.startswith("_")
+            and not name.startswith("Py")
+            and not isinstance(getattr(nereids, name), types.ModuleType)
+        }
+
+        # Intentional omissions: re-exported third-party modules or
+        # convenience aliases that aren't part of the typed surface.
+        # Keep this set tight — every entry is a drift loophole.
+        intentional_omissions: set[str] = set()
+
+        missing = runtime_names - stub_names - intentional_omissions
+        assert not missing, (
+            f"runtime symbols missing from __init__.pyi: {sorted(missing)!r}. "
+            "Either add a `def`/`class` to the stub OR justify the omission "
+            "in `intentional_omissions`."
+        )
+
+
+# ===========================================================================
+# calibrate_energy — regression smoke test for issue #555 (M13)
+# ===========================================================================
+
+
+class TestCalibrateEnergySmoke:
+    """Smoke test for the ``calibrate_energy`` PyO3 binding.
+
+    The M13 fix replaced ``as_slice()?`` borrows into NumPy memory with
+    ``as_slice()?.to_vec()`` copies so the closure passed to ``py.detach``
+    no longer holds dangling references when the GIL is released and
+    another Python thread mutates the input arrays.
+
+    A reliable concurrency exploit test for the old borrow pattern is
+    racy and difficult to write deterministically; the value here is
+    confirming the mechanical owned-Vec rewrite did not break the
+    happy path on a small synthetic case."""
+
+    def test_calibrate_energy_runs_on_synthetic_u238(self, u238_data):
+        # Use the U-238-like single-resonance fixture (resonance at 6.67 eV).
+        # Generate a clean transmission spectrum and feed it back through
+        # ``calibrate_energy``.  The fitter does a coarse grid over
+        # (L, t0, n_total); we only need a finite, non-NaN return.
+        assumed_l = 25.0
+        energies = np.linspace(1.0, 30.0, 400)
+        transmission = np.asarray(
+            nereids.forward_model(energies, [(u238_data, 5.0e-4)])
+        )
+        uncertainty = np.full_like(transmission, 0.01)
+
+        result = nereids.calibrate_energy(
+            energies,
+            transmission,
+            uncertainty,
+            [u238_data],
+            [1.0],
+            assumed_l,
+            293.6,
+        )
+
+        # All returned scalars must be finite — a dangling-borrow / GIL
+        # corruption regression typically surfaces as NaN, junk values,
+        # or a crash inside `py.detach`.
+        assert np.isfinite(result.flight_path_m)
+        assert np.isfinite(result.t0_us)
+        assert np.isfinite(result.total_density)
+        assert np.isfinite(result.reduced_chi_squared)
+        # The corrected energy grid must round-trip with the input length
+        # and be strictly ascending (basic sanity for the fitted mapping).
+        e_corr = np.asarray(result.energies_corrected)
+        assert e_corr.shape == energies.shape
+        assert np.all(np.diff(e_corr) > 0.0)
+
+    def test_calibrate_energy_input_arrays_unchanged(self, u238_data):
+        """Regression gate for the borrow→to_vec fix: after the closure
+        captures owned copies, the original NumPy arrays must round-trip
+        unchanged across the call (no in-place mutation, no aliased
+        write-back).  This is a structural rather than concurrency
+        check, but it catches the simplest class of aliasing
+        regressions if someone reverts the ``.to_vec()`` later."""
+        energies = np.linspace(1.0, 30.0, 200)
+        transmission = np.asarray(
+            nereids.forward_model(energies, [(u238_data, 5.0e-4)])
+        )
+        uncertainty = np.full_like(transmission, 0.01)
+
+        e_before = energies.copy()
+        t_before = transmission.copy()
+        s_before = uncertainty.copy()
+
+        _ = nereids.calibrate_energy(
+            energies,
+            transmission,
+            uncertainty,
+            [u238_data],
+            [1.0],
+            25.0,
+            293.6,
+        )
+
+        np.testing.assert_array_equal(energies, e_before)
+        np.testing.assert_array_equal(transmission, t_before)
+        np.testing.assert_array_equal(uncertainty, s_before)


### PR DESCRIPTION
## Summary

Two related Python-bindings soundness bugs flagged by the pre-paper audit (epic #551, sub-issue #555):

- **M5** — `from_counts_with_nuisance` was exported by the PyO3 layer (`bindings/python/src/lib.rs:2493`, `#[pyo3(name = "from_counts_with_nuisance")]`) but **missing from** `bindings/python/python/nereids/__init__.pyi`. Static type-checkers (mypy/pyright) rejected `tests/test_nereids.py:898` even though the runtime call worked. The existing drift checker (`scripts/check_python_api_drift.py`) compares stub vs the curated `python-api.md`, not stub vs PyO3 exports — so the gap was invisible.
- **M13** — `calibrate_energy` PyO3 binding (`bindings/python/src/lib.rs:2146-2191`) captured `&[f64]` references *into NumPy-owned memory* inside the `py.detach(move || …)` closure. rust-numpy 0.28 only guards borrows while the GIL is held; once detached, another Python thread could mutate/reallocate the arrays and the inner Rust slices would dangle. Every other `py.detach` site in this file already follows the `.as_slice()?.to_vec()` owned-copy pattern — `calibrate_energy` was the lone outlier.

Closes #555.

## Changes

- `bindings/python/src/lib.rs:2156-2189` — copy `energies_nominal` / `transmission` / `uncertainty` to owned `Vec<f64>` *before* `py.detach`, with an in-code comment documenting the rust-numpy borrow-lifetime contract.
- `bindings/python/python/nereids/__init__.pyi` — add `def from_counts_with_nuisance(sample_counts, flux, background) -> InputData: ...` matching the PyO3 signature.
- `scripts/python_api_allowlist.txt` — list `from_counts_with_nuisance` as an intentional `python-api.md` omission (the sibling `from_counts` is already in the curated narrative; a dedicated "Counts with explicit background" subsection can move it OUT of the allowlist later).
- `tests/test_nereids.py` — add 4 regression tests in two new classes:
  - `TestStubConformance` — `from_counts_with_nuisance` is importable + `inspect.signature` round-trips, AND every public runtime export on the compiled `nereids` module is defined in `__init__.pyi`. The latter is the inverse of the existing `check_python_api_drift.py` gate and catches future PyO3-export-without-stub drifts.
  - `TestCalibrateEnergySmoke` — `calibrate_energy` returns finite scalars and a strictly-ascending corrected-energy grid on the U-238 synthetic fixture; input NumPy arrays round-trip unchanged.

## Scope notes (intentionally out of scope)

- Extending `check_python_api_drift.py` to scan PyO3 `#[pyfunction]` / `#[pyo3(name=)]` directly would have exceeded the ~30 LOC budget specified in the task; the new `TestStubConformance.test_runtime_exports_present_in_stub` runtime check covers the same regression class via `dir(nereids)` vs stub AST. Move to a static checker in a follow-up if/when the gate becomes load-bearing for CI.
- The `calibrate_energy` stub still lacks the (optional) `resolution=None` kwarg present in the PyO3 signature; that's a separate drift instance and not in this PR's scope.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --exclude nereids-python` — 813 tests pass
- [x] `pixi run test-python` — 95 passed, 1 skipped (was 91 before; +4 new tests)
- [x] `pixi run python scripts/check_python_api_drift.py` — passes after allowlist entry
- [x] Verified the M5 regression by `inspect.signature(nereids.from_counts_with_nuisance)` now succeeds and reports `(sample_counts, flux, background)`
- [x] Verified the M13 fix by smoke-testing `calibrate_energy` on the U-238 synthetic fixture — finite return, strictly-ascending `energies_corrected`, inputs unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)