### PR TITLE
build(release): bump-version.sh updates CITATION.cff + rolls CHANGELOG; backfill 0.1.6-0.1.8

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -31,8 +31,9 @@ the wrapper that gets the bumps right and verifies CI succeeded.
 
 ## Step 2: Bump versions
 
-Seven files (treat as a single atomic edit; do not commit each separately).
-`pixi run bump-version <NEW>` (`scripts/bump-version.sh`) automates all of them:
+Six files (treat as a single atomic edit; do not commit each separately).
+`pixi run bump-version <NEW>` (`scripts/bump-version.sh`) automates all six, plus
+the Cargo.lock refresh (Step 3) — so seven files are staged together in Step 5:
 
 - [Cargo.toml](Cargo.toml)
   - `workspace.package.version = "<NEW>"` (around L16)

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,9 +1,9 @@
 # Release Pipeline
 
-Cut a new NEREIDS release. The work is mostly bumping versions in 4 files,
-tagging, and pushing — the actual building / publishing / homebrew update
-happens on CI when the tag arrives. This skill is the wrapper that gets
-the bumps right and verifies CI succeeded.
+Cut a new NEREIDS release. The work is mostly bumping versions across the
+workspace, rolling the changelog, tagging, and pushing — the actual building /
+publishing / homebrew update happens on CI when the tag arrives. This skill is
+the wrapper that gets the bumps right and verifies CI succeeded.
 
 ## Arguments
 
@@ -31,7 +31,8 @@ the bumps right and verifies CI succeeded.
 
 ## Step 2: Bump versions
 
-Five files (treat as a single atomic edit; do not commit each separately):
+Seven files (treat as a single atomic edit; do not commit each separately).
+`pixi run bump-version <NEW>` (`scripts/bump-version.sh`) automates all of them:
 
 - [Cargo.toml](Cargo.toml)
   - `workspace.package.version = "<NEW>"` (around L16)
@@ -48,9 +49,18 @@ Five files (treat as a single atomic edit; do not commit each separately):
     the CI's `update-homebrew` job substitutes into the *separate*
     `homebrew-nereids` tap repo (`Casks/nereids.rb`). Bumping the in-repo
     template anyway keeps it as a useful reference.
+- [CITATION.cff](CITATION.cff)
+  - `version: <NEW>` (around L6) and `date-released: <today>` (L7) — both
+    stamped by the bump script (the date line is updated in place; it must
+    already exist, which it does as of v0.1.8)
+- [CHANGELOG.md](CHANGELOG.md)
+  - the bump script rolls `## [Unreleased]` into a dated `## [<NEW>]` section
+    and updates the `compare/...` link-refs. Curate the release notes *under
+    `[Unreleased]`* **before** running the bump so they land in the new section.
 
-Reference: see commit `973bdf2` (Release v0.1.7) for the exact diff
-shape — five files, ~26 line changes total.
+Reference: commit `973bdf2` (Release v0.1.7) shows the historical five-file
+version-bump diff shape; releases now also touch `CITATION.cff` +
+`CHANGELOG.md` (~7 files total).
 
 **Skip in the bump** anything matching `0.1.<old>` in code/docs that isn't
 a version declaration (e.g. example notebooks may have hardcoded version
@@ -127,7 +137,7 @@ runs — `rm -rf target/wheels` at the top is the cleaner reset path.
 ## Step 5: Commit + tag
 
 ```
-git add Cargo.toml Cargo.lock pyproject.toml apps/gui/pyproject.toml homebrew/nereids.rb
+git add Cargo.toml Cargo.lock pyproject.toml apps/gui/pyproject.toml homebrew/nereids.rb CITATION.cff CHANGELOG.md
 git commit -S -m "Release v<NEW>"
 git tag -s v<NEW> -m "Release v<NEW>"
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,106 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   breaking change at this stage of the project; no external consumers
   of this field have been identified in the workspace or sibling repos.
 
-## [0.1.5] - 2025-03-11
+## [0.1.8] - 2026-04-27
+
+### Added
+
+- TENDL-2023 ENDF library with full MAT-table coverage (#508)
+- GUI: optional fitting of the energy scale — TZERO + flight-path L scale (#501)
+- GUI: vertically stacked image + spectrum layout in the Analyze step (#506)
+- Counts-domain joint-Poisson (KL) fitting with 2D spatial-map integration and
+  Python API parity (#450)
+- Sparse empirical-cubature forward-model surrogate for multi-isotope fits, plus
+  a scalar k=1 Chebyshev surrogate (epic #472: #479, #481, #482)
+- VENUS Hf 120-min NeXus test fixtures (via the PLEIADES submodule)
+
+### Changed
+
+- Resolution broadening rebuilt around a reusable `ResolutionPlan`, compiled to a
+  CSR `ResolutionMatrix` (~4.2× faster apply, bit-exact) and wired through the
+  fixed-grid fit models (#467, #468, #470, #478)
+- Two-pointer walk in `broaden_presorted` (~4.2× on VENUS) (#464)
+- Energy-scale (TZERO) Jacobian: density-column plan cache + partial-GAL
+  default (#469, #484, #498)
+- KL "polish" pass now off by default (~100× faster single-spectrum fits) (#487)
+
+### Fixed
+
+- MLBW batch-API correctness + dispatch consolidation, gated against VENUS (#466)
+- GUI: invalidate the cached fit when solver controls change (#507)
+- ENDF: use the OS trust roots for IAEA fetches (#505)
+- Spatial map: NaN-on-failure handling, config guards, and binding
+  validation (#461)
+- Refuse to silently collapse multiple rotation angles in the NeXus histogram
+  loader (#463)
+
+### Build
+
+- Bump `rustls-webpki` (#477) and `rand` (#449)
+
+## [0.1.7] - 2026-04-04
+
+### Added
+
+- Uncertainty estimation and propagation, Phases 1-4 (#446)
+- Python bindings for NeXus histogram and event loading (#447)
+- Resolution-aware analytical Jacobians (#445)
+
+### Fixed
+
+- Apply resolution broadening *after* Beer-Lambert, including the temperature
+  path of `TransmissionFitModel` (#442 → #443, #444)
+
+## [0.1.6] - 2026-03-23
+
+### Added
+
+- Unified typed fitting pipeline: a solver-agnostic `ForwardModel` trait, typed
+  `InputData` constructors (`from_counts` / `from_transmission`),
+  `UnifiedFitConfig`, and the `fit_spectrum_typed` / `spatial_map_typed` entry
+  points (Python + Rust)
+- True multi-level Breit-Wigner (MLBW) with a coherent U-matrix, replacing the
+  prior SLBW-dispatch approximation
+- SAMMY-style normalization and background fitting for transmission, plus a
+  KL-native background model for counts data
+- Counts + KL temperature fitting with analytical Doppler temperature derivatives
+- Unresolved-resonance region: LFW=1 (energy-dependent fission widths) and all
+  five ENDF interpolation laws (INT=1..5)
+- Energy calibration (`calibrate_energy`) with resolution broadening
+- Constrained isotope-group fitting (core, GUI, and a tutorial notebook)
+- Analytical Jacobian for the Poisson solver (incl. a temperature derivative)
+
+### Changed
+
+- Consolidated the fitting stack on a single optimizer and API: removed the
+  external L-BFGS-B solver and the legacy pre-typed fitting/spatial API (the
+  Poisson/KL path now uses an analytic Gauss-Newton step with an internal
+  finite-difference L-BFGS fallback)
+- ROI spectrum averaging now uses inverse-variance weighting instead of an
+  arithmetic mean
+- `spatial_map` / `sparse_reconstruct` `n_total` now count *attempted* pixels,
+  not only successes
+- Wrapped large shared buffers (`sample_data`, `open_beam_data`,
+  `spectrum_values`) in `Arc` to avoid per-pixel clones (#374)
+- Project files now persist normalized uncertainty, dead-pixel masks, and the
+  anorm / background maps
+
+### Fixed
+
+- RML phase-convention correction (+ documented SAMMY truth sources); MLBW phase
+  convention + total cross-section regression
+- JENDL-5 Eu-151/153 parse failure: deduplicated URR energy grid (#402, #411)
+- Detectability SNR computation and resolution-grid handling
+- GUI ENDF-fetch defects and chip layout (#403, #410)
+- Data-integrity hardening: reject synthetic energy axes, count load errors,
+  eliminate silent pixel drops
+
+### Project
+
+- Added `CITATION.cff`, `CONTRIBUTING.md`, `CHANGELOG.md`, a Code of Conduct, and
+  a Zenodo DOI badge
+
+## [0.1.5] - 2026-03-11
 
 ### Fixed
 - Switched HTTP backend from `native-tls` to `rustls-tls` to eliminate
@@ -29,7 +128,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Fixed PyPI sdist LICENSE file path
 - Built Python wheels for all supported versions (3.10-3.13) on all platforms
 
-## [0.1.0] - 2025-03-10
+## [0.1.0] - 2026-03-11
 
 ### Added
 
@@ -90,5 +189,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Documentation site: mdBook user guide + rustdoc API reference on GitHub Pages
 - SAMMY validation suite: 43 test cases validated against SAMMY reference code
 
+[Unreleased]: https://github.com/ornlneutronimaging/NEREIDS/compare/v0.1.8...HEAD
+[0.1.8]: https://github.com/ornlneutronimaging/NEREIDS/compare/v0.1.7...v0.1.8
+[0.1.7]: https://github.com/ornlneutronimaging/NEREIDS/compare/v0.1.6...v0.1.7
+[0.1.6]: https://github.com/ornlneutronimaging/NEREIDS/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/ornlneutronimaging/NEREIDS/compare/v0.1.0...v0.1.5
 [0.1.0]: https://github.com/ornlneutronimaging/NEREIDS/releases/tag/v0.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,8 @@ title: "NEREIDS: Neutron Resonance Resolved Imaging Data Analysis System"
 message: "If you use this software, please cite it as below."
 type: software
 license: BSD-3-Clause
-version: 0.1.5
+version: 0.1.8
+date-released: 2026-04-27
 doi: 10.5281/zenodo.18973054
 url: https://ornlneutronimaging.github.io/NEREIDS/
 repository-code: https://github.com/ornlneutronimaging/NEREIDS

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -11,7 +11,10 @@
 #   3. pyproject.toml  (Python bindings)
 #   4. apps/gui/pyproject.toml  (GUI wheel)
 #   5. homebrew/nereids.rb  (local template)
-#   6. Cargo.lock  (via cargo update --workspace)
+#   6. pyproject.toml  — nereids-gui optional-dependency pin
+#   7. CITATION.cff  — version + date-released
+#   8. CHANGELOG.md  — roll [Unreleased] → new dated section + link-refs
+#   9. Cargo.lock  (via cargo update --workspace)
 #
 # The script does NOT touch:
 #   - Test fixtures with hardcoded versions (those are test data)
@@ -21,6 +24,8 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_URL="https://github.com/ornlneutronimaging/NEREIDS"
+RELEASE_DATE="$(date +%F)" # YYYY-MM-DD; portable on BSD + GNU date
 
 # --- Parse arguments ---
 NEW_VERSION=""
@@ -85,6 +90,43 @@ apply_sed() {
     echo "  updated: $file"
 }
 
+# --- Helper: roll the CHANGELOG [Unreleased] section to the new version ---
+# Freezes the curated `## [Unreleased]` notes into a dated `## [NEW]` section
+# (Keep a Changelog workflow) and fixes the link-reference definitions.
+# Guarded: only touches a well-formed file, so it can never corrupt a
+# hand-maintained CHANGELOG. awk (not sed) because inserting lines portably
+# is awkward in sed — `\n` in a replacement is a GNU-only extension.
+roll_changelog() {
+    local file="$1"
+    if [ ! -f "$file" ] \
+        || ! grep -qE '^## \[Unreleased\]$' "$file" \
+        || ! grep -qE "^\[Unreleased\]: .*compare/v${CURRENT_VERSION}\.\.\.HEAD$" "$file"; then
+        echo "  skipped: $file ([Unreleased] section not in expected shape — roll manually)"
+        return
+    fi
+    if $DRY_RUN; then
+        echo "  would update: $file (roll [Unreleased] → $NEW_VERSION)"
+        return
+    fi
+    local tmp
+    tmp="$(mktemp)"
+    awk -v cur="$CURRENT_VERSION" -v new="$NEW_VERSION" -v date="$RELEASE_DATE" -v url="$REPO_URL" '
+        /^## \[Unreleased\]$/ {
+            print
+            print ""
+            print "## [" new "] - " date
+            next
+        }
+        /^\[Unreleased\]: / {
+            print "[Unreleased]: " url "/compare/v" new "...HEAD"
+            print "[" new "]: " url "/compare/v" cur "...v" new
+            next
+        }
+        { print }
+    ' "$file" >"$tmp" && mv "$tmp" "$file"
+    echo "  updated: $file (rolled [Unreleased] → $NEW_VERSION)"
+}
+
 # 1. Cargo.toml — workspace.package version
 #    This is the only bare `version = "X.Y.Z"` line (deps have `, path =` after)
 apply_sed "$REPO_ROOT/Cargo.toml" \
@@ -111,7 +153,18 @@ apply_sed "$REPO_ROOT/homebrew/nereids.rb" \
 apply_sed "$REPO_ROOT/pyproject.toml" \
     "s/nereids-gui==$CURRENT_VERSION/nereids-gui==$NEW_VERSION/"
 
-# 7. Cargo.lock — regenerate from updated Cargo.toml
+# 7. CITATION.cff — version + date-released
+#    `^version:` is anchored so it never matches the `cff-version:` line.
+#    The date-released line is updated in place; harmless no-op if absent.
+apply_sed "$REPO_ROOT/CITATION.cff" \
+    "s/^version: $CURRENT_VERSION$/version: $NEW_VERSION/"
+apply_sed "$REPO_ROOT/CITATION.cff" \
+    "s/^date-released:.*/date-released: $RELEASE_DATE/"
+
+# 8. CHANGELOG.md — roll [Unreleased] to the new dated version + link-refs
+roll_changelog "$REPO_ROOT/CHANGELOG.md"
+
+# 9. Cargo.lock — regenerate from updated Cargo.toml
 if ! $DRY_RUN; then
     echo "  updating Cargo.lock..."
     (cd "$REPO_ROOT" && cargo update --workspace 2>/dev/null)

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -64,6 +64,12 @@ if [ -z "$CURRENT_VERSION" ]; then
     exit 1
 fi
 
+# Regex-safe form of the current version for sed/grep PATTERN contexts: dots are
+# regex any-char, so escape them (e.g. a pre-release like 0.2.0-rc.1 then matches
+# literally, never an unintended 0x2x0-rcx1). NEW_VERSION needs no such form — it
+# only ever appears on sed replacement sides or as literal awk string concatenation.
+CURRENT_RE="${CURRENT_VERSION//./\\.}"
+
 if [ "$CURRENT_VERSION" = "$NEW_VERSION" ]; then
     echo "Already at version $NEW_VERSION — nothing to do."
     exit 0
@@ -75,6 +81,10 @@ if $DRY_RUN; then
 fi
 
 # --- Helper: apply sed in-place (macOS + Linux compatible) ---
+# Reports "unchanged" when the pattern matched nothing, rather than a misleading
+# "updated" — a silent no-op on release metadata (a drifted version-line format)
+# would otherwise look successful. Not a hard error: some calls (CITATION.cff
+# date-released when absent) are intentional no-ops.
 apply_sed() {
     local file="$1"
     local pattern="$2"
@@ -82,12 +92,18 @@ apply_sed() {
         echo "  would update: $file"
         return
     fi
+    local before
+    before="$(cat "$file")"
     if [[ "$OSTYPE" == darwin* ]]; then
         sed -i '' "$pattern" "$file"
     else
         sed -i "$pattern" "$file"
     fi
-    echo "  updated: $file"
+    if [ "$before" = "$(cat "$file")" ]; then
+        echo "  unchanged: $file (pattern not matched)"
+    else
+        echo "  updated: $file"
+    fi
 }
 
 # --- Helper: roll the CHANGELOG [Unreleased] section to the new version ---
@@ -98,10 +114,18 @@ apply_sed() {
 # is awkward in sed — `\n` in a replacement is a GNU-only extension.
 roll_changelog() {
     local file="$1"
-    if [ ! -f "$file" ] \
-        || ! grep -qE '^## \[Unreleased\]$' "$file" \
-        || ! grep -qE "^\[Unreleased\]: .*compare/v${CURRENT_VERSION}\.\.\.HEAD$" "$file"; then
-        echo "  skipped: $file ([Unreleased] section not in expected shape — roll manually)"
+    if [ ! -f "$file" ]; then
+        echo "  skipped: $file (not found)"
+        return
+    fi
+    # Require EXACTLY one '## [Unreleased]' heading and one matching link-ref.
+    # awk rewrites every match, so a malformed file with duplicates must be
+    # refused (not corrupted) — presence alone is not enough.
+    local n_head n_link
+    n_head=$(grep -cE '^## \[Unreleased\]$' "$file" || true)
+    n_link=$(grep -cE "^\[Unreleased\]: .*compare/v${CURRENT_RE}\.\.\.HEAD$" "$file" || true)
+    if [ "${n_head:-0}" -ne 1 ] || [ "${n_link:-0}" -ne 1 ]; then
+        echo "  skipped: $file (need exactly one '## [Unreleased]' heading and one matching '[Unreleased]:' link — roll manually)"
         return
     fi
     if $DRY_RUN; then
@@ -110,7 +134,7 @@ roll_changelog() {
     fi
     local tmp
     tmp="$(mktemp)"
-    awk -v cur="$CURRENT_VERSION" -v new="$NEW_VERSION" -v date="$RELEASE_DATE" -v url="$REPO_URL" '
+    if awk -v cur="$CURRENT_VERSION" -v new="$NEW_VERSION" -v date="$RELEASE_DATE" -v url="$REPO_URL" '
         /^## \[Unreleased\]$/ {
             print
             print ""
@@ -123,41 +147,47 @@ roll_changelog() {
             next
         }
         { print }
-    ' "$file" >"$tmp" && mv "$tmp" "$file"
-    echo "  updated: $file (rolled [Unreleased] → $NEW_VERSION)"
+    ' "$file" >"$tmp"; then
+        mv "$tmp" "$file"
+        echo "  updated: $file (rolled [Unreleased] → $NEW_VERSION)"
+    else
+        rm -f "$tmp"
+        echo "  ERROR: failed to roll $file" >&2
+        return 1
+    fi
 }
 
 # 1. Cargo.toml — workspace.package version
 #    This is the only bare `version = "X.Y.Z"` line (deps have `, path =` after)
 apply_sed "$REPO_ROOT/Cargo.toml" \
-    "s/^version = \"$CURRENT_VERSION\"$/version = \"$NEW_VERSION\"/"
+    "s/^version = \"$CURRENT_RE\"$/version = \"$NEW_VERSION\"/"
 
 # 2. Cargo.toml — workspace.dependencies internal crate versions
 #    These lines look like: endf-mat = { version = "0.1.0", path = "..." }
 apply_sed "$REPO_ROOT/Cargo.toml" \
-    "s/version = \"$CURRENT_VERSION\", path =/version = \"$NEW_VERSION\", path =/g"
+    "s/version = \"$CURRENT_RE\", path =/version = \"$NEW_VERSION\", path =/g"
 
 # 3. pyproject.toml (Python bindings)
 apply_sed "$REPO_ROOT/pyproject.toml" \
-    "s/^version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/"
+    "s/^version = \"$CURRENT_RE\"/version = \"$NEW_VERSION\"/"
 
 # 4. apps/gui/pyproject.toml (GUI wheel)
 apply_sed "$REPO_ROOT/apps/gui/pyproject.toml" \
-    "s/^version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/"
+    "s/^version = \"$CURRENT_RE\"/version = \"$NEW_VERSION\"/"
 
 # 5. homebrew/nereids.rb (local template)
 apply_sed "$REPO_ROOT/homebrew/nereids.rb" \
-    "s/version \"$CURRENT_VERSION\"/version \"$NEW_VERSION\"/"
+    "s/version \"$CURRENT_RE\"/version \"$NEW_VERSION\"/"
 
 # 6. pyproject.toml — gui optional dependency version
 apply_sed "$REPO_ROOT/pyproject.toml" \
-    "s/nereids-gui==$CURRENT_VERSION/nereids-gui==$NEW_VERSION/"
+    "s/nereids-gui==$CURRENT_RE/nereids-gui==$NEW_VERSION/"
 
 # 7. CITATION.cff — version + date-released
 #    `^version:` is anchored so it never matches the `cff-version:` line.
 #    The date-released line is updated in place; harmless no-op if absent.
 apply_sed "$REPO_ROOT/CITATION.cff" \
-    "s/^version: $CURRENT_VERSION$/version: $NEW_VERSION/"
+    "s/^version: $CURRENT_RE$/version: $NEW_VERSION/"
 apply_sed "$REPO_ROOT/CITATION.cff" \
     "s/^date-released:.*/date-released: $RELEASE_DATE/"
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -137,7 +137,10 @@ roll_changelog() {
         return
     fi
     local tmp
-    tmp="$(mktemp)"
+    # Explicit path template (ends in X's): works identically on GNU and BSD
+    # mktemp. (Bare `mktemp` also works on both, but the template form is
+    # unambiguous and matches the pattern used elsewhere in .claude/skills.)
+    tmp="$(mktemp "${TMPDIR:-/tmp}/bump-version-changelog.XXXXXX")"
     if awk -v cur="$CURRENT_VERSION" -v new="$NEW_VERSION" -v date="$RELEASE_DATE" -v url="$REPO_URL" '
         /^## \[Unreleased\]$/ {
             print
@@ -189,7 +192,9 @@ apply_sed "$REPO_ROOT/pyproject.toml" \
 
 # 7. CITATION.cff — version + date-released
 #    `^version:` is anchored so it never matches the `cff-version:` line.
-#    The date-released line is updated in place; harmless no-op if absent.
+#    The date-released line is rewritten in place and must already exist (it
+#    does as of v0.1.8). If the field is absent the sed is a silent no-op — the
+#    script does NOT insert it, so the date simply would not be stamped.
 apply_sed "$REPO_ROOT/CITATION.cff" \
     "s/^version: $CURRENT_RE$/version: $NEW_VERSION/"
 apply_sed "$REPO_ROOT/CITATION.cff" \

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -118,13 +118,17 @@ roll_changelog() {
         echo "  skipped: $file (not found)"
         return
     fi
-    # Require EXACTLY one '## [Unreleased]' heading and one matching link-ref.
-    # awk rewrites every match, so a malformed file with duplicates must be
-    # refused (not corrupted) — presence alone is not enough.
-    local n_head n_link
+    # Require EXACTLY one '## [Unreleased]' heading and one '[Unreleased]:' link,
+    # and that the single link matches the current version. awk rewrites *every*
+    # '## [Unreleased]' heading and *every* '[Unreleased]: ' line, so the guard
+    # must count the same broad sets it acts on (n_link_any) — not just the
+    # version-matching subset (n_link_ok) — or a file with one correct link plus
+    # a stale duplicate would pass yet get double-rewritten.
+    local n_head n_link_any n_link_ok
     n_head=$(grep -cE '^## \[Unreleased\]$' "$file" || true)
-    n_link=$(grep -cE "^\[Unreleased\]: .*compare/v${CURRENT_RE}\.\.\.HEAD$" "$file" || true)
-    if [ "${n_head:-0}" -ne 1 ] || [ "${n_link:-0}" -ne 1 ]; then
+    n_link_any=$(grep -cE '^\[Unreleased\]: ' "$file" || true)
+    n_link_ok=$(grep -cE "^\[Unreleased\]: .*compare/v${CURRENT_RE}\.\.\.HEAD$" "$file" || true)
+    if [ "${n_head:-0}" -ne 1 ] || [ "${n_link_any:-0}" -ne 1 ] || [ "${n_link_ok:-0}" -ne 1 ]; then
         echo "  skipped: $file (need exactly one '## [Unreleased]' heading and one matching '[Unreleased]:' link — roll manually)"
         return
     fi


### PR DESCRIPTION
## Summary

`scripts/bump-version.sh` bumped 5 version files + Cargo.lock but silently forgot `CITATION.cff` and `CHANGELOG.md`, so both drifted stale: CITATION was pinned at `0.1.5` (workspace + latest tag are `0.1.8`) with no `date-released`, and CHANGELOG had no `0.1.6/0.1.7/0.1.8` sections, `2025` placeholder dates, and no `[Unreleased]:` link-ref. This wires both files into the bumper (CITATION `version` + `date-released`; a guarded `roll_changelog()` that freezes `## [Unreleased]` into a dated section and fixes the `compare/...` link-refs), repairs the two drifted files, fixes a header/body block-numbering drift in the script, and syncs the `release` skill's file list + Step 5 `git add` so a skill-driven release stages the same files.

## LOC delta

- inserted: +222
- deleted:  -21
- net:      +201

**This is a feature + docs PR, not a refactor — positive net LOC is expected:**
- ~+107 is backfilled `CHANGELOG.md` release history for 0.1.6–0.1.8 (inherently additive content, derived from `git log v0.1.5..v0.1.8`).
- ~+84 net in `scripts/bump-version.sh` is new functionality (`roll_changelog()` + the CITATION block) plus review-driven correctness hardening (regex-escaped version, exactly-one-of-each guard, awk temp-file cleanup, accurate `apply_sed` reporting).
- ~+14 release-skill doc sync; ~+2 CITATION data.

## Existing-logic check

- [x] Searched the touched files for similar logic first — no prior CITATION/CHANGELOG handling existed in the bumper or the release skill, and no changelog-roll helper existed anywhere.
- [x] Reused existing logic where present: the CITATION `version`/`date-released` bumps call the existing `apply_sed` helper rather than duplicating sed-in-place logic.
- [x] Positive net LOC is load-bearing — a feature (the bumper now handles 2 more files + rolls the changelog) plus backfilled release-history content; not a defensive guard or duck-tape patch around a symptom. The review-round additions harden the new feature's own correctness.
- [x] No new `validate_*`/`*_helper` duplicating an existing one — `roll_changelog()` is genuinely new; `apply_sed` was reused, not re-created.

## Test plan

- `cargo fmt --all` / `clippy --workspace --exclude nereids-python --all-targets -D warnings` / `cargo test --workspace --exclude nereids-python` — all green (no Rust/Python source touched; verified no code reads `CITATION.cff`/`CHANGELOG.md`).
- `bash -n scripts/bump-version.sh` clean.
- Live `./scripts/bump-version.sh 0.1.9 --dry-run` now lists `CITATION.cff` + `CHANGELOG.md`; live version **not** bumped (`Cargo.toml` still `0.1.8`).
- `/tmp` sandbox real-run (throwaway `9.9.9`) exercised the actual sed + awk: CITATION `version`+`date-released` bumped (`cff-version` untouched); CHANGELOG `[Unreleased]` frozen into a dated section with the curated notes moved under it; link-refs rolled to `vNEW...HEAD` + new compare ref.
- Guard regressions (never corrupt a malformed file): a changelog missing the `[Unreleased]:` link, with no `[Unreleased]` heading, with a duplicate heading, or with one correct + one stale `[Unreleased]:` link all **skip unchanged**; the single-correct-link happy path rolls.
- `CITATION.cff` validated as CFF/YAML (`date-released` parses as a `date` type); backfilled CHANGELOG dates match the real tag dates and the `2025→2026` corrections are confirmed against `git`.

## Linked issues / audit references

- None — user-directed release-metadata hygiene; no tracking issue (not inventing one per repo policy).

---

AI-assisted (commits carry the `Assisted-With:` trailer). Reviewed via `/review-pipeline`: 3 rounds, Claude self-audit + Codex external review, converged to zero P1/P2 in Round 3. Round 1 surfaced 4 robustness issues; Round 2 (Codex) caught that the Round-1 guard fix was itself incomplete (its link count was narrower than awk's rewrite scope); Round 3 confirmed clean across both LLM families.
