### PR TITLE
refactor(tests): consolidate interp_spectrum + broaden_presorted_reference oracles (-130 LOC)

### DIFF
--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -2114,7 +2114,7 @@ impl std::error::Error for ResolutionParseError {}
 /// production API surface.
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_support {
-    use super::{ResolutionPlan, TabulatedResolution};
+    use super::{DIVISION_FLOOR, NEAR_ZERO_FLOOR, ResolutionPlan, TabulatedResolution};
 
     /// Build a [`ResolutionPlan`] directly from its SoA fields.
     ///
@@ -2189,12 +2189,165 @@ pub mod test_support {
     /// integration-test oracle uses the exact same constant as
     /// the SUT, preserving bit-exact equivalence.
     pub const TOF_FACTOR: f64 = super::TOF_FACTOR;
+
+    /// Bit-exact regression oracle: binary-search piecewise-linear
+    /// interpolation of `spectrum` onto target energy `e`.  Mirror of
+    /// the pre-optimization in-src reference; called transitively by
+    /// [`broaden_presorted_reference`] inside its inner convolution
+    /// loop.
+    ///
+    /// **Do not "clean up" this function.** Consumers are bit-exact
+    /// equivalence tests that pin the optimized two-pointer path in
+    /// `TabulatedResolution::broaden_presorted` against this byte-
+    /// identical reference.  A rewrite that shifts edge cases by even
+    /// one bit (e.g. swapping the upper-bound binary search for
+    /// `partition_point`, or changing the `<=` to `<` in the midpoint
+    /// comparison) would flip the comparison and invalidate the
+    /// regression suite.  See `feedback_bit_exact_oracle_verbatim.md`.
+    pub fn interp_spectrum(energies: &[f64], spectrum: &[f64], e: f64) -> Option<f64> {
+        let n = energies.len();
+        if n == 0 {
+            return None;
+        }
+        if e < energies[0] || e > energies[n - 1] {
+            return None;
+        }
+        let mut lo = 0;
+        let mut hi = n - 1;
+        while hi - lo > 1 {
+            let mid = (lo + hi) / 2;
+            if energies[mid] <= e {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        let span = energies[hi] - energies[lo];
+        if span.abs() < NEAR_ZERO_FLOOR {
+            return Some(spectrum[lo]);
+        }
+        let frac = (e - energies[lo]) / span;
+        Some(spectrum[lo] + frac * (spectrum[hi] - spectrum[lo]))
+    }
+
+    /// Bit-exact regression oracle: pre-optimization reference
+    /// implementation of [`TabulatedResolution::broaden_presorted`].
+    /// Used by the in-src + integration + microbench bit-exact test
+    /// suites that pin the optimized two-pointer path against this
+    /// reference.
+    ///
+    /// Same "do not refactor" caveat as [`interp_spectrum`].  Reads
+    /// `tab.flight_path_m()` via the public getter so the oracle stays
+    /// callable from integration tests (the underlying field is
+    /// private; the getter is a no-op wrapper, so byte-equivalence
+    /// against the original in-src field access is preserved).
+    pub fn broaden_presorted_reference(
+        tab: &TabulatedResolution,
+        energies: &[f64],
+        spectrum: &[f64],
+    ) -> Vec<f64> {
+        let n = energies.len();
+        if n == 0 {
+            return vec![];
+        }
+
+        let mut result = vec![0.0f64; n];
+
+        for i in 0..n {
+            let e = energies[i];
+            if e <= 0.0 {
+                result[i] = spectrum[i];
+                continue;
+            }
+
+            let tof_center = TOF_FACTOR * tab.flight_path_m() / e.sqrt();
+            let (offsets, weights) = tab.interpolated_kernel(e);
+
+            let mut sum = 0.0;
+            let mut norm = 0.0;
+
+            for k in 0..offsets.len() {
+                let dt = offsets[k];
+                let w = weights[k];
+                if w <= 0.0 {
+                    continue;
+                }
+
+                let tof_prime = tof_center + dt;
+                if tof_prime <= 0.0 {
+                    continue;
+                }
+
+                let e_prime = (TOF_FACTOR * tab.flight_path_m() / tof_prime).powi(2);
+
+                let s = match interp_spectrum(energies, spectrum, e_prime) {
+                    Some(v) => v,
+                    None => continue,
+                };
+
+                let dt_width = if k > 0 && k < offsets.len() - 1 {
+                    (offsets[k + 1] - offsets[k - 1]) * 0.5
+                } else if k == 0 && offsets.len() > 1 {
+                    offsets[1] - offsets[0]
+                } else if k == offsets.len() - 1 && offsets.len() > 1 {
+                    offsets[k] - offsets[k - 1]
+                } else {
+                    1.0
+                };
+
+                let weight = w * dt_width.abs();
+                sum += weight * s;
+                norm += weight;
+            }
+
+            result[i] = if norm > DIVISION_FLOOR {
+                sum / norm
+            } else {
+                spectrum[i]
+            };
+        }
+
+        result
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use nereids_core::constants;
+
+    // ── Smoke tests for the test_support oracles (`interp_spectrum` +
+    //    `broaden_presorted_reference`).  The 7+ bit-exact tests below
+    //    exercise the math thoroughly; these smoke tests just pin the
+    //    boundary-condition return-shape behavior of the oracles so a
+    //    future refactor that breaks empty-input or out-of-range
+    //    handling fails loudly rather than only via bit-exact diffs.
+
+    #[test]
+    fn test_support_interp_spectrum_empty_returns_none() {
+        assert_eq!(test_support::interp_spectrum(&[], &[], 1.0), None);
+    }
+
+    #[test]
+    fn test_support_interp_spectrum_out_of_range_returns_none() {
+        let energies = [1.0, 2.0, 3.0];
+        let spectrum = [10.0, 20.0, 30.0];
+        assert_eq!(
+            test_support::interp_spectrum(&energies, &spectrum, 0.5),
+            None
+        );
+        assert_eq!(
+            test_support::interp_spectrum(&energies, &spectrum, 3.5),
+            None
+        );
+    }
+
+    #[test]
+    fn test_support_broaden_presorted_reference_empty_returns_empty() {
+        let tab = test_support::trivial_tabulated_resolution(25.0);
+        let out = test_support::broaden_presorted_reference(&tab, &[], &[]);
+        assert!(out.is_empty());
+    }
 
     #[test]
     fn test_tof_factor_consistency() {
@@ -2532,105 +2685,11 @@ mod tests {
     // output against a canonical reference implementation that preserves
     // the pre-optimization code path.
 
-    /// Binary-search spectrum interpolation.  Preserved here because the
-    /// reference broaden_presorted uses it; the production inner loop now
-    /// uses a two-pointer walk and no longer needs this helper.
-    fn interp_spectrum(energies: &[f64], spectrum: &[f64], e: f64) -> Option<f64> {
-        let n = energies.len();
-        if n == 0 {
-            return None;
-        }
-        if e < energies[0] || e > energies[n - 1] {
-            return None;
-        }
-        let mut lo = 0;
-        let mut hi = n - 1;
-        while hi - lo > 1 {
-            let mid = (lo + hi) / 2;
-            if energies[mid] <= e {
-                lo = mid;
-            } else {
-                hi = mid;
-            }
-        }
-        let span = energies[hi] - energies[lo];
-        if span.abs() < NEAR_ZERO_FLOOR {
-            return Some(spectrum[lo]);
-        }
-        let frac = (e - energies[lo]) / span;
-        Some(spectrum[lo] + frac * (spectrum[hi] - spectrum[lo]))
-    }
-
-    /// Reference implementation — the pre-optimization broaden_presorted.
-    /// Kept in the test module only; used solely as the equivalence oracle.
-    fn broaden_presorted_reference(
-        tab: &TabulatedResolution,
-        energies: &[f64],
-        spectrum: &[f64],
-    ) -> Vec<f64> {
-        let n = energies.len();
-        if n == 0 {
-            return vec![];
-        }
-
-        let mut result = vec![0.0f64; n];
-
-        for i in 0..n {
-            let e = energies[i];
-            if e <= 0.0 {
-                result[i] = spectrum[i];
-                continue;
-            }
-
-            let tof_center = TOF_FACTOR * tab.flight_path_m / e.sqrt();
-            let (offsets, weights) = tab.interpolated_kernel(e);
-
-            let mut sum = 0.0;
-            let mut norm = 0.0;
-
-            for k in 0..offsets.len() {
-                let dt = offsets[k];
-                let w = weights[k];
-                if w <= 0.0 {
-                    continue;
-                }
-
-                let tof_prime = tof_center + dt;
-                if tof_prime <= 0.0 {
-                    continue;
-                }
-
-                let e_prime = (TOF_FACTOR * tab.flight_path_m / tof_prime).powi(2);
-
-                let s = match interp_spectrum(energies, spectrum, e_prime) {
-                    Some(v) => v,
-                    None => continue,
-                };
-
-                let dt_width = if k > 0 && k < offsets.len() - 1 {
-                    (offsets[k + 1] - offsets[k - 1]) * 0.5
-                } else if k == 0 && offsets.len() > 1 {
-                    offsets[1] - offsets[0]
-                } else if k == offsets.len() - 1 && offsets.len() > 1 {
-                    offsets[k] - offsets[k - 1]
-                } else {
-                    1.0
-                };
-
-                let weight = w * dt_width.abs();
-                sum += weight * s;
-                norm += weight;
-            }
-
-            result[i] = if norm > DIVISION_FLOOR {
-                sum / norm
-            } else {
-                spectrum[i]
-            };
-        }
-
-        result
-    }
+    // The `interp_spectrum` + `broaden_presorted_reference` oracles
+    // were promoted to `test_support` so the integration tests
+    // (`tests/venus_usr_resolution{,_microbench}.rs`) share the same
+    // byte-identical reference.  Imported below.
+    use super::test_support::broaden_presorted_reference;
 
     /// Synthetic TabulatedResolution with 3 reference energies and a
     /// triangular kernel of varying widths.  Deterministic, no I/O.

--- a/crates/nereids-physics/tests/venus_usr_resolution.rs
+++ b/crates/nereids-physics/tests/venus_usr_resolution.rs
@@ -21,115 +21,15 @@
 mod common;
 
 use nereids_physics::resolution::{
-    ResolutionError, ResolutionMatrix, ResolutionPlan, TabulatedResolution, apply_r,
-    apply_resolution_with_matrix, test_support,
+    ResolutionError, ResolutionMatrix, ResolutionPlan, apply_r, apply_resolution_with_matrix,
+    test_support,
 };
 
-// ── Helpers (duplicated from `src/resolution.rs` tests — keeping
-//    the crate's public surface minimal per issue #497 scope) ─────
-
-fn interp_spectrum(energies: &[f64], spectrum: &[f64], e: f64) -> Option<f64> {
-    // Verbatim copy of the canonical helper at
-    // crates/nereids-physics/src/resolution.rs:2541 (used by the
-    // in-src `broaden_presorted_reference` oracle).  Codex flagged
-    // an earlier rewritten variant in PR #545 round-1 review as
-    // semantically divergent (binary_search_by + early-return on
-    // exact hits vs upper-bound search + always-interpolate) —
-    // either path of divergence can flip the bit-exact comparison
-    // on exact-grid-hit / duplicate-grid edge cases.  Keep this in
-    // sync with the in-src version verbatim; if the production
-    // helper changes, mirror the change here.
-    let n = energies.len();
-    if n == 0 {
-        return None;
-    }
-    if e < energies[0] || e > energies[n - 1] {
-        return None;
-    }
-    let mut lo = 0;
-    let mut hi = n - 1;
-    while hi - lo > 1 {
-        let mid = (lo + hi) / 2;
-        if energies[mid] <= e {
-            lo = mid;
-        } else {
-            hi = mid;
-        }
-    }
-    let span = energies[hi] - energies[lo];
-    if span.abs() < nereids_core::constants::NEAR_ZERO_FLOOR {
-        return Some(spectrum[lo]);
-    }
-    let frac = (e - energies[lo]) / span;
-    Some(spectrum[lo] + frac * (spectrum[hi] - spectrum[lo]))
-}
-
-/// Reference implementation — the pre-optimization
-/// `broaden_presorted`.  Used solely as the equivalence oracle in
-/// the bit-exact test below.  Duplicated from `src/resolution.rs`
-/// rather than promoting the crate-internal helper to `pub`; uses
-/// `test_support::TOF_FACTOR` + `test_support::interpolated_kernel`
-/// so the oracle and SUT share the exact same constants and
-/// interior math.
-fn broaden_presorted_reference(
-    tab: &TabulatedResolution,
-    energies: &[f64],
-    spectrum: &[f64],
-) -> Vec<f64> {
-    use nereids_core::constants::DIVISION_FLOOR;
-    let tof_factor = test_support::TOF_FACTOR;
-
-    let n = energies.len();
-    if n == 0 {
-        return vec![];
-    }
-    let mut result = vec![0.0f64; n];
-    for i in 0..n {
-        let e = energies[i];
-        if e <= 0.0 {
-            result[i] = spectrum[i];
-            continue;
-        }
-        let tof_center = tof_factor * tab.flight_path_m() / e.sqrt();
-        let (offsets, weights) = test_support::interpolated_kernel(tab, e);
-        let mut sum = 0.0;
-        let mut norm = 0.0;
-        for k in 0..offsets.len() {
-            let dt = offsets[k];
-            let w = weights[k];
-            if w <= 0.0 {
-                continue;
-            }
-            let tof_prime = tof_center + dt;
-            if tof_prime <= 0.0 {
-                continue;
-            }
-            let e_prime = (tof_factor * tab.flight_path_m() / tof_prime).powi(2);
-            let s = match interp_spectrum(energies, spectrum, e_prime) {
-                Some(v) => v,
-                None => continue,
-            };
-            let dt_width = if k > 0 && k < offsets.len() - 1 {
-                (offsets[k + 1] - offsets[k - 1]) * 0.5
-            } else if k == 0 && offsets.len() > 1 {
-                offsets[1] - offsets[0]
-            } else if k == offsets.len() - 1 && offsets.len() > 1 {
-                offsets[k] - offsets[k - 1]
-            } else {
-                1.0
-            };
-            let weight = w * dt_width.abs();
-            sum += weight * s;
-            norm += weight;
-        }
-        result[i] = if norm > DIVISION_FLOOR {
-            sum / norm
-        } else {
-            spectrum[i]
-        };
-    }
-    result
-}
+// The `interp_spectrum` + `broaden_presorted_reference` oracles were
+// promoted to `nereids_physics::resolution::test_support` so this
+// integration test shares the byte-identical reference with the in-src
+// tests and the microbench.  Imported via the `test_support` module
+// already in scope above.
 
 fn assert_bit_exact(reference: &[f64], actual: &[f64], label: &str) {
     assert_eq!(reference.len(), actual.len(), "{label}: length mismatch");
@@ -209,7 +109,7 @@ fn test_broaden_presorted_bit_exact_on_venus_usr() {
         })
         .collect();
 
-    let reference = broaden_presorted_reference(&tab, &energies, &spectrum);
+    let reference = test_support::broaden_presorted_reference(&tab, &energies, &spectrum);
     let actual = test_support::broaden_presorted(&tab, &energies, &spectrum);
     assert_bit_exact(&reference, &actual, "venus_usr_synthetic_resolution");
 }

--- a/crates/nereids-physics/tests/venus_usr_resolution_microbench.rs
+++ b/crates/nereids-physics/tests/venus_usr_resolution_microbench.rs
@@ -24,7 +24,7 @@
 
 mod common;
 
-use nereids_physics::resolution::{TabulatedResolution, apply_r, test_support};
+use nereids_physics::resolution::{apply_r, test_support};
 
 /// Two-pointer `broaden_presorted` vs binary-search reference.  Pins
 /// the bit-exact sink equality between the two paths so a future
@@ -58,7 +58,7 @@ fn test_broaden_presorted_bench() {
     let start = std::time::Instant::now();
     let mut sink_ref = 0.0f64;
     for _ in 0..repeats {
-        let r = broaden_presorted_reference(&tab, &energies, &spectrum);
+        let r = test_support::broaden_presorted_reference(&tab, &energies, &spectrum);
         sink_ref += r.iter().sum::<f64>();
     }
     let t_ref = start.elapsed();
@@ -224,95 +224,6 @@ fn resolution_matrix_apply_microbench() {
     );
 }
 
-// ── Local helper duplicated from `src/resolution.rs` ─────────────
-
-fn interp_spectrum(energies: &[f64], spectrum: &[f64], e: f64) -> Option<f64> {
-    // Verbatim copy of crates/nereids-physics/src/resolution.rs:2541.
-    // See PR #545 round-1 review (Codex) for why a "modernized"
-    // binary_search variant is wrong here: the oracle must match
-    // the in-src helper byte for byte so the bit-exact comparison
-    // does not silently flip on exact-grid-hit edge cases.
-    let n = energies.len();
-    if n == 0 {
-        return None;
-    }
-    if e < energies[0] || e > energies[n - 1] {
-        return None;
-    }
-    let mut lo = 0;
-    let mut hi = n - 1;
-    while hi - lo > 1 {
-        let mid = (lo + hi) / 2;
-        if energies[mid] <= e {
-            lo = mid;
-        } else {
-            hi = mid;
-        }
-    }
-    let span = energies[hi] - energies[lo];
-    if span.abs() < nereids_core::constants::NEAR_ZERO_FLOOR {
-        return Some(spectrum[lo]);
-    }
-    let frac = (e - energies[lo]) / span;
-    Some(spectrum[lo] + frac * (spectrum[hi] - spectrum[lo]))
-}
-
-fn broaden_presorted_reference(
-    tab: &TabulatedResolution,
-    energies: &[f64],
-    spectrum: &[f64],
-) -> Vec<f64> {
-    use nereids_core::constants::DIVISION_FLOOR;
-    let tof_factor = test_support::TOF_FACTOR;
-
-    let n = energies.len();
-    if n == 0 {
-        return vec![];
-    }
-    let mut result = vec![0.0f64; n];
-    for i in 0..n {
-        let e = energies[i];
-        if e <= 0.0 {
-            result[i] = spectrum[i];
-            continue;
-        }
-        let tof_center = tof_factor * tab.flight_path_m() / e.sqrt();
-        let (offsets, weights) = test_support::interpolated_kernel(tab, e);
-        let mut sum = 0.0;
-        let mut norm = 0.0;
-        for k in 0..offsets.len() {
-            let dt = offsets[k];
-            let w = weights[k];
-            if w <= 0.0 {
-                continue;
-            }
-            let tof_prime = tof_center + dt;
-            if tof_prime <= 0.0 {
-                continue;
-            }
-            let e_prime = (tof_factor * tab.flight_path_m() / tof_prime).powi(2);
-            let s = match interp_spectrum(energies, spectrum, e_prime) {
-                Some(v) => v,
-                None => continue,
-            };
-            let dt_width = if k > 0 && k < offsets.len() - 1 {
-                (offsets[k + 1] - offsets[k - 1]) * 0.5
-            } else if k == 0 && offsets.len() > 1 {
-                offsets[1] - offsets[0]
-            } else if k == offsets.len() - 1 && offsets.len() > 1 {
-                offsets[k] - offsets[k - 1]
-            } else {
-                1.0
-            };
-            let weight = w * dt_width.abs();
-            sum += weight * s;
-            norm += weight;
-        }
-        result[i] = if norm > DIVISION_FLOOR {
-            sum / norm
-        } else {
-            spectrum[i]
-        };
-    }
-    result
-}
+// Helpers `interp_spectrum` + `broaden_presorted_reference` live in
+// `test_support` so this microbench, the in-src tests, and
+// `venus_usr_resolution.rs` share one byte-identical oracle.


### PR DESCRIPTION
## Summary

Wave 2 PR-5 of the architecture-audit refactor sprint. Consolidates
6 duplicated copies of 2 bit-exact regression-test oracle functions
(`interp_spectrum`, `broaden_presorted_reference`) across 3 files into
2 canonical `pub fn` items in `nereids_physics::resolution::test_support`.

Closes test-duplication v2 finding F3 from
`.research/audit-r4-architecture-v2/SUMMARY-v2.md`. Single-crate
consolidation, no Cargo.toml changes.

**Pure test-side refactor. Byte-equivalence preserved.** All 9 in-src
bit-exact tests + 1 integration test + 1 microbench continue to pass
against the consolidated oracle. **Bit-exact equivalence is now
strictly stronger than the 3-copy regime**: all 11 consumers share one
byte-identical reference, so the oracle cannot silently drift from
itself.

## Why this matters (per `feedback_bit_exact_oracle_verbatim.md`)

PR #545's lesson: when relocating bit-exact-oracle helpers, the
consolidated version must be **byte-identical** to the original. A
"cleaner" `binary_search_by` rewrite vs the original upper-bound +
always-interpolate would disagree at exact-grid-hit / duplicate-grid
edge cases, flipping the comparison. The 6 current copies have
identical logic; the only differences are API-path artifacts.

This PR moves the bodies **verbatim** with one mandatory adjustment:
`tab.flight_path_m` (private field) → `tab.flight_path_m()` (public
getter). The getter at `resolution.rs:844-846` returns the field
unchanged, so byte-equivalence holds.

## Sites consolidated

| Copy | Location | Original LOC |
|---|---|---:|
| #1 | `src/resolution.rs:2538-2562` (private `interp_spectrum`) | 25 |
| #2 | `src/resolution.rs:2566-2633` (private `broaden_presorted_reference`) | 70 |
| #3 | `tests/venus_usr_resolution.rs:31-65` | 35 |
| #4 | `tests/venus_usr_resolution.rs:74-132` | 59 |
| #5 | `tests/venus_usr_resolution_microbench.rs:229-258` | 30 |
| #6 | `tests/venus_usr_resolution_microbench.rs:260-318` | 59 |

## API surface

Two new public items in `nereids_physics::resolution::test_support`,
alongside the 5 existing PR #545 items (`plan_from_raw_parts`,
`trivial_tabulated_resolution`, `broaden_presorted`, `interpolated_kernel`,
`TOF_FACTOR`):

```rust
pub fn interp_spectrum(energies: &[f64], spectrum: &[f64], e: f64) -> Option<f64>;
pub fn broaden_presorted_reference(
    tab: &TabulatedResolution,
    energies: &[f64],
    spectrum: &[f64],
) -> Vec<f64>;
```

Both carry rustdoc warnings explicitly preserving the "do not refactor
this oracle" caveat — future maintainers see the bit-exact contract at
the doc-comment level.

No naming collisions: `broaden_presorted_reference` ≠ `broaden_presorted`
(the existing shim around the optimized production method).

## Wiring

**No Cargo.toml changes.** `nereids-physics` already has the
`[features] test-support` flag from PR #545; integration tests already
link with `features = ["test-support"]` via the self-dev-dep.

In-src test module: added `use super::test_support::broaden_presorted_reference;`
so the 9 existing call sites stay unqualified. Two integration tests
call `test_support::broaden_presorted_reference(...)` via the existing
`test_support` module import. Removed now-unused `TabulatedResolution`
imports from both integration tests (the local helper signatures were
their only consumers).

## Smoke tests added (3)

In the existing `#[cfg(test)] mod tests` block at `resolution.rs`:
- `test_support::interp_spectrum` empty input → `None`
- `test_support::interp_spectrum` out-of-range → `None`
- `test_support::broaden_presorted_reference` empty input → empty `Vec`

These pin boundary-condition return-shape behavior so a future refactor
that breaks empty / out-of-range handling fails loudly rather than only
showing up as a bit-exact diff.

## LOC delta

| Bucket | + | - |
|---|---:|---:|
| `src/resolution.rs`: add 2 public oracles + constants import + 3 smoke tests + comment shim | +145 | -95 |
| `tests/venus_usr_resolution.rs`: delete copies #3, #4 + header block; unused `TabulatedResolution` import stripped | +5 | -110 |
| `tests/venus_usr_resolution_microbench.rs`: delete copies #5, #6; unused `TabulatedResolution` import stripped | +5 | -94 |
| Inter-module blank lines + 2 qualified call-site updates | +17 | -3 |
| **Totals** | **+172** | **-302** |

**NET: -130 LOC** ✓

Audit projected -121; Phase 1 inventory refined to -134. Actual -130 is
within ~3% of both — methodology working as intended.

## Existing-logic check

Per `.claude/templates/fix-subagent-prompt.md`:
- 2 new public items match the audit's API exactly. No additions beyond
  the locked surface.
- 3 boundary-condition smoke tests; no new helpers.
- 9 in-src bit-exact tests + 1 integration + 1 microbench unchanged
  except for the `test_support::` prefix on call sites.
- Byte-equivalence: the consolidated bodies are verbatim copies of the
  in-src reference (`src/resolution.rs:2538-2562` and `:2566-2633` as
  they existed on main `bf604f9`), with only the documented
  `tab.flight_path_m` → `tab.flight_path_m()` adjustment.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --exclude nereids-python` — **905 passed, 0 failed, 0 ignored** (was 902 on main; +3 new smoke tests)
- N/A: `pixi run test-python` — no Python surface touched. Will run as part of `/post-merge`.

## Cumulative sprint state after PR-5

| PR | Theme | Net LOC |
|---|---|---:|
| #580 | Governance scaffolding | +small |
| #581 | Delete network/diagnostic tests | -472 |
| #582 | Delete dead production code | -485 |
| #583 | Externalize ENDF fixtures | -160 |
| #584 | Promote test_support + migrate 17 sites | -219 |
| #585 | Python fixture + drift fix | +14 |
| **PR-5 (this)** | **Consolidate resolution oracles** | **-130** |
| **Cumulative deletion-side** | | **~-1452 LOC** |

## Linked

- Architecture audit sprint: Wave 2 PR-5
- Plan: `.research/audit-r4-architecture-v2/SUMMARY-v2.md` (test-duplication F3)
- Reference: PR #545 `test_support` pattern (`crates/nereids-physics/src/resolution.rs:2106-2192`)
- Next: Wave 2 PR-6 (smaller test-side consolidations: calibration round-trip, FE56 SAMMY fixtures, Xorshift PRNG dedup, parser URR fixtures — target ~-100 LOC)
