### PR TITLE
refactor(tests): consolidate Python U-238 fixtures + fix 6.67/6.674 drift

### DIFF
--- a/tests/_fixtures.py
+++ b/tests/_fixtures.py
@@ -1,0 +1,60 @@
+"""Shared synthetic-fixture builders for the Python test suite.
+
+Energy 6.674 aligns to the Rust-side ``u238_single_resonance()`` in
+``nereids_endf::resonance::test_support`` (architecture-audit F13:
+fixes the historical Python ``6.67`` vs Rust ``6.674`` drift).
+"""
+
+import nereids
+
+
+def _make_single_resonance(
+    z=92,
+    a=238,
+    awr=236.006,
+    scattering_radius=9.48,
+    energy=6.674,
+    j=0.5,
+    gn=0.0015,
+    gg=0.023,
+    target_spin=0.0,
+    formalism=None,
+):
+    """Build a minimal single-resonance isotope for testing."""
+    return nereids.create_resonance_data(
+        z=z,
+        a=a,
+        awr=awr,
+        scattering_radius=scattering_radius,
+        resonances=[(energy, j, gn, gg)],
+        target_spin=target_spin,
+        formalism=formalism,
+    )
+
+
+def _synthetic_u238_data():
+    """Single-resonance U-238 ``ResonanceData`` at the 6.674 eV anchor."""
+    return nereids.create_resonance_data(
+        z=92,
+        a=238,
+        awr=236.006,
+        scattering_radius=9.48,
+        resonances=[(6.674, 0.5, 0.0015, 0.023)],
+        target_spin=0.0,
+    )
+
+
+def _synthetic_u238_entry(initial_density=0.001):
+    """MCP-manifest entry dict carrying a single-resonance U-238 fixture."""
+    return {
+        "isotope": "U-238",
+        "initial_density": initial_density,
+        "synthetic_resonance": {
+            "z": 92,
+            "a": 238,
+            "awr": 236.006,
+            "scattering_radius": 9.48,
+            "target_spin": 0.0,
+            "resonances": [[6.674, 0.5, 0.0015, 0.023]],
+        },
+    }

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -31,6 +31,8 @@ from nereids.mcp.server import (
     validate_resonance_dataset,
 )
 
+from _fixtures import _synthetic_u238_data, _synthetic_u238_entry
+
 
 @pytest.fixture(autouse=True)
 def clear_registry():
@@ -285,32 +287,6 @@ class TestInputValidation:
 # ---------------------------------------------------------------------------
 # Manifest-driven workflow tools
 # ---------------------------------------------------------------------------
-
-
-def _synthetic_u238_entry(initial_density=0.001):
-    return {
-        "isotope": "U-238",
-        "initial_density": initial_density,
-        "synthetic_resonance": {
-            "z": 92,
-            "a": 238,
-            "awr": 236.006,
-            "scattering_radius": 9.48,
-            "target_spin": 0.0,
-            "resonances": [[6.67, 0.5, 0.0015, 0.023]],
-        },
-    }
-
-
-def _synthetic_u238_data():
-    return nereids.create_resonance_data(
-        z=92,
-        a=238,
-        awr=236.006,
-        scattering_radius=9.48,
-        resonances=[(6.67, 0.5, 0.0015, 0.023)],
-        target_spin=0.0,
-    )
 
 
 def _write_json_frontmatter_manifest(tmp_path, analysis):

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -12,38 +12,16 @@ import pytest
 
 import nereids
 
+from _fixtures import _make_single_resonance
+
 
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
 # ---------------------------------------------------------------------------
 
-def _make_single_resonance(
-    z=92,
-    a=238,
-    awr=236.006,
-    scattering_radius=9.48,
-    energy=6.67,
-    j=0.5,
-    gn=0.0015,
-    gg=0.023,
-    target_spin=0.0,
-    formalism=None,
-):
-    """Build a minimal single-resonance isotope for testing."""
-    return nereids.create_resonance_data(
-        z=z,
-        a=a,
-        awr=awr,
-        scattering_radius=scattering_radius,
-        resonances=[(energy, j, gn, gg)],
-        target_spin=target_spin,
-        formalism=formalism,
-    )
-
-
 @pytest.fixture
 def u238_data():
-    """Single-resonance U-238-like isotope (6.67 eV resonance)."""
+    """Single-resonance U-238-like isotope (6.674 eV resonance)."""
     return _make_single_resonance()
 
 


### PR DESCRIPTION
## Summary

Wave 2 PR-4b of the architecture-audit refactor sprint. Completes Wave 2
by consolidating the 3 Python U-238 synthetic-fixture helpers into a
shared `tests/_fixtures.py` module and **fixing the audit-flagged
`6.67` vs `6.674` Python/Rust drift**.

Closes test-duplication v2 finding F13 from
`.research/audit-r4-architecture-v2/SUMMARY-v2.md`. Stacks on
PR #584 (Wave 2 PR-4a, Rust side, merged at `bf604f9`).

**Primary value: correctness fix, not LOC reduction.**

## Drift fix (audit's headline F13)

Python `tests/test_nereids.py:25` defaulted `energy=6.67`. Rust
`nereids_endf::resonance::test_support::u238_single_resonance()` uses
`energy=6.674`. Both intend to encode the canonical U-238 6.674 eV
first negative resonance, but the 2-vs-3-sig-fig drift was historically
invisible because peak-position assertions tolerate a 4 meV shift. The
audit explicitly flagged this as the F13 highest-risk sub-finding.

After this PR: **all three Python helpers default to 6.674**, aligned
to Rust. Drift cannot re-emerge without an explicit edit to the
canonical default in `tests/_fixtures.py`.

## Sites consolidated

| Old location | New location |
|---|---|
| `tests/test_nereids.py:20-41` (`_make_single_resonance`) | `tests/_fixtures.py::_make_single_resonance` |
| `tests/test_mcp.py:290-302` (`_synthetic_u238_entry`) | `tests/_fixtures.py::_synthetic_u238_entry` |
| `tests/test_mcp.py:305-313` (`_synthetic_u238_data`) | `tests/_fixtures.py::_synthetic_u238_data` |

Imports added: `from _fixtures import _make_single_resonance` in
`test_nereids.py`; `from _fixtures import _synthetic_u238_data,
_synthetic_u238_entry` in `test_mcp.py`. Pytest's default
`--import-mode=prepend` puts `tests/` on `sys.path` so the bare-name
import resolves.

## LOC delta

| Bucket | Inserted | Deleted |
|---|---:|---:|
| `tests/_fixtures.py` (new) — 3 fixtures + 6-line module docstring + import | +60 | 0 |
| `tests/test_nereids.py` — delete helper + 1 import + docstring `6.67`→`6.674` | +3 | -22 |
| `tests/test_mcp.py` — delete 2 helpers + 1 import | +2 | -29 |
| **Totals** | **+65** | **-51** |

**NET: +14 LOC**

The audit projected NET -3 (39-LOC fixture file + 2 import LOC, vs
44 LOC of deleted helpers). Engineering reality on Python module
consolidation: 3-helper move into a new shared module cannot beat
~+10 LOC of inherent module-level overhead (docstring, `import`
statement, inter-fn blank lines). The 39-LOC audit budget assumed
crammed-kwargs formatting (~45-LOC minimum); a clear-style file lands
at ~60 LOC. Going lower would sacrifice readability for ~5-15 LOC and
is not worth it.

**This is a calibration data point** for audit-projection accuracy on
Python consolidations: the audit's LOC arithmetic underestimated by
~17 LOC. To be added to the methodology doc in Wave 5.

## Existing-logic check

Per `.claude/templates/fix-subagent-prompt.md` mandatory pre-step:

- No new helpers beyond the 3 moved.
- Module-level `import nereids` + 6-line docstring are inherent to
  having any new Python module — not new helper logic.
- No production code touched.
- Pure test-side refactor + one numerical value alignment
  (6.67 → 6.674) per the audit's drift-fix mandate.

## Scope boundaries (per locked plan)

User opted for "audit scope only" — F13 fix limited to the energy-value
drift. **NOT in this PR**:
- `scattering_radius=9.48` vs Rust `9.4285` (audit didn't include).
- Inline `6.67` literals at `test_nereids.py:213/246/258/1906` and
  related (not in the 3 helpers). These remain `6.67`; tests
  unaffected.

If a follow-up wants to chase these, file as a separate small PR.

## Test plan

- [x] `pixi run test-python` — **164 passed, 0 failed** (unchanged from main `bf604f9`).
  - The 4 mEV energy shift (6.67 → 6.674) is well below all Python
    assertion tolerances on peak-position and cross-section magnitude
    — confirmed by zero test failures. No assertion re-tuning required.
- N/A: `cargo fmt` / `cargo clippy` / `cargo test` — Python-only PR.

## Cumulative sprint state after PR-4b

| PR | Theme | Net LOC |
|---|---|---:|
| #580 | Governance scaffolding | +small |
| #581 | Delete network/diagnostic tests | -472 |
| #582 | Delete dead production code | -485 |
| #583 | Externalize ENDF fixtures | -160 |
| #584 | Promote test_support + migrate 17 sites | -219 |
| **PR-4b (this)** | **Python fixture consolidation + drift fix** | **+14** |
| **Cumulative deletion-side** | | **~-1322 LOC** |

## Linked

- Architecture audit sprint: Wave 2 PR-4b (completes Wave 2)
- Plan: `.research/audit-r4-architecture-v2/SUMMARY-v2.md` (test-duplication F13)
- PR-4a (Rust side, merged): `#584`
- Next: Wave 2 PR-5 (`interp_spectrum` / `broaden_presorted_reference` consolidation, target ~-121 LOC)
