### PR TITLE
refactor(pipeline): extract build_energy_scale_transmission_model helper (-78 LOC)

### DIFF
--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -1056,67 +1056,7 @@ fn fit_transmission_lm(
 
     // Build model — use EnergyScaleTransmissionModel when energy-scale is enabled
     let model: Box<dyn FitModel> = if let Some((t0_idx, ls_idx)) = energy_scale_indices {
-        // Energy-scale model needs precomputed Doppler-broadened cross-sections.
-        // Precompute them if not already available.
-        let n_params = config.n_density_params();
-        let xs = if let Some(xs) = &config.precomputed_cross_sections {
-            Arc::clone(xs)
-        } else {
-            // Precompute Doppler-broadened σ(E) on the nominal energy grid.
-            // Resolution is NOT applied here — it's done inside the model's evaluate().
-            let instrument = config
-                .resolution
-                .clone()
-                .map(|r| Arc::new(InstrumentParams { resolution: r }));
-            let xs_raw = nereids_transmission::broadened_cross_sections(
-                config.energies(),
-                &config.resonance_data,
-                config.temperature_k,
-                instrument.as_deref(),
-                None,
-            )
-            .map_err(PipelineError::Transmission)?;
-            Arc::new(xs_raw)
-        };
-        // Collapse grouped isotopes if needed
-        let effective_xs =
-            if let (Some(di), Some(dr)) = (&config.density_indices, &config.density_ratios) {
-                if xs.len() == di.len() && di.len() == dr.len() {
-                    let n_e = xs[0].len();
-                    let mut eff = vec![vec![0.0f64; n_e]; n_params];
-                    for ((&idx, &ratio), member_xs) in di.iter().zip(dr.iter()).zip(xs.iter()) {
-                        for (j, &sigma) in member_xs.iter().enumerate() {
-                            eff[idx][j] += ratio * sigma;
-                        }
-                    }
-                    Arc::new(eff)
-                } else {
-                    xs
-                }
-            } else {
-                xs
-            };
-        // After group-collapsing, effective_xs has n_params entries.
-        // Use identity mapping because each XS entry maps to its own
-        // density parameter (same as PrecomputedTransmissionModel line 1443).
-        let density_indices: Vec<usize> = (0..n_params).collect();
-        let instrument = config
-            .resolution
-            .clone()
-            .map(|r| Arc::new(InstrumentParams { resolution: r }));
-        let mut es_model = EnergyScaleTransmissionModel::new(
-            effective_xs,
-            Arc::new(density_indices),
-            config.energies.clone(),
-            config.flight_path_m,
-            t0_idx,
-            ls_idx,
-            instrument,
-        );
-        if let Some(method) = config.tzero_jacobian_method {
-            es_model = es_model.with_jacobian_method(method);
-        }
-        Box::new(es_model)
+        build_energy_scale_transmission_model(config, t0_idx, ls_idx)?
     } else {
         build_transmission_model(config, n_density_params, _temperature_index)?
     };
@@ -1268,59 +1208,7 @@ fn fit_transmission_poisson(
 
     // Build inner model (energy-scale or precomputed)
     let model: Box<dyn FitModel> = if let Some((t0_idx, ls_idx)) = energy_scale_indices {
-        let n_params = config.n_density_params();
-        let xs = if let Some(xs) = &config.precomputed_cross_sections {
-            Arc::clone(xs)
-        } else {
-            let instrument = config
-                .resolution
-                .clone()
-                .map(|r| Arc::new(InstrumentParams { resolution: r }));
-            let xs_raw = nereids_transmission::broadened_cross_sections(
-                config.energies(),
-                &config.resonance_data,
-                config.temperature_k,
-                instrument.as_deref(),
-                None,
-            )
-            .map_err(PipelineError::Transmission)?;
-            Arc::new(xs_raw)
-        };
-        let effective_xs =
-            if let (Some(di), Some(dr)) = (&config.density_indices, &config.density_ratios) {
-                if xs.len() == di.len() && di.len() == dr.len() {
-                    let n_e = xs[0].len();
-                    let mut eff = vec![vec![0.0f64; n_e]; n_params];
-                    for ((&idx, &ratio), member_xs) in di.iter().zip(dr.iter()).zip(xs.iter()) {
-                        for (j, &sigma_val) in member_xs.iter().enumerate() {
-                            eff[idx][j] += ratio * sigma_val;
-                        }
-                    }
-                    Arc::new(eff)
-                } else {
-                    xs
-                }
-            } else {
-                xs
-            };
-        let density_indices: Vec<usize> = (0..n_params).collect();
-        let instrument = config
-            .resolution
-            .clone()
-            .map(|r| Arc::new(InstrumentParams { resolution: r }));
-        let mut es_model = EnergyScaleTransmissionModel::new(
-            effective_xs,
-            Arc::new(density_indices),
-            config.energies.clone(),
-            config.flight_path_m,
-            t0_idx,
-            ls_idx,
-            instrument,
-        );
-        if let Some(method) = config.tzero_jacobian_method {
-            es_model = es_model.with_jacobian_method(method);
-        }
-        Box::new(es_model)
+        build_energy_scale_transmission_model(config, t0_idx, ls_idx)?
     } else {
         build_transmission_model(config, n_density_params, temperature_index)?
     };
@@ -1477,59 +1365,7 @@ fn fit_counts_joint_poisson(
 
     // ── Build pure transmission model ──
     let t_model: Box<dyn FitModel> = if let Some((t0_idx, ls_idx)) = energy_scale_indices {
-        let n_params = config.n_density_params();
-        let xs = if let Some(xs) = &config.precomputed_cross_sections {
-            Arc::clone(xs)
-        } else {
-            let instrument = config
-                .resolution
-                .clone()
-                .map(|r| Arc::new(InstrumentParams { resolution: r }));
-            let xs_raw = nereids_transmission::broadened_cross_sections(
-                config.energies(),
-                &config.resonance_data,
-                config.temperature_k,
-                instrument.as_deref(),
-                None,
-            )
-            .map_err(PipelineError::Transmission)?;
-            Arc::new(xs_raw)
-        };
-        let effective_xs =
-            if let (Some(di), Some(dr)) = (&config.density_indices, &config.density_ratios) {
-                if xs.len() == di.len() && di.len() == dr.len() {
-                    let n_e = xs[0].len();
-                    let mut eff = vec![vec![0.0f64; n_e]; n_params];
-                    for ((&idx, &ratio), member_xs) in di.iter().zip(dr.iter()).zip(xs.iter()) {
-                        for (j, &sigma_val) in member_xs.iter().enumerate() {
-                            eff[idx][j] += ratio * sigma_val;
-                        }
-                    }
-                    Arc::new(eff)
-                } else {
-                    xs
-                }
-            } else {
-                xs
-            };
-        let density_indices: Vec<usize> = (0..n_params).collect();
-        let instrument = config
-            .resolution
-            .clone()
-            .map(|r| Arc::new(InstrumentParams { resolution: r }));
-        let mut es_model = EnergyScaleTransmissionModel::new(
-            effective_xs,
-            Arc::new(density_indices),
-            config.energies.clone(),
-            config.flight_path_m,
-            t0_idx,
-            ls_idx,
-            instrument,
-        );
-        if let Some(method) = config.tzero_jacobian_method {
-            es_model = es_model.with_jacobian_method(method);
-        }
-        Box::new(es_model)
+        build_energy_scale_transmission_model(config, t0_idx, ls_idx)?
     } else {
         build_transmission_model(config, n_density_params, temperature_index)?
     };
@@ -1952,6 +1788,92 @@ fn append_background_params(
         back_d,
         back_f,
     }
+}
+
+/// Build an [`EnergyScaleTransmissionModel`] for the energy-scale fit branch
+/// of `fit_transmission_lm` / `fit_transmission_poisson` /
+/// `fit_counts_joint_poisson`.
+///
+/// Absorbs the 3 byte-identical construction blocks that used to live inline
+/// in each fitter (see commit `1b4131f` for the pre-extraction pattern).
+/// Stays private — internal pipeline construction detail, not part of the
+/// crate's public surface.
+///
+/// The energy-scale model needs precomputed Doppler-broadened cross-sections.
+/// If `config.precomputed_cross_sections` is `Some`, reuses them; otherwise
+/// computes σ(E) on `config.energies()` (resolution is NOT applied here — it
+/// is applied inside the model's `evaluate()` via the wrapped
+/// [`InstrumentParams`]).  When grouped isotopes are active
+/// (`config.density_indices` and `config.density_ratios` both `Some` and
+/// length-consistent), collapses the per-member cross-sections into per-group
+/// effective cross-sections using the ratio weights; the resulting
+/// `effective_xs` then carries `n_params` entries (one per density
+/// parameter), so the model's `density_indices` is the identity mapping
+/// `(0..n_params)`.
+///
+/// `t0_idx` and `ls_idx` are the parameter indices for `t0` and `l_scale`,
+/// produced by [`append_energy_scale_params`] at each fitter's setup.
+fn build_energy_scale_transmission_model(
+    config: &UnifiedFitConfig,
+    t0_idx: usize,
+    ls_idx: usize,
+) -> Result<Box<dyn FitModel>, PipelineError> {
+    let n_params = config.n_density_params();
+    let xs = if let Some(xs) = &config.precomputed_cross_sections {
+        Arc::clone(xs)
+    } else {
+        let instrument = config
+            .resolution
+            .clone()
+            .map(|r| Arc::new(InstrumentParams { resolution: r }));
+        let xs_raw = nereids_transmission::broadened_cross_sections(
+            config.energies(),
+            &config.resonance_data,
+            config.temperature_k,
+            instrument.as_deref(),
+            None,
+        )
+        .map_err(PipelineError::Transmission)?;
+        Arc::new(xs_raw)
+    };
+    let effective_xs =
+        if let (Some(di), Some(dr)) = (&config.density_indices, &config.density_ratios) {
+            if xs.len() == di.len() && di.len() == dr.len() {
+                let n_e = xs[0].len();
+                let mut eff = vec![vec![0.0f64; n_e]; n_params];
+                for ((&idx, &ratio), member_xs) in di.iter().zip(dr.iter()).zip(xs.iter()) {
+                    for (j, &sigma) in member_xs.iter().enumerate() {
+                        eff[idx][j] += ratio * sigma;
+                    }
+                }
+                Arc::new(eff)
+            } else {
+                xs
+            }
+        } else {
+            xs
+        };
+    // After group-collapsing, effective_xs has n_params entries.  Use identity
+    // mapping because each XS entry maps to its own density parameter (same as
+    // PrecomputedTransmissionModel).
+    let density_indices: Vec<usize> = (0..n_params).collect();
+    let instrument = config
+        .resolution
+        .clone()
+        .map(|r| Arc::new(InstrumentParams { resolution: r }));
+    let mut es_model = EnergyScaleTransmissionModel::new(
+        effective_xs,
+        Arc::new(density_indices),
+        config.energies.clone(),
+        config.flight_path_m,
+        t0_idx,
+        ls_idx,
+        instrument,
+    );
+    if let Some(method) = config.tzero_jacobian_method {
+        es_model = es_model.with_jacobian_method(method);
+    }
+    Ok(Box::new(es_model))
 }
 
 /// Build the transmission forward model, selecting precomputed or full path.


### PR DESCRIPTION
## Summary

Wave 3 PR-7 of the architecture-audit refactor sprint. Closes
duplication-scan v2 finding F9 — the audit calls this "the only
credible LOC-reducer in the entire duplication-scan pass."

Extracts 3 byte-identical `EnergyScaleTransmissionModel` construction
blocks from `crates/nereids-pipeline/src/pipeline.rs` (one each inside
`fit_transmission_lm`, `fit_transmission_poisson`,
`fit_counts_joint_poisson`) into a single private helper
`fn build_energy_scale_transmission_model(config, t0_idx, ls_idx)`.

**This is production code**, not test code. All 3 sites are inside
public-API call paths reached via `fit_spectrum_typed`. Eliminates a
real 3-way drift hazard.

## Byte-equivalence preserved by construction

The 3 inline blocks were byte-identical in construction logic; only
cosmetic deltas before this PR:

- Site #1 had documentation comments; sites #2/#3 didn't.
- Site #1 inner loop var was `sigma`; sites #2/#3 used `sigma_val`.
  (Identical semantics — both bind a reference to the same `f64`.)

The new helper carries the site-#1 comment density (authoritative
documentation of the construction sequence) and site-#1 variable name
`sigma`. Per-byte verbatim lift; no production logic changed.

## Helper API

```rust
fn build_energy_scale_transmission_model(
    config: &UnifiedFitConfig,
    t0_idx: usize,
    ls_idx: usize,
) -> Result<Box<dyn FitModel>, PipelineError>
```

- **Private** (`fn`, not `pub fn`) per audit guidance: "ship only if the helper can stay private."
- **3-arg signature** — well below clippy's 7-arg threshold; no `#[allow(...)]` or param struct.
- `n_params = config.n_density_params()` computed inside the helper (was identical at all 3 sites; doesn't belong in the signature).

## LOC delta

| Bucket | + | - |
|---|---:|---:|
| New helper body + rustdoc + Box wrap | +84 | 0 |
| 3 replacement call sites (one-liners) | +5 | 0 |
| Delete site #1 inline block | 0 | -62 |
| Delete site #2 inline block | 0 | -54 |
| Delete site #3 inline block | 0 | -54 |
| Misc | 0 | +3 |
| **Totals** | **+89** | **-167** |

**NET: -78 LOC**

| | Audit | Plan | Actual |
|---|---:|---:|---:|
| Net LOC | -13 | -45 | **-78** ✓ |

Beats all three estimates — primarily because I dropped the planned
~35 LOC of helper-specific unit tests after verifying they'd duplicate
existing integration coverage.

## Test scope deviation (intentional)

**Zero helper-specific unit tests added.** Justification:

- All 905 existing tests pass after the verbatim extraction —
  byte-equivalence is the strongest possible coverage for a pure
  verbatim refactor.
- The 3 existing integration tests in `pipeline.rs`
  (`test_energy_scale_returns_fitted_params`,
  `test_energy_scale_rejects_temperature`,
  `test_no_energy_scale_returns_none`) cover the full helper code
  path end-to-end through the public-API surface.
- Adding 4 helper-specific tests would duplicate this coverage with
  ~35 LOC of inflation — exactly the anti-DRY pattern
  `feedback_fixes_must_consolidate_not_duplicate.md` warns about.

**Methodology note**: for pure verbatim extractions like this one,
byte-equivalence + existing integration tests are sufficient. If a
future change to the helper's *internals* (not a pure extraction) needs
targeted unit coverage, add the tests then. Don't pre-emptively add
tests that only re-prove what byte-equivalence already proves.

## Existing-logic check

Per `.claude/templates/fix-subagent-prompt.md`:

- No new public surface in `nereids-pipeline`. Helper is `fn`, called
  only from the 3 sites within the same file.
- No production logic changed. Per-byte verbatim lift.
- DRY governance: eliminates a 3-way drift hazard. Future evolution of
  the construction sequence now lives in exactly one place rather than
  three.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --exclude nereids-python` — **905 passed, 0 failed, 0 ignored** — exact match with main `1b4131f`
- [x] `pixi run test-python` — **164 passed** — verified end-to-end through the `fit_spectrum_typed` PyO3 binding that all 3 sites are reached by

## Cumulative sprint state after PR-7

| PR | Theme | Net LOC |
|---|---|---:|
| #580 | Governance scaffolding | +small |
| #581-#587 (Waves 1-2) | | -1559 |
| **PR-7 (this)** | **Energy-scale model helper extraction** | **-78** |
| **Cumulative deletion-side** | | **~-1637 LOC** |

After PR-7: **9 of 10 sprint PRs landed**. Remaining: PR-8 (`ParallelSlices` / `EnergySeries` newtype promotion, target ~-79 LOC, completes Wave 3), PR-9 (LRF=7 KRM=3 physics, +80 feature work), PR-10 (methodology doc, +400 durable artifact).

## Linked

- Architecture audit sprint: Wave 3 PR-7
- Plan: `.research/audit-r4-architecture-v2/SUMMARY-v2.md` (duplication-scan F9)
- Existing private builders mirrored: `build_transmission_model`, `build_density_params`, `append_temperature_param`, `append_energy_scale_params` in the same file
