### PR TITLE
fix(physics): SLBW/MLBW velocity-factor double-count + Doppler grid validation

### DIFF
--- a/crates/nereids-physics/src/doppler.rs
+++ b/crates/nereids-physics/src/doppler.rs
@@ -83,6 +83,36 @@ pub enum DopplerError {
         /// Number of cross-section values.
         cross_sections: usize,
     },
+    /// An energy value is non-finite (NaN/±∞) or non-positive (≤ 0).
+    ///
+    /// The FGM velocity transform computes `v = √E`, so non-positive or
+    /// non-finite energies produce NaN velocities that silently propagate
+    /// through the convolution. Per-point guards in the convolution loop
+    /// rely on `v < FLOOR` comparisons which evaluate to `false` for NaN
+    /// (see "NaN bypasses guards" project convention), so the function
+    /// would return wrong outputs rather than erroring. The contract is
+    /// "every energy is finite and strictly positive."
+    InvalidEnergy {
+        /// Position in the energy array where the bad value was found.
+        index: usize,
+        /// The offending energy value.
+        value: f64,
+    },
+    /// The energy grid is not strictly increasing at `index`.
+    ///
+    /// `doppler_broaden` uses `partition_point` over the extended velocity
+    /// grid (built from `energies` via `v = √E`), which has an unspecified
+    /// return value on an unsorted slice and therefore would silently
+    /// produce garbage indices in release builds. The contract is
+    /// "energies are strictly ascending"; duplicate points are also rejected.
+    UnsortedEnergies {
+        /// Position where the strict-ascending invariant was first violated.
+        index: usize,
+        /// The previous (smaller-index) energy value.
+        previous: f64,
+        /// The current (larger-index) energy value that broke the invariant.
+        current: f64,
+    },
 }
 
 impl fmt::Display for DopplerError {
@@ -95,11 +125,59 @@ impl fmt::Display for DopplerError {
                 f,
                 "energies length ({energies}) must match cross_sections length ({cross_sections})"
             ),
+            Self::InvalidEnergy { index, value } => write!(
+                f,
+                "energies[{index}] = {value} is not finite or not strictly positive \
+                 (Doppler broadening requires every energy to satisfy is_finite() && > 0)"
+            ),
+            Self::UnsortedEnergies {
+                index,
+                previous,
+                current,
+            } => write!(
+                f,
+                "energies[{index}] = {current} is not strictly greater than \
+                 energies[{}] = {previous} (Doppler broadening requires the \
+                 energy grid to be strictly ascending)",
+                index.saturating_sub(1)
+            ),
         }
     }
 }
 
 impl std::error::Error for DopplerError {}
+
+/// Validate that `energies` satisfies the Doppler-broadening grid contract:
+/// every entry is finite, strictly positive, and strictly greater than the
+/// previous entry. An empty slice is permitted (the caller has its own
+/// length-handling fast path).
+///
+/// The check is O(n) and is run unconditionally on every entry to
+/// `doppler_broaden` and `doppler_broaden_with_derivative` so that
+/// malformed grids surface as a typed `Err` rather than silent NaN
+/// propagation or unspecified `partition_point` behaviour.
+fn validate_doppler_grid(energies: &[f64]) -> Result<(), DopplerError> {
+    for (i, &e) in energies.iter().enumerate() {
+        if !e.is_finite() || e <= 0.0 {
+            return Err(DopplerError::InvalidEnergy { index: i, value: e });
+        }
+        if i > 0 {
+            // Safe to use `e <= prev` here: the `is_finite()` check above
+            // already rejected any NaN entries, so the partial-ord comparison
+            // is total. (NaN comparisons returning false would otherwise
+            // silently let NaN through this branch.)
+            let prev = energies[i - 1];
+            if e <= prev {
+                return Err(DopplerError::UnsortedEnergies {
+                    index: i,
+                    previous: prev,
+                    current: e,
+                });
+            }
+        }
+    }
+    Ok(())
+}
 
 /// Doppler broadening parameters.
 #[derive(Debug, Clone, Copy)]
@@ -188,12 +266,20 @@ fn erfc_val(x: f64) -> f64 {
 /// Free Gas Model integral from SAMMY manual Eq. III B1.7.
 ///
 /// # Arguments
-/// * `energies` — Energy grid in eV (must be positive and sorted ascending).
+/// * `energies` — Energy grid in eV. Every entry must satisfy
+///   `is_finite() && > 0.0`, and the grid must be **strictly ascending**
+///   (duplicates are rejected). The contract is enforced at the public
+///   boundary by `validate_doppler_grid`.
 /// * `cross_sections` — Unbroadened cross-sections in barns at each energy point.
 /// * `params` — Doppler broadening parameters (temperature and AWR).
 ///
 /// # Returns
 /// Doppler-broadened cross-sections in barns on the same energy grid.
+///
+/// # Errors
+/// * `DopplerError::LengthMismatch` if `energies.len() != cross_sections.len()`.
+/// * `DopplerError::InvalidEnergy` if any energy is non-finite or ≤ 0.
+/// * `DopplerError::UnsortedEnergies` if the grid is not strictly ascending.
 ///
 /// # Algorithm
 /// 1. Convert energy grid to velocity space (v = √E).
@@ -212,6 +298,13 @@ pub fn doppler_broaden(
             cross_sections: cross_sections.len(),
         });
     }
+
+    // Validate the energy-grid contract before any sqrt / partition_point /
+    // interpolation work. Without this guard, NaN energies would silently
+    // produce NaN velocities (and the per-point `v < FLOOR` check evaluates
+    // to false for NaN, allowing NaN to enter the convolution kernel), and
+    // unsorted grids would give unspecified `partition_point` indices.
+    validate_doppler_grid(energies)?;
 
     if params.temperature_k() <= 0.0 || energies.is_empty() {
         return Ok(cross_sections.to_vec());
@@ -453,6 +546,17 @@ pub fn doppler_broaden(
 ///
 /// SAMMY uses finite differences for this (mfgm4.f90 Xdofgm, Del=0.02).
 /// Our analytical approach is exact and avoids the 3× broadening cost.
+///
+/// # Arguments
+/// * `energies` — Energy grid in eV. Same contract as [`doppler_broaden`]:
+///   every entry must be finite and strictly positive, and the grid must
+///   be strictly ascending. The first `doppler_broaden` call below
+///   propagates the validation error through the `?` operator.
+/// * `cross_sections` — Unbroadened cross-sections in barns at each energy point.
+/// * `params` — Doppler broadening parameters (temperature and AWR).
+///
+/// # Errors
+/// Returns the same `DopplerError` variants as [`doppler_broaden`].
 pub fn doppler_broaden_with_derivative(
     energies: &[f64],
     cross_sections: &[f64],

--- a/crates/nereids-physics/src/doppler.rs
+++ b/crates/nereids-physics/src/doppler.rs
@@ -74,7 +74,14 @@ impl fmt::Display for DopplerParamsError {
 impl std::error::Error for DopplerParamsError {}
 
 /// Errors from Doppler broadening computation (not parameter construction).
+///
+/// Marked `#[non_exhaustive]` because this enum is publicly exported from
+/// `nereids-physics` and may grow new validation variants over time (e.g. if
+/// future contracts add bounds on AWR/energy combinations). Without the
+/// attribute, adding a variant would be a SemVer-breaking change for any
+/// downstream crate that exhaustively matches on `DopplerError`.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum DopplerError {
     /// Energy and cross-section arrays have different lengths.
     LengthMismatch {
@@ -127,8 +134,7 @@ impl fmt::Display for DopplerError {
             ),
             Self::InvalidEnergy { index, value } => write!(
                 f,
-                "energies[{index}] = {value} is not finite or not strictly positive \
-                 (Doppler broadening requires every energy to satisfy is_finite() && > 0)"
+                "energies[{index}] = {value} is not finite or not strictly positive (Doppler broadening requires every energy to satisfy is_finite() && > 0)"
             ),
             Self::UnsortedEnergies {
                 index,
@@ -136,9 +142,7 @@ impl fmt::Display for DopplerError {
                 current,
             } => write!(
                 f,
-                "energies[{index}] = {current} is not strictly greater than \
-                 energies[{}] = {previous} (Doppler broadening requires the \
-                 energy grid to be strictly ascending)",
+                "energies[{index}] = {current} is not strictly greater than energies[{}] = {previous} (Doppler broadening requires the energy grid to be strictly ascending)",
                 index.saturating_sub(1)
             ),
         }
@@ -799,6 +803,48 @@ fn interpolate_cross_section(energies: &[f64], cross_sections: &[f64], energy: f
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- DopplerError Display rendering tests ---
+    //
+    // The Display impls use single-line format-string literals to avoid
+    // embedding indentation into the rendered error messages. These tests
+    // pin that contract: a stray `\<newline>    ` continuation in the
+    // literal would silently inject a run of spaces into the user-facing
+    // string and would only be caught by eyeballing log output.
+
+    #[test]
+    fn test_doppler_error_display_no_embedded_indentation() {
+        let e = DopplerError::InvalidEnergy {
+            index: 1,
+            value: f64::NAN,
+        };
+        let rendered = format!("{e}");
+        assert!(
+            !rendered.contains("  "),
+            "InvalidEnergy Display contains double-space (embedded indentation?): {rendered:?}"
+        );
+
+        let e = DopplerError::UnsortedEnergies {
+            index: 3,
+            previous: 4.0,
+            current: 2.5,
+        };
+        let rendered = format!("{e}");
+        assert!(
+            !rendered.contains("  "),
+            "UnsortedEnergies Display contains double-space (embedded indentation?): {rendered:?}"
+        );
+
+        let e = DopplerError::LengthMismatch {
+            energies: 5,
+            cross_sections: 4,
+        };
+        let rendered = format!("{e}");
+        assert!(
+            !rendered.contains("  "),
+            "LengthMismatch Display contains double-space (embedded indentation?): {rendered:?}"
+        );
+    }
 
     // --- DopplerParams::new() validation tests ---
 

--- a/crates/nereids-physics/src/slbw.rs
+++ b/crates/nereids-physics/src/slbw.rs
@@ -622,11 +622,16 @@ mod tests {
         // Γ_n(E) = Γ_n(E_r) · P_l(E)/P_l(E_r) (no extra √(E/E_r) factor;
         // see module docstring). No broadening kernel is applied on either
         // side — both are evaluated on the same unbroadened energy grid, so
-        // Doppler is not a source of discrepancy here. The residual we expect
-        // for a single isolated s-wave resonance is the algebraic difference
-        // between RM's 3×3 channel-matrix denominator and SLBW's scalar
-        // (E − E_r) − iΓ/2 denominator, plus the MLBW interference term
-        // (single-level vs multi-level summation) — collectively much smaller
+        // Doppler is not a source of discrepancy here.
+        //
+        // For a single isolated resonance there is no multi-level interference
+        // contribution: MLBW summation degenerates to SLBW when only one
+        // resonance is present (the cross-resonance interference terms in
+        // SAMMY `mlb/mmlb3.f90` vanish term-by-term). The residual we expect
+        // is therefore purely the algebraic difference between RM's
+        // channel-matrix denominator det(I − K) (3×3 here: elastic + capture +
+        // two fission channels collapse to elastic + capture for Γ_f = 0) and
+        // SLBW's scalar (E − E_r) − iΓ/2 denominator. This is much smaller
         // than the ~10-15 % gap the previous comment claimed, which was a
         // symptom of a double-counted velocity factor that has since been
         // removed.

--- a/crates/nereids-physics/src/slbw.rs
+++ b/crates/nereids-physics/src/slbw.rs
@@ -39,8 +39,24 @@
 //!                − 2·Γ_n(E)·Γ_tot·sin²φ / D                 (interference, Γ part)
 //!              ]
 //!
-//! where Γ_n(E) = Γ_n(E_r) × √(E/E_r) × P_l(E)/P_l(E_r)
-//! and Γ_tot = Γ_n(E) + Γ_γ + Γ_f.
+//! where Γ_n(E) = Γ_n(E_r) × P_l(E)/P_l(E_r) per ENDF-6 §D.1.1 eq D.7
+//! (ENDF-102 Formats Manual, IAEA public PDF page 357), and
+//! Γ_tot = Γ_n(E) + Γ_γ + Γ_f.
+//!
+//! The penetrability ratio already carries the full energy dependence of
+//! the neutron width. For s-wave (l=0), P_0(ρ) = ρ ∝ √E, so the ratio
+//! P_0(E)/P_0(E_r) = √(E/E_r) supplies the entire √E low-energy scaling;
+//! multiplying by a separate √(E/E_r) factor double-counts the wave-number
+//! dependence and yields Γ_n ∝ E rather than the physically correct
+//! Γ_n ∝ √E (1/v capture). The reference implementations all use the
+//! penetrability-ratio-only form:
+//!
+//! - NJOY/RECONR `src/reconr.f90` `csslbw`/`csmlbw`/`csmlbw2`:
+//!   `gne = gn*pe*rper` (with `rper = 1/per`).
+//! - SAMMY `mlb/mmlb4.f90` `Abpart_Mlb` (lines 88-100) accumulates
+//!   `Γ_n(E) = 2·P_l(E)·γ_n²` from reduced amplitudes `γ_n` obtained via
+//!   `γ_n² = GN/(2·P_l(E_r))` (SAMMY `new/mnew3.f90:307-339` `Betset`),
+//!   which is algebraically identical to ENDF D.7 after substitution.
 //!
 //! The sign of the `Γ_tot·sin²φ` interference term is negative. This is
 //! equivalent to SAMMY's `(1 − cos2φ)·A + sin2φ·B + Aaathr·D` form at
@@ -63,8 +79,9 @@ use crate::reich_moore::{CrossSections, PrecomputedJGroup, group_resonances_by_j
 
 // ─── Per-resonance precomputed invariants for SLBW ────────────────────────────
 //
-// In SLBW, the energy-dependent neutron width is:
-//   Γ_n(E) = Γ_n(E_r) × √(E/E_r) × P_l(E)/P_l(E_r)
+// In SLBW, the energy-dependent neutron width is (ENDF-6 §D.1.1 eq D.7,
+// matching NJOY/RECONR `csslbw`/`csmlbw` and SAMMY `mlb/mmlb4.f90:88-100`):
+//   Γ_n(E) = Γ_n(E_r) × P_l(E)/P_l(E_r)
 //
 // The quantities that depend only on resonance parameters (not on E):
 //   - P_l(E_r): penetrability at resonance energy
@@ -307,11 +324,16 @@ pub(crate) fn slbw_evaluate_with_cached_jgroups(
         for res in &jg.resonances {
             let e_r = res.energy;
 
-            // Energy-dependent neutron width:
-            // Γ_n(E) = Γ_n(E_r) × √(E/E_r) × P_l(E)/P_l(E_r)
+            // Energy-dependent neutron width (ENDF-6 §D.1.1 eq D.7):
+            //   Γ_n(E) = Γ_n(E_r) × P_l(E)/P_l(E_r)
+            // The penetrability ratio already carries the full √E (s-wave)
+            // velocity dependence; an extra √(E/E_r) multiplier would
+            // double-count the wave-number factor (see module docstring).
+            // Matches NJOY/RECONR `csslbw` `gne = gn*pe*rper` and SAMMY
+            // `mlb/mmlb4.f90:88-100` after the reduced-amplitude substitution.
             // P_l(E_r) is pre-computed in res.p_at_er (Issue #87).
             let gamma_n = if e_r.abs() > PIVOT_FLOOR && res.p_at_er > PIVOT_FLOOR {
-                res.gn_abs * (energy_ev / e_r.abs()).sqrt() * p_at_e / res.p_at_er
+                res.gn_abs * p_at_e / res.p_at_er
             } else {
                 0.0
             };
@@ -423,8 +445,11 @@ pub(crate) fn mlbw_evaluate_with_cached_jgroups(
 
         for res in &jg.resonances {
             let e_r = res.energy;
+            // Energy-dependent neutron width (ENDF-6 §D.1.1 eq D.7;
+            // section D.1.2 states MLBW uses the same width conversion as
+            // SLBW). Matches NJOY/RECONR `csmlbw` `gne = gn*pe*rper`.
             let gamma_n = if e_r.abs() > PIVOT_FLOOR && res.p_at_er > PIVOT_FLOOR {
-                res.gn_abs * (energy_ev / e_r.abs()).sqrt() * p_at_e / res.p_at_er
+                res.gn_abs * p_at_e / res.p_at_er
             } else {
                 0.0
             };
@@ -593,10 +618,12 @@ mod tests {
         };
 
         // Compare at several energies near the resonance peak.
-        // Note: RM and SLBW differ in how they handle energy-dependent
-        // neutron widths away from the peak. SLBW includes an extra √(E/E_r)
-        // velocity factor in Γ_n(E), leading to ~10-15% differences in the
-        // resonance wings. At the peak and very near it, they agree well.
+        // Both formalisms apply the ENDF-6 §D.1.1 eq D.7 energy dependence
+        // Γ_n(E) = Γ_n(E_r) · P_l(E)/P_l(E_r) (no extra √(E/E_r) factor;
+        // see module docstring), so for a single isolated s-wave resonance
+        // they should agree to within Doppler/MLBW-vs-SLBW differences,
+        // not by ~10-15 % as the previous comment claimed (that gap was
+        // a symptom of a double-counted velocity factor, now removed).
         for &e in &[6.5, 6.674, 7.0] {
             let rm = reich_moore::cross_sections_at_energy(&rm_data, e);
             let slbw = slbw_cross_sections(&slbw_data, e);

--- a/crates/nereids-physics/src/slbw.rs
+++ b/crates/nereids-physics/src/slbw.rs
@@ -620,10 +620,16 @@ mod tests {
         // Compare at several energies near the resonance peak.
         // Both formalisms apply the ENDF-6 §D.1.1 eq D.7 energy dependence
         // Γ_n(E) = Γ_n(E_r) · P_l(E)/P_l(E_r) (no extra √(E/E_r) factor;
-        // see module docstring), so for a single isolated s-wave resonance
-        // they should agree to within Doppler/MLBW-vs-SLBW differences,
-        // not by ~10-15 % as the previous comment claimed (that gap was
-        // a symptom of a double-counted velocity factor, now removed).
+        // see module docstring). No broadening kernel is applied on either
+        // side — both are evaluated on the same unbroadened energy grid, so
+        // Doppler is not a source of discrepancy here. The residual we expect
+        // for a single isolated s-wave resonance is the algebraic difference
+        // between RM's 3×3 channel-matrix denominator and SLBW's scalar
+        // (E − E_r) − iΓ/2 denominator, plus the MLBW interference term
+        // (single-level vs multi-level summation) — collectively much smaller
+        // than the ~10-15 % gap the previous comment claimed, which was a
+        // symptom of a double-counted velocity factor that has since been
+        // removed.
         for &e in &[6.5, 6.674, 7.0] {
             let rm = reich_moore::cross_sections_at_energy(&rm_data, e);
             let slbw = slbw_cross_sections(&slbw_data, e);

--- a/crates/nereids-physics/tests/doppler_validation.rs
+++ b/crates/nereids-physics/tests/doppler_validation.rs
@@ -1,0 +1,183 @@
+//! Regression tests for the `doppler_broaden` energy-grid contract.
+//!
+//! `doppler_broaden` and `doppler_broaden_with_derivative` are public
+//! physics leaves that previously trusted their callers to supply a
+//! positive, finite, strictly ascending energy grid. A malformed grid
+//! would not panic but would silently propagate NaN through the FGM
+//! convolution kernel (because `NaN < FLOOR` is false, bypassing the
+//! per-point velocity guard) or return unspecified `partition_point`
+//! indices on an unsorted slice — both yielding wrong outputs rather
+//! than typed errors.
+//!
+//! These tests pin the typed-error contract:
+//! - NaN / ±∞ / 0 / negative energies → `DopplerError::InvalidEnergy`.
+//! - Non-strictly-ascending grids → `DopplerError::UnsortedEnergies`.
+//! - The same contract applies to the derivative variant (which
+//!   delegates to `doppler_broaden` for its forward pass).
+
+use nereids_physics::doppler::{
+    DopplerError, DopplerParams, doppler_broaden, doppler_broaden_with_derivative,
+};
+
+fn params() -> DopplerParams {
+    // Pick any valid params; we never reach the convolution because
+    // validation rejects the bad grid first.
+    DopplerParams::new(300.0, 238.0).expect("valid params")
+}
+
+#[test]
+fn test_doppler_rejects_nan_energy() {
+    let energies = vec![1.0, f64::NAN, 3.0];
+    let xs = vec![10.0, 20.0, 30.0];
+    let err = doppler_broaden(&energies, &xs, &params()).expect_err("NaN must be rejected");
+    match err {
+        DopplerError::InvalidEnergy { index, value } => {
+            assert_eq!(index, 1);
+            assert!(value.is_nan(), "expected NaN value, got {value}");
+        }
+        other => panic!("expected InvalidEnergy, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_doppler_rejects_negative_energy() {
+    let energies = vec![1.0, -2.0, 3.0];
+    let xs = vec![10.0, 20.0, 30.0];
+    let err =
+        doppler_broaden(&energies, &xs, &params()).expect_err("negative energy must be rejected");
+    assert!(
+        matches!(
+            err,
+            DopplerError::InvalidEnergy {
+                index: 1,
+                value: v
+            } if v == -2.0
+        ),
+        "expected InvalidEnergy at index 1 with value -2.0, got {err:?}"
+    );
+}
+
+#[test]
+fn test_doppler_rejects_zero_energy() {
+    // Doppler broadening transforms to velocity space v = √E. Zero energy
+    // would give v = 0, and the per-point convolution skips v < FLOOR — so
+    // it would not crash, but the contract is "strictly positive" since
+    // E = 0 has no physical meaning as an incident neutron energy.
+    let energies = vec![0.0, 1.0, 2.0];
+    let xs = vec![10.0, 20.0, 30.0];
+    let err = doppler_broaden(&energies, &xs, &params()).expect_err("zero energy must be rejected");
+    assert!(
+        matches!(
+            err,
+            DopplerError::InvalidEnergy {
+                index: 0,
+                value: 0.0
+            }
+        ),
+        "expected InvalidEnergy at index 0 with value 0.0, got {err:?}"
+    );
+}
+
+#[test]
+fn test_doppler_rejects_positive_infinity_energy() {
+    let energies = vec![1.0, 2.0, f64::INFINITY];
+    let xs = vec![10.0, 20.0, 30.0];
+    let err = doppler_broaden(&energies, &xs, &params()).expect_err("+inf must be rejected");
+    assert!(
+        matches!(
+            err,
+            DopplerError::InvalidEnergy { index: 2, value } if value == f64::INFINITY
+        ),
+        "expected InvalidEnergy at index 2 with value +inf, got {err:?}"
+    );
+}
+
+#[test]
+fn test_doppler_rejects_unsorted_energies() {
+    // 4.0 > 3.0 satisfies strictly-ascending against the previous entry;
+    // the violation is at index 3 where 2.5 < 4.0.
+    let energies = vec![1.0, 2.0, 4.0, 2.5, 5.0];
+    let xs = vec![10.0, 20.0, 30.0, 25.0, 50.0];
+    let err = doppler_broaden(&energies, &xs, &params())
+        .expect_err("descending segment must be rejected");
+    match err {
+        DopplerError::UnsortedEnergies {
+            index,
+            previous,
+            current,
+        } => {
+            assert_eq!(index, 3);
+            assert_eq!(previous, 4.0);
+            assert_eq!(current, 2.5);
+        }
+        other => panic!("expected UnsortedEnergies, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_doppler_rejects_duplicate_energies() {
+    // Strict ascending: equal neighbouring points are also rejected so
+    // that the partition_point binary searches never get duplicate
+    // boundary energies (which would produce zero-width FGM segments).
+    let energies = vec![1.0, 2.0, 2.0, 3.0];
+    let xs = vec![10.0, 20.0, 20.0, 30.0];
+    let err = doppler_broaden(&energies, &xs, &params())
+        .expect_err("duplicate energies must be rejected");
+    match err {
+        DopplerError::UnsortedEnergies {
+            index,
+            previous,
+            current,
+        } => {
+            assert_eq!(index, 2);
+            assert_eq!(previous, 2.0);
+            assert_eq!(current, 2.0);
+        }
+        other => panic!("expected UnsortedEnergies, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_doppler_accepts_valid_grid() {
+    let energies = vec![1.0, 2.0, 5.0, 10.0];
+    let xs = vec![10.0, 5.0, 1.0, 0.5];
+    let result = doppler_broaden(&energies, &xs, &params()).expect("valid grid must succeed");
+    assert_eq!(result.len(), energies.len());
+    for v in &result {
+        assert!(v.is_finite() && *v >= 0.0, "got non-finite/neg result {v}");
+    }
+}
+
+#[test]
+fn test_doppler_with_derivative_inherits_validation_nan() {
+    let energies = vec![1.0, f64::NAN, 3.0];
+    let xs = vec![10.0, 20.0, 30.0];
+    let err = doppler_broaden_with_derivative(&energies, &xs, &params())
+        .expect_err("derivative variant must reject NaN energies");
+    assert!(
+        matches!(
+            err,
+            DopplerError::InvalidEnergy { index: 1, value } if value.is_nan()
+        ),
+        "expected InvalidEnergy at index 1, got {err:?}"
+    );
+}
+
+#[test]
+fn test_doppler_with_derivative_inherits_validation_unsorted() {
+    let energies = vec![1.0, 3.0, 2.0];
+    let xs = vec![10.0, 30.0, 20.0];
+    let err = doppler_broaden_with_derivative(&energies, &xs, &params())
+        .expect_err("derivative variant must reject unsorted energies");
+    assert!(
+        matches!(
+            err,
+            DopplerError::UnsortedEnergies {
+                index: 2,
+                previous,
+                current
+            } if previous == 3.0 && current == 2.0
+        ),
+        "expected UnsortedEnergies at index 2, got {err:?}"
+    );
+}

--- a/crates/nereids-physics/tests/samtry_validation.rs
+++ b/crates/nereids-physics/tests/samtry_validation.rs
@@ -2667,18 +2667,27 @@ fn test_tr129a_pu242_endf_total_xs() {
         "raa.plt",
     );
     // Pu-242: SLBW (LRF=1), total cross-section, no broadening.
-    // Known limitation: SLBW potential scattering differs from SAMMY at
-    // very low energies.  ENDF has NER=2 (RRR+URR) but only RRR is used.
+    // ENDF has NER=2 (RRR+URR) but only RRR is used in this comparison.
+    // After removing the double-counted √(E/E_r) velocity factor from
+    // Γ_n(E) per ENDF-6 §D.1.1 eq D.7 (matches NJOY/RECONR + SAMMY),
+    // mean error dropped from ~0.13 to ~0.003 and max from ~0.96 to ~0.013.
+    // Threshold tightened ~50× to lock in the improvement.
     assert!(!rd.ranges.is_empty());
     let result = validate_unbroadened_with_resonance_data(&rd, &plt, 0.05);
     eprintln!(
         "tr129a Pu242: max_rel={:.6}, mean_rel={:.6}, n={}, worst@{:.4} keV",
         result.max_rel_error, result.mean_rel_error, result.n_points, result.worst_energy_kev
     );
+    // Measured post-fix: mean ≈ 0.003, max ≈ 0.013.
     assert!(
-        result.mean_rel_error < 0.60,
-        "mean {:.4} > 60%",
+        result.mean_rel_error < 0.01,
+        "mean {:.4} > 1% (regression: velocity-factor double-count or worse)",
         result.mean_rel_error
+    );
+    assert!(
+        result.max_rel_error < 0.05,
+        "max {:.4} > 5% (regression: velocity-factor double-count or worse)",
+        result.max_rel_error
     );
 }
 
@@ -2691,26 +2700,28 @@ fn test_tr129c_na23_endf_total_xs() {
         "rcc.plt",
     );
     // Na-23: MLBW (LRF=2), total cross-section.
-    // True MLBW (coherent U-matrix) now implemented.  Only 3 reference points
-    // at coarse energies — agreement with SAMMY MLBW needs investigation
-    // for closely-spaced Na-23 resonances.  Track separately rather than
-    // using a loose threshold that hides real discrepancies.
+    // True MLBW (coherent U-matrix) implemented.  Only 3 reference points
+    // at coarse energies.  After removing the double-counted √(E/E_r)
+    // velocity factor from the MLBW Γ_n(E) formula (ENDF-6 §D.1.1 eq D.7,
+    // §D.1.2 says MLBW uses same conversion), mean error dropped from
+    // ~0.45 to ~0.002 and max from ~0.50 to ~0.004 — well within SAMMY's
+    // own ENDF reconstruction noise on this coarse 3-point grid.
     assert!(!rd.ranges.is_empty());
     let result = validate_unbroadened_with_resonance_data(&rd, &plt, 0.05);
     eprintln!(
         "tr129c Na23: max_rel={:.6}, mean_rel={:.6}, n={}, worst@{:.4} keV",
         result.max_rel_error, result.mean_rel_error, result.n_points, result.worst_energy_kev
     );
-    // TODO: MLBW Na-23 needs fine-grained comparison against SAMMY at
-    // resonance energies, not just 3 coarse points.  The current 45% mean
-    // error at 3 points may be dominated by a single high-energy point
-    // where URR contribution (not yet implemented) matters.
-    // Temporarily relax threshold to avoid blocking other fixes, but
-    // this MUST be investigated.
+    // Measured post-fix: mean ≈ 0.002, max ≈ 0.004.
     assert!(
-        result.mean_rel_error < 0.50,
-        "mean {:.4} > 50%",
+        result.mean_rel_error < 0.01,
+        "mean {:.4} > 1% (regression: velocity-factor double-count or worse)",
         result.mean_rel_error
+    );
+    assert!(
+        result.max_rel_error < 0.05,
+        "max {:.4} > 5% (regression: velocity-factor double-count or worse)",
+        result.max_rel_error
     );
 }
 
@@ -2737,18 +2748,24 @@ fn test_tr129g_am241_endf_total_xs() {
         "tape135_9543_2",
         "rgg.plt",
     );
-    // Am-241: MLBW (LRF=2), total cross-section.
-    // Known limitation: SLBW/MLBW potential scattering at very low energies
-    // differs from SAMMY (only 6 reference points).
+    // Am-241: MLBW (LRF=2), total cross-section, 6 reference points.
+    // After removing the double-counted √(E/E_r) velocity factor, mean
+    // error dropped from ~0.27 to ~0.19 and max from ~0.96 to ~0.76 —
+    // significant improvement but a residual MLBW/URR-coupling
+    // discrepancy remains (likely the URR contribution Am-241 has in
+    // NER=2 but this NEREIDS path does not yet include). Threshold
+    // tightened to 0.30 (mean) to lock in the velocity-factor portion
+    // of the improvement without blocking other work on the residual.
     assert!(!rd.ranges.is_empty());
     let result = validate_unbroadened_with_resonance_data(&rd, &plt, 0.05);
     eprintln!(
         "tr129g Am241: max_rel={:.6}, mean_rel={:.6}, n={}, worst@{:.4} keV",
         result.max_rel_error, result.mean_rel_error, result.n_points, result.worst_energy_kev
     );
+    // Measured post-fix: mean ≈ 0.19, max ≈ 0.76.
     assert!(
-        result.mean_rel_error < 0.80,
-        "mean {:.4} > 80%",
+        result.mean_rel_error < 0.30,
+        "mean {:.4} > 30% (regression: velocity-factor double-count or worse)",
         result.mean_rel_error
     );
 }

--- a/crates/nereids-physics/tests/slbw_elastic_oracle.rs
+++ b/crates/nereids-physics/tests/slbw_elastic_oracle.rs
@@ -96,8 +96,10 @@ fn oracle_elastic_swave_single_resonance(data: &ResonanceData, energy_ev: f64) -
     let rho_r = rho(res.energy.abs(), awr, radius_r);
     let p_l_r = penetrability(0, rho_r);
 
-    // Γ_n(E) = Γ_n(E_r) · √(E/E_r) · P_l(E)/P_l(E_r)
-    let gamma_n = res.gn.abs() * (energy_ev / res.energy.abs()).sqrt() * p_l_e / p_l_r;
+    // Γ_n(E) = Γ_n(E_r) · P_l(E)/P_l(E_r) per ENDF-6 §D.1.1 eq D.7.
+    // The penetrability ratio already carries the full √E dependence
+    // for s-wave; an extra √(E/E_r) multiplier would double-count it.
+    let gamma_n = res.gn.abs() * p_l_e / p_l_r;
     let gamma_total = gamma_n + res.gg + res.gfa.abs() + res.gfb.abs();
 
     let de = energy_ev - res.energy;

--- a/crates/nereids-physics/tests/slbw_velocity_factor.rs
+++ b/crates/nereids-physics/tests/slbw_velocity_factor.rs
@@ -1,0 +1,178 @@
+//! Regression test for the SLBW/MLBW energy-dependent neutron-width formula.
+//!
+//! Per ENDF-6 §D.1.1 equation D.7 (ENDF-102 Formats Manual, IAEA public PDF
+//! page 357), the SLBW/MLBW neutron width has the energy dependence
+//!
+//!   Γ_n(E) = Γ_n(E_r) × P_l(E) / P_l(E_r)
+//!
+//! with NO additional √(E/E_r) multiplier. For neutral s-wave (l=0),
+//! P_0(ρ)=ρ ∝ √E so the penetrability ratio P_0(E)/P_0(E_r) = √(E/E_r)
+//! already supplies the full √E low-energy velocity factor. Multiplying
+//! by a separate √(E/E_r) would yield Γ_n ∝ E (and σ_capture ≈ constant
+//! in the 1/v limit) instead of Γ_n ∝ √E (and σ_capture ∝ 1/v).
+//!
+//! Reference implementations:
+//! - NJOY/RECONR `src/reconr.f90` `csslbw`/`csmlbw`: `gne = gn*pe*rper`.
+//! - SAMMY `mlb/mmlb4.f90:88-100` `Abpart_Mlb` (via `γ_n² = GN/(2·P_l(E_r))`
+//!   from `new/mnew3.f90:307-339` `Betset`).
+//!
+//! These tests pin the corrected formula and would have caught the
+//! double-counted velocity factor on day one of the SLBW evaluator's
+//! existence.
+
+use nereids_core::types::Isotope;
+use nereids_endf::resonance::{
+    LGroup, Resonance, ResonanceData, ResonanceFormalism, ResonanceRange,
+};
+use nereids_physics::reich_moore;
+use nereids_physics::slbw::slbw_cross_sections;
+
+/// Single isolated s-wave U-238 6.674 eV resonance, SLBW formalism.
+///
+/// I = 0 so g_J = 1 for J = 1/2. Naps = 1 (use AP for everything).
+fn u238_slbw_single_resonance() -> ResonanceData {
+    ResonanceData {
+        isotope: Isotope::new(92, 238).unwrap(),
+        za: 92238,
+        awr: 236.006,
+        ranges: vec![ResonanceRange {
+            energy_low: 1e-6,
+            energy_high: 1e5,
+            resolved: true,
+            formalism: ResonanceFormalism::SLBW,
+            target_spin: 0.0,
+            scattering_radius: 9.4285,
+            naps: 1,
+            ap_table: None,
+            l_groups: vec![LGroup {
+                l: 0,
+                awr: 236.006,
+                apl: 0.0,
+                qx: 0.0,
+                lrx: 0,
+                resonances: vec![Resonance {
+                    energy: 6.674,
+                    j: 0.5,
+                    gn: 1.493e-3,
+                    gg: 23.0e-3,
+                    gfa: 0.0,
+                    gfb: 0.0,
+                }],
+            }],
+            rml: None,
+            urr: None,
+            r_external: vec![],
+        }],
+    }
+}
+
+/// Same isolated resonance but as Reich-Moore. This is the "ground-truth"
+/// formalism — its width formula is independently implemented and known
+/// to match SAMMY/NJOY for isolated resonances.
+fn u238_rm_single_resonance() -> ResonanceData {
+    let mut data = u238_slbw_single_resonance();
+    data.ranges[0].formalism = ResonanceFormalism::ReichMoore;
+    data
+}
+
+/// At E = E_r the penetrability ratio is 1 by construction, so Γ_n(E_r) = GN.
+/// Below the resonance, in the 1/v regime, capture must scale as 1/√E for an
+/// s-wave neutron width Γ_n ∝ √E. With the buggy formula Γ_n ∝ E, the
+/// 1/v slope is wiped out and capture becomes ~constant below the peak.
+///
+/// Test: σ_cap(E/4) / σ_cap(E) ≈ 2 at energies well below the resonance.
+/// Buggy formula would give a ratio ≈ 1.
+#[test]
+fn slbw_capture_scales_as_one_over_v_below_resonance() {
+    let data = u238_slbw_single_resonance();
+
+    // Use thermal-energy probes far below the 6.674 eV resonance, where
+    // the resonant denominator is dominated by (E-E_r)² ≈ E_r², so the
+    // capture cross-section is essentially Γ_n(E) · Γ_γ × (π/k²) / E_r².
+    // Both Γ_n ∝ √E and (π/k²) ∝ 1/E contribute to the 1/v low-E slope.
+    let e_lo = 0.001_f64; // 1 meV
+    let e_hi = 4.0 * e_lo; // 4 meV
+
+    let xs_lo = slbw_cross_sections(&data, e_lo);
+    let xs_hi = slbw_cross_sections(&data, e_hi);
+
+    // For Γ_n ∝ √E and π/k² ∝ 1/E:
+    //   σ_cap(E) ∝ Γ_n(E) / E ∝ √E / E = 1/√E (1/v)
+    // so σ_cap(E_lo) / σ_cap(E_hi) ≈ √(E_hi / E_lo) = √4 = 2.
+    let ratio = xs_lo.capture / xs_hi.capture;
+    assert!(
+        (ratio - 2.0).abs() < 0.02,
+        "σ_cap(E/4)/σ_cap(E) = {ratio:.4} (expected ≈ 2.0 for 1/v); \
+         a ratio near 1 indicates the double-counted velocity factor \
+         (Γ_n ∝ E) is back."
+    );
+}
+
+/// Γ_n(E) at E = E_r/4 must equal Γ_n(E_r)/2 for an s-wave resonance,
+/// not Γ_n(E_r)/4. The capture cross-section is proportional to Γ_n at
+/// fixed (π/k², g_J, denominator), so:
+///
+///   σ_cap(E_r/4) × (E_r/4) / [σ_cap(E_r) × E_r]  · ratio of denominators
+///
+/// gives a direct probe of Γ_n's energy scaling.
+///
+/// Here we compare the SLBW evaluator against Reich-Moore on the same
+/// isolated s-wave resonance. Both formalisms apply Γ_n(E) = GN·P_l(E)/P_l(E_r);
+/// the formula difference between them is only in the elastic
+/// channel (resonance-resonance interference, RM uses U-matrix), so for
+/// a SINGLE isolated resonance with capture-dominated kernel they must
+/// agree on σ_cap below resonance to within Reich-Moore's resonance-mixing
+/// terms (which vanish for one resonance).
+///
+/// With the buggy double-counted velocity factor, SLBW capture was off
+/// by a factor of √(E/E_r) below the peak.
+#[test]
+fn slbw_matches_reich_moore_capture_below_resonance() {
+    let slbw_data = u238_slbw_single_resonance();
+    let rm_data = u238_rm_single_resonance();
+
+    // Probe at thermal energies (well below the 6.674 eV peak).
+    for &e in &[0.0253, 0.1, 0.5, 1.0, 3.0] {
+        let slbw = slbw_cross_sections(&slbw_data, e);
+        let rm = reich_moore::cross_sections_at_energy(&rm_data, e);
+        let denom = rm.capture.abs().max(1e-12);
+        let rel = (slbw.capture - rm.capture).abs() / denom;
+        assert!(
+            rel < 5e-3,
+            "SLBW vs Reich-Moore capture disagree at E = {e} eV: \
+             SLBW = {} barns, RM = {} barns, rel = {:.4}. \
+             Disagreement at this scale below resonance indicates the \
+             velocity-factor double-count is still present.",
+            slbw.capture,
+            rm.capture,
+            rel
+        );
+    }
+}
+
+/// MLBW formalism: same width formula as SLBW. Use a synthetic single
+/// s-wave resonance and verify 1/v capture below the peak.
+fn u238_mlbw_single_resonance() -> ResonanceData {
+    let mut data = u238_slbw_single_resonance();
+    data.ranges[0].formalism = ResonanceFormalism::MLBW;
+    data
+}
+
+#[test]
+fn mlbw_capture_scales_as_one_over_v_below_resonance() {
+    let data = u238_mlbw_single_resonance();
+    let e_lo = 0.001_f64;
+    let e_hi = 4.0 * e_lo;
+
+    // MLBW is dispatched via reich_moore::cross_sections_at_energy.
+    let xs_lo = reich_moore::cross_sections_at_energy(&data, e_lo);
+    let xs_hi = reich_moore::cross_sections_at_energy(&data, e_hi);
+
+    let ratio = xs_lo.capture / xs_hi.capture;
+    assert!(
+        (ratio - 2.0).abs() < 0.02,
+        "MLBW σ_cap(E/4)/σ_cap(E) = {ratio:.4} (expected ≈ 2.0 for 1/v); \
+         a ratio near 1 indicates the double-counted velocity factor \
+         (Γ_n ∝ E) is back in the MLBW path."
+    );
+}

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -1616,9 +1616,18 @@ class TestVenusMlbwRegression:
         # Linux CI / macOS dev / any future backend, but orders of
         # magnitude tighter than the ~33 % MLBW dispatch error this gate
         # is meant to catch.
-        EXPECTED_DENSITY = 0.00011222100300548643
-        EXPECTED_CHI2_R = 218950.98638784938
-        EXPECTED_ITERATIONS = 27
+        #
+        # Baseline regenerated after NV-1 SLBW/MLBW velocity-factor fix
+        # (issue #568): the buggy MLBW had Γ_n(E) ∝ E for s-wave instead
+        # of ∝ √E per ENDF-6 §D.1.1 eq D.7. After removing the extra
+        # √(E/E_r) factor at slbw.rs:314 / :427, MLBW σ in the wings is
+        # larger, so the LM fit on aggregated Hf-177 converges at a
+        # ~28 % lower density (1.122e-4 → 8.110e-5 atoms/barn) — the
+        # physically correct direction. Iteration count also dropped
+        # (27 → 14) because the corrected objective is less ill-conditioned.
+        EXPECTED_DENSITY = 8.110428369849131e-05
+        EXPECTED_CHI2_R = 219657.76973394692
+        EXPECTED_ITERATIONS = 14
 
         FLOAT_TOL = pytest.approx
         assert float(result.densities[0]) == FLOAT_TOL(EXPECTED_DENSITY, rel=1e-6), (


### PR DESCRIPTION
## Summary

This PR closes two of the eight confirmed bugs from NEREIDS audit Round 2.
Both findings were independently confirmed by two LLM families with
primary-source access to the ENDF-6 Formats Manual, SAMMY source, and
NJOY/RECONR source.

### NV-1 — SLBW/MLBW Γ_n(E) velocity-factor double-count (#568) [P0]

**Bug.** Both the SLBW evaluator (`crates/nereids-physics/src/slbw.rs:314`)
and the MLBW evaluator (`crates/nereids-physics/src/slbw.rs:427`) multiplied
the energy-dependent neutron width by an extra `√(E/|E_r|)` factor:

```rust
// before
res.gn_abs * (energy_ev / e_r.abs()).sqrt() * p_at_e / res.p_at_er
```

This double-counts the wave-number dependence that is already inside the
penetrability ratio. For s-wave (l=0), `P_0(ρ) = ρ ∝ √E`, so
`P_0(E)/P_0(E_r) = √(E/|E_r|)` already supplies the entire √E velocity
scaling. The extra multiplier yielded `Γ_n ∝ E` (and `σ_cap ≈ const` in
the 1/v limit) instead of the physically correct `Γ_n ∝ √E` (and
`σ_cap ∝ 1/v`).

**Primary-source citation.** ENDF-6 §D.1.1 equation D.7 (ENDF-102 Formats
Manual, IAEA public PDF page 357):

```
Γ_nr(E) = P_l(E) · Γ_nr(|E_r|) / P_l(|E_r|)
```

§D.1.2 states LRF=2 (MLBW) uses the same neutron-width conversion.

- **NJOY/RECONR** `src/reconr.f90` `csslbw` / `csmlbw` / `csmlbw2`:
  `gne = gn*pe*rper` (with `rper = 1/per`).
- **SAMMY** `mlb/mmlb4.f90:88-100` `Abpart_Mlb` accumulates
  `Γ_n(E) = 2·P_l(E)·γ_n²` from reduced amplitudes `γ_n²` obtained via
  `γ_n² = GN/(2·P_l(E_r))` in `new/mnew3.f90:307-339` `Betset`.
  After substitution this is algebraically identical to ENDF D.7.

**Fix.** Removed the `(energy_ev / e_r.abs()).sqrt()` factor at both call
sites; updated the module/precompute docstrings to cite ENDF-6 §D.1.1 +
NJOY/SAMMY references; updated the parallel formula in the
`slbw_elastic_oracle.rs` test oracle in lockstep (the oracle is an
algebra cross-check on the elastic-interference term, not on the
velocity factor, so it must track the corrected production formula).

**Regression test** (`crates/nereids-physics/tests/slbw_velocity_factor.rs`):

- `slbw_capture_scales_as_one_over_v_below_resonance` —
  `σ_cap(1 meV) / σ_cap(4 meV) ≈ 2` for the U-238 6.674 eV resonance
  (the buggy formula gives a ratio ≈ 1).
- `slbw_matches_reich_moore_capture_below_resonance` — SLBW and
  Reich-Moore capture must agree to ≤ 0.5 % below resonance for an
  isolated s-wave resonance. The bug previously caused this assertion to
  fail by a factor of `√(E/E_r)` per energy point.
- `mlbw_capture_scales_as_one_over_v_below_resonance` — same 1/v test
  applied to the MLBW evaluator.

**samtry impact** (cargo test -p nereids-physics --test samtry_validation
-- --nocapture):

| Test | Before (mean_rel) | Before (max_rel) | After (mean_rel) | After (max_rel) |
|------|------------------:|-----------------:|-----------------:|----------------:|
| tr129a Pu-242 (SLBW LRF=1) | 0.13 | 0.96 | **0.003** | **0.013** |
| tr129c Na-23  (MLBW LRF=2) | 0.45 | 0.50 | **0.002** | **0.004** |
| tr129g Am-241 (MLBW LRF=2) | 0.27 | 0.96 | **0.19** | **0.76** |
| tr028  Pu-241 (LRF=1, RM path used) | 0.0002 | 0.002 | unchanged | unchanged |

tr129g still has a notable residual after the fix; the velocity-factor
component improved dramatically, but the remaining ~19 % mean error is
consistent with the URR contribution that Am-241 has in NER=2 but this
NEREIDS path does not yet include. Threshold tightened to 0.30 (mean)
to lock in the velocity-factor improvement without blocking unrelated
URR work.

This is the keystone Round-2 finding, analogous to PR #550's M1 sign
error (also a latent multi-month bug invisible to existing samtry
validation because the bias was below tolerance on the tested cases).

### NV-5 — Doppler broadening energy-grid validation (#572) [P1]

**Bug.** `doppler::doppler_broaden` and `doppler_broaden_with_derivative`
are public physics leaves whose rustdoc documented "energies must be
positive and sorted ascending" but enforced only the length-parity
between `energies` and `cross_sections`. Codex's call-graph analysis
identified several public Rust callers and GUI paths that can deliver
malformed grids (NaN, ≤ 0, unsorted, duplicate) without upstream
validation:

- `transmission::broadened_cross_sections_from_base` /
  `broadened_cross_sections_with_analytical_derivative_from_base` /
  `forward_model_from_base_xs` skip the per-energy
  `cross_sections_at_energy` assertion (which protects the other
  formalism leaves per issue #558) because they re-use a precomputed
  base-Xs cache, leaving Doppler exposed.
- `transmission::forward_model` / `broadened_cross_sections` validate
  monotonicity only when `instrument.is_some()`.
- `UnifiedFitConfig::new` does not re-validate the grid; GUI restore /
  energy-edges paths only check positivity, not finiteness or order.

A NaN energy would bypass the per-point `v < FLOOR` velocity guard
(`NaN < x` is false), feed NaN into the FGM convolution, and silently
return wrong outputs. An unsorted grid would yield unspecified
`partition_point` indices in release builds.

**Fix.** Added a `validate_doppler_grid` helper plus two typed
`DopplerError` variants (`InvalidEnergy { index, value }` and
`UnsortedEnergies { index, previous, current }`), called from both
`doppler_broaden` and (via the forward-pass delegate)
`doppler_broaden_with_derivative`. Rustdoc on both functions now states
the contract explicitly.

**Regression tests** (`crates/nereids-physics/tests/doppler_validation.rs`):
NaN / ±∞ / 0 / negative / descending / duplicate grids all return the
expected typed error, on both the forward function and the
derivative variant.

## Methodology

This fix was identified by NEREIDS audit Round 2 broad pass and confirmed
by Phase 3 cross-LLM-family verification with primary-source access
(ENDF-6 Formats Manual, SAMMY source tree, NJOY/RECONR source). See
`.research/audit-r2/confirmation/SUMMARY.md` for methodology details.

Confirmation reports:
- NV-1: [`.research/audit-r2/confirmation/codex/NV-1.md`](.research/audit-r2/confirmation/codex/NV-1.md), [`.research/audit-r2/confirmation/claude/NV-1.md`](.research/audit-r2/confirmation/claude/NV-1.md)
- NV-5: [`.research/audit-r2/confirmation/codex/NV-5.md`](.research/audit-r2/confirmation/codex/NV-5.md), [`.research/audit-r2/confirmation/claude/NV-5.md`](.research/audit-r2/confirmation/claude/NV-5.md)

Both NV-1 confirmation reports independently reached `confirmed-bug HIGH`
with the same derivation from primary sources. NV-5 synthesis: Codex's
pure-Rust + GUI reach analysis (`partial-bug` with broader reach) is
correct; Claude's "not-a-bug" classification only covered the Python
binding boundary, which Codex confirmed is protected but identified
unprotected public Rust paths.

## Test plan

- [x] `cargo fmt --all` clean.
- [x] `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings` clean.
- [x] `cargo test -p nereids-physics` — 214 unit + 89 samtry + 9 doppler-validation + 3 slbw-velocity-factor + 3 elastic-oracle + 8 venus-usr + 5 surrogate/microbench tests all pass.
- [x] tr129a (Pu-242 SLBW) max_rel dropped from 0.96 to 0.013 — primary witness for the bug.
- [x] Existing slbw_elastic_oracle high-ρ peak / off-peak tests still pass at REL_TOL = 1e-10 after oracle's own Γ_n formula was updated in lockstep.
- [ ] (Out of scope for this PR) Future work: URR contribution for Am-241 (NER=2 case) to close the residual 19 % mean error on tr129g.

Closes #568.
Closes #572.

🤖 Generated with [Claude Code](https://claude.com/claude-code)