### PR TITLE
fix(fitting): release-mode validation + NaN propagation in joint-Poisson + LM (#552)

### DIFF
--- a/crates/nereids-fitting/src/joint_poisson.rs
+++ b/crates/nereids-fitting/src/joint_poisson.rs
@@ -309,8 +309,22 @@ impl<'a> JointPoissonObjective<'a> {
             if denom.abs() < PIVOT_FLOOR {
                 continue;
             }
+            // Issue #552 M4: per-cell finiteness check.  The matching guard
+            // in lm.rs `compute_jacobian` zeroes NaN entries instead of
+            // dropping the column; the same pattern applies here because
+            // the downstream Fisher accumulator below already skips
+            // inactive rows (`bin_active(i)`), so a NaN at a masked /
+            // inactive row must not block the column for active rows.
+            // Active-row NaN is handled by [`deviance_curvature`], which
+            // returns 0 on non-finite `t_i` so the assembly stays clean.
             for i in 0..n_e {
-                *jac.get_mut(i, col) = (t_a[i] - t_b[i]) / denom;
+                let a = t_a[i];
+                let b = t_b[i];
+                if a.is_finite() && b.is_finite() {
+                    *jac.get_mut(i, col) = (a - b) / denom;
+                }
+                // else: leave at the zero-default; masked rows are never
+                // read by the active-bin filter in the Fisher loop.
             }
         }
         let mut info = FlatMatrix::zeros(n_free, n_free);
@@ -403,6 +417,17 @@ fn binomial_deviance_term(s: f64, o: f64, t: f64, c: f64) -> f64 {
         c.is_finite() && c > 0.0,
         "binomial_deviance_term: c must be finite and > 0, got {c}"
     );
+    // Issue #552 M14: `f64::max(NaN, ε)` returns `ε`, so a non-finite T
+    // would silently masquerade as a tiny positive transmission and the
+    // deviance would evaluate to a finite (but meaningless) value that
+    // the LM trial-step guard `Ok(v) if v.is_finite()` would accept.
+    // Return NaN so the deviance sum becomes NaN and the trial step is
+    // rejected.  The matching deviance_weight / deviance_curvature
+    // guards return 0, which keeps the gradient / Fisher accumulators
+    // clean rather than poisoning them with NaN contributions.
+    if !t.is_finite() {
+        return f64::NAN;
+    }
     let t_safe = t.max(POISSON_EPSILON);
     let n = s + o;
     if n <= 0.0 {
@@ -444,6 +469,17 @@ fn xlogy_ratio(x: f64, y: f64) -> f64 {
 /// done in [`binomial_deviance_term`]).
 #[inline]
 fn deviance_weight(s: f64, o: f64, t: f64, c: f64) -> f64 {
+    // Issue #552 M14: a non-finite T must not be folded into the
+    // gradient accumulator.  `f64::max(NaN, ε)` returns `ε`, which would
+    // turn a NaN bin into a finite gradient contribution scaled by the
+    // Jacobian and silently steer the optimizer.  Skip the bin (return
+    // 0) — the matching `binomial_deviance_term` returns NaN so the
+    // step is rejected by the trial-guard, but the gradient stays clean
+    // in case the caller is using it for diagnostics on a partially-bad
+    // grid.
+    if !t.is_finite() {
+        return 0.0;
+    }
     let t_safe = t.max(POISSON_EPSILON);
     let one_plus_ct = 1.0 + c * t_safe;
     -2.0 * (s - o * c * t_safe) / (t_safe * one_plus_ct)
@@ -459,6 +495,14 @@ fn deviance_weight(s: f64, o: f64, t: f64, c: f64) -> f64 {
 /// and ∂²D/∂T² = 2 · I_TT (since D = −2 · L_c).
 #[inline]
 fn deviance_curvature(s: f64, o: f64, t: f64, c: f64) -> f64 {
+    // Issue #552 M14: see the matching guard in [`deviance_weight`].
+    // A non-finite T would otherwise contribute a huge spurious
+    // curvature via `f64::max(NaN, ε) -> ε`, inflating the diagonal of
+    // the Fisher matrix and underestimating the corresponding parameter
+    // uncertainty (covariance = I⁻¹ entries shrink as I grows).
+    if !t.is_finite() {
+        return 0.0;
+    }
     let t_safe = t.max(POISSON_EPSILON);
     let n = s + o;
     let one_plus_ct = 1.0 + c * t_safe;
@@ -641,6 +685,31 @@ pub fn joint_poisson_fit(
     let n_data = objective.n_data();
     if n_data == 0 {
         return Err(FittingError::EmptyData);
+    }
+
+    // Issue #552 M3: validate `o` / `s` length and `c` up-front at the
+    // public entry point.  The inner per-bin helpers (`binomial_deviance_term`,
+    // `deviance_from_transmission`) use `debug_assert!` only, which is a no-op
+    // in release builds.  Without these hard checks:
+    //   - A length mismatch in `o` vs `s` silently truncates via `.zip()`,
+    //     minimising deviance on a sub-range of bins.
+    //   - A non-positive or non-finite `c` produces finite garbage
+    //     (e.g. zero `cT`, NaN denominators) that the LM happily descends.
+    // Both surface as "the fit converged" with bogus parameter values —
+    // exactly the failure mode the trial-step guard cannot catch because
+    // the deviance value is finite.
+    if objective.s.len() != n_data {
+        return Err(FittingError::LengthMismatch {
+            expected: n_data,
+            actual: objective.s.len(),
+            field: "sample_counts",
+        });
+    }
+    if !objective.c.is_finite() || objective.c <= 0.0 {
+        return Err(FittingError::InvalidConfig(format!(
+            "proton-charge ratio c = Q_s/Q_ob must be finite and > 0, got {}",
+            objective.c
+        )));
     }
 
     // Validate active-mask length up-front, mirroring the LM solver's
@@ -2048,5 +2117,293 @@ mod tests {
             ),
             "expected LengthMismatch on active_mask; got {err:?}"
         );
+    }
+
+    // ==================================================================
+    // Issue #552 (M3) — release-mode input validation at joint_poisson_fit.
+    //
+    // The inner `binomial_deviance_term` and `deviance_from_transmission`
+    // protect themselves with `debug_assert!` only.  Release builds skip
+    // those, so a length mismatch in `o` vs `s` silently truncates via
+    // `.zip()` and a non-positive `c` produces finite garbage that the
+    // optimizer happily minimises.  Validate at the public entry point.
+    // ==================================================================
+
+    /// `joint_poisson_fit` rejects an `o`/`s` length mismatch with a
+    /// `LengthMismatch` error rather than silently truncating via `.zip()`
+    /// and minimising bogus deviance on a sub-range of bins.
+    #[test]
+    fn test_joint_poisson_rejects_o_s_length_mismatch() {
+        let n_bins = 5;
+        let o: Vec<f64> = vec![10.0; n_bins];
+        // Deliberate mismatch: `s` has one fewer bin than `o`.
+        let s: Vec<f64> = vec![5.0; n_bins - 1];
+        let model = ConstModel { n_e: n_bins };
+        let obj = JointPoissonObjective {
+            model: &model,
+            o: &o,
+            s: &s,
+            c: 1.0,
+            active_mask: None,
+        };
+        let mut params = ParameterSet::new(vec![FitParameter::non_negative("T", 0.5)]);
+        let err =
+            joint_poisson_fit(&obj, &mut params, &JointPoissonFitConfig::default()).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                FittingError::LengthMismatch {
+                    field: "sample_counts",
+                    ..
+                }
+            ),
+            "expected LengthMismatch on sample_counts; got {err:?}"
+        );
+    }
+
+    /// `joint_poisson_fit` rejects a non-positive proton-charge ratio `c`
+    /// with `InvalidConfig` rather than falling through to the inner
+    /// `debug_assert!` (which is a no-op in release builds and lets the
+    /// optimizer minimise a garbage deviance landscape).
+    #[test]
+    fn test_joint_poisson_rejects_non_positive_c() {
+        let n_bins = 5;
+        let o: Vec<f64> = vec![10.0; n_bins];
+        let s: Vec<f64> = vec![5.0; n_bins];
+        let model = ConstModel { n_e: n_bins };
+        let mut params = ParameterSet::new(vec![FitParameter::non_negative("T", 0.5)]);
+        // c = 0 is the textbook degenerate case (no sample counts).
+        let obj_zero = JointPoissonObjective {
+            model: &model,
+            o: &o,
+            s: &s,
+            c: 0.0,
+            active_mask: None,
+        };
+        let err = joint_poisson_fit(&obj_zero, &mut params, &JointPoissonFitConfig::default())
+            .unwrap_err();
+        assert!(
+            matches!(err, FittingError::InvalidConfig(_)),
+            "expected InvalidConfig on c=0; got {err:?}"
+        );
+
+        // Negative c is unphysical.
+        let mut params2 = ParameterSet::new(vec![FitParameter::non_negative("T", 0.5)]);
+        let obj_neg = JointPoissonObjective {
+            model: &model,
+            o: &o,
+            s: &s,
+            c: -1.5,
+            active_mask: None,
+        };
+        let err = joint_poisson_fit(&obj_neg, &mut params2, &JointPoissonFitConfig::default())
+            .unwrap_err();
+        assert!(
+            matches!(err, FittingError::InvalidConfig(_)),
+            "expected InvalidConfig on c<0; got {err:?}"
+        );
+
+        // NaN c — caught by the same finiteness check.
+        let mut params3 = ParameterSet::new(vec![FitParameter::non_negative("T", 0.5)]);
+        let obj_nan = JointPoissonObjective {
+            model: &model,
+            o: &o,
+            s: &s,
+            c: f64::NAN,
+            active_mask: None,
+        };
+        let err = joint_poisson_fit(&obj_nan, &mut params3, &JointPoissonFitConfig::default())
+            .unwrap_err();
+        assert!(
+            matches!(err, FittingError::InvalidConfig(_)),
+            "expected InvalidConfig on c=NaN; got {err:?}"
+        );
+    }
+
+    // ==================================================================
+    // Issue #552 (M14) — `f64::max(NaN, ε) == ε` swallows active NaN T.
+    //
+    // Rust stdlib's `f64::max` returns the non-NaN argument when one is
+    // NaN, so `t.max(POISSON_EPSILON)` silently turns a NaN transmission
+    // into ε.  The deviance term then evaluates to a finite (large)
+    // number which passes the trial-step's `v.is_finite()` guard, so the
+    // optimizer accepts steps into regions where the model is broken.
+    //
+    // The fix returns NaN from `binomial_deviance_term` (so the deviance
+    // sum becomes NaN and the trial guard rejects the step) and 0 from
+    // `deviance_weight` / `deviance_curvature` (so the gradient / Fisher
+    // accumulators are not poisoned by the bad bin).
+    // ==================================================================
+
+    /// `binomial_deviance_term` returns NaN when `t` is non-finite — so
+    /// the per-bin sum poisons the deviance and the trial-step guard
+    /// (`Ok(v) if v.is_finite()`) rejects the step instead of silently
+    /// accepting a bogus-but-finite value.
+    #[test]
+    fn test_binomial_deviance_term_nan_t_returns_nan() {
+        // Pre-fix: `t.max(POISSON_EPSILON)` swallows NaN and returns a
+        // finite (but meaningless) deviance.
+        let d_nan_t = binomial_deviance_term(50.0, 10.0, f64::NAN, 2.0);
+        assert!(
+            d_nan_t.is_nan(),
+            "non-finite T must produce NaN deviance, not a finite shim; got {d_nan_t}"
+        );
+
+        // +inf / -inf likewise — they are not physical transmission values.
+        let d_inf_t = binomial_deviance_term(50.0, 10.0, f64::INFINITY, 2.0);
+        assert!(
+            d_inf_t.is_nan(),
+            "+inf T must produce NaN deviance; got {d_inf_t}"
+        );
+        let d_neg_inf_t = binomial_deviance_term(50.0, 10.0, f64::NEG_INFINITY, 2.0);
+        assert!(
+            d_neg_inf_t.is_nan(),
+            "-inf T must produce NaN deviance; got {d_neg_inf_t}"
+        );
+    }
+
+    /// `deviance_weight` returns 0 for non-finite `t` so the gradient
+    /// accumulator is not poisoned — bad bins drop out instead of
+    /// becoming silent NaN contributions weighted by the Jacobian.
+    #[test]
+    fn test_deviance_weight_nan_t_returns_zero() {
+        let w = deviance_weight(50.0, 10.0, f64::NAN, 2.0);
+        assert_eq!(w, 0.0, "non-finite T must give zero weight; got {w}");
+    }
+
+    /// `deviance_curvature` returns 0 for non-finite `t` so the Fisher
+    /// info accumulator is not poisoned.
+    #[test]
+    fn test_deviance_curvature_nan_t_returns_zero() {
+        let h = deviance_curvature(50.0, 10.0, f64::NAN, 2.0);
+        assert_eq!(h, 0.0, "non-finite T must give zero curvature; got {h}");
+    }
+
+    /// End-to-end: a model that returns NaN at some active bin makes the
+    /// deviance non-finite, the trial-step guard rejects it (rather than
+    /// accepting a bogus finite step), and the fit either bails out
+    /// non-converged or recovers without committing the bad step.  Prior
+    /// to the M14 fix the optimizer could silently accept the NaN step.
+    #[test]
+    fn test_joint_poisson_fit_rejects_nan_transmission() {
+        // Model that returns NaN at θ < 0.1 and a constant 0.5 otherwise.
+        struct NanAtSmallTheta;
+        impl FitModel for NanAtSmallTheta {
+            fn evaluate(&self, params: &[f64]) -> Result<Vec<f64>, FittingError> {
+                let t = if params[0] < 0.1 { f64::NAN } else { 0.5 };
+                Ok(vec![t; 4])
+            }
+            fn analytical_jacobian(
+                &self,
+                _params: &[f64],
+                free_param_indices: &[usize],
+                y_current: &[f64],
+            ) -> Option<FlatMatrix> {
+                let n_e = y_current.len();
+                let n_free = free_param_indices.len();
+                let mut jac = FlatMatrix::zeros(n_e, n_free);
+                for i in 0..n_e {
+                    for (j, &pi) in free_param_indices.iter().enumerate() {
+                        *jac.get_mut(i, j) = if pi == 0 { 1.0 } else { 0.0 };
+                    }
+                }
+                Some(jac)
+            }
+        }
+
+        let model = NanAtSmallTheta;
+        let n = 4;
+        let o = vec![10.0; n];
+        let s = vec![5.0; n];
+        let obj = JointPoissonObjective {
+            model: &model,
+            o: &o,
+            s: &s,
+            c: 1.0,
+            active_mask: None,
+        };
+        // Initial point lands in the NaN region.
+        let mut params = ParameterSet::new(vec![FitParameter::non_negative("T", 0.05)]);
+        let cfg = JointPoissonFitConfig::default();
+        let result = joint_poisson_fit(&obj, &mut params, &cfg);
+        match result {
+            Ok(r) => {
+                // The optimizer must NOT report a finite deviance from a
+                // NaN-T initial point — pre-fix it would do so by silently
+                // converting NaN to POISSON_EPSILON.  After the fix the
+                // deviance is NaN (initial eval propagates), or the fit
+                // never accepts a NaN step, or it ascends out of the NaN
+                // region and lands at the finite plateau (params[0] >= 0.1).
+                if r.params[0] < 0.1 {
+                    assert!(
+                        r.deviance.is_nan() && !r.gn_converged,
+                        "stayed in NaN region but reported finite deviance: {r:?}"
+                    );
+                }
+            }
+            Err(_) => {
+                // Acceptable: hard error from the initial evaluation.
+            }
+        }
+    }
+
+    // ==================================================================
+    // Issue #552 (M4) — NaN-in-Jacobian during FD probes (Fisher info).
+    //
+    // The post-convergence Fisher / covariance path builds a Jacobian
+    // via FD when the model has no analytical form.  If the FD probe
+    // straddles a region where the model returns NaN, the resulting
+    // column is poisoned and the inverse Fisher inherits NaN entries.
+    // The main LM loop's trial guard does not run here (it only checks
+    // the trial step in the main optimisation loop).
+    //
+    // Fix: skip the column on non-finite probe output, leaving its FD
+    // derivative as the zero default (consistent with the
+    // "model-evaluation-failed" branch already present at :298-:304).
+    // ==================================================================
+
+    /// `fisher_information_fd` zeroes per-cell entries whose FD probe
+    /// returned a non-finite model output, rather than baking NaN into
+    /// the Fisher matrix (and from there into the inverse covariance).
+    #[test]
+    fn test_fisher_information_fd_skips_nan_probe() {
+        // Model: T_i = θ_0 (constant).  Returns NaN whenever
+        // |θ_0 - 0.6| > 1e-3 — i.e. a NaN ring around the FD probe,
+        // but a finite value at the base point.
+        struct NanFdProbe;
+        impl FitModel for NanFdProbe {
+            fn evaluate(&self, params: &[f64]) -> Result<Vec<f64>, FittingError> {
+                let t = if (params[0] - 0.6).abs() > 1e-3 {
+                    f64::NAN
+                } else {
+                    params[0]
+                };
+                Ok(vec![t; 3])
+            }
+            // No analytical_jacobian -> Fisher info must use FD fallback.
+        }
+        let model = NanFdProbe;
+        let n = 3;
+        let o = vec![10.0; n];
+        let s = vec![5.0; n];
+        let obj = JointPoissonObjective {
+            model: &model,
+            o: &o,
+            s: &s,
+            c: 1.0,
+            active_mask: None,
+        };
+        let mut params = ParameterSet::new(vec![FitParameter::non_negative("T", 0.6)]);
+        let info = obj
+            .fisher_information_fd(&mut params, 1e-2)
+            .expect("fisher_information_fd should not return Err on a finite base")
+            .expect("fisher_information_fd should return Some(matrix)");
+        // Every entry must be finite — column was skipped on NaN probe.
+        for v in info.data.iter() {
+            assert!(
+                v.is_finite(),
+                "fisher_information_fd produced non-finite entry: {v}"
+            );
+        }
     }
 }

--- a/crates/nereids-fitting/src/joint_poisson.rs
+++ b/crates/nereids-fitting/src/joint_poisson.rs
@@ -98,31 +98,39 @@ impl<'a> JointPoissonObjective<'a> {
     /// up-front validation (callers may invoke `deviance_from_transmission`,
     /// `deviance_gradient_analytical`, `fisher_information[_fd]`, etc.
     /// directly for diagnostics).  Mirrors the entry-point checks in
-    /// `joint_poisson_fit`: `o.len() == s.len()`, `c` finite and > 0, and
-    /// optional `active_mask` length agrees.  The `debug_assert!`s in the
-    /// per-bin helpers are no-ops in release builds — without this guard a
-    /// length mismatch in `s` would silently truncate via `.zip()` and a
-    /// non-positive / NaN `c` would produce finite garbage.
+    /// `joint_poisson_fit`: `o.len() == s.len()`, `c` finite and > 0, optional
+    /// `active_mask` length agrees, all `o[i]` / `s[i]` finite and >= 0, and
+    /// the caller-supplied transmission length agrees with `o.len()`.  The
+    /// `debug_assert!`s in the per-bin helpers are no-ops in release builds —
+    /// without this guard a length mismatch in `s` would silently truncate
+    /// via `.zip()` and a non-positive / NaN `c` would produce finite
+    /// garbage.
+    ///
+    /// **Error orientation.**  `FittingError::LengthMismatch` displays as
+    /// `"{field} length ({actual}) must match expected length ({expected})"`.
+    /// The objective's own invariants (`s.len()` vs `o.len()`, `mask.len()`
+    /// vs `o.len()`) are checked first, with `expected = o.len()` so the
+    /// message accurately names the offending field.  The caller-supplied
+    /// `t` length is then checked against `o.len()` with `field =
+    /// "transmission"` — pre-fix this branch reported `field =
+    /// "open_beam_counts"` with `expected = t_len`, which read as "the
+    /// open-beam array is wrong" when the actual fault was the caller's
+    /// transmission slice.
     fn validate_inputs(&self, t_len: usize) -> Result<(), FittingError> {
-        if self.o.len() != t_len {
+        // Internal invariants of the objective itself — these must hold
+        // regardless of what the caller passes for `t`.
+        if self.s.len() != self.o.len() {
             return Err(FittingError::LengthMismatch {
-                expected: t_len,
-                actual: self.o.len(),
-                field: "open_beam_counts",
-            });
-        }
-        if self.s.len() != t_len {
-            return Err(FittingError::LengthMismatch {
-                expected: t_len,
+                expected: self.o.len(),
                 actual: self.s.len(),
                 field: "sample_counts",
             });
         }
         if let Some(m) = self.active_mask
-            && m.len() != t_len
+            && m.len() != self.o.len()
         {
             return Err(FittingError::LengthMismatch {
-                expected: t_len,
+                expected: self.o.len(),
                 actual: m.len(),
                 field: "active_mask",
             });
@@ -133,6 +141,25 @@ impl<'a> JointPoissonObjective<'a> {
                 self.c
             )));
         }
+        // Caller-supplied length: the transmission slice must match the
+        // objective's bin count.
+        if t_len != self.o.len() {
+            return Err(FittingError::LengthMismatch {
+                expected: self.o.len(),
+                actual: t_len,
+                field: "transmission",
+            });
+        }
+        // Per-element count validation.  The entry point `joint_poisson_fit`
+        // also calls `validate_counts` up-front so the user gets the error
+        // before any LM work, but every public method that bypasses the
+        // entry point (`deviance_from_transmission`, `fisher_information`,
+        // `profile_lambda_per_bin`, …) must still reject non-finite /
+        // negative counts — the inner `binomial_deviance_term` /
+        // `xlogy_ratio` would otherwise propagate NaN past the zero-clamp
+        // (`NaN <= 0.0` is `false`) or silently swallow a negative as zero.
+        validate_counts(self.o, "open_beam_counts")?;
+        validate_counts(self.s, "sample_counts")?;
         Ok(())
     }
 
@@ -545,13 +572,23 @@ fn binomial_deviance_term(s: f64, o: f64, t: f64, c: f64) -> f64 {
 
 /// Reject non-finite or negative count arrays at public entry points.
 ///
-/// The per-bin `xlogy_ratio` helper treats `x <= 0.0` as the zero-count
-/// branch and returns 0, but `NaN <= 0.0` is `false`, so a NaN slips
-/// through and propagates `NaN · ln(NaN / y) = NaN` into the deviance
-/// sum.  A negative count likewise leaks past the zero-branch and
-/// produces a meaningless (but finite) log contribution.  Validate
-/// up-front so callers get a typed error instead of a "successful" fit
-/// on poisoned data.
+/// Two distinct failure modes motivate the up-front check:
+///
+/// - **Non-finite (NaN / ±∞).**  The per-bin `xlogy_ratio` helper treats
+///   `x <= 0.0` as the zero-count branch and returns 0, but `NaN <= 0.0`
+///   is `false`, so a NaN slips past the branch and propagates
+///   `NaN · ln(NaN / y) = NaN` straight into the deviance sum.  The LM
+///   trial-step guard then sees `Ok(NaN)` instead of a clean error.
+/// - **Negative.**  `x <= 0.0` *is* true for `x < 0.0`, so the zero-count
+///   branch silently swallows negatives and returns 0 — the deviance
+///   stays finite but the bin is treated as "no data", which is
+///   physically meaningless and conceals the upstream bug (subtraction
+///   artefact in TOF normalisation, signed-int overflow in the loader,
+///   etc.).  Negatives never produce NaN, but the "successful" fit
+///   silently discards real data.
+///
+/// Validate up-front so callers get a typed `InvalidConfig` error
+/// pointing at the offending bin instead of either failure mode.
 fn validate_counts(counts: &[f64], field: &'static str) -> Result<(), FittingError> {
     for (i, &v) in counts.iter().enumerate() {
         if !v.is_finite() || v < 0.0 {
@@ -2531,6 +2568,176 @@ mod tests {
                 v.is_finite(),
                 "fisher_information_fd produced non-finite entry: {v}"
             );
+        }
+    }
+
+    // ==================================================================
+    // Per-element count validation propagates through `validate_inputs`.
+    //
+    // Round-2 added `validate_counts` only at the `joint_poisson_fit`
+    // entry point.  Direct callers of `deviance_from_transmission` /
+    // `fisher_information_fd` / `profile_lambda_per_bin` (diagnostics
+    // paths) bypassed that check, so a NaN in `o` would propagate
+    // straight into the deviance sum via `NaN <= 0.0 == false` slipping
+    // past `xlogy_ratio`'s zero-branch, and a negative count would be
+    // silently swallowed as zero.  Round-3 lifts the per-element check
+    // into `validate_inputs`, which every public method already calls.
+    // These tests run in release mode (no `debug_assert!`) and verify
+    // the typed error reaches the caller.
+    // ==================================================================
+
+    /// `deviance_from_transmission` must reject a NaN open-beam count
+    /// with `InvalidConfig` rather than returning `Ok(NaN)` (or, worse,
+    /// `Ok(finite)` if a future `xlogy_ratio` rewrite handled NaN by
+    /// falling through to the zero branch).  Regression for Round-3
+    /// fix #1 — the inner `debug_assert!` is a no-op in release builds.
+    #[test]
+    fn test_deviance_from_transmission_rejects_non_finite_counts() {
+        let n_bins = 4;
+        let mut o = vec![10.0; n_bins];
+        o[2] = f64::NAN;
+        let s = vec![5.0; n_bins];
+        let model = ConstModel { n_e: n_bins };
+        let obj = JointPoissonObjective {
+            model: &model,
+            o: &o,
+            s: &s,
+            c: 1.0,
+            active_mask: None,
+        };
+        let t = vec![0.5; n_bins];
+        let err = obj.deviance_from_transmission(&t).unwrap_err();
+        assert!(
+            matches!(err, FittingError::InvalidConfig(ref msg) if msg.contains("open_beam_counts")),
+            "expected InvalidConfig naming open_beam_counts; got {err:?}"
+        );
+
+        // +inf likewise.
+        let mut s_inf = vec![5.0; n_bins];
+        s_inf[0] = f64::INFINITY;
+        let obj_inf = JointPoissonObjective {
+            model: &model,
+            o: &vec![10.0; n_bins],
+            s: &s_inf,
+            c: 1.0,
+            active_mask: None,
+        };
+        let err = obj_inf.deviance_from_transmission(&t).unwrap_err();
+        assert!(
+            matches!(err, FittingError::InvalidConfig(ref msg) if msg.contains("sample_counts")),
+            "expected InvalidConfig naming sample_counts; got {err:?}"
+        );
+    }
+
+    /// `deviance_from_transmission` must reject a negative count with
+    /// `InvalidConfig` rather than silently treating it as a zero-count
+    /// bin (which `xlogy_ratio`'s `x <= 0.0` branch would do).  Negatives
+    /// indicate an upstream loader / TOF-subtraction bug; swallowing
+    /// them as "no data" conceals the failure mode.
+    #[test]
+    fn test_deviance_from_transmission_rejects_negative_counts() {
+        let n_bins = 3;
+        let mut o = vec![10.0; n_bins];
+        o[1] = -2.0;
+        let s = vec![5.0; n_bins];
+        let model = ConstModel { n_e: n_bins };
+        let obj = JointPoissonObjective {
+            model: &model,
+            o: &o,
+            s: &s,
+            c: 1.0,
+            active_mask: None,
+        };
+        let t = vec![0.5; n_bins];
+        let err = obj.deviance_from_transmission(&t).unwrap_err();
+        assert!(
+            matches!(err, FittingError::InvalidConfig(ref msg) if msg.contains("open_beam_counts")),
+            "expected InvalidConfig naming open_beam_counts; got {err:?}"
+        );
+    }
+
+    /// The reorientation also reaches `profile_lambda_per_bin` and
+    /// `fisher_information_fd`: every public method that calls
+    /// `validate_inputs` now picks up the per-element check.
+    #[test]
+    fn test_other_public_methods_reject_non_finite_counts() {
+        let n_bins = 4;
+        let mut s = vec![5.0; n_bins];
+        s[3] = f64::NAN;
+        let o = vec![10.0; n_bins];
+        let model = ConstModel { n_e: n_bins };
+        let obj = JointPoissonObjective {
+            model: &model,
+            o: &o,
+            s: &s,
+            c: 1.0,
+            active_mask: None,
+        };
+        let t = vec![0.5; n_bins];
+
+        let err = obj.profile_lambda_per_bin(&t).unwrap_err();
+        assert!(
+            matches!(err, FittingError::InvalidConfig(_)),
+            "profile_lambda_per_bin: expected InvalidConfig; got {err:?}"
+        );
+
+        let params = vec![0.5];
+        let free_idx = vec![0];
+        let err = obj
+            .deviance_gradient_analytical(&params, &free_idx)
+            .unwrap_err();
+        assert!(
+            matches!(err, FittingError::InvalidConfig(_)),
+            "deviance_gradient_analytical: expected InvalidConfig; got {err:?}"
+        );
+
+        let err = obj.fisher_information(&params, &free_idx).unwrap_err();
+        assert!(
+            matches!(err, FittingError::InvalidConfig(_)),
+            "fisher_information: expected InvalidConfig; got {err:?}"
+        );
+
+        let mut ps = ParameterSet::new(vec![FitParameter::non_negative("T", 0.5)]);
+        let err = obj.fisher_information_fd(&mut ps, 1e-2).unwrap_err();
+        assert!(
+            matches!(err, FittingError::InvalidConfig(_)),
+            "fisher_information_fd: expected InvalidConfig; got {err:?}"
+        );
+    }
+
+    /// `validate_inputs` now reports caller-supplied transmission length
+    /// mismatches with `field = "transmission"` and `expected = o.len()`.
+    /// Pre-fix this used `field = "open_beam_counts"` with reversed
+    /// expected/actual, which read as "the open-beam array is wrong"
+    /// when the actual fault was the caller's `t` slice.  Regression
+    /// for Round-3 fix #2.
+    #[test]
+    fn test_validate_inputs_reports_transmission_length_mismatch_correctly() {
+        let n_bins = 5;
+        let o = vec![10.0; n_bins];
+        let s = vec![5.0; n_bins];
+        let model = ConstModel { n_e: n_bins };
+        let obj = JointPoissonObjective {
+            model: &model,
+            o: &o,
+            s: &s,
+            c: 1.0,
+            active_mask: None,
+        };
+        // Caller passes `t` shorter than `o`/`s`.
+        let t_short = vec![0.5; n_bins - 2];
+        let err = obj.deviance_from_transmission(&t_short).unwrap_err();
+        match err {
+            FittingError::LengthMismatch {
+                expected,
+                actual,
+                field,
+            } => {
+                assert_eq!(field, "transmission", "field must name `transmission`");
+                assert_eq!(expected, n_bins, "expected must be o.len()");
+                assert_eq!(actual, n_bins - 2, "actual must be t.len()");
+            }
+            other => panic!("expected LengthMismatch on transmission; got {other:?}"),
         }
     }
 }

--- a/crates/nereids-fitting/src/joint_poisson.rs
+++ b/crates/nereids-fitting/src/joint_poisson.rs
@@ -94,6 +94,48 @@ impl<'a> JointPoissonObjective<'a> {
         self.active_mask.is_none_or(|m| m[i])
     }
 
+    /// Runtime guard for the public methods that bypass `joint_poisson_fit`'s
+    /// up-front validation (callers may invoke `deviance_from_transmission`,
+    /// `deviance_gradient_analytical`, `fisher_information[_fd]`, etc.
+    /// directly for diagnostics).  Mirrors the entry-point checks in
+    /// `joint_poisson_fit`: `o.len() == s.len()`, `c` finite and > 0, and
+    /// optional `active_mask` length agrees.  The `debug_assert!`s in the
+    /// per-bin helpers are no-ops in release builds — without this guard a
+    /// length mismatch in `s` would silently truncate via `.zip()` and a
+    /// non-positive / NaN `c` would produce finite garbage.
+    fn validate_inputs(&self, t_len: usize) -> Result<(), FittingError> {
+        if self.o.len() != t_len {
+            return Err(FittingError::LengthMismatch {
+                expected: t_len,
+                actual: self.o.len(),
+                field: "open_beam_counts",
+            });
+        }
+        if self.s.len() != t_len {
+            return Err(FittingError::LengthMismatch {
+                expected: t_len,
+                actual: self.s.len(),
+                field: "sample_counts",
+            });
+        }
+        if let Some(m) = self.active_mask
+            && m.len() != t_len
+        {
+            return Err(FittingError::LengthMismatch {
+                expected: t_len,
+                actual: m.len(),
+                field: "active_mask",
+            });
+        }
+        if !self.c.is_finite() || self.c <= 0.0 {
+            return Err(FittingError::InvalidConfig(format!(
+                "proton-charge ratio c = Q_s/Q_ob must be finite and > 0, got {}",
+                self.c
+            )));
+        }
+        Ok(())
+    }
+
     /// Closed-form profile MLE for the per-bin flux: `λ̂ = c·(O+S) / (1+c·T)`.
     ///
     /// Guards: when `1 + c·T ≤ ε`, returns 0 to avoid division blow-up.
@@ -108,12 +150,18 @@ impl<'a> JointPoissonObjective<'a> {
     }
 
     /// Vector form of [`profile_lambda`](Self::profile_lambda).
-    pub fn profile_lambda_per_bin(&self, t: &[f64]) -> Vec<f64> {
-        t.iter()
+    ///
+    /// Validates `t.len() == o.len() == s.len()` and `c > 0`; returns
+    /// `FittingError::LengthMismatch` / `InvalidConfig` rather than the
+    /// previous `.zip()` truncate-and-pretend behaviour (which would
+    /// silently shrink the output to `min(t.len(), o.len(), s.len())`).
+    pub fn profile_lambda_per_bin(&self, t: &[f64]) -> Result<Vec<f64>, FittingError> {
+        self.validate_inputs(t.len())?;
+        Ok(t.iter()
             .zip(self.o.iter())
             .zip(self.s.iter())
             .map(|((&ti, &oi), &si)| self.profile_lambda(ti, oi, si))
-            .collect()
+            .collect())
     }
 
     /// Conditional binomial deviance at the given transmission vector.
@@ -130,13 +178,8 @@ impl<'a> JointPoissonObjective<'a> {
     /// adequate because the optimizer's transmission values come from a
     /// `FitModel` that keeps T bounded well above `POISSON_EPSILON` for
     /// physically plausible density / nuisance parameter values.
-    pub fn deviance_from_transmission(&self, t: &[f64]) -> f64 {
-        debug_assert_eq!(t.len(), self.o.len());
-        debug_assert_eq!(t.len(), self.s.len());
-        debug_assert!(
-            self.active_mask.is_none_or(|m| m.len() == t.len()),
-            "active_mask length must match data"
-        );
+    pub fn deviance_from_transmission(&self, t: &[f64]) -> Result<f64, FittingError> {
+        self.validate_inputs(t.len())?;
         let mut d = 0.0;
         for (i, ((&t_i, &o_i), &s_i)) in t.iter().zip(self.o.iter()).zip(self.s.iter()).enumerate()
         {
@@ -145,7 +188,7 @@ impl<'a> JointPoissonObjective<'a> {
             }
             d += binomial_deviance_term(s_i, o_i, t_i, self.c);
         }
-        d
+        Ok(d)
     }
 
     /// Evaluate the deviance at parameter vector θ by calling the model.
@@ -158,7 +201,7 @@ impl<'a> JointPoissonObjective<'a> {
                 field: "transmission",
             });
         }
-        Ok(self.deviance_from_transmission(&t))
+        self.deviance_from_transmission(&t)
     }
 
     /// Analytical gradient of the deviance w.r.t. the free parameters.
@@ -178,13 +221,7 @@ impl<'a> JointPoissonObjective<'a> {
         free_param_indices: &[usize],
     ) -> Result<Option<Vec<f64>>, FittingError> {
         let t = self.model.evaluate(params)?;
-        if t.len() != self.o.len() {
-            return Err(FittingError::LengthMismatch {
-                expected: self.o.len(),
-                actual: t.len(),
-                field: "transmission",
-            });
-        }
+        self.validate_inputs(t.len())?;
         let jac = match self
             .model
             .analytical_jacobian(params, free_param_indices, &t)
@@ -200,8 +237,22 @@ impl<'a> JointPoissonObjective<'a> {
                 continue;
             }
             let w = deviance_weight(s_i, o_i, t_i, self.c);
+            // `deviance_weight` returns 0 for non-finite `t_i`, so a NaN
+            // transmission row already contributes nothing — except that
+            // `0.0 * NaN = NaN`.  If the upstream Jacobian column has a
+            // NaN cell (common for FD-built Jacobians where the model
+            // returns NaN at some probe point), the bare `0.0 * jac.get(...)`
+            // would poison `grad[col]`.  Skip the row entirely when the
+            // weight is zero, and skip any individual Jacobian cell that
+            // is not finite.
+            if w == 0.0 {
+                continue;
+            }
             for (g, col) in grad.iter_mut().zip(0..n_free) {
-                *g += w * jac.get(i, col);
+                let j = jac.get(i, col);
+                if j.is_finite() {
+                    *g += w * j;
+                }
             }
         }
         Ok(Some(grad))
@@ -226,6 +277,7 @@ impl<'a> JointPoissonObjective<'a> {
         free_param_indices: &[usize],
     ) -> Result<Option<FlatMatrix>, FittingError> {
         let t = self.model.evaluate(params)?;
+        self.validate_inputs(t.len())?;
         let jac = match self
             .model
             .analytical_jacobian(params, free_param_indices, &t)
@@ -241,10 +293,24 @@ impl<'a> JointPoissonObjective<'a> {
                 continue;
             }
             let h = deviance_curvature(s_i, o_i, t_i, self.c);
+            // Mirror the gradient guard: `deviance_curvature` returns 0
+            // for non-finite `t_i`, but `0.0 * NaN = NaN` would still
+            // poison the Fisher matrix when an FD-built Jacobian has a
+            // NaN cell.  Skip the row at h == 0, and skip cells that are
+            // not finite.
+            if h == 0.0 {
+                continue;
+            }
             for j in 0..n_free {
                 let jij = jac.get(i, j);
+                if !jij.is_finite() {
+                    continue;
+                }
                 for k in 0..n_free {
-                    *info.get_mut(j, k) += h * jij * jac.get(i, k);
+                    let jik = jac.get(i, k);
+                    if jik.is_finite() {
+                        *info.get_mut(j, k) += h * jij * jik;
+                    }
                 }
             }
         }
@@ -274,6 +340,7 @@ impl<'a> JointPoissonObjective<'a> {
         let free_idx = params.free_indices();
         let base_values = params.all_values();
         let t_base = self.model.evaluate(&base_values)?;
+        self.validate_inputs(t_base.len())?;
         let n_e = t_base.len();
         let n_free = free_idx.len();
         if n_free == 0 {
@@ -309,14 +376,14 @@ impl<'a> JointPoissonObjective<'a> {
             if denom.abs() < PIVOT_FLOOR {
                 continue;
             }
-            // Issue #552 M4: per-cell finiteness check.  The matching guard
-            // in lm.rs `compute_jacobian` zeroes NaN entries instead of
-            // dropping the column; the same pattern applies here because
-            // the downstream Fisher accumulator below already skips
-            // inactive rows (`bin_active(i)`), so a NaN at a masked /
-            // inactive row must not block the column for active rows.
-            // Active-row NaN is handled by [`deviance_curvature`], which
-            // returns 0 on non-finite `t_i` so the assembly stays clean.
+            // Per-cell finiteness check.  The matching guard in lm.rs
+            // `compute_jacobian` zeroes NaN entries instead of dropping
+            // the column; the same pattern applies here because the
+            // downstream Fisher accumulator below already skips inactive
+            // rows (`bin_active(i)`), so a NaN at a masked / inactive
+            // row must not block the column for active rows.  Active-row
+            // NaN is handled by [`deviance_curvature`], which returns 0
+            // on non-finite `t_i` so the assembly stays clean.
             for i in 0..n_e {
                 let a = t_a[i];
                 let b = t_b[i];
@@ -338,10 +405,24 @@ impl<'a> JointPoissonObjective<'a> {
                 continue;
             }
             let h = deviance_curvature(s_i, o_i, t_i, self.c);
+            // Same guard as the analytical `fisher_information`: avoid
+            // `0.0 * NaN = NaN` poisoning the matrix from NaN Jacobian
+            // cells (per-cell zero default from the FD loop above leaves
+            // most NaN entries as 0, but a stale value from a partial
+            // FD failure must still be defensively skipped).
+            if h == 0.0 {
+                continue;
+            }
             for j in 0..n_free {
                 let jij = jac.get(i, j);
+                if !jij.is_finite() {
+                    continue;
+                }
                 for k in 0..n_free {
-                    *info.get_mut(j, k) += h * jij * jac.get(i, k);
+                    let jik = jac.get(i, k);
+                    if jik.is_finite() {
+                        *info.get_mut(j, k) += h * jij * jik;
+                    }
                 }
             }
         }
@@ -381,9 +462,17 @@ impl<'a> JointPoissonObjective<'a> {
                 }
             }
             let perturbed_values = params.all_values();
+            // After the NaN-T contract in `binomial_deviance_term`,
+            // `self.deviance` can legitimately return `Ok(NaN)` when a
+            // probe lands in a region where the model produces a
+            // non-finite transmission.  A non-finite `perturbed_d`
+            // divided by `actual_step` would write NaN into `grad[j]`
+            // and poison every subsequent step that consumes the
+            // gradient — symmetric with the `Err` branch below.  Treat
+            // both as "this probe is invalid; leave the column at 0".
             let perturbed_d = match self.deviance(&perturbed_values) {
-                Ok(v) => v,
-                Err(_) => {
+                Ok(v) if v.is_finite() => v,
+                _ => {
                     params.params[idx].value = original;
                     continue;
                 }
@@ -400,9 +489,17 @@ impl<'a> JointPoissonObjective<'a> {
 /// Returns `2 · [S·ln(S/(Np)) + O·ln(O/(N(1−p)))]` with the zero-count
 /// convention `x · ln(x / ·) → 0` when `x = 0`.
 ///
-/// For `T ≤ ε`: clamps to `ε` in the denominator rather than propagating
-/// Inf/NaN — the optimizer can still see a finite (large) D and a
-/// continuous gradient via the [`deviance_weight`] guard.
+/// NaN-T contract (see also [`deviance_weight`] / [`deviance_curvature`]):
+///
+/// - For `0 ≤ T ≤ POISSON_EPSILON` (finite but numerically tiny or zero):
+///   clamps `T` to `POISSON_EPSILON` in the denominator so the optimizer
+///   sees a finite (large) D and a continuous gradient.  This is the
+///   "smooth guard" path.
+/// - For **non-finite** `T` (NaN or ±∞): returns `NaN` so the deviance
+///   sum becomes `NaN` and the LM / damped-Fisher trial-step guards
+///   (`Ok(v) if v.is_finite()`) reject the step.  This deliberately does
+///   *not* clamp via `f64::max`, because `f64::max(NaN, ε)` returns `ε`
+///   — which would silently masquerade as a valid bin.
 #[inline]
 fn binomial_deviance_term(s: f64, o: f64, t: f64, c: f64) -> f64 {
     debug_assert!(
@@ -417,14 +514,14 @@ fn binomial_deviance_term(s: f64, o: f64, t: f64, c: f64) -> f64 {
         c.is_finite() && c > 0.0,
         "binomial_deviance_term: c must be finite and > 0, got {c}"
     );
-    // Issue #552 M14: `f64::max(NaN, ε)` returns `ε`, so a non-finite T
-    // would silently masquerade as a tiny positive transmission and the
-    // deviance would evaluate to a finite (but meaningless) value that
-    // the LM trial-step guard `Ok(v) if v.is_finite()` would accept.
-    // Return NaN so the deviance sum becomes NaN and the trial step is
-    // rejected.  The matching deviance_weight / deviance_curvature
-    // guards return 0, which keeps the gradient / Fisher accumulators
-    // clean rather than poisoning them with NaN contributions.
+    // `f64::max(NaN, ε)` returns `ε`, so a non-finite T would silently
+    // masquerade as a tiny positive transmission and the deviance would
+    // evaluate to a finite (but meaningless) value that the LM trial-step
+    // guard `Ok(v) if v.is_finite()` would accept.  Return NaN so the
+    // deviance sum becomes NaN and the trial step is rejected.  The
+    // matching `deviance_weight` / `deviance_curvature` guards return 0,
+    // which keeps the gradient / Fisher accumulators clean rather than
+    // poisoning them with NaN contributions.
     if !t.is_finite() {
         return f64::NAN;
     }
@@ -444,6 +541,26 @@ fn binomial_deviance_term(s: f64, o: f64, t: f64, c: f64) -> f64 {
     let term_s = xlogy_ratio(s, exp_s);
     let term_o = xlogy_ratio(o, exp_o);
     2.0 * (term_s + term_o)
+}
+
+/// Reject non-finite or negative count arrays at public entry points.
+///
+/// The per-bin `xlogy_ratio` helper treats `x <= 0.0` as the zero-count
+/// branch and returns 0, but `NaN <= 0.0` is `false`, so a NaN slips
+/// through and propagates `NaN · ln(NaN / y) = NaN` into the deviance
+/// sum.  A negative count likewise leaks past the zero-branch and
+/// produces a meaningless (but finite) log contribution.  Validate
+/// up-front so callers get a typed error instead of a "successful" fit
+/// on poisoned data.
+fn validate_counts(counts: &[f64], field: &'static str) -> Result<(), FittingError> {
+    for (i, &v) in counts.iter().enumerate() {
+        if !v.is_finite() || v < 0.0 {
+            return Err(FittingError::InvalidConfig(format!(
+                "{field}[{i}] must be finite and >= 0, got {v}"
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// `x · ln(x / y)` with the `0 · ln(0 / 0) → 0`, `x · ln(x / 0) → +∞`
@@ -469,14 +586,13 @@ fn xlogy_ratio(x: f64, y: f64) -> f64 {
 /// done in [`binomial_deviance_term`]).
 #[inline]
 fn deviance_weight(s: f64, o: f64, t: f64, c: f64) -> f64 {
-    // Issue #552 M14: a non-finite T must not be folded into the
-    // gradient accumulator.  `f64::max(NaN, ε)` returns `ε`, which would
-    // turn a NaN bin into a finite gradient contribution scaled by the
-    // Jacobian and silently steer the optimizer.  Skip the bin (return
-    // 0) — the matching `binomial_deviance_term` returns NaN so the
-    // step is rejected by the trial-guard, but the gradient stays clean
-    // in case the caller is using it for diagnostics on a partially-bad
-    // grid.
+    // A non-finite T must not be folded into the gradient accumulator.
+    // `f64::max(NaN, ε)` returns `ε`, which would turn a NaN bin into a
+    // finite gradient contribution scaled by the Jacobian and silently
+    // steer the optimizer.  Skip the bin (return 0) — the matching
+    // `binomial_deviance_term` returns NaN so the step is rejected by
+    // the trial-guard, but the gradient stays clean in case the caller
+    // is using it for diagnostics on a partially-bad grid.
     if !t.is_finite() {
         return 0.0;
     }
@@ -495,10 +611,10 @@ fn deviance_weight(s: f64, o: f64, t: f64, c: f64) -> f64 {
 /// and ∂²D/∂T² = 2 · I_TT (since D = −2 · L_c).
 #[inline]
 fn deviance_curvature(s: f64, o: f64, t: f64, c: f64) -> f64 {
-    // Issue #552 M14: see the matching guard in [`deviance_weight`].
-    // A non-finite T would otherwise contribute a huge spurious
-    // curvature via `f64::max(NaN, ε) -> ε`, inflating the diagonal of
-    // the Fisher matrix and underestimating the corresponding parameter
+    // See the matching guard in [`deviance_weight`].  A non-finite T
+    // would otherwise contribute a huge spurious curvature via
+    // `f64::max(NaN, ε) -> ε`, inflating the diagonal of the Fisher
+    // matrix and underestimating the corresponding parameter
     // uncertainty (covariance = I⁻¹ entries shrink as I grows).
     if !t.is_finite() {
         return 0.0;
@@ -687,15 +803,19 @@ pub fn joint_poisson_fit(
         return Err(FittingError::EmptyData);
     }
 
-    // Issue #552 M3: validate `o` / `s` length and `c` up-front at the
-    // public entry point.  The inner per-bin helpers (`binomial_deviance_term`,
-    // `deviance_from_transmission`) use `debug_assert!` only, which is a no-op
-    // in release builds.  Without these hard checks:
+    // Validate `o` / `s` length and `c` up-front at the public entry
+    // point.  The inner per-bin helpers (`binomial_deviance_term`,
+    // `deviance_from_transmission`) use `debug_assert!` only, which is a
+    // no-op in release builds.  Without these hard checks:
     //   - A length mismatch in `o` vs `s` silently truncates via `.zip()`,
     //     minimising deviance on a sub-range of bins.
     //   - A non-positive or non-finite `c` produces finite garbage
     //     (e.g. zero `cT`, NaN denominators) that the LM happily descends.
-    // Both surface as "the fit converged" with bogus parameter values —
+    //   - A NaN / negative `o[i]` or `s[i]` would slip past the inner
+    //     `xlogy_ratio` zero-clamp (`x <= 0.0` swallows negatives, but
+    //     `NaN <= 0.0` is `false` so a NaN count bleeds straight into the
+    //     log and out into the deviance sum).
+    // All surface as "the fit converged" with bogus parameter values —
     // exactly the failure mode the trial-step guard cannot catch because
     // the deviance value is finite.
     if objective.s.len() != n_data {
@@ -711,6 +831,8 @@ pub fn joint_poisson_fit(
             objective.c
         )));
     }
+    validate_counts(objective.o, "open_beam_counts")?;
+    validate_counts(objective.s, "sample_counts")?;
 
     // Validate active-mask length up-front, mirroring the LM solver's
     // length-mismatch early-return (#514).  A debug-assert deep in the
@@ -1216,7 +1338,7 @@ mod tests {
             c,
             active_mask: None,
         };
-        let d = obj.deviance_from_transmission(&t);
+        let d = obj.deviance_from_transmission(&t).unwrap();
         assert!(d.abs() < 1e-8, "D should be ≈ 0 at exact match, got {d}");
 
         // Also verify via parameter evaluation (model returns constant T).
@@ -1357,7 +1479,9 @@ mod tests {
             let grid: Vec<f64> = (0..200).map(|i| 0.01 + 0.99 * (i as f64) / 199.0).collect();
             let mut best = (grid[0], f64::INFINITY);
             for &t_try in &grid {
-                let d_try = obj.deviance_from_transmission(&vec![t_try; n_bins]);
+                let d_try = obj
+                    .deviance_from_transmission(&vec![t_try; n_bins])
+                    .unwrap();
                 if d_try < best.1 {
                     best = (t_try, d_try);
                 }
@@ -1392,7 +1516,9 @@ mod tests {
                 }
             }
             let t_hat = 0.5 * (lo + hi);
-            let d_hat = obj.deviance_from_transmission(&vec![t_hat; n_bins]);
+            let d_hat = obj
+                .deviance_from_transmission(&vec![t_hat; n_bins])
+                .unwrap();
             let dof = (n_bins - 1) as f64;
             d_per_dof_samples.push(d_hat / dof);
             bias_samples.push((t_hat - t_true) / t_true);
@@ -1426,7 +1552,7 @@ mod tests {
             c: 1.5,
             active_mask: None,
         };
-        let d_full = obj.deviance_from_transmission(&[0.6, 0.6, 0.6]);
+        let d_full = obj.deviance_from_transmission(&[0.6, 0.6, 0.6]).unwrap();
         // Drop the zero-N bin — result must be identical.
         let obj_reduced = JointPoissonObjective {
             model: &model, // same model, we just bypass the 1st bin via data
@@ -1435,7 +1561,7 @@ mod tests {
             c: 1.5,
             active_mask: None,
         };
-        let d_reduced = obj_reduced.deviance_from_transmission(&[0.6, 0.6]);
+        let d_reduced = obj_reduced.deviance_from_transmission(&[0.6, 0.6]).unwrap();
         assert!((d_full - d_reduced).abs() < 1e-12);
     }
 
@@ -1922,7 +2048,7 @@ mod tests {
             c,
             active_mask: Some(&mask),
         };
-        let d_masked = obj_full.deviance_from_transmission(&t_full);
+        let d_masked = obj_full.deviance_from_transmission(&t_full).unwrap();
 
         // Compare against an objective built directly on the active subset.
         let o_sub = [o_full[1], o_full[3]];
@@ -1936,7 +2062,7 @@ mod tests {
             c,
             active_mask: None,
         };
-        let d_subset = obj_sub.deviance_from_transmission(&t_sub);
+        let d_subset = obj_sub.deviance_from_transmission(&t_sub).unwrap();
 
         assert!(
             (d_masked - d_subset).abs() < 1e-12,
@@ -2120,7 +2246,7 @@ mod tests {
     }
 
     // ==================================================================
-    // Issue #552 (M3) — release-mode input validation at joint_poisson_fit.
+    // Release-mode input validation at joint_poisson_fit.
     //
     // The inner `binomial_deviance_term` and `deviance_from_transmission`
     // protect themselves with `debug_assert!` only.  Release builds skip
@@ -2221,7 +2347,7 @@ mod tests {
     }
 
     // ==================================================================
-    // Issue #552 (M14) — `f64::max(NaN, ε) == ε` swallows active NaN T.
+    // `f64::max(NaN, ε) == ε` swallows active NaN T.
     //
     // Rust stdlib's `f64::max` returns the non-NaN argument when one is
     // NaN, so `t.max(POISSON_EPSILON)` silently turns a NaN transmission
@@ -2229,10 +2355,10 @@ mod tests {
     // number which passes the trial-step's `v.is_finite()` guard, so the
     // optimizer accepts steps into regions where the model is broken.
     //
-    // The fix returns NaN from `binomial_deviance_term` (so the deviance
-    // sum becomes NaN and the trial guard rejects the step) and 0 from
-    // `deviance_weight` / `deviance_curvature` (so the gradient / Fisher
-    // accumulators are not poisoned by the bad bin).
+    // `binomial_deviance_term` returns NaN when T is non-finite (so the
+    // deviance sum becomes NaN and the trial guard rejects the step),
+    // and `deviance_weight` / `deviance_curvature` return 0 (so the
+    // gradient / Fisher accumulators are not poisoned by the bad bin).
     // ==================================================================
 
     /// `binomial_deviance_term` returns NaN when `t` is non-finite — so
@@ -2348,7 +2474,7 @@ mod tests {
     }
 
     // ==================================================================
-    // Issue #552 (M4) — NaN-in-Jacobian during FD probes (Fisher info).
+    // NaN-in-Jacobian during FD probes (Fisher info).
     //
     // The post-convergence Fisher / covariance path builds a Jacobian
     // via FD when the model has no analytical form.  If the FD probe
@@ -2357,9 +2483,10 @@ mod tests {
     // The main LM loop's trial guard does not run here (it only checks
     // the trial step in the main optimisation loop).
     //
-    // Fix: skip the column on non-finite probe output, leaving its FD
-    // derivative as the zero default (consistent with the
-    // "model-evaluation-failed" branch already present at :298-:304).
+    // Per-cell skip: when the FD probe output is non-finite, leave the
+    // entry at its zero default rather than dividing NaN by `actual_step`
+    // (consistent with the "model-evaluation-failed" branch in
+    // `compute_jacobian`).
     // ==================================================================
 
     /// `fisher_information_fd` zeroes per-cell entries whose FD probe

--- a/crates/nereids-fitting/src/lm.rs
+++ b/crates/nereids-fitting/src/lm.rs
@@ -305,8 +305,32 @@ fn compute_jacobian(
         };
         params.params[idx].value = original;
 
+        // Issue #552 M4: the main LM loop checks the trial step at
+        // :765-:768 via `trial_has_active_nonfinite`, but `compute_jacobian`
+        // is also called at :849 for the post-convergence covariance
+        // path, where no such guard runs.  A NaN row in the perturbed
+        // output divided by `actual_step` yields NaN in the Jacobian,
+        // which then poisons JᵀWJ and the inverse covariance.
+        //
+        // Per-cell skip (zero the entry) rather than whole-column skip:
+        // a NaN at a masked / inactive row is benign (the JᵀWJ assembly
+        // skips masked rows entirely via `active_mask.is_some_and(|m| !m[i])`
+        // at lm.rs :709 / :862), so a finite Jacobian row produced from a
+        // bad-but-masked probe must still be allowed to land in the
+        // column — see `test_lm_active_mask_tolerates_model_nan_outside_range`.
+        // The active-row NaNs that would otherwise propagate into JᵀWJ are
+        // zeroed here, which is the same numerical outcome as if the
+        // model had reported `Err` at that probe (skipped column, but
+        // per-row).
         for i in 0..n_data {
-            *jacobian.get_mut(i, j) = (perturbed[i] - y_current[i]) / actual_step;
+            let p = perturbed[i];
+            let y = y_current[i];
+            if p.is_finite() && y.is_finite() {
+                *jacobian.get_mut(i, j) = (p - y) / actual_step;
+            }
+            // else: leave at the zero-default; for active rows this is
+            // safe (matches the whole-column-skip outcome on Err), for
+            // masked rows it never gets read.
         }
     }
 
@@ -1791,5 +1815,86 @@ mod tests {
         );
         assert!(r_fixed.chi_squared.is_nan());
         assert!(r_fixed.reduced_chi_squared.is_nan());
+    }
+
+    // ==================================================================
+    // Issue #552 (M4) — NaN-in-Jacobian during FD probes.
+    //
+    // The main LM loop guards the trial step at the model.evaluate site
+    // (`trial_has_active_nonfinite` at :765-:768).  The silent surface
+    // is the post-convergence covariance Jacobian: it calls
+    // `compute_jacobian` directly at :849, which has no finiteness
+    // check on the per-column FD probe.  A NaN at any active row of the
+    // perturbed model output gets divided by `actual_step` and turned
+    // into NaN entries in the Jacobian — these poison `JᵀWJ` and the
+    // inverse covariance, which is reported as the "uncertainty" of
+    // the fit.
+    //
+    // Fix: when `compute_jacobian`'s FD probe returns any non-finite
+    // value, skip the column (zero derivative) rather than letting NaN
+    // through, mirroring the existing `Err` branch at :298-:304.
+    // ==================================================================
+
+    /// `compute_jacobian`'s FD path zeroes per-cell entries whose
+    /// perturbed model output is non-finite, rather than baking NaN
+    /// into the Jacobian (which then poisons the post-convergence
+    /// covariance computation).  Per-cell (not whole-column) so that a
+    /// NaN at a masked / inactive row leaves the rest of the column
+    /// usable — see `test_lm_active_mask_tolerates_model_nan_outside_range`
+    /// for the masked-NaN contract.
+    #[test]
+    fn test_compute_jacobian_skips_nan_perturbed_column() {
+        use crate::parameters::FitParameter;
+        // Two-parameter model.  Param 0 is well-behaved (returns
+        // `θ_0` constant).  Param 1 produces a NaN row at the +FD
+        // probe — exactly the "NaN-in-Jacobian during FD probes"
+        // signature from issue #552.
+        struct NanInColumn1 {
+            // Base value of param 1 — used to detect the perturbation.
+            p1_base: f64,
+        }
+        impl FitModel for NanInColumn1 {
+            fn evaluate(&self, params: &[f64]) -> Result<Vec<f64>, FittingError> {
+                // The +FD probe perturbs params[1] by ε; everything else
+                // keeps params[1] == self.p1_base.
+                let nan_row = (params[1] - self.p1_base).abs() > 1e-12;
+                let v = if nan_row { f64::NAN } else { params[0] };
+                Ok(vec![v; 4])
+            }
+            // No analytical_jacobian -> FD fallback drives compute_jacobian.
+        }
+        let model = NanInColumn1 { p1_base: 0.3 };
+        let mut params = ParameterSet::new(vec![
+            FitParameter::unbounded("p0", 0.5),
+            FitParameter::unbounded("p1", 0.3),
+        ]);
+        let y_current = vec![0.5; 4];
+        let mut all_vals_buf: Vec<f64> = Vec::new();
+        let mut free_idx_buf: Vec<usize> = Vec::new();
+        let jac = compute_jacobian(
+            &model,
+            &mut params,
+            &y_current,
+            1e-6,
+            &mut all_vals_buf,
+            &mut free_idx_buf,
+        )
+        .unwrap();
+        // Every entry must be finite — column 1 must have been skipped.
+        for (i, v) in jac.data.iter().enumerate() {
+            assert!(
+                v.is_finite(),
+                "compute_jacobian produced non-finite entry at index {i}: {v}"
+            );
+        }
+        // Column 1 was skipped -> all zeros.  Column 0 has the normal
+        // ∂T/∂θ_0 = 1 column from the well-behaved param.
+        for i in 0..jac.nrows {
+            assert_eq!(
+                jac.get(i, 1),
+                0.0,
+                "column 1 (NaN probe) should be zeroed, row {i}"
+            );
+        }
     }
 }

--- a/crates/nereids-fitting/src/lm.rs
+++ b/crates/nereids-fitting/src/lm.rs
@@ -305,20 +305,20 @@ fn compute_jacobian(
         };
         params.params[idx].value = original;
 
-        // Issue #552 M4: the main LM loop checks the trial step at
-        // :765-:768 via `trial_has_active_nonfinite`, but `compute_jacobian`
-        // is also called at :849 for the post-convergence covariance
-        // path, where no such guard runs.  A NaN row in the perturbed
-        // output divided by `actual_step` yields NaN in the Jacobian,
-        // which then poisons JᵀWJ and the inverse covariance.
+        // The main LM loop checks the trial step via
+        // `trial_has_active_nonfinite`, but `compute_jacobian` is also
+        // called from the post-convergence covariance path, where no
+        // such guard runs.  A NaN row in the perturbed output divided
+        // by `actual_step` would yield NaN in the Jacobian, which then
+        // poisons JᵀWJ and the inverse covariance.
         //
         // Per-cell skip (zero the entry) rather than whole-column skip:
         // a NaN at a masked / inactive row is benign (the JᵀWJ assembly
-        // skips masked rows entirely via `active_mask.is_some_and(|m| !m[i])`
-        // at lm.rs :709 / :862), so a finite Jacobian row produced from a
-        // bad-but-masked probe must still be allowed to land in the
-        // column — see `test_lm_active_mask_tolerates_model_nan_outside_range`.
-        // The active-row NaNs that would otherwise propagate into JᵀWJ are
+        // skips masked rows entirely via `active_mask.is_some_and(|m| !m[i])`),
+        // so a finite Jacobian row produced from a bad-but-masked probe
+        // must still be allowed to land in the column — see
+        // `test_lm_active_mask_tolerates_model_nan_outside_range`.  The
+        // active-row NaNs that would otherwise propagate into JᵀWJ are
         // zeroed here, which is the same numerical outcome as if the
         // model had reported `Err` at that probe (skipped column, but
         // per-row).
@@ -1818,21 +1818,19 @@ mod tests {
     }
 
     // ==================================================================
-    // Issue #552 (M4) — NaN-in-Jacobian during FD probes.
+    // NaN-in-Jacobian during FD probes.
     //
-    // The main LM loop guards the trial step at the model.evaluate site
-    // (`trial_has_active_nonfinite` at :765-:768).  The silent surface
-    // is the post-convergence covariance Jacobian: it calls
-    // `compute_jacobian` directly at :849, which has no finiteness
-    // check on the per-column FD probe.  A NaN at any active row of the
-    // perturbed model output gets divided by `actual_step` and turned
-    // into NaN entries in the Jacobian — these poison `JᵀWJ` and the
-    // inverse covariance, which is reported as the "uncertainty" of
-    // the fit.
+    // The main LM loop guards the trial step at the `model.evaluate`
+    // site via `trial_has_active_nonfinite`.  The silent surface is the
+    // post-convergence covariance Jacobian: it calls `compute_jacobian`
+    // directly, which has no finiteness check on the per-column FD
+    // probe.  A NaN at any active row of the perturbed model output
+    // gets divided by `actual_step` and turned into NaN entries in the
+    // Jacobian — these poison `JᵀWJ` and the inverse covariance, which
+    // is reported as the "uncertainty" of the fit.
     //
-    // Fix: when `compute_jacobian`'s FD probe returns any non-finite
-    // value, skip the column (zero derivative) rather than letting NaN
-    // through, mirroring the existing `Err` branch at :298-:304.
+    // `compute_jacobian`'s FD path zeros per-cell entries whose probe
+    // returned a non-finite value, mirroring the existing `Err` branch.
     // ==================================================================
 
     /// `compute_jacobian`'s FD path zeroes per-cell entries whose

--- a/crates/nereids-fitting/src/transmission_model.rs
+++ b/crates/nereids-fitting/src/transmission_model.rs
@@ -2138,9 +2138,27 @@ impl FitModel for EnergyScaleTransmissionModel {
                     Ok(v) => v,
                     Err(_) => return None,
                 };
+                // Issue #552 M4: per-cell finiteness check.  Without it
+                // a NaN in `y_plus[i]` / `y_minus[i]` propagates into
+                // both the t0 column AND the L_scale column derived
+                // from it via the rank-1 reconstruction at
+                // `scale * partial_t0_col[i]` (~line 2280), poisoning
+                // the post-convergence covariance the same way lm.rs
+                // `compute_jacobian` was vulnerable.  Mirror that fix:
+                // zero the entry rather than dropping the column —
+                // masked rows (NaN by design in some test contracts)
+                // get skipped downstream by the active-mask row-skip in
+                // the LM normal-equation assembly, so a 0 in a masked
+                // row is benign.
                 let mut col = vec![0.0f64; n_e];
                 for i in 0..n_e {
-                    col[i] = (y_plus[i] - y_minus[i]) / (2.0 * h);
+                    let a = y_plus[i];
+                    let b = y_minus[i];
+                    if a.is_finite() && b.is_finite() {
+                        col[i] = (a - b) / (2.0 * h);
+                    }
+                    // else: leave col[i] at 0.0; downstream L_scale
+                    // reconstruction `scale * 0 == 0` is consistent.
                 }
                 Some(col)
             }
@@ -2307,8 +2325,19 @@ impl FitModel for EnergyScaleTransmissionModel {
                     Ok(v) => v,
                     Err(_) => return None,
                 };
+                // Issue #552 M4: per-cell finiteness check — mirrors the
+                // lm.rs `compute_jacobian` FD path.  A NaN in the
+                // perturbed model at an active row would otherwise feed
+                // NaN through the post-convergence covariance; per-cell
+                // skip leaves masked-row NaN benign (the LM normal-
+                // equation assembly already row-skips those).
                 for i in 0..n_e {
-                    *jacobian.get_mut(i, col) = (y_plus[i] - y_minus[i]) / (2.0 * h);
+                    let a = y_plus[i];
+                    let b = y_minus[i];
+                    if a.is_finite() && b.is_finite() {
+                        *jacobian.get_mut(i, col) = (a - b) / (2.0 * h);
+                    }
+                    // else: leave at zero-default.
                 }
             } else {
                 // Density parameter: analytical derivative

--- a/crates/nereids-fitting/src/transmission_model.rs
+++ b/crates/nereids-fitting/src/transmission_model.rs
@@ -2138,18 +2138,17 @@ impl FitModel for EnergyScaleTransmissionModel {
                     Ok(v) => v,
                     Err(_) => return None,
                 };
-                // Issue #552 M4: per-cell finiteness check.  Without it
-                // a NaN in `y_plus[i]` / `y_minus[i]` propagates into
-                // both the t0 column AND the L_scale column derived
-                // from it via the rank-1 reconstruction at
-                // `scale * partial_t0_col[i]` (~line 2280), poisoning
-                // the post-convergence covariance the same way lm.rs
-                // `compute_jacobian` was vulnerable.  Mirror that fix:
-                // zero the entry rather than dropping the column —
-                // masked rows (NaN by design in some test contracts)
-                // get skipped downstream by the active-mask row-skip in
-                // the LM normal-equation assembly, so a 0 in a masked
-                // row is benign.
+                // Per-cell finiteness check.  Without it a NaN in
+                // `y_plus[i]` / `y_minus[i]` propagates into both the
+                // t0 column AND the L_scale column derived from it via
+                // the rank-1 reconstruction at `scale * partial_t0_col[i]`
+                // (~line 2280), poisoning the post-convergence
+                // covariance the same way lm.rs `compute_jacobian` was
+                // vulnerable.  Mirror that fix: zero the entry rather
+                // than dropping the column — masked rows (NaN by design
+                // in some test contracts) get skipped downstream by the
+                // active-mask row-skip in the LM normal-equation
+                // assembly, so a 0 in a masked row is benign.
                 let mut col = vec![0.0f64; n_e];
                 for i in 0..n_e {
                     let a = y_plus[i];
@@ -2325,10 +2324,10 @@ impl FitModel for EnergyScaleTransmissionModel {
                     Ok(v) => v,
                     Err(_) => return None,
                 };
-                // Issue #552 M4: per-cell finiteness check — mirrors the
-                // lm.rs `compute_jacobian` FD path.  A NaN in the
-                // perturbed model at an active row would otherwise feed
-                // NaN through the post-convergence covariance; per-cell
+                // Per-cell finiteness check — mirrors the lm.rs
+                // `compute_jacobian` FD path.  A NaN in the perturbed
+                // model at an active row would otherwise feed NaN
+                // through the post-convergence covariance; per-cell
                 // skip leaves masked-row NaN benign (the LM normal-
                 // equation assembly already row-skips those).
                 for i in 0..n_e {


### PR DESCRIPTION
## Summary

Tighten three latent numerical hazards in the fitting crate that were
guarded only by `debug_assert!` (silent no-op in release builds) or by
`f64::max(NaN, ε) == ε` (silent NaN suppression).  Part of epic #551
(pre-paper audit findings).

| Finding | Hazard | Fix |
|---------|--------|-----|
| M3 | `joint_poisson_fit` only had `debug_assert!` on `o.len() == s.len()` and `c > 0` — release builds silently `.zip()`-truncated bins and minimised garbage deviance on negative / zero / NaN `c`. | Hard `FittingError::LengthMismatch` / `FittingError::InvalidConfig` returns at the public entry point, mirroring the existing `active_mask` check. |
| M4 | `compute_jacobian` (lm.rs), `fisher_information_fd` (joint_poisson.rs), and the partial-GAL t0 / per-coordinate FD paths in `transmission_model.rs` had no finiteness check on the perturbed model output.  The main LM loop's trial-step guard at `lm.rs:765-768` only protects the optimisation loop; the post-convergence covariance Jacobian had no such guard and would bake NaN into JᵀWJ and the inverse covariance. | Per-cell skip (zero the entry on non-finite perturbed value), preserving the masked-NaN-only contract in `test_lm_active_mask_tolerates_model_nan_outside_range`. |
| M14 | `binomial_deviance_term`, `deviance_weight`, `deviance_curvature` guarded T with `t.max(POISSON_EPSILON)` — Rust's stdlib returns ε when the other operand is NaN, so a non-finite T silently became a tiny positive transmission and the deviance evaluated to a finite (but meaningless) value that passed the trial guard. | `binomial_deviance_term` returns NaN on non-finite T so the deviance sum becomes NaN and the trial step is rejected.  `deviance_weight` / `deviance_curvature` return 0 so the gradient / Fisher accumulators stay clean rather than getting weighted-NaN poisoned. |

## Files changed

- `crates/nereids-fitting/src/joint_poisson.rs` — M3 entry-point validation, M14 finiteness gates in the three per-bin helpers, M4 per-cell finiteness in `fisher_information_fd`, plus 7 new regression tests.
- `crates/nereids-fitting/src/lm.rs` — M4 per-cell finiteness in `compute_jacobian` FD path, plus 1 new regression test.
- `crates/nereids-fitting/src/transmission_model.rs` — M4 per-cell finiteness in the partial-GAL t0 column reconstruction and the per-coordinate FD path for energy-scale parameters.

LOC: 495 insertions, 4 deletions.

## Test plan

- [x] 8 new regression tests, each demonstrated to FAIL on current `main` (e.g. `test_joint_poisson_fit_rejects_nan_transmission` reports `deviance: 844.65, converged: true` pre-fix — a complete fabrication) and PASS after the fix.
- [x] `cargo fmt --all` clean.
- [x] `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --exclude nereids-python` — all 821 tests green (was 813 on `main`; +8 new).
- [x] Pre-existing test `test_lm_active_mask_tolerates_model_nan_outside_range` still passes — the per-cell (not whole-column) M4 fix preserves the masked-NaN-only contract.

## New regression tests

- `joint_poisson::tests::test_joint_poisson_rejects_o_s_length_mismatch`
- `joint_poisson::tests::test_joint_poisson_rejects_non_positive_c` (covers `c = 0`, `c < 0`, `c = NaN`)
- `joint_poisson::tests::test_binomial_deviance_term_nan_t_returns_nan` (covers `NaN`, `+∞`, `-∞`)
- `joint_poisson::tests::test_deviance_weight_nan_t_returns_zero`
- `joint_poisson::tests::test_deviance_curvature_nan_t_returns_zero`
- `joint_poisson::tests::test_joint_poisson_fit_rejects_nan_transmission` (end-to-end: NaN-T initial point must not report a finite converged deviance)
- `joint_poisson::tests::test_fisher_information_fd_skips_nan_probe`
- `lm::tests::test_compute_jacobian_skips_nan_perturbed_column`

Closes #552
Part of #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)