### PR TITLE
fix(tests): synthesize VENUS USR kernel to eliminate silent CI no-op (#557)

### DIFF
--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -2835,13 +2835,12 @@ mod tests {
     }
 
     // ---------------------------------------------------------------
-    // Fixture-gated regression test moved to
+    // VENUS-like regression test moved to
     // `crates/nereids-physics/tests/venus_usr_resolution.rs`
     // (`test_broaden_presorted_bit_exact_on_venus_usr`) — see issue
-    // #497.  The fixture (`_fts_bl10_0p5meV_1keV_25pts.txt`) is the
-    // VENUS instrument SAMMY-format tabulated resolution kernel; the
-    // integration test uses an early-return idiom keyed off
-    // `common::venus_usr_resolution_path()` instead of `#[ignore]`.
+    // #497.  The integration test parses a synthetic SAMMY USR-format
+    // kernel via `common::synthetic_venus_usr_tab()` (the real VENUS
+    // BL10 fixture is not approved for public release; issue #557).
     // ---------------------------------------------------------------
 
     #[test]
@@ -3172,12 +3171,13 @@ mod tests {
     }
 
     // ---------------------------------------------------------------
-    // Fixture-gated microbenchmarks moved to
+    // VENUS-like microbenchmarks moved to
     // `crates/nereids-physics/tests/venus_usr_resolution_microbench.rs`
     // (`test_broaden_presorted_bench`, `test_plan_reuse_bench`,
     // `resolution_matrix_apply_microbench`) — see issue #497.  They
-    // use the early-return idiom keyed off
-    // `common::venus_usr_resolution_path()` instead of `#[ignore]`.
+    // parse a synthetic SAMMY USR-format kernel via
+    // `common::synthetic_venus_usr_tab()` (the real VENUS BL10
+    // fixture is not approved for public release; issue #557).
     // ---------------------------------------------------------------
 
     // ---------- ResolutionMatrix (CSR compile) tests ----------
@@ -3188,12 +3188,11 @@ mod tests {
     // passthrough rows, `-0.0` sentinel rows, regular linear-interp
     // rows, CSR invariants, and the non-finite contract exclusion.
     //
-    // Fixture-dependent end-to-end equivalence tests against the
-    // production VENUS USR operator (SAMMY-format kernel) at
-    // realistic grid sizes (512, 3471) live in
+    // End-to-end equivalence tests against the VENUS-like USR
+    // operator (synthetic SAMMY-format kernel) at realistic grid
+    // sizes (512, 3471) live in
     // `crates/nereids-physics/tests/venus_usr_resolution.rs` — see
-    // issue #497.  They use the early-return idiom keyed off
-    // `common::venus_usr_resolution_path()` instead of `#[ignore]`.
+    // issues #497 and #557.
 
     /// Hybrid abs+rel tolerance used across equivalence tests.  Guards
     /// against the `a ≈ 0` trap where `a.abs().max(1e-300)` produces
@@ -3341,7 +3340,7 @@ mod tests {
     }
 
     // ---------------------------------------------------------------
-    // Fixture-gated end-to-end VENUS USR equivalence tests moved to
+    // End-to-end VENUS-like USR equivalence tests moved to
     // `crates/nereids-physics/tests/venus_usr_resolution.rs`
     // (`resolution_matrix_is_row_stochastic_on_venus_kernel`,
     //  `resolution_matrix_apply_equivalent_to_plan_apply_on_venus_kernel`,
@@ -3349,9 +3348,9 @@ mod tests {
     //  `resolution_matrix_apply_equivalent_across_densities`,
     //  `resolution_matrix_csr_column_indices_sorted_per_row`,
     //  `resolution_matrix_grid_mismatch_detected`,
-    //  `resolution_matrix_length_mismatch_detected`) — see issue
-    // #497.  They use the early-return idiom keyed off
-    // `common::venus_usr_resolution_path()` instead of `#[ignore]`.
+    //  `resolution_matrix_length_mismatch_detected`) — see issues
+    // #497 and #557.  They parse a synthetic SAMMY USR-format kernel
+    // via `common::synthetic_venus_usr_tab()`.
     // ---------------------------------------------------------------
 
     #[test]

--- a/crates/nereids-physics/src/surrogate.rs
+++ b/crates/nereids-physics/src/surrogate.rs
@@ -1677,11 +1677,11 @@ mod tests {
     }
 
     // ---------------------------------------------------------------
-    // Fixture-gated real-VENUS-kernel cubature regression
+    // VENUS-like cubature regression
     // (`cubature_real_venus_k1_forward_equivalence`) moved to
     // `crates/nereids-physics/tests/venus_usr_surrogate.rs` — see
-    // issue #497.  It uses the early-return idiom keyed off
-    // `common::venus_usr_resolution_path()` instead of `#[ignore]`.
+    // issues #497 and #557.  It parses a synthetic SAMMY USR-format
+    // kernel via `common::synthetic_venus_usr_tab()`.
     // ---------------------------------------------------------------
 
     // ── Scalar (k = 1) surrogate tests — PR #475 ───────────────────
@@ -1813,10 +1813,10 @@ mod tests {
     }
 
     // ---------------------------------------------------------------
-    // Fixture-gated real-VENUS-kernel scalar Chebyshev regression
+    // VENUS-like scalar Chebyshev regression
     // (`scalar_chebyshev_real_venus_k1_regression`) moved to
     // `crates/nereids-physics/tests/venus_usr_surrogate.rs` — see
-    // issue #497.  It uses the early-return idiom keyed off
-    // `common::venus_usr_resolution_path()` instead of `#[ignore]`.
+    // issues #497 and #557.  It parses a synthetic SAMMY USR-format
+    // kernel via `common::synthetic_venus_usr_tab()`.
     // ---------------------------------------------------------------
 }

--- a/crates/nereids-physics/tests/README.md
+++ b/crates/nereids-physics/tests/README.md
@@ -1,29 +1,35 @@
 # Integration tests for `nereids-physics`
 
-## Fixture-gated tests
+## VENUS USR resolution tests
 
-Some tests require external instrument-characterization data that
-ORNL has not approved for public release. The fixture file is:
+The three `venus_usr_*.rs` integration tests exercise the SAMMY USR
+(user-supplied tabulated resolution) parser + broadening pipeline that
+the SoftwareX paper documents.
 
-- `_fts_bl10_0p5meV_1keV_25pts.txt` — VENUS instrument tabulated
-  resolution kernel (SAMMY USR format).  Place at the workspace root.
+Historically these tests loaded an external instrument-characterization
+file — `_fts_bl10_0p5meV_1keV_25pts.txt`, the VENUS BL10 (SNS Beam
+Line 10) kernel — that ORNL has not approved for public release.  The
+file is gitignored (`.gitignore:49`); on CI / fresh checkouts the
+tests early-returned silently, leaving the SAMMY-format kernel path
+with zero CI coverage (issue #557).
 
-These tests use the early-return idiom rather than `#[ignore]`:
+The tests now build a **synthetic** SAMMY USR-format kernel
+in-memory via [`common::synthetic_venus_usr_tab`]
+(`tests/common/mod.rs`).  The synthetic kernel is parsed through the
+same `TabulatedResolution::from_text` entry point the production
+fixture used, so every stage of the kernel pipeline (parser → plan
+→ apply → CSR compile → matvec) is exercised on every `cargo test`
+invocation.
 
-```rust
-let Some(path) = common::venus_usr_resolution_path() else { return; };
-```
+### No-op-regression pre-check
 
-When the fixture is present, the test exercises real-instrument
-coverage.  When absent (CI, fresh checkouts), the test is a no-op
-and `cargo test` reports it as passed — no "ignored" noise.
+Every test that broadens via `plan.apply` / `compile_to_matrix`
+calls `common::assert_kernel_broadens(&plan, &energies)` up front.
+This asserts `‖T_kernel − T_none‖_∞ > 1 % · ‖T_none‖_∞` on a sharp
+Gaussian-dip probe spectrum, so a future tweak that collapses the
+synthetic kernel toward a delta (which would silently turn every
+equivalence test into a vacuous identity) fails loudly at the first
+test instead.
 
-## Why not `#[ignore]`?
-
-Historical reason: previous test scaffolding used
-`#[ignore = "requires PLEIADES resolution file ..."]`.  The label
-"PLEIADES" was a misnomer (PLEIADES is a Python wrapper around
-SAMMY; this file is a SAMMY-format kernel for the VENUS
-instrument).  The `#[ignore]` mechanism also conflated
-fixture-gating with broken-on-purpose tests, and didn't enforce
-that fixture-present runs actually executed.  See issue #497.
+See PR #544 for the silent-no-op-via-kernel-shrink failure mode
+this pre-check guards against.

--- a/crates/nereids-physics/tests/common/mod.rs
+++ b/crates/nereids-physics/tests/common/mod.rs
@@ -1,22 +1,208 @@
-//! Common helpers for fixture-gated integration tests.
+//! Common helpers for integration tests exercising the SAMMY USR
+//! (tabulated user-supplied resolution) parser + broadening pipeline
+//! on a synthetic VENUS-like kernel.
+//!
+//! # Why synthetic instead of the real VENUS fixture?
+//!
+//! The production VENUS BL10 kernel file
+//! (`_fts_bl10_0p5meV_1keV_25pts.txt`) is gitignored per `.gitignore:49`
+//! — ORNL has **not approved that file for public release**, so we
+//! cannot vendor it under `tests/data/` to make CI exercise the real
+//! kernel.
+//!
+//! Previously, [`venus_usr_resolution_path`] returned
+//! `Option<PathBuf>::None` whenever the gitignored file was absent
+//! (i.e., on every CI run and every fresh checkout), and the 13
+//! fixture-gated tests in this directory all early-returned via
+//! `let Some(path) = … else { return; };`. The net effect was that
+//! the SAMMY USR-format kernel path that the SoftwareX paper documents
+//! had **zero CI coverage**, as confirmed empirically when issue #557
+//! moved the fixture aside and saw all 13 tests still report
+//! `passed; 0 ignored`.
+//!
+//! The fix is to generate a SAMMY USR-format kernel **in-memory** with
+//! shape comparable to the production fixture (triangular kernels,
+//! 25-point reference-energy grid spanning meV → keV) and parse it via
+//! the same [`TabulatedResolution::from_text`] entry point the
+//! production fixture uses. This exercises every stage of the
+//! production pipeline (`from_text` parser → `plan` + `apply` →
+//! `compile_to_matrix` + `apply_r`) on a kernel that is **non-trivially
+//! broadening** (verified by [`assert_kernel_broadens`] — see PR #544
+//! for the silent-no-op-regression-via-kernel-shrink failure mode this
+//! pre-check guards against).
+//!
+//! Tests that previously used the early-return idiom now unconditionally
+//! call [`synthetic_venus_usr_tab`] and assert real expectations on
+//! every `cargo test` run.
 
-use std::path::PathBuf;
+use nereids_physics::resolution::{ResolutionPlan, TabulatedResolution};
 
-/// Locate the VENUS instrument tabulated resolution fixture
-/// (`_fts_bl10_0p5meV_1keV_25pts.txt`, SAMMY USR format) at the
-/// workspace root.  The fixture is gitignored per ORNL release
-/// policy (.gitignore:48 — "Instrument resolution files (not
-/// approved for public release)").
+/// Flight path (m) the synthetic kernel is built for. Matches the
+/// `flight_path_m = 25.0` argument previously used with the real
+/// VENUS BL10 fixture so the test grids (7 – 200 eV uniform) sit at
+/// production-like TOF values.
+pub const SYNTHETIC_FLIGHT_PATH_M: f64 = 25.0;
+
+/// Half-width of the synthetic triangular kernel in TOF microseconds.
 ///
-/// Returns `Some(path)` when the fixture is present (developer
-/// machines with the file at repo root) and `None` otherwise (CI
-/// runners, fresh checkouts).  Callers should early-return on `None`
-/// so the test becomes a no-op without `#[ignore]` noise in
-/// `cargo test` output.
-pub fn venus_usr_resolution_path() -> Option<PathBuf> {
-    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()? // crates/
-        .parent()? // workspace root
-        .join("_fts_bl10_0p5meV_1keV_25pts.txt");
-    if p.exists() { Some(p) } else { None }
+/// Chosen large enough that, at the lower edge of the test grid
+/// (E = 7 eV), the energy-space FWHM `2·E^(3/2) / (TOF_FACTOR · L) · w`
+/// is several times the grid bin width on the 512-point uniform
+/// 7 – 200 eV grid — so broadening visibly couples neighbouring bins
+/// and [`assert_kernel_broadens`] sees a > 1 % deviation from the
+/// unbroadened input on the dip-shape probe spectrum below. The 0.5
+/// μs scale is the same order of magnitude as the production VENUS
+/// kernel's central-lobe half-width.
+const SYNTHETIC_HALF_WIDTH_US: f64 = 0.5;
+
+/// Number of (offset, weight) samples per reference-energy block.
+/// Matches the order-of-magnitude density of the production fixture
+/// (which has ~500 samples per block over a wider TOF span; we use
+/// fewer samples because the support here is narrower).
+const SYNTHETIC_POINTS_PER_BLOCK: usize = 41;
+
+/// Generate a SAMMY USR-format resolution-kernel text block with a
+/// VENUS-like reference-energy grid and triangular kernels.
+///
+/// The returned string is byte-feedable to
+/// [`TabulatedResolution::from_text`] — it follows the SAMMY USR
+/// format exactly:
+///
+/// ```text
+/// <header line>
+/// <separator line>
+/// <ref_energy_1>   0.000000000000000e+000
+/// <dt_offset>      <weight>
+/// <dt_offset>      <weight>
+/// ...
+/// <blank line>
+/// <ref_energy_2>   0.000000000000000e+000
+/// ...
+/// ```
+///
+/// Reference-energy grid spans 5 meV to 1 keV in 25 log-spaced points
+/// (mirroring the production file's `0p5meV_1keV_25pts` shape, except
+/// we start at 5 meV instead of 0.5 meV — the test grids only probe
+/// 7 – 200 eV, so the low-E padding is for parser-path coverage of
+/// the bracketing-kernel interpolation logic, not for actual use).
+///
+/// Each block contains a symmetric triangular kernel of half-width
+/// [`SYNTHETIC_HALF_WIDTH_US`] μs sampled at
+/// [`SYNTHETIC_POINTS_PER_BLOCK`] points. The kernel is intentionally
+/// identical across ref energies so the bracketing-kernel
+/// log-interpolation path in [`TabulatedResolution::interpolated_kernel`]
+/// is exercised on a stable shape (energy-dependent kernel widths
+/// would test the same code paths but add unnecessary variability
+/// to the equivalence-tolerance arithmetic).
+pub fn synthetic_venus_usr_text() -> String {
+    let mut out = String::new();
+    out.push_str("SYNTHETIC VENUS-like USR kernel — triangular FWHM 1us PSR\n");
+    out.push_str("-----\n");
+
+    // 25 log-spaced reference energies between 5e-3 eV and 1e3 eV.
+    let n_ref = 25usize;
+    let e_min = 5.0e-3_f64;
+    let e_max = 1.0e3_f64;
+    let log_e_min = e_min.ln();
+    let log_e_max = e_max.ln();
+    for i in 0..n_ref {
+        let frac = (i as f64) / ((n_ref - 1) as f64);
+        let e_ref = (log_e_min + frac * (log_e_max - log_e_min)).exp();
+        // Ref-energy line: <E>   0.0  (the parser treats the second
+        // column as a zero marker).
+        out.push_str(&format!("{e_ref:.15e}   0.000000000000000e+000\n"));
+
+        // Triangular kernel: weights w(dt) = max(0, 1 − |dt|/half_width).
+        // Symmetric about dt = 0, with the dt = 0 sample omitted in
+        // production fixtures (the ref-energy line is the dt = 0
+        // marker) but we keep dt ≠ 0 samples both sides.
+        let half = SYNTHETIC_HALF_WIDTH_US;
+        let n_pts = SYNTHETIC_POINTS_PER_BLOCK;
+        let dt_step = 2.0 * half / ((n_pts - 1) as f64);
+        for k in 0..n_pts {
+            let dt = -half + (k as f64) * dt_step;
+            let w = (1.0 - dt.abs() / half).max(0.0);
+            // SAMMY format: free-form whitespace-separated doubles.
+            out.push_str(&format!("{dt:.15e}   {w:.15e}\n"));
+        }
+        // Block separator (blank line).
+        out.push('\n');
+    }
+
+    out
+}
+
+/// Parse the synthetic kernel and return the live
+/// [`TabulatedResolution`]. Goes through the production parser
+/// [`TabulatedResolution::from_text`] so the parsing code path is
+/// exercised on every test invocation.
+///
+/// Panics if the synthetic text is malformed — that would be a
+/// generator bug, not a test failure.
+pub fn synthetic_venus_usr_tab() -> TabulatedResolution {
+    let text = synthetic_venus_usr_text();
+    TabulatedResolution::from_text(&text, SYNTHETIC_FLIGHT_PATH_M)
+        .expect("synthetic VENUS USR text must parse via from_text")
+}
+
+/// Pre-check (PR #544 pattern) that the synthetic kernel actually
+/// broadens a probe spectrum. Guards against future tweaks to
+/// [`SYNTHETIC_HALF_WIDTH_US`] or the grid that would silently turn
+/// the kernel into a no-op (delta-kernel), which would let
+/// equivalence-style tests pass vacuously while no longer exercising
+/// the broadening math.
+///
+/// Asserts `‖T_kernel − T_none‖_∞ > THRESHOLD · ‖T_none‖_∞` where
+/// `T_none` is the input probe spectrum and `T_kernel` is the same
+/// spectrum after broadening with the supplied plan. The probe
+/// spectrum is a sharp Gaussian dip — its post-broadening shape is
+/// strictly different from the input unless the kernel collapses to
+/// a delta, so the contrast bound below is a robust silent-no-op
+/// detector.
+///
+/// Called from every test that broadens via `plan.apply` /
+/// `compile_to_matrix` so a regression to the synthetic kernel
+/// breaks loudly at the first test instead of letting an entire
+/// `cargo test` run pass while exercising zero broadening code.
+pub fn assert_kernel_broadens(plan: &ResolutionPlan, energies: &[f64]) {
+    // Sharp Gaussian dip at the centre of the grid. The σ_E = 0.3 eV
+    // dip is much narrower than the broadened lobe (which spans
+    // ~ΔE = 2·E^(3/2)/(TOF_FACTOR·L) · 0.5 μs ≈ 0.4 eV at E = 100
+    // eV) so broadening visibly reshapes the dip.
+    let n = energies.len();
+    assert!(n >= 8, "probe needs at least 8 grid points");
+    let e_centre = 0.5 * (energies[0] + energies[n - 1]);
+    let sigma_e = 0.3_f64;
+    let probe: Vec<f64> = energies
+        .iter()
+        .map(|&e| 1.0 - 0.8 * (-((e - e_centre).powi(2)) / (2.0 * sigma_e * sigma_e)).exp())
+        .collect();
+
+    let broadened = plan.apply(&probe);
+    assert_eq!(broadened.len(), probe.len(), "plan.apply length mismatch");
+
+    let probe_inf = probe.iter().map(|x| x.abs()).fold(0.0_f64, f64::max);
+    let diff_inf = probe
+        .iter()
+        .zip(broadened.iter())
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0_f64, f64::max);
+
+    // Threshold: 1% of ‖probe‖_∞. The dip depth is 0.8 so this
+    // requires the broadening to move at least one grid point by
+    // ≥ 0.008 in absolute terms — a delta-kernel produces exactly
+    // zero deviation, well below this floor.
+    const THRESHOLD: f64 = 0.01;
+    let floor = THRESHOLD * probe_inf;
+    assert!(
+        diff_inf > floor,
+        "synthetic VENUS kernel is acting as a no-op on the probe \
+         spectrum: ‖T_kernel − T_none‖_∞ = {diff_inf:.3e}, expected \
+         > {floor:.3e} (= {THRESHOLD} · ‖T_none‖_∞ = {probe_inf:.3e}). \
+         A future tweak to SYNTHETIC_HALF_WIDTH_US or the kernel shape \
+         has collapsed the kernel toward a delta — every equivalence \
+         test downstream will pass vacuously. See PR #544 for the \
+         silent-no-op-regression failure mode this pre-check guards \
+         against."
+    );
 }

--- a/crates/nereids-physics/tests/common/mod.rs
+++ b/crates/nereids-physics/tests/common/mod.rs
@@ -10,7 +10,7 @@
 //! cannot vendor it under `tests/data/` to make CI exercise the real
 //! kernel.
 //!
-//! Previously, [`venus_usr_resolution_path`] returned
+//! Previously, a `venus_usr_resolution_path` helper returned
 //! `Option<PathBuf>::None` whenever the gitignored file was absent
 //! (i.e., on every CI run and every fresh checkout), and the 13
 //! fixture-gated tests in this directory all early-returned via
@@ -45,14 +45,16 @@ pub const SYNTHETIC_FLIGHT_PATH_M: f64 = 25.0;
 
 /// Half-width of the synthetic triangular kernel in TOF microseconds.
 ///
-/// Chosen large enough that, at the lower edge of the test grid
-/// (E = 7 eV), the energy-space FWHM `2·E^(3/2) / (TOF_FACTOR · L) · w`
-/// is several times the grid bin width on the 512-point uniform
-/// 7 – 200 eV grid — so broadening visibly couples neighbouring bins
-/// and [`assert_kernel_broadens`] sees a > 1 % deviation from the
-/// unbroadened input on the dip-shape probe spectrum below. The 0.5
-/// μs scale is the same order of magnitude as the production VENUS
-/// kernel's central-lobe half-width.
+/// The energy-space half-width `ΔE = 2·E / TOF · w` at the lower edge
+/// of the test grid (E = 7 eV, L = 25 m → TOF ≈ 683 µs) is only
+/// ≈ 0.010 eV, well below the 512-point uniform 7 – 200 eV grid bin
+/// width of ≈ 0.378 eV — i.e., the kernel is sub-bin at the low-energy
+/// edge. Broadening still visibly perturbs the dip-shape probe in
+/// [`assert_kernel_broadens`] because the probe is centred at the
+/// middle of the grid (E ≈ 103 eV), where the energy-space half-width
+/// grows like `E^(3/2)` and the kernel straddles several bins. The
+/// 0.5 μs scale is the same order of magnitude as the production
+/// VENUS kernel's central-lobe half-width.
 const SYNTHETIC_HALF_WIDTH_US: f64 = 0.5;
 
 /// Number of (offset, weight) samples per reference-energy block.
@@ -96,7 +98,7 @@ const SYNTHETIC_POINTS_PER_BLOCK: usize = 41;
 /// to the equivalence-tolerance arithmetic).
 pub fn synthetic_venus_usr_text() -> String {
     let mut out = String::new();
-    out.push_str("SYNTHETIC VENUS-like USR kernel — triangular FWHM 1us PSR\n");
+    out.push_str("SYNTHETIC VENUS-like USR kernel — triangular base 1us / FWHM 0.5us PSR\n");
     out.push_str("-----\n");
 
     // 25 log-spaced reference energies between 5e-3 eV and 1e3 eV.

--- a/crates/nereids-physics/tests/common/mod.rs
+++ b/crates/nereids-physics/tests/common/mod.rs
@@ -110,14 +110,19 @@ pub fn synthetic_venus_usr_text() -> String {
     for i in 0..n_ref {
         let frac = (i as f64) / ((n_ref - 1) as f64);
         let e_ref = (log_e_min + frac * (log_e_max - log_e_min)).exp();
-        // Ref-energy line: <E>   0.0  (the parser treats the second
-        // column as a zero marker).
+        // Ref-energy line: <E>   0.0  (the parser ignores the second
+        // column on the first line of a block — see
+        // `TabulatedResolution::from_text`, which captures only `x`
+        // as `current_energy`; we emit `0.0` as a conventional
+        // placeholder).
         out.push_str(&format!("{e_ref:.15e}   0.000000000000000e+000\n"));
 
         // Triangular kernel: weights w(dt) = max(0, 1 − |dt|/half_width).
-        // Symmetric about dt = 0, with the dt = 0 sample omitted in
-        // production fixtures (the ref-energy line is the dt = 0
-        // marker) but we keep dt ≠ 0 samples both sides.
+        // Symmetric about dt = 0. Since `SYNTHETIC_POINTS_PER_BLOCK`
+        // is odd (41), the inner loop emits the dt = 0 sample at
+        // k = (n_pts − 1) / 2 in addition to the symmetric dt ≠ 0
+        // pairs; the parser accepts it as an ordinary (offset,
+        // weight) entry.
         let half = SYNTHETIC_HALF_WIDTH_US;
         let n_pts = SYNTHETIC_POINTS_PER_BLOCK;
         let dt_step = 2.0 * half / ((n_pts - 1) as f64);

--- a/crates/nereids-physics/tests/venus_usr_resolution.rs
+++ b/crates/nereids-physics/tests/venus_usr_resolution.rs
@@ -1,18 +1,22 @@
-//! Fixture-gated regression tests for the VENUS USR resolution
-//! operator and CSR-compiled [`crate::resolution::ResolutionMatrix`].
+//! Regression tests for the VENUS-like USR resolution operator and
+//! CSR-compiled [`crate::resolution::ResolutionMatrix`].
 //!
-//! These tests load the SAMMY-format tabulated resolution kernel for
-//! the VENUS instrument (SNS Beam Line 10) from a gitignored file at
-//! the workspace root.  When the fixture is absent (CI, fresh
-//! checkouts), each test early-returns and is reported as passing —
-//! no `#[ignore]` noise.  When the fixture is present, the tests
-//! pin bit-exactness (where the test name says so) or hybrid
-//! abs+rel equivalence within `1e-12` against the slow oracle
-//! [`broaden_presorted_reference`].
+//! These tests build a synthetic SAMMY USR-format kernel via
+//! [`common::synthetic_venus_usr_tab`] (see that module for the
+//! ORNL-release-policy rationale that rules out vendoring the real
+//! VENUS BL10 fixture). The kernel is parsed via the same
+//! [`TabulatedResolution::from_text`] entry point the production
+//! pipeline uses, so every stage of the SAMMY USR path is exercised
+//! on every `cargo test` run.
 //!
-//! See `tests/README.md` for the rationale behind the early-return
-//! idiom and issue #497 for the move from `#[ignore]`'d tests in
-//! `src/resolution.rs`.
+//! Each broadening-equivalence test calls [`common::assert_kernel_broadens`]
+//! up front so a future regression that collapses the synthetic
+//! kernel toward a delta — which would silently turn every
+//! equivalence test into a vacuous identity — fails loudly at the
+//! first test instead. See PR #544 for the silent-no-op-via-kernel-
+//! shrink failure mode this pre-check guards against, and issue #557
+//! for the original CI-coverage gap that motivated the synthetic
+//! replacement.
 
 mod common;
 
@@ -152,17 +156,21 @@ fn max_hybrid_err(a: &[f64], b: &[f64]) -> f64 {
 }
 
 /// Build a `TabulatedResolution` + plan + matrix on a uniform energy
-/// grid using the VENUS USR fixture kernel.  Helper duplicated from
+/// grid using the synthetic VENUS-like USR kernel from
+/// [`common::synthetic_venus_usr_tab`]. Helper duplicated from
 /// `src/resolution.rs` rather than promoted to the public API.
 ///
-/// Panics if the fixture is missing — callers must early-return via
-/// [`common::venus_usr_resolution_path`] BEFORE invoking this.
-fn build_fixture_plan_and_matrix(
-    fixture_path: &std::path::Path,
-    n_grid: usize,
-) -> (Vec<f64>, ResolutionPlan, ResolutionMatrix) {
-    let text = std::fs::read_to_string(fixture_path).expect("read VENUS USR fixture");
-    let res = TabulatedResolution::from_text(&text, 25.0).expect("parse VENUS USR fixture");
+/// **Does not** call `common::assert_kernel_broadens` itself — that
+/// pre-check is meaningless at small grid sizes (the synthetic
+/// kernel's energy-space FWHM is sub-bin once the grid coarsens to
+/// `n_grid ≤ 128` on the 7 – 200 eV range), and small-grid callers
+/// like `resolution_matrix_grid_mismatch_detected` only need a valid
+/// matrix to test validation-path errors. Tests that exercise the
+/// actual broadening math must call
+/// [`common::assert_kernel_broadens`] themselves; see the equivalence
+/// tests below for the pattern.
+fn build_fixture_plan_and_matrix(n_grid: usize) -> (Vec<f64>, ResolutionPlan, ResolutionMatrix) {
+    let res = common::synthetic_venus_usr_tab();
     let energies: Vec<f64> = (0..n_grid)
         .map(|i| 7.0 + (200.0 - 7.0) * (i as f64) / ((n_grid - 1) as f64))
         .collect();
@@ -173,23 +181,23 @@ fn build_fixture_plan_and_matrix(
 
 // ── Tests ─────────────────────────────────────────────────────────
 
-/// Real VENUS BL10 (SNS) resolution kernel, SAMMY USR format, on a
-/// real Hf-like resonance spectrum over the full VENUS analysis
-/// grid.  This is the closest regression of the production A.1 /
-/// B.2 workload.
+/// VENUS-like USR resolution kernel (synthetic SAMMY-format
+/// triangular kernel, see `common::synthetic_venus_usr_text`) on a
+/// Hf-like resonance-dip spectrum over a production-scale analysis
+/// grid. This is the closest regression of the production A.1 / B.2
+/// workload that we can ship as a public test — the real VENUS BL10
+/// fixture is not approved for public release (see `common/mod.rs`).
 #[test]
 fn test_broaden_presorted_bit_exact_on_venus_usr() {
-    let Some(path) = common::venus_usr_resolution_path() else {
-        return;
-    };
-    let text = std::fs::read_to_string(&path).expect("read VENUS USR fixture");
-    let tab = TabulatedResolution::from_text(&text, 25.0).unwrap();
+    let tab = common::synthetic_venus_usr_tab();
 
     // Production-like grid: uniform 7..200 eV with ~3500 bins
     let n = 3471;
     let energies: Vec<f64> = (0..n)
         .map(|i| 7.0 + i as f64 * ((200.0 - 7.0) / (n - 1) as f64))
         .collect();
+    let plan = tab.plan(&energies).expect("build plan on sorted grid");
+    common::assert_kernel_broadens(&plan, &energies);
     // Resonance-dip spectrum (toy model, exercises the math regardless
     // of actual Hf σ, which is what we want for an interp test).
     let spectrum: Vec<f64> = energies
@@ -203,18 +211,15 @@ fn test_broaden_presorted_bit_exact_on_venus_usr() {
 
     let reference = broaden_presorted_reference(&tab, &energies, &spectrum);
     let actual = test_support::broaden_presorted(&tab, &energies, &spectrum);
-    assert_bit_exact(&reference, &actual, "venus_usr_real_resolution");
+    assert_bit_exact(&reference, &actual, "venus_usr_synthetic_resolution");
 }
 
-/// End-to-end row-stochasticity on the real VENUS kernel,
-/// 512-point grid.  Gated on the VENUS USR resolution fixture
-/// (SAMMY-format).
+/// End-to-end row-stochasticity on the synthetic VENUS-like kernel,
+/// 512-point grid.
 #[test]
 fn resolution_matrix_is_row_stochastic_on_venus_kernel() {
-    let Some(path) = common::venus_usr_resolution_path() else {
-        return;
-    };
-    let (_energies, _plan, matrix) = build_fixture_plan_and_matrix(&path, 512);
+    let (energies, plan, matrix) = build_fixture_plan_and_matrix(512);
+    common::assert_kernel_broadens(&plan, &energies);
     for i in 0..matrix.len() {
         let start = matrix.row_starts()[i] as usize;
         let end = matrix.row_starts()[i + 1] as usize;
@@ -230,10 +235,8 @@ fn resolution_matrix_is_row_stochastic_on_venus_kernel() {
 
 #[test]
 fn resolution_matrix_apply_equivalent_to_plan_apply_on_venus_kernel() {
-    let Some(path) = common::venus_usr_resolution_path() else {
-        return;
-    };
-    let (_energies, plan, matrix) = build_fixture_plan_and_matrix(&path, 512);
+    let (energies, plan, matrix) = build_fixture_plan_and_matrix(512);
+    common::assert_kernel_broadens(&plan, &energies);
     let n_grid = matrix.len();
     let spec: Vec<f64> = (0..n_grid)
         .map(|i| {
@@ -254,9 +257,9 @@ fn resolution_matrix_apply_equivalent_to_plan_apply_on_venus_kernel() {
 }
 
 /// Production-grid guardrail for the `1e-12` tolerance documented
-/// on `ResolutionPlan::compile_to_matrix`.  The 3471-bin VENUS grid
-/// has ~82 entries per row, so accumulation error is an order of
-/// magnitude larger than on the synthetic multi-row tests in
+/// on `ResolutionPlan::compile_to_matrix`.  The 3471-bin grid has
+/// many entries per row, so accumulation error is an order of
+/// magnitude larger than on the small multi-row tests in
 /// `src/resolution.rs`; this test pins the equivalence bound at
 /// production scale so a future regression in either `apply` or
 /// `apply_r` summation order fails loudly.  Logs the observed
@@ -264,10 +267,8 @@ fn resolution_matrix_apply_equivalent_to_plan_apply_on_venus_kernel() {
 /// the actual headroom against the 1e-12 ceiling.
 #[test]
 fn resolution_matrix_apply_equivalent_at_production_grid() {
-    let Some(path) = common::venus_usr_resolution_path() else {
-        return;
-    };
-    let (_energies, plan, matrix) = build_fixture_plan_and_matrix(&path, 3471);
+    let (energies, plan, matrix) = build_fixture_plan_and_matrix(3471);
+    common::assert_kernel_broadens(&plan, &energies);
     let n_grid = matrix.len();
     // Same Beer-Lambert test spectrum as the 512-point test.
     let spec: Vec<f64> = (0..n_grid)
@@ -283,7 +284,7 @@ fn resolution_matrix_apply_equivalent_at_production_grid() {
     let max_err = max_hybrid_err(&plan_out, &matrix_out);
     eprintln!(
         "3471-grid apply_r vs plan.apply observed max_hybrid_err = {:.3e} \
-         (ceiling 1e-12; theoretical bound ~1e-13 per row × 82 rows/entry)",
+         (ceiling 1e-12; theoretical bound ~1e-13 per row × NNZ/entry)",
         max_err,
     );
     assert!(
@@ -295,10 +296,8 @@ fn resolution_matrix_apply_equivalent_at_production_grid() {
 
 #[test]
 fn resolution_matrix_apply_equivalent_across_densities() {
-    let Some(path) = common::venus_usr_resolution_path() else {
-        return;
-    };
-    let (_energies, plan, matrix) = build_fixture_plan_and_matrix(&path, 512);
+    let (energies, plan, matrix) = build_fixture_plan_and_matrix(512);
+    common::assert_kernel_broadens(&plan, &energies);
     let n_grid = matrix.len();
     for &n_density in &[1e-5_f64, 1e-4, 1.6e-4, 1e-3] {
         let spec: Vec<f64> = (0..n_grid)
@@ -323,10 +322,7 @@ fn resolution_matrix_apply_equivalent_across_densities() {
 
 #[test]
 fn resolution_matrix_csr_column_indices_sorted_per_row() {
-    let Some(path) = common::venus_usr_resolution_path() else {
-        return;
-    };
-    let (_energies, _plan, matrix) = build_fixture_plan_and_matrix(&path, 256);
+    let (_energies, _plan, matrix) = build_fixture_plan_and_matrix(256);
     for i in 0..matrix.len() {
         let start = matrix.row_starts()[i] as usize;
         let end = matrix.row_starts()[i + 1] as usize;
@@ -344,10 +340,7 @@ fn resolution_matrix_csr_column_indices_sorted_per_row() {
 
 #[test]
 fn resolution_matrix_grid_mismatch_detected() {
-    let Some(path) = common::venus_usr_resolution_path() else {
-        return;
-    };
-    let (energies, _plan, matrix) = build_fixture_plan_and_matrix(&path, 128);
+    let (energies, _plan, matrix) = build_fixture_plan_and_matrix(128);
     let spec = vec![1.0_f64; matrix.len()];
 
     // Same grid → passes.
@@ -369,10 +362,7 @@ fn resolution_matrix_grid_mismatch_detected() {
 
 #[test]
 fn resolution_matrix_length_mismatch_detected() {
-    let Some(path) = common::venus_usr_resolution_path() else {
-        return;
-    };
-    let (energies, _plan, matrix) = build_fixture_plan_and_matrix(&path, 64);
+    let (energies, _plan, matrix) = build_fixture_plan_and_matrix(64);
     let short_spec = vec![1.0_f64; matrix.len() - 1];
     let err = apply_resolution_with_matrix(&energies, &matrix, &short_spec)
         .expect_err("length mismatch must error");

--- a/crates/nereids-physics/tests/venus_usr_resolution.rs
+++ b/crates/nereids-physics/tests/venus_usr_resolution.rs
@@ -1,5 +1,5 @@
 //! Regression tests for the VENUS-like USR resolution operator and
-//! CSR-compiled [`crate::resolution::ResolutionMatrix`].
+//! CSR-compiled [`nereids_physics::resolution::ResolutionMatrix`].
 //!
 //! These tests build a synthetic SAMMY USR-format kernel via
 //! [`common::synthetic_venus_usr_tab`] (see that module for the

--- a/crates/nereids-physics/tests/venus_usr_resolution_microbench.rs
+++ b/crates/nereids-physics/tests/venus_usr_resolution_microbench.rs
@@ -1,4 +1,4 @@
-//! Fixture-gated microbenchmarks for the VENUS USR resolution
+//! Microbenchmarks for the synthetic VENUS-like USR resolution
 //! operator and CSR `ResolutionMatrix` apply paths.
 //!
 //! These are slow tests intentionally separated from the regression
@@ -7,9 +7,13 @@
 //! walk vs binary search, plan-reuse vs per-call, CSR matvec vs
 //! plan apply).
 //!
-//! When the VENUS USR fixture is absent (CI, fresh checkouts), each
-//! microbench early-returns and is reported as passing — no
-//! `#[ignore]` noise.  See issue #497.
+//! The kernel is the synthetic SAMMY USR-format kernel from
+//! [`common::synthetic_venus_usr_tab`]; see that module for the
+//! ORNL-release-policy rationale ruling out the real VENUS BL10
+//! fixture. Wall-clock numbers reported here are **lower bounds on
+//! the optimization payoff** because the synthetic kernel is narrower
+//! than the production fixture (~41 sample points vs ~500), but
+//! the relative-speedup math is robust to kernel size.
 //!
 //! Run manually with `--nocapture --release`, e.g.:
 //!
@@ -28,16 +32,19 @@ use nereids_physics::resolution::{TabulatedResolution, apply_r, test_support};
 /// the bit-exact regression test.
 #[test]
 fn test_broaden_presorted_bench() {
-    let Some(path) = common::venus_usr_resolution_path() else {
-        return;
-    };
-    let text = std::fs::read_to_string(&path).expect("read VENUS USR fixture");
-    let tab = TabulatedResolution::from_text(&text, 25.0).unwrap();
+    let tab = common::synthetic_venus_usr_tab();
 
     let n = 3471;
     let energies: Vec<f64> = (0..n)
         .map(|i| 7.0 + i as f64 * ((200.0 - 7.0) / (n - 1) as f64))
         .collect();
+    {
+        // No-op-regression pre-check: must precede the bit-exact
+        // sink-equality assertion below, which would pass vacuously
+        // if the kernel collapsed to a delta.
+        let pre_plan = tab.plan(&energies).expect("build plan on sorted grid");
+        common::assert_kernel_broadens(&pre_plan, &energies);
+    }
     let spectrum: Vec<f64> = energies
         .iter()
         .map(|&e| {
@@ -66,7 +73,7 @@ fn test_broaden_presorted_bench() {
 
     let speedup = t_ref.as_secs_f64() / t_new.as_secs_f64();
     eprintln!(
-        "broaden_presorted microbench (n_grid={n}, repeats={repeats}, 499-pt kernel):\n\
+        "broaden_presorted microbench (n_grid={n}, repeats={repeats}, synthetic kernel):\n\
          reference (binary search): {t_ref:?}  (sink={sink_ref:.3})\n\
          two-pointer walk         : {t_new:?}  (sink={sink_new:.3})\n\
          speedup                  : {speedup:.2}x"
@@ -82,16 +89,19 @@ fn test_broaden_presorted_bench() {
 /// the plan internally on every call.
 #[test]
 fn test_plan_reuse_bench() {
-    let Some(path) = common::venus_usr_resolution_path() else {
-        return;
-    };
-    let text = std::fs::read_to_string(&path).expect("read VENUS USR fixture");
-    let tab = TabulatedResolution::from_text(&text, 25.0).unwrap();
+    let tab = common::synthetic_venus_usr_tab();
 
     let n = 3471;
     let energies: Vec<f64> = (0..n)
         .map(|i| 7.0 + i as f64 * ((200.0 - 7.0) / (n - 1) as f64))
         .collect();
+    {
+        // No-op-regression pre-check: must precede the bit-exact
+        // sink-equality assertion below, which would pass vacuously
+        // if the kernel collapsed to a delta.
+        let pre_plan = tab.plan(&energies).expect("build plan on sorted grid");
+        common::assert_kernel_broadens(&pre_plan, &energies);
+    }
 
     // Many spectra simulating an LM fit's sequence of evaluations.
     let repeats = 100;
@@ -133,7 +143,7 @@ fn test_plan_reuse_bench() {
 
     let speedup = t_percall.as_secs_f64() / (t_build + t_apply_total).as_secs_f64();
     eprintln!(
-        "plan-reuse microbench (n_grid={n}, {repeats} spectra, 499-pt kernel):\n\
+        "plan-reuse microbench (n_grid={n}, {repeats} spectra, synthetic kernel):\n\
          per-call broaden_presorted : {t_percall:?}  (sink={sink_percall:.3})\n\
          plan build (once)          : {t_build:?}\n\
          apply × {repeats}          : {t_apply_total:?}\n\
@@ -145,23 +155,20 @@ fn test_plan_reuse_bench() {
 }
 
 /// `apply_r` (ResolutionMatrix CSR) vs `ResolutionPlan::apply`,
-/// 3471-bin VENUS production grid × 100 spectra.  Exercised
-/// manually to decide whether the CSR compile + CSR matvec beats
-/// the plan's two-pointer walk at the no-SIMD-no-unsafe baseline
-/// promised in #473.
+/// 3471-bin production grid × 100 spectra.  Exercised manually to
+/// decide whether the CSR compile + CSR matvec beats the plan's
+/// two-pointer walk at the no-SIMD-no-unsafe baseline promised in
+/// #473.
 #[test]
 fn resolution_matrix_apply_microbench() {
-    let Some(path) = common::venus_usr_resolution_path() else {
-        return;
-    };
-    let text = std::fs::read_to_string(&path).expect("read VENUS USR fixture");
-    let tab = TabulatedResolution::from_text(&text, 25.0).unwrap();
+    let tab = common::synthetic_venus_usr_tab();
 
     let n = 3471_usize;
     let energies: Vec<f64> = (0..n)
         .map(|i| 7.0 + i as f64 * ((200.0 - 7.0) / (n - 1) as f64))
         .collect();
     let plan = tab.plan(&energies).expect("sorted grid must validate");
+    common::assert_kernel_broadens(&plan, &energies);
 
     let t_compile = std::time::Instant::now();
     let matrix = plan.compile_to_matrix();

--- a/crates/nereids-physics/tests/venus_usr_surrogate.rs
+++ b/crates/nereids-physics/tests/venus_usr_surrogate.rs
@@ -47,7 +47,7 @@ fn max_hybrid_err(a: &[f64], b: &[f64]) -> f64 {
 /// test does not re-measure that; it only checks forward-model
 /// correctness.
 #[test]
-fn cubature_real_venus_k1_forward_equivalence() {
+fn cubature_venus_like_k1_forward_equivalence() {
     let tab = common::synthetic_venus_usr_tab();
 
     // Smaller production-ish grid (512 instead of 3471) to keep
@@ -77,7 +77,7 @@ fn cubature_real_venus_k1_forward_equivalence() {
     let training = SparseEmpiricalCubaturePlan::default_training_points(&train_max);
     let anchor = SparseEmpiricalCubaturePlan::default_jacobian_anchor(&train_max);
     let cub = SparseEmpiricalCubaturePlan::build(&matrix, &sigma, 1, &training, &anchor)
-        .expect("build k=1 cubature on real VENUS kernel");
+        .expect("build k=1 cubature on VENUS-like kernel");
 
     // At each training density, cubature = exact.
     for n_s in training.iter() {
@@ -119,7 +119,7 @@ fn cubature_real_venus_k1_forward_equivalence() {
     );
 }
 
-/// Real-VENUS regression test for the Chebyshev scalar surrogate on
+/// VENUS-like regression test for the Chebyshev scalar surrogate on
 /// the 3471-bin VENUS production grid with synthetic Hf-like σ.
 /// Asserts forward accuracy ≤ 1e-5 at VENUS density (issue #475
 /// success criterion) and logs per-call wall time.  PR #475 benched
@@ -129,7 +129,7 @@ fn cubature_real_venus_k1_forward_equivalence() {
 /// hardware-dependent and intentionally not pinned here; the
 /// accuracy bound stays portable.
 #[test]
-fn scalar_chebyshev_real_venus_k1_regression() {
+fn scalar_chebyshev_venus_like_k1_regression() {
     let tab = common::synthetic_venus_usr_tab();
 
     // VENUS production grid size.

--- a/crates/nereids-physics/tests/venus_usr_surrogate.rs
+++ b/crates/nereids-physics/tests/venus_usr_surrogate.rs
@@ -1,14 +1,15 @@
-//! Fixture-gated regression tests for the surrogate cubature and
-//! scalar-Chebyshev plans on the real VENUS USR resolution kernel
-//! (SAMMY-format).
+//! Regression tests for the surrogate cubature and scalar-Chebyshev
+//! plans on a synthetic VENUS-like SAMMY USR resolution kernel.
 //!
-//! When the fixture is absent (CI, fresh checkouts), each test
-//! early-returns and is reported as passing — no `#[ignore]` noise.
-//! See `tests/README.md` and issue #497.
+//! The kernel is the synthetic SAMMY USR-format kernel from
+//! [`common::synthetic_venus_usr_tab`]; the real VENUS BL10 fixture
+//! is not approved for public release (see `common/mod.rs` for the
+//! full rationale and issue #557 for the CI-coverage gap this
+//! replaces).
 
 mod common;
 
-use nereids_physics::resolution::{ResolutionMatrix, TabulatedResolution, apply_r};
+use nereids_physics::resolution::{ResolutionMatrix, apply_r};
 use nereids_physics::surrogate::{ScalarChebyshevPlan, SparseEmpiricalCubaturePlan};
 
 // ── Helpers duplicated from `src/surrogate.rs` ───────────────────
@@ -47,11 +48,7 @@ fn max_hybrid_err(a: &[f64], b: &[f64]) -> f64 {
 /// correctness.
 #[test]
 fn cubature_real_venus_k1_forward_equivalence() {
-    let Some(path) = common::venus_usr_resolution_path() else {
-        return;
-    };
-    let text = std::fs::read_to_string(&path).expect("read VENUS USR fixture");
-    let tab = TabulatedResolution::from_text(&text, 25.0).expect("parse fixture");
+    let tab = common::synthetic_venus_usr_tab();
 
     // Smaller production-ish grid (512 instead of 3471) to keep
     // LP-per-row cost tractable within a single test — the cubature
@@ -62,6 +59,7 @@ fn cubature_real_venus_k1_forward_equivalence() {
         .map(|i| 7.0 + (200.0 - 7.0) * (i as f64) / ((n_grid - 1) as f64))
         .collect();
     let plan = tab.plan(&energies).expect("build plan on sorted grid");
+    common::assert_kernel_broadens(&plan, &energies);
     let matrix = plan.compile_to_matrix();
 
     // Synthetic Gaussian-resonance σ on the real energy grid — we
@@ -132,11 +130,7 @@ fn cubature_real_venus_k1_forward_equivalence() {
 /// accuracy bound stays portable.
 #[test]
 fn scalar_chebyshev_real_venus_k1_regression() {
-    let Some(path) = common::venus_usr_resolution_path() else {
-        return;
-    };
-    let text = std::fs::read_to_string(&path).expect("read VENUS USR fixture");
-    let tab = TabulatedResolution::from_text(&text, 25.0).expect("parse fixture");
+    let tab = common::synthetic_venus_usr_tab();
 
     // VENUS production grid size.
     let n_grid = 3471_usize;
@@ -144,6 +138,7 @@ fn scalar_chebyshev_real_venus_k1_regression() {
         .map(|i| 7.0 + (200.0 - 7.0) * (i as f64) / ((n_grid - 1) as f64))
         .collect();
     let plan = std::sync::Arc::new(tab.plan(&energies).expect("build plan on sorted grid"));
+    common::assert_kernel_broadens(&plan, &energies);
     let matrix = plan.compile_to_matrix();
     let matrix_nnz = matrix.nnz();
 


### PR DESCRIPTION
## Summary

The 13 `#[test]` functions across `tests/venus_usr_resolution.rs`,
`tests/venus_usr_resolution_microbench.rs`, and
`tests/venus_usr_surrogate.rs` previously gated on the gitignored real
VENUS BL10 fixture (`_fts_bl10_0p5meV_1keV_25pts.txt`) via the
early-return idiom

```rust
let Some(path) = common::venus_usr_resolution_path() else { return; };
```

Because `.gitignore:49` lists `_fts_*.txt` per ORNL release policy
("Instrument resolution files (not approved for public release)"), the
fixture is **always absent** on CI and fresh checkouts, so all 13
tests silently reported `passed; 0 ignored` while exercising **zero**
of the SAMMY USR kernel path the SoftwareX paper documents. Issue
#557 confirms this empirically — moving the developer's local fixture
aside reproduces the same vacuous pass.

## Decision: option (b) synthetic, not (a) vendoring

The issue offered two options. Option (a) — vendor a trimmed real
fixture under `tests/data/` — is ruled out by the same ORNL release
policy that put `_fts_*.txt` in the gitignore. Option (b) —
programmatically generate a SAMMY USR-format kernel and feed it through
the production `TabulatedResolution::from_text` entry point — preserves
CI coverage of the full parser → plan → apply → CSR matvec pipeline
on every `cargo test` run without shipping any restricted data.

## Changes

- **`crates/nereids-physics/tests/common/mod.rs`** (full rewrite, 208
  LOC): three public helpers
  - `synthetic_venus_usr_text() -> String` emits a SAMMY USR-format
    kernel: 25 log-spaced reference energies (5 meV → 1 keV, mirroring
    the production fixture's `0p5meV_1keV_25pts` shape) with a
    symmetric 41-point triangular kernel of half-width 0.5 μs in TOF
    space.
  - `synthetic_venus_usr_tab() -> TabulatedResolution` parses that text
    via `TabulatedResolution::from_text(..., 25.0)` — the same parser
    entry point production used — so the parsing code path is
    exercised on every test invocation.
  - `assert_kernel_broadens(plan, energies)` is the PR #544-style
    no-op-regression pre-check: it asserts
    `‖T_kernel − T_none‖_∞ > 0.01 · ‖T_none‖_∞` on a sharp Gaussian-dip
    probe so a future tweak that collapses the synthetic kernel toward
    a delta — which would let every equivalence test pass vacuously
    again — fails loudly at the first test.

- **3 test files** (`venus_usr_resolution.rs`,
  `venus_usr_resolution_microbench.rs`, `venus_usr_surrogate.rs`): all
  13 tests switch from the early-return idiom to unconditional
  `common::synthetic_venus_usr_tab()`. The four equivalence /
  row-stochastic / bit-exact tests + the 3 microbenches + 2 surrogate
  tests call `assert_kernel_broadens` up front; the three
  validation-path tests (`grid_mismatch_detected`,
  `length_mismatch_detected`, `csr_column_indices_sorted_per_row`)
  skip it because they only need a valid matrix to drive error-path
  assertions and run at small grid sizes where the synthetic kernel is
  intentionally sub-bin.

- **`tests/README.md`**: rewritten to document the synthetic-kernel
  approach and the no-op-regression pre-check.

- **`src/resolution.rs` and `src/surrogate.rs`**: four sign-post
  comments updated to point at `common::synthetic_venus_usr_tab()`
  and reference #557.

## Empirical confirmation the pre-check fires

While wiring the pre-check into `build_fixture_plan_and_matrix`, an
initial run failed at `resolution_matrix_grid_mismatch_detected`
(128-bin grid) and `resolution_matrix_length_mismatch_detected`
(64-bin grid) with `‖T_kernel − T_none‖_∞` = 2.1e-3 and 5.9e-8
respectively, both below the 1e-2 threshold. Diagnosis: at those
coarse grid sizes the synthetic kernel's energy-space FWHM is sub-bin
(≈ 0.4 eV vs 1.5 – 3 eV bin spacing on 7 – 200 eV), so broadening *is*
effectively a no-op for that grid. The fix was to lift the pre-check
out of the build helper and put it only on broadening-equivalence
tests, leaving the validation-path tests to build the matrix without
triggering it. This is exactly the silent-no-op-via-grid-or-kernel-
shrink mode PR #544 warned about — and the pre-check did its job.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude nereids-python` (all crates green)
- [x] `cargo test -p nereids-physics --test venus_usr_resolution -- --nocapture` → 8 passed; 0 silently skipped
- [x] `cargo test -p nereids-physics --test venus_usr_resolution_microbench -- --nocapture` → 3 passed
- [x] `cargo test -p nereids-physics --test venus_usr_surrogate -- --nocapture` → 2 passed (Chebyshev `max_err @ VENUS = 1.668e-15`, well under the 1e-5 ceiling from issue #475)

Closes #557

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>