### PR TITLE
fix(fitting): joint_poisson all-fixed NaN must not report gn_converged

### DIFF
--- a/crates/nereids-fitting/src/joint_poisson.rs
+++ b/crates/nereids-fitting/src/joint_poisson.rs
@@ -1096,7 +1096,16 @@ fn damped_fisher_stage(
         let free_idx = params.free_indices();
         let n_free = free_idx.len();
         if n_free == 0 {
-            converged = true;
+            // All parameters fixed: we are not optimizing; convergence is
+            // well-defined only if the already-computed deviance at the
+            // current parameters is finite.  If the model returned
+            // non-finite transmission, `binomial_deviance_term` propagates
+            // that as NaN deviance (see the non-finite-T contract at
+            // lines 525-554 / 552), and a non-finite deviance cannot be
+            // reported as a converged fit.  LM applies the same guard in
+            // its `n_free == 0` path at `lm.rs:584-607`; the matching LM
+            // regression is `test_all_fixed_params_nan_model`.
+            converged = d_current.is_finite();
             break;
         }
 
@@ -2508,6 +2517,66 @@ mod tests {
                 // Acceptable: hard error from the initial evaluation.
             }
         }
+    }
+
+    /// All-fixed parameters + NaN transmission must NOT be reported as
+    /// `gn_converged = true`.
+    ///
+    /// The `n_free == 0` shortcut in `damped_fisher_stage` previously set
+    /// `converged = true` unconditionally, so a fit with every parameter
+    /// fixed and a model that returns NaN at active bins would return
+    /// `deviance = NaN` together with `gn_converged = true`.  Downstream
+    /// pipeline code (`pipeline.rs`'s `gn_converged || polish_converged`)
+    /// would then surface that pixel as a "converged" fit in the spatial
+    /// map.  The guard at the top of `damped_fisher_stage` now keys
+    /// convergence off `d_current.is_finite()`.
+    ///
+    /// Mirrors `lm.rs::test_all_fixed_params_nan_model` (issue #125.1),
+    /// which exercises the equivalent guard in
+    /// `levenberg_marquardt_with_mask`.
+    #[test]
+    fn test_joint_poisson_all_fixed_nan_transmission_does_not_converge() {
+        struct NanModel {
+            n_e: usize,
+        }
+        impl FitModel for NanModel {
+            fn evaluate(&self, _params: &[f64]) -> Result<Vec<f64>, FittingError> {
+                Ok(vec![f64::NAN; self.n_e])
+            }
+        }
+
+        let n_bins = 5;
+        let o = vec![10.0; n_bins];
+        let s = vec![5.0; n_bins];
+        let model = NanModel { n_e: n_bins };
+        let obj = JointPoissonObjective {
+            model: &model,
+            o: &o,
+            s: &s,
+            c: 1.0,
+            active_mask: None,
+        };
+        let mut params = ParameterSet::new(vec![FitParameter::fixed("T", 0.5)]);
+        let cfg = JointPoissonFitConfig::default();
+
+        let r = joint_poisson_fit(&obj, &mut params, &cfg).unwrap();
+
+        assert!(
+            r.deviance.is_nan(),
+            "expected NaN deviance from all-fixed NaN model; got {}",
+            r.deviance
+        );
+        assert!(
+            r.deviance_per_dof.is_nan(),
+            "expected NaN deviance_per_dof; got {}",
+            r.deviance_per_dof
+        );
+        assert!(
+            !r.gn_converged,
+            "all-fixed NaN deviance must not be reported as GN-converged",
+        );
+        assert_eq!(r.n_free, 0);
+        assert_eq!(r.n_active, n_bins);
     }
 
     // ==================================================================

--- a/crates/nereids-fitting/src/joint_poisson.rs
+++ b/crates/nereids-fitting/src/joint_poisson.rs
@@ -948,11 +948,18 @@ pub fn joint_poisson_fit(
     let gn_converged = stage1.converged;
 
     // Stage 2: Nelder-Mead polish on free parameters, seeded from stage-1 θ.
+    //
+    // Guard against the all-fixed configuration: `nelder_mead_minimize`
+    // requires a non-empty `x0` (asserts in `nelder_mead.rs`).  When every
+    // parameter is fixed there is nothing to polish, so skip stage 2 and
+    // leave the polish flags at their default `false` values.  This path
+    // is reachable from pipeline callers that pin all params and set
+    // `with_counts_enable_polish(Some(true))`.
     let mut polish_iterations = 0usize;
     let mut polish_converged = false;
     let mut polish_improved = false;
-    if config.enable_polish {
-        let free_idx = params.free_indices();
+    let free_idx = params.free_indices();
+    if config.enable_polish && !free_idx.is_empty() {
         let bounds: Vec<(f64, f64)> = free_idx
             .iter()
             .map(|&i| (params.params[i].lower, params.params[i].upper))
@@ -1100,11 +1107,11 @@ fn damped_fisher_stage(
             // well-defined only if the already-computed deviance at the
             // current parameters is finite.  If the model returned
             // non-finite transmission, `binomial_deviance_term` propagates
-            // that as NaN deviance (see the non-finite-T contract at
-            // lines 525-554 / 552), and a non-finite deviance cannot be
-            // reported as a converged fit.  LM applies the same guard in
-            // its `n_free == 0` path at `lm.rs:584-607`; the matching LM
-            // regression is `test_all_fixed_params_nan_model`.
+            // that as NaN deviance (see the non-finite-T contract documented
+            // on `binomial_deviance_term`), and a non-finite deviance cannot
+            // be reported as a converged fit.  LM applies the same guard in
+            // the `n_free == 0` branch of `levenberg_marquardt_with_mask`;
+            // the matching LM regression is `test_all_fixed_params_nan_model`.
             converged = d_current.is_finite();
             break;
         }
@@ -2577,6 +2584,85 @@ mod tests {
         );
         assert_eq!(r.n_free, 0);
         assert_eq!(r.n_active, n_bins);
+        // The damped-Fisher loop increments `iter` before the `n_free == 0`
+        // branch hits `break`, so the all-fixed path always reports exactly
+        // one iteration.  Lock that in so future loop refactors don't
+        // silently drift the iteration count.
+        assert_eq!(
+            r.gn_iterations, 1,
+            "all-fixed branch should report exactly one iteration",
+        );
+    }
+
+    /// Companion to [`test_joint_poisson_all_fixed_nan_transmission_does_not_converge`]
+    /// covering the polish-enabled path.
+    ///
+    /// `nelder_mead_minimize` asserts that `x0` is non-empty (see
+    /// `nelder_mead.rs`), which used to panic when stage 2 was invoked with
+    /// every parameter fixed.  The polish entry-point now short-circuits on
+    /// `free_indices().is_empty()`, so the call must return cleanly with
+    /// `polish_converged == false` and the stage-1 NaN deviance preserved.
+    /// Mirrors the pipeline configuration in `nereids-pipeline` where
+    /// `with_counts_enable_polish(Some(true))` is set independently of
+    /// whether the parameter set has any free entries.
+    #[test]
+    fn test_joint_poisson_all_fixed_nan_transmission_with_polish_does_not_panic() {
+        struct NanModel {
+            n_e: usize,
+        }
+        impl FitModel for NanModel {
+            fn evaluate(&self, _params: &[f64]) -> Result<Vec<f64>, FittingError> {
+                Ok(vec![f64::NAN; self.n_e])
+            }
+        }
+
+        let n_bins = 5;
+        let o = vec![10.0; n_bins];
+        let s = vec![5.0; n_bins];
+        let model = NanModel { n_e: n_bins };
+        let obj = JointPoissonObjective {
+            model: &model,
+            o: &o,
+            s: &s,
+            c: 1.0,
+            active_mask: None,
+        };
+        let mut params = ParameterSet::new(vec![FitParameter::fixed("T", 0.5)]);
+        let cfg = JointPoissonFitConfig {
+            enable_polish: true,
+            ..JointPoissonFitConfig::default()
+        };
+
+        // Must not panic — the empty-x0 guard short-circuits stage 2.
+        let r = joint_poisson_fit(&obj, &mut params, &cfg).unwrap();
+
+        assert!(
+            r.deviance.is_nan(),
+            "expected NaN deviance from all-fixed NaN model; got {}",
+            r.deviance
+        );
+        assert!(
+            !r.gn_converged,
+            "all-fixed NaN deviance must not be reported as GN-converged",
+        );
+        assert!(
+            !r.polish_converged,
+            "polish stage must report not-converged when skipped on all-fixed params",
+        );
+        assert!(
+            !r.polish_improved,
+            "polish stage cannot have improved the deviance when it was skipped",
+        );
+        assert_eq!(
+            r.polish_iterations, 0,
+            "polish stage must report zero iterations when skipped",
+        );
+        assert_eq!(r.n_free, 0);
+        assert_eq!(r.n_active, n_bins);
+        assert_eq!(
+            r.gn_iterations, 1,
+            "all-fixed branch should report exactly one iteration",
+        );
     }
 
     // ==================================================================

--- a/crates/nereids-fitting/src/joint_poisson.rs
+++ b/crates/nereids-fitting/src/joint_poisson.rs
@@ -955,11 +955,20 @@ pub fn joint_poisson_fit(
     // leave the polish flags at their default `false` values.  This path
     // is reachable from pipeline callers that pin all params and set
     // `with_counts_enable_polish(Some(true))`.
+    //
+    // Also short-circuit polish when stage 1 ended on a non-finite
+    // deviance: there is no meaningful starting deviance to refine, and
+    // the acceptance test `nm.fun < best_d_stage1` would degrade to
+    // `finite < NaN == false` (discarding the NM result) while
+    // `nm.self_converged` could still be `true`, leaking a spurious
+    // converged flag together with a NaN final deviance.  Mirrors the
+    // LM `n_free == 0` early-return at `lm.rs:584-607`, which refuses to
+    // report a converged fit when the model emits NaN at active bins.
     let mut polish_iterations = 0usize;
     let mut polish_converged = false;
     let mut polish_improved = false;
     let free_idx = params.free_indices();
-    if config.enable_polish && !free_idx.is_empty() {
+    if config.enable_polish && !free_idx.is_empty() && best_d_stage1.is_finite() {
         let bounds: Vec<(f64, f64)> = free_idx
             .iter()
             .map(|&i| (params.params[i].lower, params.params[i].upper))
@@ -2663,6 +2672,78 @@ mod tests {
             r.gn_iterations, 1,
             "all-fixed branch should report exactly one iteration",
         );
+    }
+
+    /// Polish path with at least one **free** parameter must not report
+    /// `polish_converged = true` when stage 1 ended on a non-finite
+    /// deviance.
+    ///
+    /// Without the `best_d_stage1.is_finite()` short-circuit in the polish
+    /// guard, Nelder-Mead would still run and return a finite `nm.fun`
+    /// (its infeasible-point handler maps NaN evaluations to `+∞` and
+    /// contracts away from them).  The commit test `nm.fun < best_d_stage1`
+    /// then reduces to `finite < NaN == false`, so the polish step is
+    /// discarded — but `polish_converged` would inherit `nm.self_converged`
+    /// regardless, leaking a spurious converged flag together with a NaN
+    /// final deviance.  Downstream pipeline code (`pipeline.rs`'s
+    /// `gn_converged || polish_converged`) would then surface that fit as
+    /// converged in the spatial map.
+    ///
+    /// Symmetric to the all-fixed NaN guard above: stage 2 refuses to run
+    /// when there is no finite stage-1 deviance to refine.
+    #[test]
+    fn test_joint_poisson_polish_does_not_report_converged_when_stage1_nan() {
+        struct NanModel {
+            n_e: usize,
+        }
+        impl FitModel for NanModel {
+            fn evaluate(&self, _params: &[f64]) -> Result<Vec<f64>, FittingError> {
+                Ok(vec![f64::NAN; self.n_e])
+            }
+        }
+
+        let n_bins = 5;
+        let o = vec![10.0; n_bins];
+        let s = vec![5.0; n_bins];
+        let model = NanModel { n_e: n_bins };
+        let obj = JointPoissonObjective {
+            model: &model,
+            o: &o,
+            s: &s,
+            c: 1.0,
+            active_mask: None,
+        };
+        // At least one FREE parameter so polish actually runs (unlike
+        // `test_joint_poisson_all_fixed_nan_transmission_with_polish_does_not_panic`,
+        // which exercises the empty-free-set short-circuit instead).
+        let mut params = ParameterSet::new(vec![FitParameter::non_negative("T", 0.5)]);
+        let cfg = JointPoissonFitConfig {
+            enable_polish: true,
+            ..JointPoissonFitConfig::default()
+        };
+
+        let r = joint_poisson_fit(&obj, &mut params, &cfg).unwrap();
+
+        assert!(
+            r.deviance.is_nan(),
+            "expected NaN deviance from NaN model; got {}",
+            r.deviance
+        );
+        assert!(!r.gn_converged, "stage 1 cannot converge on NaN deviance",);
+        assert!(
+            !r.polish_converged,
+            "stage 2 must not report converged when stage 1 ended non-finite",
+        );
+        assert!(
+            !r.polish_improved,
+            "polish cannot have improved a NaN starting deviance",
+        );
+        assert_eq!(
+            r.polish_iterations, 0,
+            "polish must not run when stage 1 is non-finite",
+        );
+        assert_eq!(r.n_free, 1);
+        assert_eq!(r.n_active, n_bins);
     }
 
     // ==================================================================


### PR DESCRIPTION
## Bug (NV-8, sub-issue #571)

`damped_fisher_stage` (`crates/nereids-fitting/src/joint_poisson.rs:1098-1101`) reported `converged = true` for the `n_free == 0` shortcut without inspecting the already-computed `d_current`. Combined with `binomial_deviance_term`'s explicit non-finite-T contract (`joint_poisson.rs:525-554`), which deliberately propagates active NaN transmission as `deviance = NaN` so trial-step guards can reject the step, the result was that `joint_poisson_fit` could return:

- `deviance = NaN`
- `deviance_per_dof = NaN`
- `n_active > 0`, `n_free == 0`
- `gn_converged = true`  ← objectively wrong

The spatial pipeline at `crates/nereids-pipeline/src/pipeline.rs:1625` surfaces `gn_converged || polish_converged` as the user-visible `SpectrumFitResult.converged`. So any pixel with all parameters user-fixed and a model that evaluated to NaN at the fixed parameter vector (e.g. a degenerate temperature/density/resolution combination) would appear in the output spatial map as `converged = true, deviance = NaN`.

## Parallel reference (same bug class, already fixed elsewhere)

LM's `n_free == 0` path applies the equivalent guard at `crates/nereids-fitting/src/lm.rs:584-607` (issue #125.1, `model_has_active_nonfinite`) and is covered by regression test `test_all_fixed_params_nan_model` (`lm.rs:1233-1253`). `poisson.rs::try_early_return_fixed` (`poisson.rs:722-731`) similarly checks `nll.is_finite()` before reporting `converged = true`. The joint-Poisson fitter was the lone outlier among the three solvers — the pattern existed, it just wasn't propagated.

## Fix

One-line change at `joint_poisson.rs:1098-1099`:

```diff
 if n_free == 0 {
-    converged = true;
+    // All parameters fixed: convergence is well-defined only if the
+    // already-computed deviance at the current parameters is finite.
+    converged = d_current.is_finite();
     break;
 }
```

The structural-guard style (check the cost, not the model output) matches `poisson.rs::try_early_return_fixed` and is sufficient because `binomial_deviance_term` already poisons the deviance sum to NaN on any non-finite active T.

## Regression test

`test_joint_poisson_all_fixed_nan_transmission_does_not_converge` (`joint_poisson.rs`, in the existing test module) mirrors `lm.rs::test_all_fixed_params_nan_model`:

- Mock `FitModel` that returns `vec![f64::NAN; n_e]` regardless of parameters.
- All parameters declared `FitParameter::fixed`.
- 5 active bins, default `JointPoissonFitConfig`.
- Asserts `r.deviance.is_nan()`, `r.deviance_per_dof.is_nan()`, `!r.gn_converged`, plus `n_free == 0` and `n_active == n_bins` to pin the path taken.

Pre-fix this test fails (`gn_converged == true`); post-fix it passes.

## Confirmation reports

Both LLM families reached `confirmed-bug` HIGH with the same one-character fix:

- `.research/audit-r2/confirmation/codex/NV-8.md`
- `.research/audit-r2/confirmation/claude/NV-8.md`

## Methodology

This PR is one of 8 fixes (PR-A through PR-H) landing the confirmed bugs from the NEREIDS Audit Round 2 Phase 3b. Each finding was independently re-derived by Claude and Codex with access to the source tree before any code change. Cross-LLM-family agreement at HIGH confidence is the gate for proceeding to a fix; reports disagreeing or sitting at MEDIUM are pulled into a third-pass loop instead. The two NV-8 reports converged on the same `damped_fisher_stage:1099` site, the same fix (`= true` → `= d_current.is_finite()`), and the same LM parallel (`test_all_fixed_params_nan_model`), so the fix shipped without further investigation overhead.

Closes #571.