### PR TITLE
chore(governance): PR template + fix-subagent-prompt template + .private/ gitignore

### DIFF
--- a/.claude/templates/fix-subagent-prompt.md
+++ b/.claude/templates/fix-subagent-prompt.md
@@ -1,0 +1,100 @@
+# Fix-subagent prompt template
+
+Use this template when prompting a subagent to apply a fix. It encodes the
+DRY governance from `feedback_fixes_must_consolidate_not_duplicate.md` and
+the no-scope-dodging rule from `feedback_no_scope_dodging.md`. Adapt the
+[bracketed] sections per fix; do NOT delete the mandatory pre-steps.
+
+---
+
+You are applying a code fix to NEREIDS at commit `[HEAD-or-branch-head]`.
+
+**Worktree (cd here first):** `[absolute path]`
+**Branch:** `[branch name]`
+
+## Mandatory pre-step 1 — search for existing logic
+
+BEFORE writing any new code:
+
+1. Search the crate(s) you'll touch for existing logic that matches the
+   problem shape. Use ripgrep:
+   ```
+   rg -n '[pattern matching the problem shape]' crates/[crate]/src/
+   ```
+2. If similar logic already exists:
+   - PREFER refactoring or extending the existing one
+   - If the existing one is in the wrong place, MOVE it (and update callers)
+   - DO NOT add a parallel implementation
+3. If NO similar logic exists, prefer:
+   - A newtype that carries the invariant (validated once, used freely)
+   - A single shared function (called from N sites) over N inline checks
+   - Deleting a buggy code path over guarding it
+
+**State explicitly in your final report**: *"I searched for X using
+`rg ...`. Found Y in `file:line` / found nothing similar. Therefore I
+[refactored existing | added new because of justified absence]."*
+
+## Mandatory pre-step 2 — LOC-delta projection
+
+Before writing the fix, estimate:
+- inserted: +N
+- deleted:  -M
+- net:      ±K
+
+If NET > 0 for what's supposed to be a fix (not a feature), pause and ask
+yourself:
+
+> "Could this same correctness outcome be achieved by removing code instead
+> of adding it?"
+
+If yes, restructure the fix to do that. If no (because the problem genuinely
+requires new structure — a real newtype, a consolidating function, etc.),
+proceed and document why the addition is load-bearing.
+
+## Your specific fix scope
+
+[Describe the bug or refactor. Cite file:line. Cite primary source if
+applicable: SAMMY src/, ENDF-6 Formats Manual, NJOY repo, PyO3 docs, etc.]
+
+[For physics-correctness fixes, include the primary-source citation
+verbatim. For refactors, link to the audit finding in
+`.research/audit-r{N}-architecture/...`.]
+
+## Process
+
+1. cd to the worktree
+2. Run the pre-step searches (Mandatory pre-step 1); document findings
+3. Apply the fix
+4. Run pre-commit gates:
+   ```bash
+   cargo fmt --all
+   cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings
+   cargo test --workspace --exclude nereids-python
+   # ONLY if touching physics-correctness code (SLBW/MLBW/RM/RML, Doppler,
+   # resolution, fitting math): also run
+   pixi run test-python
+   ```
+5. Commit via `./scripts/worktree-commit.sh <worktree-name> "<message>" <files>`
+6. Stop. Report:
+   - Commit hash
+   - Actual LOC delta (run `git diff --stat <parent>..HEAD | tail -1`)
+   - Mandatory pre-step 1 search findings (the exact `rg` commands and results)
+   - Any adjacent issues you noticed but did NOT fix (so the parent agent
+     can flag them for follow-up; do not silently expand scope)
+
+## Strict rules
+
+- **No GitHub-meta in code comments** (no `PR #N`, no `round-N review:`).
+  Why-the-code-is-shaped-this-way goes in code comments; when/which-PR
+  goes in commit messages and PR descriptions.
+- **No new helpers without ≥1 deletion** (DRY governance). If you add a
+  `validate_X`, you must delete the inline `X` checks at the call sites.
+- **No scope-cutting.** Do the full fix as specified. Adjacent issues
+  outside scope go in the "noticed but didn't fix" report, never into
+  silent dropped scope.
+- **No bypassing pre-commit gates** (no `--no-verify`, no skipped tests).
+- **No skipping GPG signing.** Use `./scripts/worktree-commit.sh` which
+  handles GPG.
+- **No touching files outside your declared scope.** If the fix requires
+  touching a sibling file, declare it explicitly in the scope section
+  before proceeding.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,56 @@
+<!--
+NEREIDS PR template — keep this template visible in your PR body.
+Replace each section's placeholder with your specific content.
+
+The LOC-delta and existing-logic check exist because the audit-R2/R3 fix
+sprints accumulated duck-tape patches that were caught in the architecture
+audit (.research/audit-r4-architecture/). Filling these in honestly is
+the load-bearing control, not the template existing.
+-->
+
+## Summary
+
+<!-- 1-3 sentences: what changes, and why. Cite the issue or audit finding that motivated it. -->
+
+## LOC delta
+
+<!-- Run: git diff --stat <merge-base>..HEAD | tail -1 -->
+
+- inserted: +N
+- deleted:  -M
+- net:      ±K
+
+## Existing-logic check (mandatory for refactor PRs; informational for feature PRs)
+
+- [ ] I searched the crate(s) I touched for similar logic before adding new code
+- [ ] If similar logic exists, this PR refactors/consolidates it rather than duplicating
+- [ ] If this PR has positive net LOC, the new code is load-bearing structure (a newtype carrying an invariant, a centralized validator replacing scattered ones, a feature, etc.) — not a defensive guard or duck-tape patch around a symptom
+- [ ] No new `validate_*` or `*_helper` function was added if a similar one already exists in the same crate
+
+If any box above could not be checked, the PR body explains why.
+
+## Test plan
+
+<!--
+- Which existing tests still pass (cargo test, pixi run test-python)
+- Which tests were added/updated and what regime they exercise (especially: the regime that would have exposed the bug pre-fix)
+- For physics-correctness changes: which SAMMY/ENDF/NJOY primary source was checked
+-->
+
+## Linked issues / audit references
+
+<!--
+- Closes #N (must be a real issue; do not invent numbers)
+- Refs #M (related but not closed)
+- Refs .research/audit-r4-architecture/{report}.md  (if motivated by the architecture audit)
+-->
+
+---
+
+<!--
+For AI-assisted PRs:
+- Cite the session ID and link to the .research/audit-* reports the change is based on
+- The agent must include the LOC-delta numbers; "I'll let you compute them" is not acceptable
+
+Trailer for AI-coauthored commits is added by ./scripts/worktree-commit.sh.
+-->

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ _fts_*.txt
 # (do NOT gitignore Cargo.lock)
 .prototypes/
 .research/
+.private/
 .claude/settings.local.json
 tmp/
 


### PR DESCRIPTION
## Summary

Setup commit for the architecture-audit corrective. Adds two governance files
that gate every refactor PR in the upcoming sprint:

1. **`.github/pull_request_template.md`** — every PR now displays a structured
   LOC delta (`+inserted / -deleted / NET`) and an existing-logic check that the
   author confirms before merge. This makes the duck-tape pattern (adding code
   while claiming to fix something) visible to reviewers.

2. **`.claude/templates/fix-subagent-prompt.md`** — canonical template for
   prompting fix subagents. Mandatory pre-steps before any code is written:
   search for existing logic to refactor/extend, project LOC delta upfront, and
   confirm the addition is load-bearing rather than defensive guard scaffolding.
   Encodes the DRY governance and the "no scope dodging" principle from the
   audit-R4 architecture work.

3. **`.gitignore`** — adds `.private/` alongside `.research/` for non-tracked
   working notes (meeting prep, personal context).

## LOC delta

- inserted: +157
- deleted:  -0
- net:      +157

## Existing-logic check

- [x] I searched the repo for existing PR template / fix prompt — none existed
- [x] No existing logic to consolidate (these are new governance scaffolding)
- [x] The +LOC is load-bearing: it gates every subsequent refactor PR via the
      template's required LOC-delta field

## Test plan

- No code logic changes; nothing to test.
- The PR template renders on this very PR (verify in the GitHub UI).
- The fix-subagent-prompt template will be referenced by the next refactor PR's
  subagent invocation.

## Why this is its own PR

The user (project lead) explicitly noted being review-bandwidth-limited. PR-0
is small (157 LOC of governance scaffolding) and self-contained, so it reviews
fast. PR-1 (the first actual refactor — pure deletion of ~466 LOC of dead test
files) then ships under the new template with a clean LOC delta and no governance
noise mixed in.

## Linked

- Architecture audit reports: `.research/audit-r4-architecture/` (gitignored)
- Re-sized v2 audit + Phase 2 plan: `.research/audit-r4-architecture-v2/SUMMARY-v2.md`
- Memory governance entries: `feedback_fixes_must_consolidate_not_duplicate.md`,
  `feedback_no_scope_dodging.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)