### PR TITLE
PR-A: input-validation hardening (core / io / pipeline) — #595

### DIFF
--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -468,11 +468,19 @@ def forward_model(
     ...
 
 def tof_to_energy(tof_us: float, flight_path_m: float) -> float:
-    """Convert time-of-flight (us) to energy (eV)."""
+    """Convert time-of-flight (us) to energy (eV).
+
+    Raises ``ValueError`` if ``tof_us`` or ``flight_path_m`` is non-positive
+    or non-finite.
+    """
     ...
 
 def energy_to_tof(energy_ev: float, flight_path_m: float) -> float:
-    """Convert energy (eV) to time-of-flight (us)."""
+    """Convert energy (eV) to time-of-flight (us).
+
+    Raises ``ValueError`` if ``energy_ev`` or ``flight_path_m`` is
+    non-positive or non-finite.
+    """
     ...
 
 def load_endf(

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -952,27 +952,63 @@ fn forward_model<'py>(
 /// Convert time-of-flight (μs) to energy (eV).
 ///
 /// Args:
-///     tof_us: Time-of-flight in microseconds.
-///     flight_path_m: Flight path in meters.
+///     tof_us: Time-of-flight in microseconds (must be positive and finite).
+///     flight_path_m: Flight path in meters (must be positive and finite).
 ///
 /// Returns:
 ///     Energy in eV.
+///
+/// Raises:
+///     ValueError: If ``tof_us`` or ``flight_path_m`` is non-positive or
+///         non-finite. The underlying conversion returns NaN for such input;
+///         the binding rejects it explicitly so a bad TOF axis surfaces as an
+///         error here rather than silently poisoning a downstream energy grid.
 #[pyfunction]
-fn tof_to_energy(tof_us: f64, flight_path_m: f64) -> f64 {
-    nereids_core::constants::tof_to_energy(tof_us, flight_path_m)
+fn tof_to_energy(tof_us: f64, flight_path_m: f64) -> PyResult<f64> {
+    if !tof_us.is_finite() || tof_us <= 0.0 {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "tof_us must be positive and finite, got {tof_us}"
+        )));
+    }
+    if !flight_path_m.is_finite() || flight_path_m <= 0.0 {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "flight_path_m must be positive and finite, got {flight_path_m}"
+        )));
+    }
+    Ok(nereids_core::constants::tof_to_energy(
+        tof_us,
+        flight_path_m,
+    ))
 }
 
 /// Convert energy (eV) to time-of-flight (μs).
 ///
 /// Args:
-///     energy_ev: Energy in eV.
-///     flight_path_m: Flight path in meters.
+///     energy_ev: Energy in eV (must be positive and finite).
+///     flight_path_m: Flight path in meters (must be positive and finite).
 ///
 /// Returns:
 ///     Time-of-flight in microseconds.
+///
+/// Raises:
+///     ValueError: If ``energy_ev`` or ``flight_path_m`` is non-positive or
+///         non-finite (mirrors ``tof_to_energy``).
 #[pyfunction]
-fn energy_to_tof(energy_ev: f64, flight_path_m: f64) -> f64 {
-    nereids_core::constants::energy_to_tof(energy_ev, flight_path_m)
+fn energy_to_tof(energy_ev: f64, flight_path_m: f64) -> PyResult<f64> {
+    if !energy_ev.is_finite() || energy_ev <= 0.0 {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "energy_ev must be positive and finite, got {energy_ev}"
+        )));
+    }
+    if !flight_path_m.is_finite() || flight_path_m <= 0.0 {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "flight_path_m must be positive and finite, got {flight_path_m}"
+        )));
+    }
+    Ok(nereids_core::constants::energy_to_tof(
+        energy_ev,
+        flight_path_m,
+    ))
 }
 
 /// Load ENDF resonance data for an isotope from the IAEA database.

--- a/crates/nereids-core/src/constants.rs
+++ b/crates/nereids-core/src/constants.rs
@@ -42,14 +42,42 @@ pub fn energy_to_wavelength_angstrom(energy_ev: f64) -> f64 {
 /// Convert neutron time-of-flight (μs) and flight path (m) to energy (eV).
 ///
 /// E = ½·m_n·(L/t)²
+///
+/// # Domain contract
+/// Returns [`f64::NAN`] for out-of-domain input rather than a misleading
+/// value: a non-positive `tof_us` is unphysical (the unguarded formula
+/// squares the velocity, so a *negative* TOF would return a *positive*
+/// energy, and `tof_us == 0` would return `+∞`), and a non-finite `tof_us`
+/// or `flight_path_m` cannot map to a real energy. Callers that need to
+/// surface bad input as an error (e.g. the PyO3 boundary) check the input
+/// before calling or test the result with `is_finite()`; the in-crate
+/// callers (`nereids_io::tof`, the GUI) already guard `tof > 0 && finite`
+/// up-front, so this NaN sentinel never fires on valid data.
 pub fn tof_to_energy(tof_us: f64, flight_path_m: f64) -> f64 {
+    // `is_finite()` first excludes NaN, so the `<= 0.0` total-order
+    // comparisons that follow are well-defined (clippy's
+    // `neg_cmp_op_on_partial_ord`).
+    if !tof_us.is_finite() || tof_us <= 0.0 || !flight_path_m.is_finite() {
+        return f64::NAN;
+    }
     let t_s = tof_us * 1.0e-6;
     let v = flight_path_m / t_s;
     0.5 * NEUTRON_MASS_KG * v * v / EV_TO_JOULES
 }
 
 /// Convert neutron energy (eV) to time-of-flight (μs) given flight path (m).
+///
+/// # Domain contract
+/// Mirrors [`tof_to_energy`]: returns [`f64::NAN`] for a non-positive or
+/// non-finite `energy_ev` (the unguarded formula takes `√energy`, so a
+/// negative energy would yield a `NaN` velocity and `energy_ev == 0` would
+/// yield `+∞`) or a non-finite `flight_path_m`. This keeps the two
+/// directions consistent — both refuse out-of-domain input instead of
+/// returning a plausible-looking number.
 pub fn energy_to_tof(energy_ev: f64, flight_path_m: f64) -> f64 {
+    if !energy_ev.is_finite() || energy_ev <= 0.0 || !flight_path_m.is_finite() {
+        return f64::NAN;
+    }
     let v = (2.0 * energy_ev * EV_TO_JOULES / NEUTRON_MASS_KG).sqrt();
     (flight_path_m / v) * 1.0e6
 }
@@ -103,5 +131,61 @@ mod tests {
         // Thermal neutrons at 0.0253 eV should have λ ≈ 1.8 Å
         let lambda = energy_to_wavelength_angstrom(0.0253);
         assert!((lambda - 1.8).abs() < 0.1);
+    }
+
+    #[test]
+    fn test_tof_to_energy_rejects_non_positive_and_non_finite() {
+        let l = 25.0;
+        // Negative TOF used to return a *positive* energy (v² hides the
+        // sign), masking an upstream sign/loader bug.
+        assert!(
+            tof_to_energy(-100.0, l).is_nan(),
+            "negative TOF must be NaN"
+        );
+        // Zero TOF used to return +∞.
+        assert!(tof_to_energy(0.0, l).is_nan(), "zero TOF must be NaN");
+        assert!(tof_to_energy(f64::NAN, l).is_nan(), "NaN TOF must stay NaN");
+        assert!(
+            tof_to_energy(f64::INFINITY, l).is_nan(),
+            "Inf TOF must be NaN"
+        );
+        assert!(
+            tof_to_energy(100.0, f64::NAN).is_nan(),
+            "NaN flight path must be NaN"
+        );
+        assert!(
+            tof_to_energy(100.0, f64::INFINITY).is_nan(),
+            "Inf flight path must be NaN"
+        );
+        // Valid input still produces a finite, positive energy.
+        assert!(tof_to_energy(100.0, l).is_finite());
+        assert!(tof_to_energy(100.0, l) > 0.0);
+    }
+
+    #[test]
+    fn test_energy_to_tof_rejects_non_positive_and_non_finite() {
+        let l = 25.0;
+        // Negative energy used to return NaN already (√ of negative), but
+        // zero energy returned +∞ — both are now an explicit NaN contract.
+        assert!(
+            energy_to_tof(-1.0, l).is_nan(),
+            "negative energy must be NaN"
+        );
+        assert!(energy_to_tof(0.0, l).is_nan(), "zero energy must be NaN");
+        assert!(
+            energy_to_tof(f64::NAN, l).is_nan(),
+            "NaN energy must stay NaN"
+        );
+        assert!(
+            energy_to_tof(f64::INFINITY, l).is_nan(),
+            "Inf energy must be NaN"
+        );
+        assert!(
+            energy_to_tof(10.0, f64::NAN).is_nan(),
+            "NaN flight path must be NaN"
+        );
+        // Valid input still produces a finite, positive TOF.
+        assert!(energy_to_tof(10.0, l).is_finite());
+        assert!(energy_to_tof(10.0, l) > 0.0);
     }
 }

--- a/crates/nereids-core/src/constants.rs
+++ b/crates/nereids-core/src/constants.rs
@@ -45,19 +45,26 @@ pub fn energy_to_wavelength_angstrom(energy_ev: f64) -> f64 {
 ///
 /// # Domain contract
 /// Returns [`f64::NAN`] for out-of-domain input rather than a misleading
-/// value: a non-positive `tof_us` is unphysical (the unguarded formula
-/// squares the velocity, so a *negative* TOF would return a *positive*
-/// energy, and `tof_us == 0` would return `+∞`), and a non-finite `tof_us`
-/// or `flight_path_m` cannot map to a real energy. Callers that need to
-/// surface bad input as an error (e.g. the PyO3 boundary) check the input
-/// before calling or test the result with `is_finite()`; the in-crate
-/// callers (`nereids_io::tof`, the GUI) already guard `tof > 0 && finite`
-/// up-front, so this NaN sentinel never fires on valid data.
+/// value. Both arguments must be finite and strictly positive:
+/// * a non-positive `tof_us` is unphysical — the unguarded formula squares
+///   the velocity, so a *negative* TOF would return a *positive* energy, and
+///   `tof_us == 0` would return `+∞`;
+/// * a non-positive `flight_path_m` is equally unphysical — `flight_path_m
+///   == 0` makes the velocity (and energy) `0`, and a *negative* flight path
+///   would (after squaring) return a *positive* energy, masking a bad
+///   detector geometry the same way a negative TOF would;
+/// * a non-finite `tof_us` or `flight_path_m` cannot map to a real energy.
+///
+/// Callers that need to surface bad input as an error (e.g. the PyO3
+/// boundary) check the input before calling or test the result with
+/// `is_finite()`; the in-crate callers (`nereids_io::tof`, the GUI) already
+/// guard `tof > 0 && finite` up-front, so this NaN sentinel never fires on
+/// valid data.
 pub fn tof_to_energy(tof_us: f64, flight_path_m: f64) -> f64 {
     // `is_finite()` first excludes NaN, so the `<= 0.0` total-order
     // comparisons that follow are well-defined (clippy's
     // `neg_cmp_op_on_partial_ord`).
-    if !tof_us.is_finite() || tof_us <= 0.0 || !flight_path_m.is_finite() {
+    if !tof_us.is_finite() || tof_us <= 0.0 || !flight_path_m.is_finite() || flight_path_m <= 0.0 {
         return f64::NAN;
     }
     let t_s = tof_us * 1.0e-6;
@@ -68,14 +75,20 @@ pub fn tof_to_energy(tof_us: f64, flight_path_m: f64) -> f64 {
 /// Convert neutron energy (eV) to time-of-flight (μs) given flight path (m).
 ///
 /// # Domain contract
-/// Mirrors [`tof_to_energy`]: returns [`f64::NAN`] for a non-positive or
-/// non-finite `energy_ev` (the unguarded formula takes `√energy`, so a
-/// negative energy would yield a `NaN` velocity and `energy_ev == 0` would
-/// yield `+∞`) or a non-finite `flight_path_m`. This keeps the two
+/// Mirrors [`tof_to_energy`]: returns [`f64::NAN`] unless *both* arguments are
+/// finite and strictly positive. A non-positive or non-finite `energy_ev` (the
+/// unguarded formula takes `√energy`, so a negative energy would yield a `NaN`
+/// velocity and `energy_ev == 0` would yield `+∞`), and a non-positive or
+/// non-finite `flight_path_m` (which would yield a zero or *negative* TOF — a
+/// physically impossible time), are all rejected. This keeps the two
 /// directions consistent — both refuse out-of-domain input instead of
 /// returning a plausible-looking number.
 pub fn energy_to_tof(energy_ev: f64, flight_path_m: f64) -> f64 {
-    if !energy_ev.is_finite() || energy_ev <= 0.0 || !flight_path_m.is_finite() {
+    if !energy_ev.is_finite()
+        || energy_ev <= 0.0
+        || !flight_path_m.is_finite()
+        || flight_path_m <= 0.0
+    {
         return f64::NAN;
     }
     let v = (2.0 * energy_ev * EV_TO_JOULES / NEUTRON_MASS_KG).sqrt();
@@ -157,6 +170,18 @@ mod tests {
             tof_to_energy(100.0, f64::INFINITY).is_nan(),
             "Inf flight path must be NaN"
         );
+        // Zero flight path used to return a finite 0 energy (v = L/t = 0),
+        // masking a bad detector geometry.
+        assert!(
+            tof_to_energy(100.0, 0.0).is_nan(),
+            "zero flight path must be NaN"
+        );
+        // Negative flight path used to return a *positive* energy (v² hides
+        // the sign), the same trap as a negative TOF.
+        assert!(
+            tof_to_energy(100.0, -25.0).is_nan(),
+            "negative flight path must be NaN"
+        );
         // Valid input still produces a finite, positive energy.
         assert!(tof_to_energy(100.0, l).is_finite());
         assert!(tof_to_energy(100.0, l) > 0.0);
@@ -183,6 +208,20 @@ mod tests {
         assert!(
             energy_to_tof(10.0, f64::NAN).is_nan(),
             "NaN flight path must be NaN"
+        );
+        assert!(
+            energy_to_tof(10.0, f64::INFINITY).is_nan(),
+            "Inf flight path must be NaN"
+        );
+        // Zero / negative flight path used to return 0 / a *negative* TOF —
+        // a physically impossible time.
+        assert!(
+            energy_to_tof(10.0, 0.0).is_nan(),
+            "zero flight path must be NaN"
+        );
+        assert!(
+            energy_to_tof(10.0, -25.0).is_nan(),
+            "negative flight path must be NaN"
         );
         // Valid input still produces a finite, positive TOF.
         assert!(energy_to_tof(10.0, l).is_finite());

--- a/crates/nereids-core/src/elements.rs
+++ b/crates/nereids-core/src/elements.rs
@@ -134,6 +134,31 @@ mod tests {
     }
 
     #[test]
+    fn prop_za_roundtrip_over_accepted_domain() {
+        // Property: for every isotope `Isotope::new` accepts, the ZA
+        // encode→decode round-trip is lossless:
+        //     isotope_from_za(za_from_isotope(iso)) == iso
+        //
+        // This holds precisely because `Isotope::new` now rejects A >= 1000
+        // (which would carry into the Z field of `Z×1000 + A`). Exhaustively
+        // sweep the accepted domain (Z in 0..=118, A in 1..=999, Z <= A) so a
+        // future relaxation of the A bound breaks this test immediately.
+        for z in 0u32..=118 {
+            for a in 1u32..=999 {
+                let Ok(iso) = Isotope::new(z, a) else {
+                    // Skip pairs `new` rejects (e.g. Z > A); the property is
+                    // only claimed over the *accepted* domain.
+                    continue;
+                };
+                let za = za_from_isotope(&iso);
+                let back = isotope_from_za(za)
+                    .unwrap_or_else(|e| panic!("ZA {za} failed to decode for {iso}: {e}"));
+                assert_eq!(back, iso, "round-trip mismatch at Z={z}, A={a} (ZA={za})");
+            }
+        }
+    }
+
+    #[test]
     fn test_isotope_from_za_natural_element_returns_error() {
         // ZA=26000 → Z=26, A=0 (natural iron). A==0 fails validation.
         let result = isotope_from_za(26000);

--- a/crates/nereids-core/src/lib.rs
+++ b/crates/nereids-core/src/lib.rs
@@ -8,3 +8,4 @@ pub mod constants;
 pub mod elements;
 pub mod error;
 pub mod types;
+pub mod validation;

--- a/crates/nereids-core/src/types.rs
+++ b/crates/nereids-core/src/types.rs
@@ -46,7 +46,7 @@ impl Isotope {
     /// decodes back to `(Z=93, A=0)`, silently corrupting the isotope. The
     /// heaviest synthesised nuclide has A ≈ 295, so this bound never rejects a
     /// physically real isotope.
-    const MAX_MASS_NUMBER: u32 = 999;
+    pub const MAX_MASS_NUMBER: u32 = 999;
 
     /// Create a new isotope with validation.
     ///

--- a/crates/nereids-core/src/types.rs
+++ b/crates/nereids-core/src/types.rs
@@ -37,17 +37,37 @@ impl<'de> serde::Deserialize<'de> for Isotope {
 }
 
 impl Isotope {
+    /// Maximum encodable mass number A.
+    ///
+    /// The ENDF ZA identifier packs an isotope as `Z×1000 + A` (see
+    /// `endf_mat::za`), so A must occupy fewer than three decimal digits for
+    /// the encode/decode round-trip to be lossless. `A ≥ 1000` would carry
+    /// into the Z field — e.g. `(Z=92, A=1000)` encodes to `93000`, which
+    /// decodes back to `(Z=93, A=0)`, silently corrupting the isotope. The
+    /// heaviest synthesised nuclide has A ≈ 295, so this bound never rejects a
+    /// physically real isotope.
+    const MAX_MASS_NUMBER: u32 = 999;
+
     /// Create a new isotope with validation.
     ///
     /// # Errors
     /// Returns `NereidsError::InvalidParameter` if:
     /// - `a` is zero (mass number must be positive)
+    /// - `a > 999` (not ENDF-ZA-encodable; would corrupt the `Z×1000 + A`
+    ///   round-trip — see [`Self::MAX_MASS_NUMBER`])
     /// - `z > a` (atomic number cannot exceed mass number)
     pub fn new(z: u32, a: u32) -> Result<Self, NereidsError> {
         if a == 0 {
             return Err(NereidsError::InvalidParameter(
                 "mass number A must be positive".to_string(),
             ));
+        }
+        if a > Self::MAX_MASS_NUMBER {
+            return Err(NereidsError::InvalidParameter(format!(
+                "mass number A ({a}) must be <= {} to be ENDF-ZA-encodable \
+                 (Z×1000 + A would otherwise overflow the Z field)",
+                Self::MAX_MASS_NUMBER,
+            )));
         }
         if z > a {
             return Err(NereidsError::InvalidParameter(format!(
@@ -90,6 +110,34 @@ mod tests {
     fn test_isotope_rejects_zero_mass_number() {
         let err = Isotope::new(0, 0).unwrap_err();
         assert!(err.to_string().contains("must be positive"));
+    }
+
+    #[test]
+    fn test_isotope_rejects_mass_number_too_large() {
+        // A >= 1000 breaks the ENDF ZA round-trip (Z×1000 + A overflows
+        // into the Z field). Z=92, A=1000 would encode to 93000 → decode
+        // to (Z=93, A=0).
+        let err = Isotope::new(92, 1000).unwrap_err();
+        assert!(
+            err.to_string().contains("ENDF-ZA-encodable"),
+            "expected ZA-encodability message, got: {err}"
+        );
+        // The boundary A = 999 is still accepted.
+        assert!(Isotope::new(0, 999).is_ok());
+    }
+
+    #[test]
+    fn test_deserialize_rejects_mass_number_too_large() {
+        // The ZA-encodability guard must also fire through serde.
+        let json = r#"{"z": 92, "a": 1000}"#;
+        let result: Result<Isotope, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("ENDF-ZA-encodable")
+        );
     }
 
     #[test]
@@ -272,6 +320,21 @@ mod tests {
     fn test_subset_group_empty() {
         let err = IsotopeGroup::subset(63, &[]).unwrap_err();
         assert!(err.to_string().contains("must not be empty"));
+    }
+
+    #[test]
+    fn test_subset_group_rejects_duplicate_mass() {
+        // A repeated mass number used to be selected twice and its natural
+        // abundance double-counted in the re-normalisation, silently
+        // re-weighting the group. It must now be rejected.
+        let err = IsotopeGroup::subset(63, &[151, 151]).unwrap_err();
+        assert!(
+            err.to_string().contains("duplicate mass number"),
+            "expected duplicate-mass message, got: {err}"
+        );
+        // A duplicate anywhere in the list is caught, not just adjacent.
+        let err = IsotopeGroup::subset(63, &[151, 153, 151]).unwrap_err();
+        assert!(err.to_string().contains("duplicate mass number"));
     }
 
     #[test]
@@ -504,6 +567,7 @@ impl IsotopeGroup {
     ///
     /// # Errors
     /// - Empty `mass_numbers`
+    /// - Duplicate mass number in `mass_numbers`
     /// - Any mass number not found among natural isotopes of Z
     /// - Unknown element Z
     pub fn subset(z: u32, mass_numbers: &[u32]) -> Result<Self, NereidsError> {
@@ -511,6 +575,18 @@ impl IsotopeGroup {
             return Err(NereidsError::InvalidParameter(
                 "mass_numbers must not be empty".into(),
             ));
+        }
+        // Reject duplicate mass numbers. A repeated A would otherwise be
+        // selected twice and its natural abundance double-counted in the
+        // re-normalisation below, silently inflating that isotope's weight
+        // (e.g. `subset(63, &[151, 151])` would yield Eu-151 at ratio 1.0
+        // with Eu-153 absent — not what the caller asked for).
+        for (i, &a) in mass_numbers.iter().enumerate() {
+            if mass_numbers[..i].contains(&a) {
+                return Err(NereidsError::InvalidParameter(format!(
+                    "duplicate mass number A={a} in subset of Z={z}"
+                )));
+            }
         }
         let all_natural = elements::natural_isotopes(z);
         if all_natural.is_empty() {

--- a/crates/nereids-core/src/validation.rs
+++ b/crates/nereids-core/src/validation.rs
@@ -1,0 +1,86 @@
+//! Small numeric-invariant helpers shared across NEREIDS crates.
+//!
+//! These live in `nereids-core` (the dependency-free foundation crate) so that
+//! the same invariant is enforced identically everywhere instead of being
+//! re-implemented per crate.  Each helper returns the *first* offending
+//! `(index, value)` rather than a formatted error, so the calling crate can
+//! map the failure onto its own error type / message wording without
+//! `nereids-core` having to know about `IoError`, `FittingError`, etc.
+
+/// Locate the first element that is not finite-and-non-negative.
+///
+/// Detector counts (and other count-like quantities) are non-negative by
+/// construction — zero is legitimate, but a NaN, ±∞, or negative entry signals
+/// an upstream loader / normalisation bug.  A bare `v < 0.0` test is *not*
+/// sufficient because `NaN < 0.0` is `false`; this helper therefore rejects on
+/// `!v.is_finite() || v < 0.0`, pairing the order comparison with a finiteness
+/// check (NaN bypasses `<`).
+///
+/// Returns `Err((i, v))` for the first offending element at flat index `i`, or
+/// `Ok(())` if every element is finite and `>= 0.0`.  An empty iterator is
+/// vacuously `Ok(())`.
+pub fn first_non_finite_or_negative<I>(values: I) -> Result<(), (usize, f64)>
+where
+    I: IntoIterator<Item = f64>,
+{
+    for (i, v) in values.into_iter().enumerate() {
+        if !v.is_finite() || v < 0.0 {
+            return Err((i, v));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_is_ok() {
+        assert!(first_non_finite_or_negative(std::iter::empty::<f64>()).is_ok());
+    }
+
+    #[test]
+    fn all_finite_non_negative_is_ok() {
+        assert!(first_non_finite_or_negative([0.0, 1.0, 1e9, 2.5]).is_ok());
+    }
+
+    #[test]
+    fn rejects_negative_with_index() {
+        assert_eq!(
+            first_non_finite_or_negative([1.0, 2.0, -3.0, 4.0]),
+            Err((2, -3.0))
+        );
+    }
+
+    #[test]
+    fn rejects_nan_negative_does_not_bypass() {
+        // `NaN < 0.0` is `false`; the `is_finite()` half of the guard is what
+        // catches it.  Reported value compares unequal to itself, so match on
+        // index + NaN-ness rather than `assert_eq!` on the tuple.
+        let err = first_non_finite_or_negative([1.0, f64::NAN, 3.0]).unwrap_err();
+        assert_eq!(err.0, 1);
+        assert!(err.1.is_nan());
+    }
+
+    #[test]
+    fn rejects_positive_and_negative_infinity() {
+        assert_eq!(
+            first_non_finite_or_negative([1.0, f64::INFINITY]),
+            Err((1, f64::INFINITY))
+        );
+        assert_eq!(
+            first_non_finite_or_negative([f64::NEG_INFINITY]),
+            Err((0, f64::NEG_INFINITY))
+        );
+    }
+
+    #[test]
+    fn reports_first_offender_only() {
+        // -1.0 at index 1 comes before NaN at index 3.
+        assert_eq!(
+            first_non_finite_or_negative([1.0, -1.0, 2.0, f64::NAN]),
+            Err((1, -1.0))
+        );
+    }
+}

--- a/crates/nereids-io/src/nexus.rs
+++ b/crates/nereids-io/src/nexus.rs
@@ -362,6 +362,19 @@ pub fn load_nexus_histogram_with_mode(
                 .into(),
         ));
     }
+    // Mirror the rotation-angle guard for the sibling y / x / tof axes
+    // (counts layout is [rot_angle, y, x, tof]).  A zero-sized y, x, or tof
+    // axis is just as degenerate: it would produce an empty detector plane or
+    // an empty energy series that looks like a valid-but-empty measurement
+    // downstream instead of a clear load error.
+    for (axis, name) in [(1usize, "y"), (2, "x"), (3, "tof")] {
+        if shape[axis] == 0 {
+            return Err(IoError::InvalidParameter(format!(
+                "NeXus histogram has a zero-sized {name} axis; \
+                 /entry/histogram/counts axis {axis} must be >= 1 (shape {shape:?})"
+            )));
+        }
+    }
     match mode {
         MultiAngleMode::Error if n_rot > 1 => {
             return Err(IoError::InvalidParameter(format!(
@@ -447,8 +460,9 @@ pub fn load_nexus_histogram_with_mode(
     let flight_path_m = read_f64_attr(&hist_group, "flight_path_m")
         .or_else(|| read_f64_attr(&entry, "flight_path_m"));
 
-    // Read dead pixel mask
-    let dead_pixels = read_dead_pixel_mask(&entry);
+    // Read dead pixel mask, validated against the detector's spatial dims.
+    // counts_f64 is [tof, y, x], so (height, width) = (shape[1], shape[2]).
+    let dead_pixels = read_dead_pixel_mask(&entry, (counts_f64.shape()[1], counts_f64.shape()[2]))?;
 
     Ok(NexusHistogramData {
         counts: counts_f64,
@@ -630,8 +644,8 @@ pub fn load_nexus_events(
     let flight_path_m = read_f64_attr(&neutrons, "flight_path_m")
         .or_else(|| read_f64_attr(&entry, "flight_path_m"));
 
-    // Read dead pixel mask
-    let dead_pixels = read_dead_pixel_mask(&entry);
+    // Read dead pixel mask, validated against the requested detector dims.
+    let dead_pixels = read_dead_pixel_mask(&entry, (params.height, params.width))?;
 
     debug_assert_eq!(
         total,
@@ -740,7 +754,26 @@ fn read_tof_axis(hist_group: &hdf5::Group) -> Result<Vec<f64>, IoError> {
     let units = read_string_attr(&tof_ds, "units")?;
     let scale = tof_scale_to_us(units.as_deref())?;
 
-    Ok(raw.iter().map(|&v| v * scale).collect())
+    let edges: Vec<f64> = raw.iter().map(|&v| v * scale).collect();
+
+    // Validate the TOF axis is strictly monotonic and positive, mirroring the
+    // spectrum-file load path (`guided::load` runs `validate_monotonic` on the
+    // parsed spectrum before use).  A non-increasing, NaN, or non-positive TOF
+    // edge produces a `tof_to_energy` NaN / negative-energy downstream; reject
+    // it here at the I/O boundary instead.  Run `validate_monotonic` first — it
+    // rejects equal / decreasing / NaN, so afterwards every edge is finite and
+    // strictly increasing, and a single positivity check on the first edge
+    // proves the whole axis is positive.
+    crate::spectrum::validate_monotonic(&edges)?;
+    if let Some(&first) = edges.first()
+        && first <= 0.0
+    {
+        return Err(IoError::InvalidParameter(format!(
+            "NeXus TOF axis must be positive, but first edge is {first}"
+        )));
+    }
+
+    Ok(edges)
 }
 
 /// Read a scalar f64 attribute from a group.
@@ -751,12 +784,35 @@ fn read_f64_attr(group: &hdf5::Group, name: &str) -> Option<f64> {
         .and_then(|a| a.read_scalar::<f64>().ok())
 }
 
-/// Read dead pixel mask from `/entry/pixel_masks/dead`.
-fn read_dead_pixel_mask(entry: &hdf5::Group) -> Option<ndarray::Array2<bool>> {
-    let masks = entry.group("pixel_masks").ok()?;
-    let dead_ds = masks.dataset("dead").ok()?;
-    let dead_u8: ndarray::Array2<u8> = dead_ds.read().ok()?;
-    Some(dead_u8.mapv(|v| v != 0))
+/// Read the dead-pixel mask from `/entry/pixel_masks/dead`, validating its
+/// shape against the detector's `(height, width)`.
+///
+/// Returns `Ok(None)` when the mask group / dataset is simply absent (a file
+/// without a dead-pixel mask is valid).  Returns `Err(ShapeMismatch)` when the
+/// mask is present but does not match the counts' spatial dimensions: applying
+/// a mismatched mask would silently mask the wrong pixels (or be dropped
+/// entirely), so the mismatch is surfaced at the I/O boundary instead.
+fn read_dead_pixel_mask(
+    entry: &hdf5::Group,
+    expected_hw: (usize, usize),
+) -> Result<Option<ndarray::Array2<bool>>, IoError> {
+    let Ok(masks) = entry.group("pixel_masks") else {
+        return Ok(None);
+    };
+    let Ok(dead_ds) = masks.dataset("dead") else {
+        return Ok(None);
+    };
+    let dead_u8: ndarray::Array2<u8> = dead_ds.read().map_err(|e| {
+        IoError::InvalidParameter(format!("Failed to read /entry/pixel_masks/dead: {e}"))
+    })?;
+    let (eh, ew) = expected_hw;
+    if dead_u8.dim() != (eh, ew) {
+        return Err(IoError::ShapeMismatch(format!(
+            "dead-pixel mask shape {:?} != detector spatial dimensions ({eh}, {ew})",
+            dead_u8.dim(),
+        )));
+    }
+    Ok(Some(dead_u8.mapv(|v| v != 0)))
 }
 
 /// List the group/dataset tree structure of an HDF5 file.
@@ -1066,6 +1122,126 @@ mod tests {
                 "mode {mode:?} zero-angle rejection should name the axis, got: {msg}"
             );
         }
+    }
+
+    /// A zero-sized y / x / tof axis is just as degenerate as a zero-angle
+    /// axis and must be rejected the same way, rather than producing an empty
+    /// detector plane / energy series downstream.
+    #[test]
+    fn test_load_nexus_histogram_zero_sibling_axes_rejected() {
+        for (shape, axis_name) in [
+            ([1usize, 0, 3, 2], "y"),
+            ([1, 2, 0, 2], "x"),
+            ([1, 2, 3, 0], "tof"),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join(format!("zero_{axis_name}.h5"));
+            let counts: Vec<u64> = Vec::new(); // any axis is 0 → empty cube
+            let tof_ns = vec![1000.0, 2000.0, 3000.0];
+            create_test_histogram(&path, &counts, shape, &tof_ns, None);
+
+            let err = load_nexus_histogram(&path).unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains(&format!("zero-sized {axis_name} axis")),
+                "axis {axis_name} ({shape:?}) should be rejected by name, got: {msg}"
+            );
+        }
+    }
+
+    /// The NeXus TOF axis must be strictly monotonic and positive, mirroring
+    /// the spectrum-file path.  A non-increasing or non-positive axis would
+    /// silently feed `tof_to_energy` a bad value downstream.
+    #[test]
+    fn test_load_nexus_histogram_rejects_non_monotonic_tof() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nonmono_tof.h5");
+        // 1 angle, 1×1 spatial, 2 TOF bins → 3 edges, but they decrease.
+        let counts = vec![1u64, 2u64];
+        let tof_ns = vec![3000.0, 2000.0, 1000.0];
+        create_test_histogram(&path, &counts, [1, 1, 1, 2], &tof_ns, None);
+
+        let err = load_nexus_histogram(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("strictly increasing"),
+            "non-monotonic TOF should be rejected, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_load_nexus_histogram_rejects_non_positive_tof() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nonpos_tof.h5");
+        // First edge is zero → non-positive TOF axis.
+        let counts = vec![1u64, 2u64];
+        let tof_ns = vec![0.0, 1000.0, 2000.0];
+        create_test_histogram(&path, &counts, [1, 1, 1, 2], &tof_ns, None);
+
+        let err = load_nexus_histogram(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("must be positive"),
+            "non-positive TOF should be rejected, got: {err}"
+        );
+    }
+
+    /// Create a histogram fixture that also carries a `/entry/pixel_masks/dead`
+    /// mask of the given shape, for dead-mask shape-validation tests.
+    fn create_test_histogram_with_dead_mask(
+        path: &Path,
+        counts: &[u64],
+        shape: [usize; 4],
+        tof_ns: &[f64],
+        dead: &[u8],
+        dead_shape: [usize; 2],
+    ) {
+        create_test_histogram(path, counts, shape, tof_ns, None);
+        let file = hdf5::File::append(path).expect("reopen test file");
+        let entry = file.group("entry").expect("entry");
+        let masks = entry.create_group("pixel_masks").expect("pixel_masks");
+        masks
+            .new_dataset::<u8>()
+            .shape(dead_shape)
+            .create("dead")
+            .expect("create dead")
+            .write_raw(dead)
+            .expect("write dead");
+    }
+
+    /// A dead-pixel mask whose shape does not match the detector's spatial
+    /// dimensions must be rejected — applying it would mask the wrong pixels.
+    #[test]
+    fn test_load_nexus_histogram_rejects_mismatched_dead_mask() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad_mask.h5");
+        // counts shape [1, 2, 3, 2] → detector is 2×3; write a 5×5 mask.
+        let counts = vec![1u64; 2 * 3 * 2];
+        let tof_ns = vec![1000.0, 2000.0, 3000.0];
+        let dead = vec![0u8; 25];
+        create_test_histogram_with_dead_mask(&path, &counts, [1, 2, 3, 2], &tof_ns, &dead, [5, 5]);
+
+        let err = load_nexus_histogram(&path).unwrap_err();
+        assert!(
+            matches!(err, IoError::ShapeMismatch(_)),
+            "expected ShapeMismatch, got {err:?}"
+        );
+        assert!(err.to_string().contains("dead-pixel mask shape"));
+    }
+
+    /// A correctly-shaped dead-pixel mask still loads (no false rejection).
+    #[test]
+    fn test_load_nexus_histogram_accepts_matching_dead_mask() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ok_mask.h5");
+        let counts = vec![1u64; 2 * 3 * 2];
+        let tof_ns = vec![1000.0, 2000.0, 3000.0];
+        // 2×3 mask matching the detector; mark one pixel (row 0, col 1) dead.
+        let dead = vec![0u8, 1, 0, 0, 0, 0];
+        create_test_histogram_with_dead_mask(&path, &counts, [1, 2, 3, 2], &tof_ns, &dead, [2, 3]);
+
+        let data = load_nexus_histogram(&path).expect("matching mask should load");
+        let mask = data.dead_pixels.expect("mask present");
+        assert_eq!(mask.dim(), (2, 3));
+        assert!(mask[[0, 1]]);
     }
 
     /// Codex review: `MultiAngleMode::Error` must reject multi-angle

--- a/crates/nereids-io/src/nexus.rs
+++ b/crates/nereids-io/src/nexus.rs
@@ -756,22 +756,27 @@ fn read_tof_axis(hist_group: &hdf5::Group) -> Result<Vec<f64>, IoError> {
 
     let edges: Vec<f64> = raw.iter().map(|&v| v * scale).collect();
 
-    // Validate the TOF axis is strictly monotonic and positive, mirroring the
-    // spectrum-file load path (`guided::load` runs `validate_monotonic` on the
-    // parsed spectrum before use).  A non-increasing, NaN, or non-positive TOF
-    // edge produces a `tof_to_energy` NaN / negative-energy downstream; reject
-    // it here at the I/O boundary instead.  Run `validate_monotonic` first — it
-    // rejects equal / decreasing / NaN, so afterwards every edge is finite and
-    // strictly increasing, and a single positivity check on the first edge
-    // proves the whole axis is positive.
-    crate::spectrum::validate_monotonic(&edges)?;
-    if let Some(&first) = edges.first()
-        && first <= 0.0
-    {
-        return Err(IoError::InvalidParameter(format!(
-            "NeXus TOF axis must be positive, but first edge is {first}"
-        )));
+    // Validate the TOF axis is finite, strictly positive, and strictly
+    // increasing, mirroring the spectrum-file load path (`guided::load` runs
+    // `validate_monotonic` on the parsed spectrum before use).  A non-finite,
+    // non-positive, or non-increasing TOF edge produces a `tof_to_energy` NaN /
+    // negative-energy downstream; reject it here at the I/O boundary instead.
+    //
+    // `validate_monotonic` alone is *not* sufficient for the finite/positive
+    // half: a trailing `+∞` satisfies `prev < +∞` (so monotonicity passes), a
+    // single-edge axis never enters `windows(2)` at all, and `first <= 0.0` is
+    // bypassed by `NaN` (`NaN <= 0.0` is `false`).  Check every scaled edge
+    // explicitly with `is_finite() && > 0.0` (the `is_finite()` half is what
+    // catches `NaN` / `±∞`, which order comparisons silently pass), then defer
+    // the strictly-increasing requirement to `validate_monotonic`.
+    for (i, &edge) in edges.iter().enumerate() {
+        if !edge.is_finite() || edge <= 0.0 {
+            return Err(IoError::InvalidParameter(format!(
+                "NeXus TOF axis edge {i} must be finite and positive, got {edge}"
+            )));
+        }
     }
+    crate::spectrum::validate_monotonic(&edges)?;
 
     Ok(edges)
 }
@@ -787,21 +792,51 @@ fn read_f64_attr(group: &hdf5::Group, name: &str) -> Option<f64> {
 /// Read the dead-pixel mask from `/entry/pixel_masks/dead`, validating its
 /// shape against the detector's `(height, width)`.
 ///
-/// Returns `Ok(None)` when the mask group / dataset is simply absent (a file
-/// without a dead-pixel mask is valid).  Returns `Err(ShapeMismatch)` when the
-/// mask is present but does not match the counts' spatial dimensions: applying
-/// a mismatched mask would silently mask the wrong pixels (or be dropped
-/// entirely), so the mismatch is surfaced at the I/O boundary instead.
+/// Returns `Ok(None)` when the mask group / dataset is simply *absent* (a file
+/// without a dead-pixel mask is valid).  Returns `Err` when the mask is
+/// *present but malformed*:
+/// * `pixel_masks` exists but is not a group, or `dead` exists but is not a
+///   readable dataset — surfaced as `InvalidParameter` rather than silently
+///   treated as absence (a malformed mask is an upstream-writer bug, and
+///   silently dropping it would mask the wrong pixels or none at all);
+/// * the mask shape does not match the counts' spatial dimensions — surfaced
+///   as `ShapeMismatch`.
+///
+/// Absence vs malformed is decided by link existence (`member_names`), not by
+/// whether `group()` / `dataset()` *succeed*: those collapse "the link is not
+/// there" and "the link is there but the wrong object kind / unreadable" into
+/// the same `Err`, which would otherwise mask real corruption as absence.
 fn read_dead_pixel_mask(
     entry: &hdf5::Group,
     expected_hw: (usize, usize),
 ) -> Result<Option<ndarray::Array2<bool>>, IoError> {
-    let Ok(masks) = entry.group("pixel_masks") else {
+    // `pixel_masks` link absent → no mask (valid file).
+    let entry_members = entry
+        .member_names()
+        .map_err(|e| IoError::InvalidParameter(format!("Failed to list /entry members: {e}")))?;
+    if !entry_members.iter().any(|n| n == "pixel_masks") {
         return Ok(None);
-    };
-    let Ok(dead_ds) = masks.dataset("dead") else {
+    }
+    // Link present but not openable as a group → malformed, not absent.
+    let masks = entry.group("pixel_masks").map_err(|e| {
+        IoError::InvalidParameter(format!(
+            "/entry/pixel_masks is present but is not a readable group: {e}"
+        ))
+    })?;
+
+    // `dead` link absent → no mask (valid file).
+    let mask_members = masks.member_names().map_err(|e| {
+        IoError::InvalidParameter(format!("Failed to list /entry/pixel_masks members: {e}"))
+    })?;
+    if !mask_members.iter().any(|n| n == "dead") {
         return Ok(None);
-    };
+    }
+    // Link present but not openable as a dataset → malformed, not absent.
+    let dead_ds = masks.dataset("dead").map_err(|e| {
+        IoError::InvalidParameter(format!(
+            "/entry/pixel_masks/dead is present but is not a readable dataset: {e}"
+        ))
+    })?;
     let dead_u8: ndarray::Array2<u8> = dead_ds.read().map_err(|e| {
         IoError::InvalidParameter(format!("Failed to read /entry/pixel_masks/dead: {e}"))
     })?;
@@ -1179,9 +1214,68 @@ mod tests {
 
         let err = load_nexus_histogram(&path).unwrap_err();
         assert!(
-            err.to_string().contains("must be positive"),
+            err.to_string().contains("finite and positive"),
             "non-positive TOF should be rejected, got: {err}"
         );
+    }
+
+    /// A trailing `+∞` TOF edge satisfies `prev < +∞` so it passes a
+    /// monotonicity-only check, but it is not a real time — the per-edge
+    /// `is_finite()` guard must reject it.
+    #[test]
+    fn test_load_nexus_histogram_rejects_trailing_infinite_tof() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("inf_tail_tof.h5");
+        // 1 angle, 1×1 spatial, 2 TOF bins → 3 edges, last is +∞.
+        let counts = vec![1u64, 2u64];
+        let tof_ns = vec![1000.0, 2000.0, f64::INFINITY];
+        create_test_histogram(&path, &counts, [1, 1, 1, 2], &tof_ns, None);
+
+        let err = load_nexus_histogram(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("finite and positive"),
+            "trailing +inf TOF edge should be rejected, got: {err}"
+        );
+    }
+
+    /// A single-bin axis has only 2 edges; if a malformed scale yields a
+    /// degenerate axis the per-edge guard still fires.  A 1-edge axis never
+    /// enters `windows(2)` at all, so `validate_monotonic` is vacuously OK —
+    /// the per-edge `is_finite() && > 0` check is the only thing that rejects
+    /// a lone `NaN` / `+∞` edge.  Exercise `read_tof_axis` directly so the
+    /// single-edge case is reachable without tripping the bin-count
+    /// cross-check in `load_nexus_histogram`.
+    #[test]
+    fn test_read_tof_axis_rejects_single_nan_or_inf_edge() {
+        let dir = tempfile::tempdir().unwrap();
+
+        for (name, edge) in [("nan", f64::NAN), ("inf", f64::INFINITY)] {
+            let path = dir.path().join(format!("single_{name}_edge.h5"));
+            let file = hdf5::File::create(&path).expect("create");
+            let entry = file.create_group("entry").expect("entry");
+            let hist = entry.create_group("histogram").expect("histogram");
+            hist.new_dataset::<f64>()
+                .shape([1])
+                .create("time_of_flight")
+                .expect("create tof")
+                .write_raw(&[edge])
+                .expect("write tof");
+            // No `units` attr → legacy-ns scale (finite, so the bad edge is
+            // preserved as bad, not normalised away).
+            drop(file);
+
+            let file = hdf5::File::open(&path).expect("reopen");
+            let hist_group = file
+                .group("entry")
+                .expect("entry")
+                .group("histogram")
+                .expect("histogram");
+            let err = read_tof_axis(&hist_group).expect_err("single bad edge must reject");
+            assert!(
+                err.to_string().contains("finite and positive"),
+                "single {name} edge should be rejected, got: {err}"
+            );
+        }
     }
 
     /// Create a histogram fixture that also carries a `/entry/pixel_masks/dead`
@@ -1242,6 +1336,53 @@ mod tests {
         let mask = data.dead_pixels.expect("mask present");
         assert_eq!(mask.dim(), (2, 3));
         assert!(mask[[0, 1]]);
+    }
+
+    /// A file with *no* `pixel_masks` group is valid: the mask is absent, not
+    /// malformed, so the load succeeds with `dead_pixels == None`.
+    #[test]
+    fn test_load_nexus_histogram_absent_dead_mask_is_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("no_mask.h5");
+        let counts = vec![1u64; 2 * 3 * 2];
+        let tof_ns = vec![1000.0, 2000.0, 3000.0];
+        create_test_histogram(&path, &counts, [1, 2, 3, 2], &tof_ns, None);
+
+        let data = load_nexus_histogram(&path).expect("absent mask should load");
+        assert!(
+            data.dead_pixels.is_none(),
+            "absent dead mask must map to None"
+        );
+    }
+
+    /// A `/entry/pixel_masks/dead` link that exists but is the wrong object
+    /// kind (a group, not a dataset) is *present-but-malformed*: it must be
+    /// surfaced as an error, not silently swallowed as absence (which would
+    /// drop a real-but-corrupt mask and mask no pixels).
+    #[test]
+    fn test_load_nexus_histogram_rejects_present_but_invalid_dead_mask() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("invalid_mask.h5");
+        let counts = vec![1u64; 2 * 3 * 2];
+        let tof_ns = vec![1000.0, 2000.0, 3000.0];
+        create_test_histogram(&path, &counts, [1, 2, 3, 2], &tof_ns, None);
+
+        // Write `dead` as a *group*, not a dataset — present but malformed.
+        let file = hdf5::File::append(&path).expect("reopen");
+        let entry = file.group("entry").expect("entry");
+        let masks = entry.create_group("pixel_masks").expect("pixel_masks");
+        masks.create_group("dead").expect("dead-as-group");
+        drop(file);
+
+        let err = load_nexus_histogram(&path).unwrap_err();
+        assert!(
+            matches!(err, IoError::InvalidParameter(_)),
+            "present-but-malformed dead mask must be InvalidParameter, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("dead") && err.to_string().contains("not a readable dataset"),
+            "error should identify the malformed dead dataset, got: {err}"
+        );
     }
 
     /// Codex review: `MultiAngleMode::Error` must reject multi-angle

--- a/crates/nereids-io/src/normalization.rs
+++ b/crates/nereids-io/src/normalization.rs
@@ -96,6 +96,20 @@ pub fn normalize(
         }
     }
 
+    // Reject non-finite / negative raw counts up front.  These are detector
+    // counts (and a dark-current estimate), so a NaN or a negative value
+    // signals an upstream loader / TOF-normalisation bug.  Validating here —
+    // rather than letting the per-bin `(x - dc).max(0.0)` clamp below absorb
+    // it — is the whole point of this guard: `NaN.max(0.0) == 0.0` would have
+    // silently turned a corrupt frame into a plausible "zero counts" bin,
+    // exactly the masking the sibling `nereids_fitting::joint_poisson`
+    // `validate_counts` exists to prevent.
+    validate_counts(sample, "sample")?;
+    validate_counts(open_beam, "open_beam")?;
+    if let Some(dc) = dark_current {
+        validate_counts(dc, "dark_current")?;
+    }
+
     let shape = sample.shape();
     let (n_tof, height, width) = (shape[0], shape[1], shape[2]);
 
@@ -113,6 +127,15 @@ pub fn normalize(
                 // is small relative to signal counts (typical for VENUS MCP
                 // detectors), but underestimates σ_T for very low-signal bins
                 // where DC is comparable to the sample or OB counts.
+                //
+                // Inputs are validated finite & non-negative above, so the
+                // subtraction is always finite here; the only way it can go
+                // negative is the legitimate `dc > counts` low-count noise
+                // case (the DC estimate overshoots the measured counts in a
+                // single bin).  Floor that physical edge at 0 — this is NOT
+                // masking bad input (a NaN / negative loader bug was already
+                // rejected), it is the Method-2 convention for a dark-frame
+                // estimate that exceeds the raw counts.
                 let dc = dark_current.map_or(0.0, |dc| dc[[y, x]]);
                 let c_s = (sample[[t, y, x]] - dc).max(0.0);
                 let c_o = (open_beam[[t, y, x]] - dc).max(0.0);
@@ -152,6 +175,27 @@ pub fn normalize(
         transmission,
         uncertainty,
     })
+}
+
+/// Reject a raw-counts array that contains a non-finite or negative value.
+///
+/// Mirrors `nereids_fitting::joint_poisson::validate_counts`: detector counts
+/// are non-negative by construction (zero is legitimate), so a NaN, ±∞, or
+/// negative entry signals an upstream loader / normalisation bug that must be
+/// surfaced rather than silently clamped.  Reports the first offending flat
+/// index and value.
+fn validate_counts<D: ndarray::Dimension>(
+    counts: &ndarray::ArrayBase<impl ndarray::Data<Elem = f64>, D>,
+    field: &str,
+) -> Result<(), IoError> {
+    for (i, &v) in counts.iter().enumerate() {
+        if !v.is_finite() || v < 0.0 {
+            return Err(IoError::InvalidParameter(format!(
+                "{field} counts at flat index {i} must be finite and >= 0, got {v}"
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Extract a single spectrum (all TOF bins) from a pixel in the 3D array.
@@ -315,6 +359,67 @@ mod tests {
 
         let result = normalize(&sample, &ob, &params, None);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_normalize_rejects_nan_sample() {
+        // A NaN in the sample frame used to be swallowed by
+        // `(NaN - 0).max(0.0) == 0.0`, silently producing T = 0 as if the
+        // bin had genuinely zero counts.  It must now be rejected up front.
+        let mut sample = Array3::from_elem((1, 1, 1), 50.0);
+        sample[[0, 0, 0]] = f64::NAN;
+        let ob = Array3::from_elem((1, 1, 1), 100.0);
+        let params = NormalizationParams {
+            proton_charge_sample: 1.0,
+            proton_charge_ob: 1.0,
+        };
+        let err = normalize(&sample, &ob, &params, None).unwrap_err();
+        assert!(
+            matches!(err, IoError::InvalidParameter(_)),
+            "expected InvalidParameter, got {err:?}"
+        );
+        assert!(err.to_string().contains("sample"));
+    }
+
+    #[test]
+    fn test_normalize_rejects_negative_sample() {
+        // Negative raw counts (loader bug) used to be clamped to 0.
+        let mut sample = Array3::from_elem((1, 1, 1), 50.0);
+        sample[[0, 0, 0]] = -5.0;
+        let ob = Array3::from_elem((1, 1, 1), 100.0);
+        let params = NormalizationParams {
+            proton_charge_sample: 1.0,
+            proton_charge_ob: 1.0,
+        };
+        let err = normalize(&sample, &ob, &params, None).unwrap_err();
+        assert!(err.to_string().contains("sample"));
+    }
+
+    #[test]
+    fn test_normalize_rejects_nan_open_beam() {
+        let sample = Array3::from_elem((1, 1, 1), 50.0);
+        let mut ob = Array3::from_elem((1, 1, 1), 100.0);
+        ob[[0, 0, 0]] = f64::INFINITY;
+        let params = NormalizationParams {
+            proton_charge_sample: 1.0,
+            proton_charge_ob: 1.0,
+        };
+        let err = normalize(&sample, &ob, &params, None).unwrap_err();
+        assert!(err.to_string().contains("open_beam"));
+    }
+
+    #[test]
+    fn test_normalize_rejects_negative_dark_current() {
+        let sample = Array3::from_elem((1, 1, 1), 60.0);
+        let ob = Array3::from_elem((1, 1, 1), 110.0);
+        let mut dc = Array2::from_elem((1, 1), 10.0);
+        dc[[0, 0]] = -1.0;
+        let params = NormalizationParams {
+            proton_charge_sample: 1.0,
+            proton_charge_ob: 1.0,
+        };
+        let err = normalize(&sample, &ob, &params, Some(&dc)).unwrap_err();
+        assert!(err.to_string().contains("dark_current"));
     }
 
     #[test]

--- a/crates/nereids-io/src/normalization.rs
+++ b/crates/nereids-io/src/normalization.rs
@@ -179,23 +179,28 @@ pub fn normalize(
 
 /// Reject a raw-counts array that contains a non-finite or negative value.
 ///
-/// Mirrors `nereids_fitting::joint_poisson::validate_counts`: detector counts
-/// are non-negative by construction (zero is legitimate), so a NaN, ±∞, or
-/// negative entry signals an upstream loader / normalisation bug that must be
-/// surfaced rather than silently clamped.  Reports the first offending flat
-/// index and value.
+/// Detector counts are non-negative by construction (zero is legitimate), so a
+/// NaN, ±∞, or negative entry signals an upstream loader / normalisation bug
+/// that must be surfaced rather than silently clamped.  Reports the first
+/// offending flat index and value.
+///
+/// The finite-&-non-negative invariant itself lives in
+/// [`nereids_core::validation::first_non_finite_or_negative`] so that the
+/// `nereids-fitting` joint-Poisson and this I/O loader enforce *identical*
+/// semantics (`NaN < 0.0` is `false`, so the check pairs `is_finite()` with
+/// the order comparison); this wrapper only maps the offending element onto
+/// the `IoError` message wording.
 fn validate_counts<D: ndarray::Dimension>(
     counts: &ndarray::ArrayBase<impl ndarray::Data<Elem = f64>, D>,
     field: &str,
 ) -> Result<(), IoError> {
-    for (i, &v) in counts.iter().enumerate() {
-        if !v.is_finite() || v < 0.0 {
-            return Err(IoError::InvalidParameter(format!(
+    nereids_core::validation::first_non_finite_or_negative(counts.iter().copied()).map_err(
+        |(i, v)| {
+            IoError::InvalidParameter(format!(
                 "{field} counts at flat index {i} must be finite and >= 0, got {v}"
-            )));
-        }
-    }
-    Ok(())
+            ))
+        },
+    )
 }
 
 /// Extract a single spectrum (all TOF bins) from a pixel in the 3D array.

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -864,6 +864,11 @@ pub fn fit_spectrum_typed(
         }
     }
 
+    // Reject a malformed caller-supplied precomputed cross-section stack here,
+    // before it reaches the forward-model builders (which would otherwise panic
+    // on `xs[0].len()` / an over-long row, or silently mis-fit).
+    validate_precomputed_cross_sections(config)?;
+
     let effective_solver = config.effective_solver(input);
 
     match (input, &effective_solver) {
@@ -1613,6 +1618,65 @@ pub(crate) fn validate_transmission_background(bg: &BackgroundConfig) -> Result<
              result. Either enable both (to fit the exponential tail) or \
              disable both (4-term wrapper without exponential).",
             bg.fit_back_d, bg.fit_back_f,
+        )));
+    }
+    Ok(())
+}
+
+/// Validate a caller-supplied precomputed cross-section stack against the
+/// config's grid and isotope/group mapping, BEFORE it reaches the forward-model
+/// builders or the per-pixel rayon loop.
+///
+/// `precomputed_cross_sections` is consumed by `build_transmission_model` /
+/// `build_energy_scale_transmission_model`, which index `xs[0].len()` (panics
+/// when empty) and `params[density_indices[i]]` for each row, and write
+/// `neg_opt[j]` for every `j` in a row (an over-long row writes out of bounds).
+/// A shape mismatch there either panics deep in the LM iteration or is swallowed
+/// per-pixel as `n_failed`; validating once up front turns it into a typed
+/// `ShapeMismatch` (mapped to `PyValueError` at the Python boundary).
+///
+/// Accepted shapes (matching the builders' collapse logic):
+/// * **non-empty** — at least one σ row.
+/// * every row has length `energies.len()`.
+/// * row count is either `n_density_params` (already group-collapsed / identity)
+///   or, when groups are active, `density_indices.len()` (per-member, collapsed
+///   downstream).
+pub(crate) fn validate_precomputed_cross_sections(
+    config: &UnifiedFitConfig,
+) -> Result<(), PipelineError> {
+    let Some(xs) = config.precomputed_cross_sections() else {
+        return Ok(());
+    };
+    if xs.is_empty() {
+        return Err(PipelineError::ShapeMismatch(
+            "precomputed_cross_sections must not be empty".into(),
+        ));
+    }
+
+    let n_e = config.energies().len();
+    for (i, row) in xs.iter().enumerate() {
+        if row.len() != n_e {
+            return Err(PipelineError::ShapeMismatch(format!(
+                "precomputed_cross_sections row {i} has length {} but config.energies \
+                 has {n_e}",
+                row.len(),
+            )));
+        }
+    }
+
+    let n_params = config.n_density_params();
+    // When groups are active the per-member form (`density_indices.len()` rows)
+    // is collapsed to `n_params` rows downstream; accept either.
+    let member_rows = config.density_indices.as_ref().map(|di| di.len());
+    let row_ok = xs.len() == n_params || member_rows == Some(xs.len());
+    if !row_ok {
+        let expected = match member_rows {
+            Some(m) if m != n_params => format!("{n_params} (collapsed) or {m} (per-member)"),
+            _ => format!("{n_params}"),
+        };
+        return Err(PipelineError::ShapeMismatch(format!(
+            "precomputed_cross_sections has {} rows but expected {expected}",
+            xs.len(),
         )));
     }
     Ok(())
@@ -2635,6 +2699,99 @@ mod tests {
         assert!(
             (fitted - true_density).abs() / true_density < 0.05,
             "density: fitted={fitted}, true={true_density}"
+        );
+    }
+
+    /// Helper: a valid single-isotope transmission config + input on a short
+    /// grid, for precomputed-cross-section shape-validation tests.
+    fn precomputed_xs_fixture() -> (UnifiedFitConfig, InputData) {
+        let data = u238_single_resonance();
+        let energies: Vec<f64> = (0..11).map(|i| 1.0 + (i as f64) * 0.1).collect();
+        let (t, sigma) = synthetic_transmission(&data, 0.001, &energies);
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![data],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.001],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig::default()));
+        let input = InputData::Transmission {
+            transmission: t,
+            uncertainty: sigma,
+        };
+        (config, input)
+    }
+
+    #[test]
+    fn test_fit_rejects_empty_precomputed_cross_sections() {
+        // An empty XS stack used to panic on `xs[0].len()` deep in the
+        // forward-model builder; it must now be a typed up-front error.
+        let (config, input) = precomputed_xs_fixture();
+        let config = config.with_precomputed_cross_sections(Arc::new(Vec::new()));
+        let err = fit_spectrum_typed(&input, &config).unwrap_err();
+        assert!(
+            matches!(err, PipelineError::ShapeMismatch(_)),
+            "expected ShapeMismatch, got {err:?}"
+        );
+        assert!(err.to_string().contains("must not be empty"));
+    }
+
+    #[test]
+    fn test_fit_rejects_wrong_row_count_precomputed_cross_sections() {
+        // 1 isotope → exactly 1 σ row expected; supply 2.
+        let (config, input) = precomputed_xs_fixture();
+        let n_e = config.energies().len();
+        let bad = vec![vec![1.0; n_e], vec![1.0; n_e]];
+        let config = config.with_precomputed_cross_sections(Arc::new(bad));
+        let err = fit_spectrum_typed(&input, &config).unwrap_err();
+        assert!(
+            matches!(err, PipelineError::ShapeMismatch(_)),
+            "expected ShapeMismatch, got {err:?}"
+        );
+        assert!(err.to_string().contains("rows"));
+    }
+
+    #[test]
+    fn test_fit_rejects_wrong_energy_length_precomputed_cross_sections() {
+        // Correct row count (1) but the row is the wrong length.
+        let (config, input) = precomputed_xs_fixture();
+        let n_e = config.energies().len();
+        let bad = vec![vec![1.0; n_e + 3]];
+        let config = config.with_precomputed_cross_sections(Arc::new(bad));
+        let err = fit_spectrum_typed(&input, &config).unwrap_err();
+        assert!(
+            matches!(err, PipelineError::ShapeMismatch(_)),
+            "expected ShapeMismatch, got {err:?}"
+        );
+        assert!(err.to_string().contains("config.energies"));
+    }
+
+    #[test]
+    fn test_fit_accepts_correct_precomputed_cross_sections() {
+        // A correctly-shaped precomputed stack must still fit (no false
+        // rejection): 1 row of length n_e.
+        let (config, input) = precomputed_xs_fixture();
+        let n_e = config.energies().len();
+        let xs = phys_transmission::broadened_cross_sections(
+            config.energies(),
+            config.resonance_data(),
+            0.0,
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(xs.len(), 1);
+        assert_eq!(xs[0].len(), n_e);
+        let config = config.with_precomputed_cross_sections(Arc::new(xs));
+        // Must not error on shape; the fit itself may or may not converge,
+        // but the call must reach the solver rather than fail validation.
+        let result = fit_spectrum_typed(&input, &config);
+        assert!(
+            result.is_ok(),
+            "correctly-shaped precomputed XS must pass validation, got {result:?}"
         );
     }
 

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -1662,6 +1662,18 @@ pub(crate) fn validate_precomputed_cross_sections(
                 row.len(),
             )));
         }
+        // A correctly-shaped row of NaN / ±∞ σ passes the shape checks but
+        // poisons the forward model: every transmission sample picks up the
+        // non-finite σ and the LM residual / Fisher matrix becomes NaN, which
+        // the per-pixel dispatch then silently swallows as a failed fit.
+        // Reject non-finite σ at the boundary (`is_finite()` excludes both NaN
+        // and ±∞; a bare order comparison would let NaN through).
+        if let Some(j) = row.iter().position(|s| !s.is_finite()) {
+            return Err(PipelineError::ShapeMismatch(format!(
+                "precomputed_cross_sections row {i} has non-finite σ at energy index {j}: {}",
+                row[j],
+            )));
+        }
     }
 
     let n_params = config.n_density_params();
@@ -2202,11 +2214,26 @@ pub struct ModelJacobianResult {
 /// Density evaluation values come from `config.initial_densities`.
 /// Temperature evaluation value comes from `config.temperature_k`.
 /// α₁/α₂ evaluation values come from `config.counts_background` init fields.
+///
+/// # Errors
+/// Returns [`PipelineError::ShapeMismatch`] if `config.precomputed_cross_sections`
+/// is set but malformed (empty, wrong row count, wrong row length, or contains a
+/// non-finite σ), consistent with `fit_spectrum_typed` and `spatial_map_typed`.
 pub fn evaluate_jacobian_and_fisher(
     config: &UnifiedFitConfig,
     flux: &[f64],
     background: &[f64],
 ) -> Result<ModelJacobianResult, PipelineError> {
+    // Reject a malformed caller-supplied precomputed cross-section stack here,
+    // before it reaches `build_transmission_model`.  Without this, an empty
+    // stack is caught only deep in `PrecomputedTransmissionModel` (as an
+    // `InvalidConfig`, not a `ShapeMismatch`) and a wrong-shaped / non-finite
+    // stack indexes `xs[0]` / `neg_opt[j]` directly.  This is the third public
+    // entry point that consumes `config.precomputed_cross_sections`; it must
+    // guard the same way as `fit_spectrum_typed` / `spatial_map_typed` so all
+    // three surface the same typed `ShapeMismatch` at the boundary.
+    validate_precomputed_cross_sections(config)?;
+
     let n_density_params = config.n_density_params();
 
     // ── Build parameter vector — preserves the pre-collapse fixed-flux
@@ -2793,6 +2820,74 @@ mod tests {
             result.is_ok(),
             "correctly-shaped precomputed XS must pass validation, got {result:?}"
         );
+    }
+
+    #[test]
+    fn test_fit_rejects_non_finite_precomputed_cross_sections() {
+        // A correctly-shaped row whose σ values are NaN passes the shape
+        // checks but poisons the forward model (NaN residual swallowed as a
+        // failed pixel).  It must be rejected at the boundary.  `NaN < x` is
+        // `false`, so a bare order comparison would let it through — the
+        // `is_finite()` half of the guard is what catches it.
+        let (config, input) = precomputed_xs_fixture();
+        let n_e = config.energies().len();
+        let bad = vec![vec![f64::NAN; n_e]];
+        let config = config.with_precomputed_cross_sections(Arc::new(bad));
+        let err = fit_spectrum_typed(&input, &config).unwrap_err();
+        assert!(
+            matches!(err, PipelineError::ShapeMismatch(_)),
+            "expected ShapeMismatch, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("non-finite"),
+            "error should mention non-finite σ, got: {err}"
+        );
+
+        // ±∞ is equally rejected.
+        let (config, input) = precomputed_xs_fixture();
+        let mut row = vec![1.0; n_e];
+        row[n_e / 2] = f64::INFINITY;
+        let config = config.with_precomputed_cross_sections(Arc::new(vec![row]));
+        let err = fit_spectrum_typed(&input, &config).unwrap_err();
+        assert!(
+            matches!(err, PipelineError::ShapeMismatch(_)),
+            "expected ShapeMismatch for +inf σ, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_evaluate_jacobian_rejects_malformed_precomputed_cross_sections() {
+        // `evaluate_jacobian_and_fisher` is a third public entry point that
+        // consumes `config.precomputed_cross_sections`.  An empty stack used
+        // to reach `build_transmission_model` and panic on `xs[0].len()`; it
+        // must now fail the shared up-front validator instead.
+        let (config, _input) = precomputed_xs_fixture();
+        let n_e = config.energies().len();
+        let flux = vec![1.0; n_e];
+        let background = vec![0.0; n_e];
+
+        // `ModelJacobianResult` (the Ok type) is not `Debug`, so match on the
+        // result rather than calling `unwrap_err()`.
+        let empty = config
+            .clone()
+            .with_precomputed_cross_sections(Arc::new(Vec::new()));
+        match evaluate_jacobian_and_fisher(&empty, &flux, &background) {
+            Err(PipelineError::ShapeMismatch(msg)) => {
+                assert!(msg.contains("must not be empty"), "got: {msg}");
+            }
+            Err(other) => panic!("expected ShapeMismatch for empty XS, got {other:?}"),
+            Ok(_) => panic!("empty precomputed XS must be rejected"),
+        }
+
+        // Non-finite σ is rejected on this path too.
+        let nan = config.with_precomputed_cross_sections(Arc::new(vec![vec![f64::NAN; n_e]]));
+        match evaluate_jacobian_and_fisher(&nan, &flux, &background) {
+            Err(PipelineError::ShapeMismatch(msg)) => {
+                assert!(msg.contains("non-finite"), "got: {msg}");
+            }
+            Err(other) => panic!("expected ShapeMismatch for NaN σ, got {other:?}"),
+            Ok(_) => panic!("non-finite precomputed σ must be rejected"),
+        }
     }
 
     #[test]

--- a/crates/nereids-pipeline/src/spatial.rs
+++ b/crates/nereids-pipeline/src/spatial.rs
@@ -746,6 +746,12 @@ pub fn spatial_map_typed(
     // counts-domain solver" diagnostic.
     validate_spatial_fit_preflight(input, config)?;
 
+    // Reject a malformed caller-supplied precomputed cross-section stack once,
+    // before the per-pixel rayon loop (and before the σ_eff group-collapse
+    // below, which indexes `xs[0]`).  A freshly-computed stack carries no
+    // `precomputed_cross_sections`, so this is a no-op on the common path.
+    crate::pipeline::validate_precomputed_cross_sections(config)?;
+
     // Collect live pixel coordinates
     let mut pixel_coords: Vec<(usize, usize)> = Vec::new();
     for y in 0..height {
@@ -1412,7 +1418,17 @@ pub fn spatial_map_typed(
         })
         .collect();
 
-    if cancel.is_some_and(|c| c.load(Ordering::Relaxed)) && results.is_empty() {
+    // If cancellation was requested at any point, return `Err(Cancelled)` —
+    // NOT a partial `Ok(SpatialResult)`. The rayon closure stops launching new
+    // pixel fits once `cancel` is set, so by the time we get here `results`
+    // holds only the pixels that finished before cancellation; every other
+    // pixel would be left as a NaN hole, indistinguishable from a genuinely
+    // failed fit. A non-GUI caller (e.g. the Python binding) has no other
+    // signal that the map is incomplete, so a partial map is silently wrong.
+    // The previous `&& results.is_empty()` guard only caught the rare case
+    // where cancellation beat *every* pixel; mid-run cancellation slipped
+    // through and produced a partial map.
+    if cancel.is_some_and(|c| c.load(Ordering::Relaxed)) {
         return Err(PipelineError::Cancelled);
     }
 
@@ -1594,11 +1610,14 @@ mod tests {
         synthetic_single_resonance, u238_single_resonance,
     };
 
-    /// Build a 4x4 synthetic transmission stack from known density.
-    fn synthetic_4x4_transmission(
+    /// Build a synthetic transmission stack of shape `(n_e, height, width)`
+    /// where every pixel holds the same spectrum for a known density.
+    fn synthetic_grid_transmission(
         res_data: &nereids_endf::resonance::ResonanceData,
         true_density: f64,
         energies: &[f64],
+        height: usize,
+        width: usize,
     ) -> (Array3<f64>, Array3<f64>) {
         let n_e = energies.len();
         let xs = nereids_physics::transmission::broadened_cross_sections(
@@ -1621,11 +1640,10 @@ mod tests {
         let t_1d = model.evaluate(&[true_density]).unwrap();
         let sigma_1d: Vec<f64> = t_1d.iter().map(|&v| 0.01 * v.max(0.01)).collect();
 
-        // Fill a 4x4 grid with the same spectrum
-        let mut t_3d = Array3::zeros((n_e, 4, 4));
-        let mut u_3d = Array3::zeros((n_e, 4, 4));
-        for y in 0..4 {
-            for x in 0..4 {
+        let mut t_3d = Array3::zeros((n_e, height, width));
+        let mut u_3d = Array3::zeros((n_e, height, width));
+        for y in 0..height {
+            for x in 0..width {
                 for (i, (&t, &s)) in t_1d.iter().zip(sigma_1d.iter()).enumerate() {
                     t_3d[[i, y, x]] = t;
                     u_3d[[i, y, x]] = s;
@@ -1633,6 +1651,15 @@ mod tests {
             }
         }
         (t_3d, u_3d)
+    }
+
+    /// Build a 4x4 synthetic transmission stack from known density.
+    fn synthetic_4x4_transmission(
+        res_data: &nereids_endf::resonance::ResonanceData,
+        true_density: f64,
+        energies: &[f64],
+    ) -> (Array3<f64>, Array3<f64>) {
+        synthetic_grid_transmission(res_data, true_density, energies, 4, 4)
     }
 
     /// Build a 4x4 synthetic counts stack from known density.
@@ -1742,6 +1769,105 @@ mod tests {
         assert!(
             (mean - true_density).abs() / true_density < 0.10,
             "KL mean density: {mean}, true: {true_density}"
+        );
+    }
+
+    /// A caller-supplied precomputed cross-section stack with the wrong shape
+    /// must be rejected up front (before the rayon loop), not panic on
+    /// `xs[0]` in the σ_eff collapse / forward-model builder or be swallowed
+    /// per-pixel as `n_failed`.
+    #[test]
+    fn test_spatial_map_rejects_wrong_shape_precomputed_cross_sections() {
+        let data = u238_single_resonance();
+        let energies: Vec<f64> = (0..21).map(|i| 1.0 + (i as f64) * 0.1).collect();
+        let (t_3d, u_3d) = synthetic_4x4_transmission(&data, 0.0005, &energies);
+
+        // 1 isotope → 1 σ row expected; inject 2 rows of the right length.
+        let n_e = energies.len();
+        let bad_xs = Arc::new(vec![vec![1.0; n_e], vec![1.0; n_e]]);
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![data],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.001],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig::default()))
+        .with_precomputed_cross_sections(bad_xs);
+
+        let input = InputData3D::Transmission {
+            transmission: t_3d.view(),
+            uncertainty: u_3d.view(),
+        };
+
+        let err = spatial_map_typed(&input, &config, None, None, None)
+            .expect_err("wrong-shape precomputed XS must be rejected up front");
+        assert!(
+            matches!(err, PipelineError::ShapeMismatch(_)),
+            "expected ShapeMismatch, got {err:?}"
+        );
+    }
+
+    /// Mid-run cancellation must return `Err(Cancelled)`, not a partial
+    /// `Ok(SpatialResult)` whose cancelled pixels are left as NaN holes
+    /// (indistinguishable from genuine fit failures, with no signal to a
+    /// non-GUI caller that the map is incomplete).
+    ///
+    /// The previous post-loop guard only fired when cancellation beat *every*
+    /// pixel (`results.is_empty()`); a cancellation that lands after the first
+    /// pixel completes slipped through and produced a partial map.  This test
+    /// reproduces exactly that: a watcher thread flips `cancel` as soon as the
+    /// `progress` counter shows the first pixel finished, while the remaining
+    /// pixels are still fitting.  The pre-loop guard sees `cancel == false`
+    /// (so it does not short-circuit), pixels complete into `results`, and the
+    /// post-loop guard then observes `cancel == true` with `results`
+    /// non-empty.
+    #[test]
+    fn test_spatial_map_mid_run_cancellation_returns_err() {
+        use std::sync::atomic::{AtomicBool, AtomicUsize};
+
+        let data = u238_single_resonance();
+        let energies: Vec<f64> = (0..101).map(|i| 1.0 + (i as f64) * 0.1).collect();
+        // A wide grid: many real LM fits, so the watcher reliably flips
+        // `cancel` mid-run (after pixel 1, with dozens of pixels left to skip).
+        let (t_3d, u_3d) = synthetic_grid_transmission(&data, 0.0005, &energies, 1, 64);
+
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![data],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.001],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig::default()));
+
+        let input = InputData3D::Transmission {
+            transmission: t_3d.view(),
+            uncertainty: u_3d.view(),
+        };
+
+        let cancel = AtomicBool::new(false);
+        let progress = AtomicUsize::new(0);
+
+        let result = std::thread::scope(|s| {
+            // Watcher: once at least one pixel has finished, request
+            // cancellation while the rest are still being fit.
+            s.spawn(|| {
+                while progress.load(Ordering::Relaxed) < 1 {
+                    std::hint::spin_loop();
+                }
+                cancel.store(true, Ordering::Relaxed);
+            });
+            spatial_map_typed(&input, &config, None, Some(&cancel), Some(&progress))
+        });
+
+        assert!(
+            matches!(result, Err(PipelineError::Cancelled)),
+            "mid-run cancellation must return Err(Cancelled), got {result:?}"
         );
     }
 

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -150,6 +150,31 @@ class TestTofConversion:
         for i in range(len(centers) - 1):
             assert centers[i] < centers[i + 1], f"Expected ascending energy: centers[{i}]={centers[i]} >= centers[{i+1}]={centers[i+1]}"
 
+    def test_tof_to_energy_rejects_non_positive_and_non_finite(self):
+        """Non-positive / non-finite TOF or flight path must raise ValueError.
+
+        Without the guard the conversion silently returned a positive energy
+        for negative TOF (v**2 hides the sign) or +inf at zero TOF, masking a
+        bad TOF axis downstream.
+        """
+        fp = 20.0
+        for bad in (-100.0, 0.0, float("nan"), float("inf")):
+            with pytest.raises(ValueError):
+                nereids.tof_to_energy(bad, fp)
+        for bad_fp in (-1.0, 0.0, float("nan"), float("inf")):
+            with pytest.raises(ValueError):
+                nereids.tof_to_energy(100.0, bad_fp)
+
+    def test_energy_to_tof_rejects_non_positive_and_non_finite(self):
+        """Non-positive / non-finite energy or flight path must raise ValueError."""
+        fp = 20.0
+        for bad in (-1.0, 0.0, float("nan"), float("inf")):
+            with pytest.raises(ValueError):
+                nereids.energy_to_tof(bad, fp)
+        for bad_fp in (-1.0, 0.0, float("nan"), float("inf")):
+            with pytest.raises(ValueError):
+                nereids.energy_to_tof(10.0, bad_fp)
+
 
 # ===========================================================================
 # ResonanceData creation


### PR DESCRIPTION
Part of epic #594 · addresses sub-issue #595 (input-validation hardening: core / io / pipeline).

Fixes **9 of the 10** findings in #595. The 10th — `pipeline/spatial.rs:1094` measurement-value sanitation — was already resolved on `main` by **#592** (the auto-spawned spatial-validation task); verified via ripgrep, **not duplicated**.

## Findings fixed
| Finding | Fix |
|---|---|
| `core/constants.rs` `tof_to_energy` +energy for −TOF / `inf` at 0 | documented-NaN contract + symmetric `energy_to_tof` guard; **PyO3 forwarder rejects with `ValueError`** |
| `core/types.rs` `Isotope::new` accepts A≥1000 | reject A>999 (preserves `Z×1000+A` round-trip) + exhaustive property test |
| `core/types.rs` `IsotopeGroup::subset` dup masses | reject duplicates |
| `io/normalization.rs` `(x-dc).max(0.0)` absorbs NaN/neg | up-front `validate_counts` (sample/OB/dc finite & ≥0) rejects bad input; residual `.max(0.0)` only floors the legit `dc>counts` noise case |
| `io/nexus.rs` TOF axis unvalidated | reuse `validate_monotonic` + positivity |
| `io/nexus.rs` dead-pixel mask shape | reject shape mismatch |
| `io/nexus.rs` zero-sized axes | mirror the zero-rotation guard |
| `pipeline/spatial.rs` mid-run cancel → `Ok(partial)` | now returns `Err(Cancelled)` |
| `pipeline/pipeline.rs` precomputed-XS wrong shape | single `validate_precomputed_cross_sections`, up-front before rayon |

## Approach
Reject-don't-clamp; shared per-crate validators, no parallel logic (reused `validate_monotonic`, mirrored the `validate_counts` pattern, one `validate_precomputed_cross_sections` called from two entry points).

## Public-API changes (review focus)
- PyO3 `tof_to_energy` / `energy_to_tof`: `f64 → PyResult<f64>` (Python source-compatible; raises `ValueError` on non-positive/non-finite).
- `read_dead_pixel_mask` (private): added `(height, width)`, now `Result<Option<…>>`; both callers updated.
- `validate_precomputed_cross_sections`: new `pub(crate)`.

## Tests & gates
- 13 Rust + 2 Python regression tests, each verified to **fail against pre-fix code** (e.g. cancellation: old code returned `Ok` with 56 NaN-hole pixels and `n_failed=0`). nexus tests are `hdf5`-feature-gated.
- `cargo fmt` ✓ · clippy (workspace + `-p nereids-io --features hdf5`) ✓ · `cargo test --workspace --exclude nereids-python` ✓ · `pixi run test-python` ✓ (126 passed; **VENUS Hf-177 LM-fit baseline unchanged**).
- LOC: **+847 / −29** (guards + 15 regression tests; net-add expected for validation hardening).

Detection by the `nereids-bug-hunt` workflow (#591); each finding cross-confirmed by ≥2 LLM families.
