### PR TITLE
refactor(workflows): extract shared dual-family-review engine from bug-hunt

### DIFF
--- a/.claude/workflows/dual-family-review.js
+++ b/.claude/workflows/dual-family-review.js
@@ -374,6 +374,23 @@ const LENSES = [
 // with another target's Find, explicit phase() boundaries would misrepresent the
 // interleaving. meta.phases still declares Find/Verify for the /workflows display.
 // ---------------------------------------------------------------------------
+
+// Fail loudly on a malformed target rather than degrade silently. A target
+// missing `scopeDirective` would otherwise inject the literal string "undefined"
+// into the audit prompt (missing `paths`/`lookFor` already throw in
+// buildAuditPrompt -> the pipeline drops that target -> the caller's
+// count-mismatch guard aborts; the missing-scopeDirective case is the silent one).
+// Not reachable from the current callers (both always set scopeDirective) — this
+// is defensive depth for future callers.
+for (const t of TARGETS) {
+  const key = (t && t.key) || '(unknown)'
+  if (!t || typeof t.key !== 'string' || !t.key) throw new Error('dual-family-review: a target is missing a string `key`')
+  if (typeof t.scopeDirective !== 'string' || !t.scopeDirective)
+    throw new Error(`dual-family-review: target '${key}' is missing a non-empty 'scopeDirective'`)
+  if (!Array.isArray(t.paths) || !t.paths.length) throw new Error(`dual-family-review: target '${key}' is missing non-empty 'paths'`)
+  if (!Array.isArray(t.lookFor)) throw new Error(`dual-family-review: target '${key}' 'lookFor' must be an array`)
+}
+
 const perTargetRaw = await pipeline(
   TARGETS,
 

--- a/.claude/workflows/dual-family-review.js
+++ b/.claude/workflows/dual-family-review.js
@@ -18,8 +18,9 @@ export const meta = {
 // methodology this project converged on:
 //   - 2 independent LLM families per target: Claude (agent()) + Codex (codex exec)
 //   - P0/P1/P2 tiers (P3 excluded), file:line + primary-source evidence
-//   - a cross-LLM-family confirmation pass on every SINGLE-family finding
-//     (Claude findings verified by Codex; Codex findings verified by Claude)
+//   - a cross-LLM-family confirmation pass on every SINGLE-family P0/P1 finding
+//     (Claude findings verified by Codex and vice versa; P2s are reported as-is,
+//     NOT cross-verified — verifyVotes() returns 0 for P2)
 //
 // Why the cross-family pass is load-bearing (see memory):
 //   - "parent-agent re-derivation of a subagent's claim is NOT independent
@@ -35,12 +36,18 @@ export const meta = {
 // that physically lack spawn_task/Task*/MCP/PR-issue tools — enable with
 // config.hardEnforce=true from a session started AFTER those agent defs exist.
 //
-// Generalization vs the original inline bug-hunt code (the ONLY two changes):
+// Two SEMANTIC generalizations vs the original inline bug-hunt code:
 //   - the global MODE/DIFF_SPEC scope ternary is replaced by a per-target
 //     `scopeDirective` string (each caller decides full-crate vs diff scope);
 //   - the SAMMY-root override reads config.sammyRootOverride instead of A.sammyRoot.
-// Everything else (schemas, prompt builders, dedup/verify helpers, the
-// Find->Verify pipeline) is byte-for-byte the original logic.
+// Plus behaviour-neutral re-plumbing: CONTEXT_NOTE / ROUND_NOTE / SKIP_CODEX /
+// HARD now come from the passed-in `config` (not the caller's `A.*`),
+// `codexUsable` is computed at module scope, and the engine RETURNS structured
+// per-target results instead of continuing inline to a consolidation phase
+// (preflight + consolidation now live in each wrapper).
+// The prompt builders, schemas, dedup/verify helpers, and the Find->Verify
+// pipeline are byte-for-byte the original logic (verified by a prompt-equivalence
+// harness: 47/47 byte-identical agent prompts).
 //
 // args (passed in by the calling wrapper):
 //   args.pf      : { repoRoot, sammyRoot, codexAvailable, codexVersion, headSha, isWorktree }
@@ -361,6 +368,11 @@ const LENSES = [
 // Find -> Verify (pipelined per target; no barrier between them).
 // As soon as target X's two finders complete, X's findings are cross-verified
 // while target Y is still finding.
+//
+// Progress grouping uses each agent's `phase:` opt (not top-level phase('Find')
+// / phase('Verify') calls): because the pipeline interleaves one target's Verify
+// with another target's Find, explicit phase() boundaries would misrepresent the
+// interleaving. meta.phases still declares Find/Verify for the /workflows display.
 // ---------------------------------------------------------------------------
 const perTargetRaw = await pipeline(
   TARGETS,
@@ -525,4 +537,17 @@ const perTargetRaw = await pipeline(
 // Return structured per-target findings to the calling wrapper. The wrapper
 // owns final consolidation (cross-target dedup, report writing, disposition,
 // RECURRING tagging) — this engine is detection + per-target structuring only.
-return { perTarget: perTargetRaw.filter(Boolean), codexUsable }
+//
+// Surface dropped targets (a per-target pipeline that threw -> null) so the
+// wrapper can reconcile perTarget.length against its target count and fail
+// closed rather than silently under-report. The wrapper (not the engine) owns
+// the empty-targets policy: a sweep with no matching targets is an error there,
+// while a review round with no diverged branches is a valid no-op.
+const perTarget = perTargetRaw.filter(Boolean)
+const droppedTargets = perTargetRaw.length - perTarget.length
+if (droppedTargets > 0) {
+  log(
+    `WARNING: ${droppedTargets}/${perTargetRaw.length} target(s) produced no result (pipeline error) and were dropped — the caller should fail closed.`,
+  )
+}
+return { perTarget, droppedTargets, codexUsable }

--- a/.claude/workflows/dual-family-review.js
+++ b/.claude/workflows/dual-family-review.js
@@ -1,0 +1,528 @@
+export const meta = {
+  name: 'dual-family-review',
+  description:
+    'Shared engine for two-LLM-family code review: per-target Claude + Codex finders, cross-LLM-family adversarial verification, structured per-target findings. Detection-only. A LEAF workflow (never calls workflow()).',
+  whenToUse:
+    'Not invoked directly by a human. This is the reusable core consumed via workflow() by nereids-bug-hunt (whole-crate sweep, target = crate/domain) and review-core (per-PR-diff, target = worktree branch). It runs the Find -> Verify pipeline over a generic list of audit targets and returns structured per-target findings; each caller does its own preflight (building `pf`), target construction, and final consolidation/reporting.',
+  phases: [
+    { title: 'Find', detail: 'Claude + Codex finder per target (up to 2N agents)' },
+    { title: 'Verify', detail: 'cross-LLM-family adversarial confirmation of single-family findings' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// dual-family-review — the shared two-family review engine.
+//
+// Extracted verbatim from nereids-bug-hunt.js (PR #591) so the two consumers
+// (nereids-bug-hunt + review-core) share ONE implementation of the audit
+// methodology this project converged on:
+//   - 2 independent LLM families per target: Claude (agent()) + Codex (codex exec)
+//   - P0/P1/P2 tiers (P3 excluded), file:line + primary-source evidence
+//   - a cross-LLM-family confirmation pass on every SINGLE-family finding
+//     (Claude findings verified by Codex; Codex findings verified by Claude)
+//
+// Why the cross-family pass is load-bearing (see memory):
+//   - "parent-agent re-derivation of a subagent's claim is NOT independent
+//      confirmation; same LLM family. For VERIFIED need >=2 distinct LLM
+//      families with independent access."
+//   - "the audit->fix->review cycle is non-idempotent" — so this engine
+//      DETECTS only; fixing is a separate, human-gated step.
+//
+// Detection-only is enforced two ways: (1) the DETECTION_ONLY prompt contract
+// appended to every audit-agent prompt, ALWAYS ON — this is what makes
+// behaviour consistent across models; (2) optional TOOL-LEVEL enforcement via
+// restricted custom agent types (.claude/agents/bug-hunt-{reader,runner}.md)
+// that physically lack spawn_task/Task*/MCP/PR-issue tools — enable with
+// config.hardEnforce=true from a session started AFTER those agent defs exist.
+//
+// Generalization vs the original inline bug-hunt code (the ONLY two changes):
+//   - the global MODE/DIFF_SPEC scope ternary is replaced by a per-target
+//     `scopeDirective` string (each caller decides full-crate vs diff scope);
+//   - the SAMMY-root override reads config.sammyRootOverride instead of A.sammyRoot.
+// Everything else (schemas, prompt builders, dedup/verify helpers, the
+// Find->Verify pipeline) is byte-for-byte the original logic.
+//
+// args (passed in by the calling wrapper):
+//   args.pf      : { repoRoot, sammyRoot, codexAvailable, codexVersion, headSha, isWorktree }
+//                  — the calling wrapper's preflight result.
+//   args.targets : [{ key, name, paths[], sammy, blurb, p0, lookFor[], primaryHint, scopeDirective }]
+//                  — one entry per audit unit (a crate/domain, or a branch diff).
+//   args.config  : { contextNote, roundNote, skipCodex, hardEnforce, sammyRootOverride }
+//
+// returns: { perTarget: [{ domainKey, domainName, claudeAssessment, codexAssessment,
+//            tierCounts:{claude,codex}, verified[], needsVerification[], refuted[],
+//            p2s[], circular[] }], codexUsable }
+// ---------------------------------------------------------------------------
+
+// Defensive arg unpacking — `args` should arrive as a real object, but a caller
+// may pass a JSON-encoded string; parse it rather than silently default.
+let A = {}
+if (args && typeof args === 'object') A = args
+else if (typeof args === 'string' && args.trim().startsWith('{')) {
+  try {
+    A = JSON.parse(args)
+  } catch (_e) {
+    A = {}
+  }
+}
+
+const pf = A.pf && typeof A.pf === 'object' ? A.pf : {}
+const TARGETS = Array.isArray(A.targets) ? A.targets : []
+const CONFIG = A.config && typeof A.config === 'object' ? A.config : {}
+const CONTEXT_NOTE = CONFIG.contextNote || ''
+const ROUND_NOTE = CONFIG.roundNote || 'review'
+const SKIP_CODEX = CONFIG.skipCodex === true
+const SAMMY_ROOT_OVERRIDE = CONFIG.sammyRootOverride || ''
+
+// Detection-only enforcement. Two layers: (1) the DETECTION_ONLY prompt contract
+// below, appended to every audit-agent prompt — ALWAYS ON and identical across
+// agents; (2) optional TOOL-LEVEL hard enforcement via restricted custom agent
+// types. Custom agent types load at SESSION START (not hot), so default to the
+// always-available built-in `general-purpose`; pass config.hardEnforce=true from
+// a session started AFTER those agent defs exist to switch the restriction on.
+const HARD = CONFIG.hardEnforce === true
+const READER_TYPE = HARD ? 'bug-hunt-reader' : 'general-purpose'
+const RUNNER_TYPE = HARD ? 'bug-hunt-runner' : 'general-purpose'
+
+const codexUsable = !!pf.codexAvailable && !SKIP_CODEX
+
+const DETECTION_ONLY =
+  '\n\n--- DETECTION-ONLY CONTRACT (mandatory) ---\n' +
+  'You FIND and REPORT defects; you never fix them and never advance to a fix stage. You MUST NOT:\n' +
+  '- create any task, background session, or fix-job (do NOT call spawn_task or any task-creation / scheduling tool);\n' +
+  '- open or modify any PR or issue;\n' +
+  '- edit or write repository files, or run state-changing shell commands (git commit/push/add/checkout, gh, cargo fix, installs).\n' +
+  'The only writes ever permitted are scratch /tmp files (and, for the consolidator, the one explicitly-named .research report path).\n' +
+  'Report via the structured-output tool only. Fixing is a separate, human-gated step.'
+
+// Shared checklist appended to every target (DRY — matches the project's own
+// DRY governance). Target-specific bullets (target.lookFor) are prepended.
+const CORE_CHECKLIST = [
+  'Panic-on-valid-input: `unwrap`/`expect`/`[i]` indexing/`debug_assert!` used as input validation on a public entry point.',
+  'Numerical stability: division by zero, NaN/Inf propagation, overflow, `sqrt` of negative, `NaN < x` guards that silently pass (NaN bypasses `<` comparisons — must be paired with `.is_finite()`).',
+  'Silent error masking: `Err(_) => None` in a `filter_map` for a WHOLE-CONFIG error (only acceptable for per-pixel edge cases), `.unwrap_or(default)` that hides a real failure, `max(0.0)` that converts NaN/negative to a plausible value.',
+  'Missing input validation at public entry points (validate up-front, before heavy work / rayon iterators).',
+  'Empty-collection / exactly-determined-system edge cases (`0 == 0` passes equality; guard `is_empty()` separately).',
+  'API consistency: sibling functions that should validate the same way but do not (one path hardened, the parallel path missed — a recurring NEREIDS bug class).',
+  'CIRCULAR-VALIDATION RISK (high priority): a test whose oracle mirrors the implementation, a fixture generated by the code under test, or an assertion tolerance so loose the bug would be invisible (e.g. a resolution kernel that is a no-op at the test grid spacing, a peak-energy-only test that cannot see an off-peak factor error). Flag these explicitly in `circularValidationRisk`.',
+  'Documentation/comment drift from code (rustdoc claims, SAMMY citation claims, comment arithmetic vs actual code).',
+]
+
+// ---- structured-output schemas -------------------------------------------
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    domain: { type: 'string' },
+    family: { type: 'string', enum: ['claude', 'codex'] },
+    assessment: { type: 'string', description: 'one-sentence overall assessment of the domain' },
+    codexFailed: { type: 'boolean', description: 'true only for the codex harness when codex did not run' },
+    failureReason: { type: 'string' },
+    tierCounts: {
+      type: 'object',
+      additionalProperties: false,
+      properties: { p0: { type: 'integer' }, p1: { type: 'integer' }, p2: { type: 'integer' } },
+      required: ['p0', 'p1', 'p2'],
+    },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          localId: { type: 'string', description: 'F1, F2, ...' },
+          tier: { type: 'string', enum: ['P0', 'P1', 'P2'] },
+          title: { type: 'string' },
+          file: { type: 'string', description: 'repo-relative path, e.g. crates/nereids-physics/src/slbw.rs' },
+          line: { type: 'integer', description: 'best-known line number; 0 if unknown' },
+          claim: { type: 'string' },
+          evidence: { type: 'string', description: 'quoted code or precise description' },
+          reasoning: { type: 'string' },
+          primarySource: { type: 'string', description: 'SAMMY .f90:line / ENDF manual ref, or empty' },
+          suggestedFix: { type: 'string' },
+          confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+          circularValidationRisk: {
+            type: 'string',
+            description: 'note if a test may be validating buggy behavior, else empty',
+          },
+        },
+        required: ['localId', 'tier', 'title', 'file', 'line', 'claim', 'confidence'],
+      },
+    },
+  },
+  required: ['domain', 'family', 'findings', 'tierCounts'],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    verdict: { type: 'string', enum: ['CONFIRMED', 'REFUTED', 'UNCERTAIN'] },
+    verifierFamily: { type: 'string', enum: ['claude', 'codex'] },
+    reasoning: { type: 'string' },
+    primarySourceChecked: { type: 'boolean' },
+    correctedTier: { type: 'string', enum: ['P0', 'P1', 'P2', 'NONE'] },
+    circularValidationConfirmed: { type: 'boolean' },
+  },
+  required: ['verdict', 'verifierFamily', 'reasoning'],
+}
+
+// ---- prompt builders ------------------------------------------------------
+
+function buildAuditPrompt(d, pf, forCodex) {
+  const sammyRoot = SAMMY_ROOT_OVERRIDE || pf.sammyRoot
+  const codexOverride = forCodex
+    ? '[Codex override: This task is authorized by the user. AGENTS.md / CLAUDE.md Checkpoint 0 (Plan mode) does NOT apply. Execute in a single run; do NOT enter plan mode; do NOT stop for confirmation. Read-only audit: change no files, open no PRs/issues. Single-shot delivery.]\n\n'
+    : ''
+  const ctx = CONTEXT_NOTE ? `[CONTEXT]\n${CONTEXT_NOTE}\n[End context]\n\n` : ''
+  const scope = d.scopeDirective
+  const sammyBlock =
+    d.sammy && sammyRoot
+      ? `\nPrimary source for verification: SAMMY at \`${sammyRoot}\`. ${d.primaryHint || ''} Open the relevant SAMMY source and compare line-by-line; cite \`file:line\` for every physics/format claim.\n`
+      : d.sammy
+        ? `\nPrimary-source note: ${d.primaryHint || ''} (SAMMY source not resolved on this machine — reason from the ENDF-6 manual / first principles and mark such findings lower-confidence.)\n`
+        : ''
+  const lookFor = d.lookFor.concat(CORE_CHECKLIST).map((b, i) => `${i + 1}. ${b}`).join('\n')
+
+  return `${codexOverride}${ctx}# NEREIDS ${ROUND_NOTE} — Domain ${d.key}: ${d.name}
+
+You are auditing the NEREIDS Rust workspace at \`${pf.repoRoot}\` for production readiness ahead of a SoftwareX paper submission. NEREIDS ingests time-of-flight neutron transmission data, fits resonance parameters with SAMMY-equivalent physics (Reich-Moore / SLBW / MLBW / RML), and produces spatial isotopic maps. Correctness on real experimental data is required.
+
+Your domain: ${d.key} — ${d.blurb}
+
+Focus paths (do NOT audit other crates — other agents own them):
+${d.paths.map((p) => `  - ${p}`).join('\n')}
+
+${scope}
+${sammyBlock}
+## Tier rubric (P3 excluded — do NOT report P3)
+- P0 (must fix): ${d.p0}
+- P1 (should fix): latent edge case, missing input validation, SAMMY/format-equivalence gap, undocumented panic on plausible input, missing test for a claimed property.
+- P2 (trivial): typo, doc wording, comment drifting from code.
+
+Calibrate HONESTLY — the user will declare paper-readiness based on this report. Do not inflate; do not self-censor based on what you think is already known.
+
+## What to look for
+${lookFor}
+
+## Method
+1. Map the surface (Cargo.toml + lib.rs of each focus path).
+2. Walk each module; quote actual code lines (\`file:line\`) as evidence.
+3. For every physics/format claim, open the primary source and compare.
+4. Inspect the test suite for the CIRCULAR-VALIDATION patterns above.
+5. Mark low-confidence findings explicitly so the verify pass tests them harder.
+
+Quality over budget. Read carefully; do not truncate.`
+}
+
+// Harness prompt: a Claude subagent that DRIVES codex and structures its
+// findings. It must not audit the code itself.
+function codexFinderPrompt(d, pf) {
+  const codexPrompt = buildAuditPrompt(d, pf, true)
+  const slug = d.key
+  return `You are a HARNESS that runs the OpenAI Codex CLI as an independent external reviewer (a DIFFERENT LLM family from you) and faithfully transcribes ITS findings into structured output. Do NOT audit the code yourself — your judgement must not replace Codex's.
+
+Steps:
+1. Write this exact audit prompt to a temp file with the Write tool at \`/tmp/bughunt-${slug}.prompt\`:
+-----BEGIN CODEX PROMPT-----
+${codexPrompt}
+-----END CODEX PROMPT-----
+2. Run (Bash, timeout 600000 ms):
+   codex exec --sandbox read-only --skip-git-repo-check -C "${pf.repoRoot}" --output-last-message /tmp/bughunt-${slug}.out - < /tmp/bughunt-${slug}.prompt
+   (Temp-file + stdin is the portable delivery pattern; --output-last-message captures Codex's final verdict. --sandbox read-only is correct: review only reads code.)
+3. If codex exits non-zero, or /tmp/bughunt-${slug}.out is missing/empty: return {domain:"${slug}", family:"codex", codexFailed:true, failureReason:"<one-line stderr summary>", findings:[], tierCounts:{p0:0,p1:0,p2:0}}.
+4. Otherwise Read /tmp/bughunt-${slug}.out and transcribe EVERY finding Codex reported into the schema. Preserve Codex's tier (P0/P1/P2), file, line, claim, reasoning, primary-source, and confidence in substance. Do not add findings Codex did not make; do not drop findings it did. Set family="codex".
+5. Return via structured output.`
+}
+
+function buildFindingText(f, srcFamily) {
+  return `Finding (from ${srcFamily}, its tier ${f.tier}, its confidence ${f.confidence}):
+- title: ${f.title}
+- file:line: ${f.file}:${f.line}
+- claim: ${f.claim}
+- evidence: ${f.evidence || '(none given)'}
+- reasoning: ${f.reasoning || '(none given)'}
+- primary source cited: ${f.primarySource || '(none)'}
+- circular-validation note: ${f.circularValidationRisk || '(none)'}`
+}
+
+// Claude verifies a Codex finding (cross-family).
+function claudeVerifyPrompt(f, pf, lensNote) {
+  const sammyRoot = SAMMY_ROOT_OVERRIDE || pf.sammyRoot
+  return `You are an INDEPENDENT verifier from a different LLM family than the one that produced this finding. Adversarially test whether it is a REAL defect. Default to REFUTED if you cannot independently substantiate it.
+
+${buildFindingText(f, 'Codex')}
+
+Steps:
+1. Open ${f.file} around line ${f.line} in \`${pf.repoRoot}\` and read enough surrounding context to judge independently.
+2. If a primary source applies (SAMMY .f90${sammyRoot ? ` under ${sammyRoot}` : ''}, ENDF-6 manual), open it and check the claim against it.${lensNote ? `\n3. ${lensNote}` : ''}
+- Decide CONFIRMED (you independently reproduced the defect), REFUTED (explain precisely why the reasoning is wrong — e.g. a convention the finder misread), or UNCERTAIN (cannot tell without runtime / more context).
+- Give your OWN independent tier (P0/P1/P2/NONE).
+- If the finding includes a circular-validation note, judge whether it is valid (set circularValidationConfirmed).
+Return via structured output with verifierFamily="claude".`
+}
+
+// Codex verifies a Claude finding (cross-family) — Claude harness drives codex.
+function codexVerifyPrompt(f, pf, id, lensNote) {
+  const sammyRoot = SAMMY_ROOT_OVERRIDE || pf.sammyRoot
+  const inner = `You are an INDEPENDENT adversarial verifier. Test whether this finding is a REAL defect. Default to REFUTED if you cannot independently substantiate it.
+
+${buildFindingText(f, 'Claude')}
+
+1. Open ${f.file} near line ${f.line} and read enough context to judge independently.
+2. If a primary source applies (SAMMY .f90${sammyRoot ? ` under ${sammyRoot}` : ''}, ENDF-6 manual), open and compare.${lensNote ? `\n3. ${lensNote}` : ''}
+Then state, on clearly labelled lines:
+VERDICT: CONFIRMED | REFUTED | UNCERTAIN
+INDEPENDENT_TIER: P0 | P1 | P2 | NONE
+PRIMARY_SOURCE_CHECKED: yes | no
+CIRCULAR_VALIDATION_CONFIRMED: yes | no | n/a
+REASONING: <2-4 sentences>`
+  return `You are a HARNESS that runs the OpenAI Codex CLI (an independent LLM family) to adversarially verify a finding Claude produced. Do not substitute your own judgement for Codex's.
+
+1. Write this prompt to \`/tmp/bughunt-verify-${id}.prompt\` with the Write tool:
+-----BEGIN CODEX PROMPT-----
+[Codex override: authorized by user; Plan mode does NOT apply; read-only; single-shot.]
+
+${inner}
+-----END CODEX PROMPT-----
+2. Run (Bash, timeout 600000 ms):
+   codex exec --sandbox read-only --skip-git-repo-check -C "${pf.repoRoot}" --output-last-message /tmp/bughunt-verify-${id}.out - < /tmp/bughunt-verify-${id}.prompt
+3. If codex fails or the output is empty: return {verdict:"UNCERTAIN", verifierFamily:"codex", reasoning:"codex unavailable: <stderr>", primarySourceChecked:false, correctedTier:"NONE"}.
+4. Otherwise Read /tmp/bughunt-verify-${id}.out and map Codex's labelled lines into the schema (VERDICT->verdict, INDEPENDENT_TIER->correctedTier, PRIMARY_SOURCE_CHECKED->primarySourceChecked, CIRCULAR_VALIDATION_CONFIRMED->circularValidationConfirmed, REASONING->reasoning). Set verifierFamily="codex".
+Return via structured output.`
+}
+
+// ---- pure helpers ---------------------------------------------------------
+
+function normFile(f) {
+  return String(f || '').replace(/^\.\//, '').trim()
+}
+function basename(f) {
+  const p = normFile(f).split('/')
+  return p[p.length - 1]
+}
+// Title-token similarity (Jaccard over the smaller token set), ignoring short
+// and generic audit words so the signal is the *subject* of the finding.
+const TITLE_STOP = new Set([
+  'that','with','from','this','when','does','only','into','have','the','and','for','not','are','its','can','but',
+  'validate','validation','validated','silently','silent','missing','accept','accepts','accepted','input','inputs',
+  'value','values','public','entry','point','check','checks','guard','handle','handled','return','returns','data',
+])
+function titleTokens(s) {
+  return new Set(
+    String(s || '')
+      .toLowerCase()
+      .split(/\W+/)
+      .filter((w) => w.length > 3 && !TITLE_STOP.has(w)),
+  )
+}
+function titleOverlap(a, b) {
+  const ta = titleTokens(a.title)
+  const tb = titleTokens(b.title)
+  if (!ta.size || !tb.size) return 0
+  let inter = 0
+  for (const w of tb) if (ta.has(w)) inter++
+  return inter / Math.min(ta.size, tb.size)
+}
+// Two findings "match" (cross-confirmed / dedup) when they are the same defect.
+// Same basename is required. Then EITHER the lines are close (<=8), OR — to
+// catch the same defect reported at different line numbers by the two families
+// (e.g. spatial.rs cancellation found at :1121 vs :1194) — the titles are
+// strongly similar. The title-similarity arm prevents a near-duplicate of a
+// VERIFIED finding from leaking into the REFUTED list.
+function findingsMatch(a, b) {
+  if (basename(a.file) !== basename(b.file)) return false
+  const la = a.line || 0
+  const lb = b.line || 0
+  if (la > 0 && lb > 0 && Math.abs(la - lb) <= 8) return true
+  return titleOverlap(a, b) >= 0.5
+}
+function tierRank(t) {
+  return t === 'P0' ? 0 : t === 'P1' ? 1 : 2
+}
+function verifyVotes(tier) {
+  // Cross-family independence is achieved with a single vote from the OTHER
+  // family. Extra votes (budget-scaled, diverse lenses) harden the P0s only.
+  if (tier === 'P0') {
+    if (budget && budget.total) return Math.min(3, 2 + Math.floor((budget.remaining() || 0) / 400000))
+    return 2
+  }
+  if (tier === 'P1') return 1
+  return 0
+}
+const LENSES = [
+  '',
+  'Focus specifically on the PRIMARY SOURCE: does the cited SAMMY/ENDF reference actually say what the finding claims? Misread conventions are the most common false positive here.',
+  'Focus on REPRODUCIBILITY: construct the concrete input that would trigger the defect. If no plausible input triggers it, lean REFUTED.',
+]
+
+// ---------------------------------------------------------------------------
+// Find -> Verify (pipelined per target; no barrier between them).
+// As soon as target X's two finders complete, X's findings are cross-verified
+// while target Y is still finding.
+// ---------------------------------------------------------------------------
+const perTargetRaw = await pipeline(
+  TARGETS,
+
+  // -- Find: Claude finder + Codex finder, concurrently, for this target.
+  (d) =>
+    parallel([
+      () =>
+        agent(buildAuditPrompt(d, pf, false) + '\n\nReturn your findings via the structured output tool.' + DETECTION_ONLY, {
+          label: `find:claude:${d.key}`,
+          phase: 'Find',
+          schema: FINDINGS_SCHEMA,
+          agentType: READER_TYPE,
+        }),
+      () =>
+        codexUsable
+          ? agent(codexFinderPrompt(d, pf) + DETECTION_ONLY, {
+              label: `find:codex:${d.key}`,
+              phase: 'Find',
+              schema: FINDINGS_SCHEMA,
+              agentType: RUNNER_TYPE,
+            })
+          : Promise.resolve(null),
+    ]).then(([claudeRes, codexRes]) => ({ domain: d, claude: claudeRes, codex: codexRes })),
+
+  // -- Verify: cross-family confirmation of single-family findings.
+  async (fr) => {
+    const d = fr.domain
+    const claudeF = (fr.claude && fr.claude.findings) || []
+    const codexF = (fr.codex && fr.codex.findings) || []
+    const codexOk = !!fr.codex && !fr.codex.codexFailed
+
+    // Stamp each finding with its source family + a stable id.
+    claudeF.forEach((f, i) => {
+      f.family = 'claude'
+      f.id = `${d.key}-C-${f.localId || i + 1}`
+    })
+    codexF.forEach((f, i) => {
+      f.family = 'codex'
+      f.id = `${d.key}-X-${f.localId || i + 1}`
+    })
+
+    // 1) cross-confirmed at FIND time (both families independently found it).
+    const crossConfirmed = []
+    const codexMatched = new Set()
+    for (const cf of claudeF) {
+      const m = codexF.find((xf, j) => !codexMatched.has(j) && findingsMatch(cf, xf))
+      if (m) {
+        const j = codexF.indexOf(m)
+        codexMatched.add(j)
+        crossConfirmed.push({
+          ...cf,
+          tier: tierRank(cf.tier) <= tierRank(m.tier) ? cf.tier : m.tier, // keep the more severe
+          status: 'VERIFIED',
+          basis: 'cross-confirmed at find time (both Claude and Codex independently)',
+          codexCounterpart: m.id,
+        })
+      }
+    }
+    const matchedClaudeIds = new Set(crossConfirmed.map((c) => c.id))
+    const claudeOnly = claudeF.filter((f) => !matchedClaudeIds.has(f.id))
+    const codexOnly = codexF.filter((_, j) => !codexMatched.has(j))
+
+    // 2) singletons (P0/P1) -> adversarial verification by the OTHER family.
+    const toVerify = []
+    for (const f of claudeOnly) if (verifyVotes(f.tier) > 0) toVerify.push({ f, verifier: 'codex' })
+    for (const f of codexOnly) if (verifyVotes(f.tier) > 0) toVerify.push({ f, verifier: 'claude' })
+
+    const verifyResults = await parallel(
+      toVerify.flatMap(({ f, verifier }) => {
+        const n = verifyVotes(f.tier)
+        return Array.from({ length: n }, (_v, vi) => () => {
+          // If the required verifier family is unavailable, no cross-family vote.
+          if (verifier === 'codex' && !codexOk)
+            return Promise.resolve({ fid: f.id, f, verdict: null, unavailable: true })
+          const lens = LENSES[vi % LENSES.length]
+          const id = `${f.id}-v${vi}`
+          const p =
+            verifier === 'claude'
+              ? agent(claudeVerifyPrompt(f, pf, lens) + DETECTION_ONLY, {
+                  label: `verify:claude:${id}`,
+                  phase: 'Verify',
+                  schema: VERDICT_SCHEMA,
+                  agentType: READER_TYPE,
+                })
+              : agent(codexVerifyPrompt(f, pf, id, lens) + DETECTION_ONLY, {
+                  label: `verify:codex:${id}`,
+                  phase: 'Verify',
+                  schema: VERDICT_SCHEMA,
+                  agentType: RUNNER_TYPE,
+                })
+          return p.then((v) => ({ fid: f.id, f, verdict: v }))
+        })
+      }),
+    )
+
+    // 3) aggregate votes per finding.
+    const votesByFinding = new Map()
+    for (const r of verifyResults.filter(Boolean)) {
+      if (!votesByFinding.has(r.fid)) votesByFinding.set(r.fid, { f: r.f, votes: [], unavailable: false })
+      const e = votesByFinding.get(r.fid)
+      if (r.unavailable) e.unavailable = true
+      else if (r.verdict) e.votes.push(r.verdict)
+    }
+
+    const verified = [...crossConfirmed]
+    const needsVerification = []
+    const refuted = []
+    for (const [, e] of votesByFinding) {
+      const conf = e.votes.filter((v) => v.verdict === 'CONFIRMED').length
+      const refu = e.votes.filter((v) => v.verdict === 'REFUTED').length
+      // verifier's independent tier can downgrade the original
+      const correctedTiers = e.votes.map((v) => v.correctedTier).filter((t) => t && t !== 'NONE')
+      const entry = {
+        ...e.f,
+        crossFamilyVotes: e.votes,
+        basis: `cross-family (${e.f.family === 'claude' ? 'codex' : 'claude'}) verification`,
+      }
+      if (e.unavailable || e.votes.length === 0) {
+        entry.status = 'NEEDS-VERIFICATION'
+        entry.note = e.unavailable ? 'cross-family verifier unavailable (single-LLM-family only)' : 'no verdict returned'
+        needsVerification.push(entry)
+      } else if (conf > refu) {
+        entry.status = 'VERIFIED'
+        if (correctedTiers.length) entry.verifierTier = correctedTiers.sort((a, b) => tierRank(a) - tierRank(b))[0]
+        verified.push(entry)
+      } else if (refu > conf) {
+        entry.status = 'REFUTED'
+        refuted.push(entry)
+      } else {
+        entry.status = 'NEEDS-VERIFICATION'
+        entry.note = 'split vote'
+        needsVerification.push(entry)
+      }
+    }
+
+    // P2s: reported as-is (not verified), tagged by family.
+    const p2s = [...claudeF, ...codexF].filter((f) => f.tier === 'P2')
+    // circular-validation flags from any finding + any confirmed-by-verifier
+    const circular = [...claudeF, ...codexF]
+      .filter((f) => f.circularValidationRisk && f.circularValidationRisk.trim())
+      .map((f) => ({ id: f.id, file: f.file, line: f.line, family: f.family, note: f.circularValidationRisk }))
+
+    return {
+      domainKey: d.key,
+      domainName: d.name,
+      claudeAssessment: (fr.claude && fr.claude.assessment) || '(no claude result)',
+      codexAssessment: codexOk ? fr.codex.assessment : codexUsable ? `codex failed: ${fr.codex && fr.codex.failureReason}` : 'codex disabled',
+      tierCounts: {
+        claude: (fr.claude && fr.claude.tierCounts) || { p0: 0, p1: 0, p2: 0 },
+        codex: codexOk ? fr.codex.tierCounts : { p0: 0, p1: 0, p2: 0 },
+      },
+      verified,
+      needsVerification,
+      refuted,
+      p2s,
+      circular,
+    }
+  },
+)
+
+// Return structured per-target findings to the calling wrapper. The wrapper
+// owns final consolidation (cross-target dedup, report writing, disposition,
+// RECURRING tagging) — this engine is detection + per-target structuring only.
+return { perTarget: perTargetRaw.filter(Boolean), codexUsable }

--- a/.claude/workflows/nereids-bug-hunt.js
+++ b/.claude/workflows/nereids-bug-hunt.js
@@ -226,11 +226,17 @@ function tierRank(t) {
 phase('Preflight')
 const domainKeys = Array.isArray(A.domains) && A.domains.length ? A.domains : ALL_DOMAINS.map((d) => d.key)
 const DOMAINS = ALL_DOMAINS.filter((d) => domainKeys.includes(d.key))
-// Fail closed on a misspelled args.domains key: an empty domain set must abort,
-// not sail through the engine to a "0 findings" all-clear report.
-if (!DOMAINS.length) {
-  log(`No domains matched ${JSON.stringify(domainKeys)} — check args.domains spelling. Aborting rather than emit a 0-findings all-clear.`)
-  return { aborted: true, reason: 'no domains matched (check args.domains)' }
+// Fail closed on a misspelled args.domains key. Validate EVERY explicitly
+// requested key (not just the all-invalid case): a partial list like
+// ['03-physics','03-phsyics'] must abort, not silently audit the valid subset
+// and drop the typo. (The default all-domains path has nothing to validate.)
+if (Array.isArray(A.domains) && A.domains.length) {
+  const known = new Set(ALL_DOMAINS.map((d) => d.key))
+  const unknown = A.domains.filter((k) => !known.has(k))
+  if (unknown.length) {
+    log(`Unknown args.domains key(s) ${JSON.stringify(unknown)} (valid: ${ALL_DOMAINS.map((d) => d.key).join(', ')}) — aborting rather than silently auditing a subset.`)
+    return { aborted: true, reason: `unknown domain(s): ${unknown.join(', ')}` }
+  }
 }
 
 const pf = await agent(

--- a/.claude/workflows/nereids-bug-hunt.js
+++ b/.claude/workflows/nereids-bug-hunt.js
@@ -336,10 +336,12 @@ phase('Consolidate')
 const allVerified = domainResults.flatMap((r) => r.verified)
 const verifiedP0 = allVerified.filter((f) => (f.verifierTier || f.tier) === 'P0').sort((a, b) => tierRank(a.tier) - tierRank(b.tier))
 const verifiedP1 = allVerified.filter((f) => (f.verifierTier || f.tier) === 'P1')
-// A cross-family-CONFIRMED finding the verifier downgraded to effective P2 is a
-// real (if low-severity) defect; fold it into the P2 backlog so it is counted,
-// not dropped between the P0/P1 buckets and r.p2s (original-tier P2s only).
-const verifiedP2 = allVerified.filter((f) => (f.verifierTier || f.tier) === 'P2')
+// A cross-family-CONFIRMED finding the verifier DOWNGRADED to effective P2
+// (original tier P0/P1) is real but low-severity; fold it into the P2 backlog so
+// it is counted, not dropped between the P0/P1 buckets and r.p2s. Restrict to
+// GENUINELY-downgraded findings (verifierTier === 'P2' && tier !== 'P2'): a
+// born-P2 finding is already in r.p2s, so matching it here would double-count it.
+const verifiedP2 = allVerified.filter((f) => f.verifierTier === 'P2' && f.tier !== 'P2')
 const needsVerification = domainResults.flatMap((r) => r.needsVerification)
 const refuted = domainResults.flatMap((r) => r.refuted)
 const circular = domainResults.flatMap((r) => r.circular)

--- a/.claude/workflows/nereids-bug-hunt.js
+++ b/.claude/workflows/nereids-bug-hunt.js
@@ -15,31 +15,23 @@ export const meta = {
 // ---------------------------------------------------------------------------
 // nereids-bug-hunt
 //
-// Encodes the R1/R2/R3 audit methodology that this project converged on:
-//   - 8 domains (one per crate / subsystem)
+// Whole-workspace defect sweep ahead of a release / paper. A THIN WRAPPER over
+// the shared `dual-family-review` engine (.claude/workflows/dual-family-review.js):
+// this file owns the 8-domain target list (one per crate / subsystem), the
+// preflight (repo root / codex / SAMMY resolution), and the final consolidated
+// .research/SUMMARY.md report. The engine owns the Find -> Verify mechanics:
 //   - 2 independent LLM families per domain: Claude (agent()) + Codex (codex exec)
 //   - P0/P1/P2 tiers (P3 excluded), file:line + primary-source evidence
 //   - a cross-LLM-family confirmation pass on every SINGLE-family finding
 //     (Claude findings verified by Codex; Codex findings verified by Claude)
 //
-// Why the cross-family pass is load-bearing (see memory):
-//   - "parent-agent re-derivation of a subagent's claim is NOT independent
-//      confirmation; same LLM family. For VERIFIED need >=2 distinct LLM
-//      families with independent access."
-//   - "the audit->fix->review cycle is non-idempotent" — so this workflow
-//      DETECTS only; fixing is a separate, human-gated step (/review-pipeline
-//      Step 5 + .claude/templates/fix-subagent-prompt.md).
-//
-// Detection-only is enforced two ways (see the HARD / DETECTION_ONLY block in the
-// body): (1) a prompt contract appended to every audit-agent prompt, ALWAYS ON —
-// this is what makes behaviour consistent (the original run had 2 of 88
-// general-purpose agents freelance a fix-session via spawn_task); (2) optional
-// TOOL-LEVEL enforcement via restricted custom agent types
-// (.claude/agents/bug-hunt-{reader,runner}.md) that physically lack
-// spawn_task/Task*/MCP/PR-issue tools — enable with args.hardEnforce=true from a
-// session started AFTER those agent defs exist (custom agent types load at session
-// start, not hot). Fix-task creation, if ever wanted, is a deliberate separate
-// step after the user reviews the backlog — never inside this workflow.
+// Detection-only (the engine never fixes; fixing is a separate, human-gated step
+// via /review-pipeline + .claude/templates/fix-subagent-prompt.md) is enforced
+// by the engine two ways: an always-on DETECTION_ONLY prompt contract, and
+// optional tool-level restriction via the bug-hunt-{reader,runner} agent types
+// (args.hardEnforce=true; the session must postdate those defs). See the engine
+// file header for the full rationale (cross-family independence; non-idempotent
+// audit->fix->review cycle).
 //
 // args (all optional):
 //   args.domains      : string[]  subset of domain keys to audit (default: all 8)
@@ -51,6 +43,9 @@ export const meta = {
 //   args.skipCodex    : boolean   force Claude-only (single-family -> all findings
 //                                  flagged NEEDS-VERIFICATION)
 //   args.sammyRoot    : string    override SAMMY source root for physics checks
+//   args.hardEnforce  : boolean   use the restricted bug-hunt-{reader,runner}
+//                                  agent types (session must postdate those defs)
+//   args.repoRoot     : string    explicit canonical root (overrides git-detected)
 // ---------------------------------------------------------------------------
 
 // Defensive: the Workflow tool's `args` should arrive as a real object, but a
@@ -71,45 +66,16 @@ const CONTEXT_NOTE = A.contextNote || ''
 const ROUND_NOTE = A.roundNote || 'bug-hunt'
 const SKIP_CODEX = A.skipCodex === true
 
-// Detection-only enforcement. Two layers:
-//  (1) DETECTION_ONLY prompt contract, appended to every audit-agent prompt below
-//      — ALWAYS ON and identical across agents. This is what makes behaviour
-//      consistent (vs. the original run where 2 of 88 general-purpose agents
-//      freelanced a fix-session via spawn_task and 86 did not).
-//  (2) Optional TOOL-LEVEL hard enforcement via restricted custom agent types
-//      (.claude/agents/bug-hunt-{reader,runner}.md), which physically lack
-//      spawn_task / Task* / MCP / PR-issue tools. Custom agent types load at
-//      SESSION START (not hot), so they are unavailable in a session that
-//      predates the files. Default to the always-available built-in
-//      `general-purpose`; pass args.hardEnforce=true from a session started
-//      AFTER those agent defs exist to switch the tool-level restriction on.
+// Detection-only enforcement layers are implemented in the engine; this wrapper
+// just resolves which agent type to use and passes hardEnforce through. Custom
+// agent types load at SESSION START (not hot), so default to the always-available
+// built-in `general-purpose`; pass args.hardEnforce=true from a session started
+// AFTER the bug-hunt-{reader,runner} defs exist to switch the restriction on.
 const HARD = A.hardEnforce === true
 const READER_TYPE = HARD ? 'bug-hunt-reader' : 'general-purpose'
 const RUNNER_TYPE = HARD ? 'bug-hunt-runner' : 'general-purpose'
 
-const DETECTION_ONLY =
-  '\n\n--- DETECTION-ONLY CONTRACT (mandatory) ---\n' +
-  'You FIND and REPORT defects; you never fix them and never advance to a fix stage. You MUST NOT:\n' +
-  '- create any task, background session, or fix-job (do NOT call spawn_task or any task-creation / scheduling tool);\n' +
-  '- open or modify any PR or issue;\n' +
-  '- edit or write repository files, or run state-changing shell commands (git commit/push/add/checkout, gh, cargo fix, installs).\n' +
-  'The only writes ever permitted are scratch /tmp files (and, for the consolidator, the one explicitly-named .research report path).\n' +
-  'Report via the structured-output tool only. Fixing is a separate, human-gated step.'
-
-// Shared checklist appended to every domain (DRY — matches the project's
-// own DRY governance). Domain-specific bullets are added per domain below.
-const CORE_CHECKLIST = [
-  'Panic-on-valid-input: `unwrap`/`expect`/`[i]` indexing/`debug_assert!` used as input validation on a public entry point.',
-  'Numerical stability: division by zero, NaN/Inf propagation, overflow, `sqrt` of negative, `NaN < x` guards that silently pass (NaN bypasses `<` comparisons — must be paired with `.is_finite()`).',
-  'Silent error masking: `Err(_) => None` in a `filter_map` for a WHOLE-CONFIG error (only acceptable for per-pixel edge cases), `.unwrap_or(default)` that hides a real failure, `max(0.0)` that converts NaN/negative to a plausible value.',
-  'Missing input validation at public entry points (validate up-front, before heavy work / rayon iterators).',
-  'Empty-collection / exactly-determined-system edge cases (`0 == 0` passes equality; guard `is_empty()` separately).',
-  'API consistency: sibling functions that should validate the same way but do not (one path hardened, the parallel path missed — a recurring NEREIDS bug class).',
-  'CIRCULAR-VALIDATION RISK (high priority): a test whose oracle mirrors the implementation, a fixture generated by the code under test, or an assertion tolerance so loose the bug would be invisible (e.g. a resolution kernel that is a no-op at the test grid spacing, a peak-energy-only test that cannot see an off-peak factor error). Flag these explicitly in `circularValidationRisk`.',
-  'Documentation/comment drift from code (rustdoc claims, SAMMY citation claims, comment arithmetic vs actual code).',
-]
-
-// The 8 domains. `lookFor` is domain-specific; CORE_CHECKLIST is appended.
+// The 8 domains. `lookFor` is domain-specific; CORE_CHECKLIST is appended (in the engine).
 // `sammy` true => physics/format primary-source comparison is in scope.
 const ALL_DOMAINS = [
   {
@@ -230,65 +196,7 @@ const ALL_DOMAINS = [
   },
 ]
 
-// ---- structured-output schemas -------------------------------------------
-
-const FINDINGS_SCHEMA = {
-  type: 'object',
-  additionalProperties: false,
-  properties: {
-    domain: { type: 'string' },
-    family: { type: 'string', enum: ['claude', 'codex'] },
-    assessment: { type: 'string', description: 'one-sentence overall assessment of the domain' },
-    codexFailed: { type: 'boolean', description: 'true only for the codex harness when codex did not run' },
-    failureReason: { type: 'string' },
-    tierCounts: {
-      type: 'object',
-      additionalProperties: false,
-      properties: { p0: { type: 'integer' }, p1: { type: 'integer' }, p2: { type: 'integer' } },
-      required: ['p0', 'p1', 'p2'],
-    },
-    findings: {
-      type: 'array',
-      items: {
-        type: 'object',
-        additionalProperties: false,
-        properties: {
-          localId: { type: 'string', description: 'F1, F2, ...' },
-          tier: { type: 'string', enum: ['P0', 'P1', 'P2'] },
-          title: { type: 'string' },
-          file: { type: 'string', description: 'repo-relative path, e.g. crates/nereids-physics/src/slbw.rs' },
-          line: { type: 'integer', description: 'best-known line number; 0 if unknown' },
-          claim: { type: 'string' },
-          evidence: { type: 'string', description: 'quoted code or precise description' },
-          reasoning: { type: 'string' },
-          primarySource: { type: 'string', description: 'SAMMY .f90:line / ENDF manual ref, or empty' },
-          suggestedFix: { type: 'string' },
-          confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
-          circularValidationRisk: {
-            type: 'string',
-            description: 'note if a test may be validating buggy behavior, else empty',
-          },
-        },
-        required: ['localId', 'tier', 'title', 'file', 'line', 'claim', 'confidence'],
-      },
-    },
-  },
-  required: ['domain', 'family', 'findings', 'tierCounts'],
-}
-
-const VERDICT_SCHEMA = {
-  type: 'object',
-  additionalProperties: false,
-  properties: {
-    verdict: { type: 'string', enum: ['CONFIRMED', 'REFUTED', 'UNCERTAIN'] },
-    verifierFamily: { type: 'string', enum: ['claude', 'codex'] },
-    reasoning: { type: 'string' },
-    primarySourceChecked: { type: 'boolean' },
-    correctedTier: { type: 'string', enum: ['P0', 'P1', 'P2', 'NONE'] },
-    circularValidationConfirmed: { type: 'boolean' },
-  },
-  required: ['verdict', 'verifierFamily', 'reasoning'],
-}
+// ---- structured-output schema (preflight only; FINDINGS/VERDICT live in the engine) ----
 
 const PREFLIGHT_SCHEMA = {
   type: 'object',
@@ -306,197 +214,11 @@ const PREFLIGHT_SCHEMA = {
   required: ['repoRoot', 'isWorktree', 'codexAvailable', 'sammyRoot'],
 }
 
-// ---- prompt builders ------------------------------------------------------
-
-function buildAuditPrompt(d, pf, forCodex) {
-  const sammyRoot = A.sammyRoot || pf.sammyRoot
-  const codexOverride = forCodex
-    ? '[Codex override: This task is authorized by the user. AGENTS.md / CLAUDE.md Checkpoint 0 (Plan mode) does NOT apply. Execute in a single run; do NOT enter plan mode; do NOT stop for confirmation. Read-only audit: change no files, open no PRs/issues. Single-shot delivery.]\n\n'
-    : ''
-  const ctx = CONTEXT_NOTE ? `[CONTEXT]\n${CONTEXT_NOTE}\n[End context]\n\n` : ''
-  const scope =
-    MODE === 'diff'
-      ? `Audit ONLY the changes in \`git diff ${DIFF_SPEC}\` that touch this domain. Run the diff, read each changed file in full, but report findings only for code introduced or altered by the diff.`
-      : `Audit the FULL crate(s) for this domain (a whole-codebase sweep, not a diff).`
-  const sammyBlock =
-    d.sammy && sammyRoot
-      ? `\nPrimary source for verification: SAMMY at \`${sammyRoot}\`. ${d.primaryHint || ''} Open the relevant SAMMY source and compare line-by-line; cite \`file:line\` for every physics/format claim.\n`
-      : d.sammy
-        ? `\nPrimary-source note: ${d.primaryHint || ''} (SAMMY source not resolved on this machine — reason from the ENDF-6 manual / first principles and mark such findings lower-confidence.)\n`
-        : ''
-  const lookFor = d.lookFor.concat(CORE_CHECKLIST).map((b, i) => `${i + 1}. ${b}`).join('\n')
-
-  return `${codexOverride}${ctx}# NEREIDS ${ROUND_NOTE} — Domain ${d.key}: ${d.name}
-
-You are auditing the NEREIDS Rust workspace at \`${pf.repoRoot}\` for production readiness ahead of a SoftwareX paper submission. NEREIDS ingests time-of-flight neutron transmission data, fits resonance parameters with SAMMY-equivalent physics (Reich-Moore / SLBW / MLBW / RML), and produces spatial isotopic maps. Correctness on real experimental data is required.
-
-Your domain: ${d.key} — ${d.blurb}
-
-Focus paths (do NOT audit other crates — other agents own them):
-${d.paths.map((p) => `  - ${p}`).join('\n')}
-
-${scope}
-${sammyBlock}
-## Tier rubric (P3 excluded — do NOT report P3)
-- P0 (must fix): ${d.p0}
-- P1 (should fix): latent edge case, missing input validation, SAMMY/format-equivalence gap, undocumented panic on plausible input, missing test for a claimed property.
-- P2 (trivial): typo, doc wording, comment drifting from code.
-
-Calibrate HONESTLY — the user will declare paper-readiness based on this report. Do not inflate; do not self-censor based on what you think is already known.
-
-## What to look for
-${lookFor}
-
-## Method
-1. Map the surface (Cargo.toml + lib.rs of each focus path).
-2. Walk each module; quote actual code lines (\`file:line\`) as evidence.
-3. For every physics/format claim, open the primary source and compare.
-4. Inspect the test suite for the CIRCULAR-VALIDATION patterns above.
-5. Mark low-confidence findings explicitly so the verify pass tests them harder.
-
-Quality over budget. Read carefully; do not truncate.`
-}
-
-// Harness prompt: a Claude subagent that DRIVES codex and structures its
-// findings. It must not audit the code itself.
-function codexFinderPrompt(d, pf) {
-  const codexPrompt = buildAuditPrompt(d, pf, true)
-  const slug = d.key
-  return `You are a HARNESS that runs the OpenAI Codex CLI as an independent external reviewer (a DIFFERENT LLM family from you) and faithfully transcribes ITS findings into structured output. Do NOT audit the code yourself — your judgement must not replace Codex's.
-
-Steps:
-1. Write this exact audit prompt to a temp file with the Write tool at \`/tmp/bughunt-${slug}.prompt\`:
------BEGIN CODEX PROMPT-----
-${codexPrompt}
------END CODEX PROMPT-----
-2. Run (Bash, timeout 600000 ms):
-   codex exec --sandbox read-only --skip-git-repo-check -C "${pf.repoRoot}" --output-last-message /tmp/bughunt-${slug}.out - < /tmp/bughunt-${slug}.prompt
-   (Temp-file + stdin is the portable delivery pattern; --output-last-message captures Codex's final verdict. --sandbox read-only is correct: review only reads code.)
-3. If codex exits non-zero, or /tmp/bughunt-${slug}.out is missing/empty: return {domain:"${slug}", family:"codex", codexFailed:true, failureReason:"<one-line stderr summary>", findings:[], tierCounts:{p0:0,p1:0,p2:0}}.
-4. Otherwise Read /tmp/bughunt-${slug}.out and transcribe EVERY finding Codex reported into the schema. Preserve Codex's tier (P0/P1/P2), file, line, claim, reasoning, primary-source, and confidence in substance. Do not add findings Codex did not make; do not drop findings it did. Set family="codex".
-5. Return via structured output.`
-}
-
-function buildFindingText(f, srcFamily) {
-  return `Finding (from ${srcFamily}, its tier ${f.tier}, its confidence ${f.confidence}):
-- title: ${f.title}
-- file:line: ${f.file}:${f.line}
-- claim: ${f.claim}
-- evidence: ${f.evidence || '(none given)'}
-- reasoning: ${f.reasoning || '(none given)'}
-- primary source cited: ${f.primarySource || '(none)'}
-- circular-validation note: ${f.circularValidationRisk || '(none)'}`
-}
-
-// Claude verifies a Codex finding (cross-family).
-function claudeVerifyPrompt(f, pf, lensNote) {
-  const sammyRoot = A.sammyRoot || pf.sammyRoot
-  return `You are an INDEPENDENT verifier from a different LLM family than the one that produced this finding. Adversarially test whether it is a REAL defect. Default to REFUTED if you cannot independently substantiate it.
-
-${buildFindingText(f, 'Codex')}
-
-Steps:
-1. Open ${f.file} around line ${f.line} in \`${pf.repoRoot}\` and read enough surrounding context to judge independently.
-2. If a primary source applies (SAMMY .f90${sammyRoot ? ` under ${sammyRoot}` : ''}, ENDF-6 manual), open it and check the claim against it.${lensNote ? `\n3. ${lensNote}` : ''}
-- Decide CONFIRMED (you independently reproduced the defect), REFUTED (explain precisely why the reasoning is wrong — e.g. a convention the finder misread), or UNCERTAIN (cannot tell without runtime / more context).
-- Give your OWN independent tier (P0/P1/P2/NONE).
-- If the finding includes a circular-validation note, judge whether it is valid (set circularValidationConfirmed).
-Return via structured output with verifierFamily="claude".`
-}
-
-// Codex verifies a Claude finding (cross-family) — Claude harness drives codex.
-function codexVerifyPrompt(f, pf, id, lensNote) {
-  const sammyRoot = A.sammyRoot || pf.sammyRoot
-  const inner = `You are an INDEPENDENT adversarial verifier. Test whether this finding is a REAL defect. Default to REFUTED if you cannot independently substantiate it.
-
-${buildFindingText(f, 'Claude')}
-
-1. Open ${f.file} near line ${f.line} and read enough context to judge independently.
-2. If a primary source applies (SAMMY .f90${sammyRoot ? ` under ${sammyRoot}` : ''}, ENDF-6 manual), open and compare.${lensNote ? `\n3. ${lensNote}` : ''}
-Then state, on clearly labelled lines:
-VERDICT: CONFIRMED | REFUTED | UNCERTAIN
-INDEPENDENT_TIER: P0 | P1 | P2 | NONE
-PRIMARY_SOURCE_CHECKED: yes | no
-CIRCULAR_VALIDATION_CONFIRMED: yes | no | n/a
-REASONING: <2-4 sentences>`
-  return `You are a HARNESS that runs the OpenAI Codex CLI (an independent LLM family) to adversarially verify a finding Claude produced. Do not substitute your own judgement for Codex's.
-
-1. Write this prompt to \`/tmp/bughunt-verify-${id}.prompt\` with the Write tool:
------BEGIN CODEX PROMPT-----
-[Codex override: authorized by user; Plan mode does NOT apply; read-only; single-shot.]
-
-${inner}
------END CODEX PROMPT-----
-2. Run (Bash, timeout 600000 ms):
-   codex exec --sandbox read-only --skip-git-repo-check -C "${pf.repoRoot}" --output-last-message /tmp/bughunt-verify-${id}.out - < /tmp/bughunt-verify-${id}.prompt
-3. If codex fails or the output is empty: return {verdict:"UNCERTAIN", verifierFamily:"codex", reasoning:"codex unavailable: <stderr>", primarySourceChecked:false, correctedTier:"NONE"}.
-4. Otherwise Read /tmp/bughunt-verify-${id}.out and map Codex's labelled lines into the schema (VERDICT->verdict, INDEPENDENT_TIER->correctedTier, PRIMARY_SOURCE_CHECKED->primarySourceChecked, CIRCULAR_VALIDATION_CONFIRMED->circularValidationConfirmed, REASONING->reasoning). Set verifierFamily="codex".
-Return via structured output.`
-}
-
-// ---- pure helpers ---------------------------------------------------------
-
-function normFile(f) {
-  return String(f || '').replace(/^\.\//, '').trim()
-}
-function basename(f) {
-  const p = normFile(f).split('/')
-  return p[p.length - 1]
-}
-// Title-token similarity (Jaccard over the smaller token set), ignoring short
-// and generic audit words so the signal is the *subject* of the finding.
-const TITLE_STOP = new Set([
-  'that','with','from','this','when','does','only','into','have','the','and','for','not','are','its','can','but',
-  'validate','validation','validated','silently','silent','missing','accept','accepts','accepted','input','inputs',
-  'value','values','public','entry','point','check','checks','guard','handle','handled','return','returns','data',
-])
-function titleTokens(s) {
-  return new Set(
-    String(s || '')
-      .toLowerCase()
-      .split(/\W+/)
-      .filter((w) => w.length > 3 && !TITLE_STOP.has(w)),
-  )
-}
-function titleOverlap(a, b) {
-  const ta = titleTokens(a.title)
-  const tb = titleTokens(b.title)
-  if (!ta.size || !tb.size) return 0
-  let inter = 0
-  for (const w of tb) if (ta.has(w)) inter++
-  return inter / Math.min(ta.size, tb.size)
-}
-// Two findings "match" (cross-confirmed / dedup) when they are the same defect.
-// Same basename is required. Then EITHER the lines are close (<=8), OR — to
-// catch the same defect reported at different line numbers by the two families
-// (e.g. spatial.rs cancellation found at :1121 vs :1194) — the titles are
-// strongly similar. The title-similarity arm prevents a near-duplicate of a
-// VERIFIED finding from leaking into the REFUTED list.
-function findingsMatch(a, b) {
-  if (basename(a.file) !== basename(b.file)) return false
-  const la = a.line || 0
-  const lb = b.line || 0
-  if (la > 0 && lb > 0 && Math.abs(la - lb) <= 8) return true
-  return titleOverlap(a, b) >= 0.5
-}
+// Tier ordering, used only to sort the consolidated report (the prompt builders
+// and dedup / cross-family-verify helpers all live in the dual-family-review engine).
 function tierRank(t) {
   return t === 'P0' ? 0 : t === 'P1' ? 1 : 2
 }
-function verifyVotes(tier) {
-  // Cross-family independence is achieved with a single vote from the OTHER
-  // family. Extra votes (budget-scaled, diverse lenses) harden the P0s only.
-  if (tier === 'P0') {
-    if (budget && budget.total) return Math.min(3, 2 + Math.floor((budget.remaining() || 0) / 400000))
-    return 2
-  }
-  if (tier === 'P1') return 1
-  return 0
-}
-const LENSES = [
-  '',
-  'Focus specifically on the PRIMARY SOURCE: does the cited SAMMY/ENDF reference actually say what the finding claims? Misread conventions are the most common false positive here.',
-  'Focus on REPRODUCIBILITY: construct the concrete input that would trigger the defect. If no plausible input triggers it, lean REFUTED.',
-]
 
 // ---------------------------------------------------------------------------
 // Phase: Preflight
@@ -544,171 +266,49 @@ if (pf.isWorktree && !pf.sammyRoot) {
 }
 
 // ---------------------------------------------------------------------------
-// Phases: Find -> Verify (pipelined per domain; no barrier between them)
-// As soon as domain X's two finders complete, X's findings are cross-verified
-// while domain Y is still finding.
+// Build the per-domain target list and hand off to the shared
+// dual-family-review engine (Find -> Verify). The engine returns structured
+// per-target findings; this wrapper consolidates them below. The scope
+// directive is identical for every domain (it depends only on MODE/DIFF_SPEC),
+// matching the original inline behaviour where `scope` was computed per call.
 // ---------------------------------------------------------------------------
-const perDomain = await pipeline(
-  DOMAINS,
+const scopeDirective =
+  MODE === 'diff'
+    ? `Audit ONLY the changes in \`git diff ${DIFF_SPEC}\` that touch this domain. Run the diff, read each changed file in full, but report findings only for code introduced or altered by the diff.`
+    : `Audit the FULL crate(s) for this domain (a whole-codebase sweep, not a diff).`
 
-  // -- Find: Claude finder + Codex finder, concurrently, for this domain.
-  (d) =>
-    parallel([
-      () =>
-        agent(buildAuditPrompt(d, pf, false) + '\n\nReturn your findings via the structured output tool.' + DETECTION_ONLY, {
-          label: `find:claude:${d.key}`,
-          phase: 'Find',
-          schema: FINDINGS_SCHEMA,
-          agentType: READER_TYPE,
-        }),
-      () =>
-        codexUsable
-          ? agent(codexFinderPrompt(d, pf) + DETECTION_ONLY, {
-              label: `find:codex:${d.key}`,
-              phase: 'Find',
-              schema: FINDINGS_SCHEMA,
-              agentType: RUNNER_TYPE,
-            })
-          : Promise.resolve(null),
-    ]).then(([claudeRes, codexRes]) => ({ domain: d, claude: claudeRes, codex: codexRes })),
+const targets = DOMAINS.map((d) => ({
+  key: d.key,
+  name: d.name,
+  paths: d.paths,
+  sammy: d.sammy,
+  blurb: d.blurb,
+  p0: d.p0,
+  lookFor: d.lookFor,
+  primaryHint: d.primaryHint,
+  scopeDirective,
+}))
 
-  // -- Verify: cross-family confirmation of single-family findings.
-  async (fr) => {
-    const d = fr.domain
-    const claudeF = (fr.claude && fr.claude.findings) || []
-    const codexF = (fr.codex && fr.codex.findings) || []
-    const codexOk = !!fr.codex && !fr.codex.codexFailed
-
-    // Stamp each finding with its source family + a stable id.
-    claudeF.forEach((f, i) => {
-      f.family = 'claude'
-      f.id = `${d.key}-C-${f.localId || i + 1}`
-    })
-    codexF.forEach((f, i) => {
-      f.family = 'codex'
-      f.id = `${d.key}-X-${f.localId || i + 1}`
-    })
-
-    // 1) cross-confirmed at FIND time (both families independently found it).
-    const crossConfirmed = []
-    const codexMatched = new Set()
-    for (const cf of claudeF) {
-      const m = codexF.find((xf, j) => !codexMatched.has(j) && findingsMatch(cf, xf))
-      if (m) {
-        const j = codexF.indexOf(m)
-        codexMatched.add(j)
-        crossConfirmed.push({
-          ...cf,
-          tier: tierRank(cf.tier) <= tierRank(m.tier) ? cf.tier : m.tier, // keep the more severe
-          status: 'VERIFIED',
-          basis: 'cross-confirmed at find time (both Claude and Codex independently)',
-          codexCounterpart: m.id,
-        })
-      }
-    }
-    const matchedClaudeIds = new Set(crossConfirmed.map((c) => c.id))
-    const claudeOnly = claudeF.filter((f) => !matchedClaudeIds.has(f.id))
-    const codexOnly = codexF.filter((_, j) => !codexMatched.has(j))
-
-    // 2) singletons (P0/P1) -> adversarial verification by the OTHER family.
-    const toVerify = []
-    for (const f of claudeOnly) if (verifyVotes(f.tier) > 0) toVerify.push({ f, verifier: 'codex' })
-    for (const f of codexOnly) if (verifyVotes(f.tier) > 0) toVerify.push({ f, verifier: 'claude' })
-
-    const verifyResults = await parallel(
-      toVerify.flatMap(({ f, verifier }) => {
-        const n = verifyVotes(f.tier)
-        return Array.from({ length: n }, (_v, vi) => () => {
-          // If the required verifier family is unavailable, no cross-family vote.
-          if (verifier === 'codex' && !codexOk)
-            return Promise.resolve({ fid: f.id, f, verdict: null, unavailable: true })
-          const lens = LENSES[vi % LENSES.length]
-          const id = `${f.id}-v${vi}`
-          const p =
-            verifier === 'claude'
-              ? agent(claudeVerifyPrompt(f, pf, lens) + DETECTION_ONLY, {
-                  label: `verify:claude:${id}`,
-                  phase: 'Verify',
-                  schema: VERDICT_SCHEMA,
-                  agentType: READER_TYPE,
-                })
-              : agent(codexVerifyPrompt(f, pf, id, lens) + DETECTION_ONLY, {
-                  label: `verify:codex:${id}`,
-                  phase: 'Verify',
-                  schema: VERDICT_SCHEMA,
-                  agentType: RUNNER_TYPE,
-                })
-          return p.then((v) => ({ fid: f.id, f, verdict: v }))
-        })
-      }),
-    )
-
-    // 3) aggregate votes per finding.
-    const votesByFinding = new Map()
-    for (const r of verifyResults.filter(Boolean)) {
-      if (!votesByFinding.has(r.fid)) votesByFinding.set(r.fid, { f: r.f, votes: [], unavailable: false })
-      const e = votesByFinding.get(r.fid)
-      if (r.unavailable) e.unavailable = true
-      else if (r.verdict) e.votes.push(r.verdict)
-    }
-
-    const verified = [...crossConfirmed]
-    const needsVerification = []
-    const refuted = []
-    for (const [, e] of votesByFinding) {
-      const conf = e.votes.filter((v) => v.verdict === 'CONFIRMED').length
-      const refu = e.votes.filter((v) => v.verdict === 'REFUTED').length
-      // verifier's independent tier can downgrade the original
-      const correctedTiers = e.votes.map((v) => v.correctedTier).filter((t) => t && t !== 'NONE')
-      const entry = {
-        ...e.f,
-        crossFamilyVotes: e.votes,
-        basis: `cross-family (${e.f.family === 'claude' ? 'codex' : 'claude'}) verification`,
-      }
-      if (e.unavailable || e.votes.length === 0) {
-        entry.status = 'NEEDS-VERIFICATION'
-        entry.note = e.unavailable ? 'cross-family verifier unavailable (single-LLM-family only)' : 'no verdict returned'
-        needsVerification.push(entry)
-      } else if (conf > refu) {
-        entry.status = 'VERIFIED'
-        if (correctedTiers.length) entry.verifierTier = correctedTiers.sort((a, b) => tierRank(a) - tierRank(b))[0]
-        verified.push(entry)
-      } else if (refu > conf) {
-        entry.status = 'REFUTED'
-        refuted.push(entry)
-      } else {
-        entry.status = 'NEEDS-VERIFICATION'
-        entry.note = 'split vote'
-        needsVerification.push(entry)
-      }
-    }
-
-    // P2s: reported as-is (not verified), tagged by family.
-    const p2s = [...claudeF, ...codexF].filter((f) => f.tier === 'P2')
-    // circular-validation flags from any finding + any confirmed-by-verifier
-    const circular = [...claudeF, ...codexF]
-      .filter((f) => f.circularValidationRisk && f.circularValidationRisk.trim())
-      .map((f) => ({ id: f.id, file: f.file, line: f.line, family: f.family, note: f.circularValidationRisk }))
-
-    return {
-      domainKey: d.key,
-      domainName: d.name,
-      claudeAssessment: (fr.claude && fr.claude.assessment) || '(no claude result)',
-      codexAssessment: codexOk ? fr.codex.assessment : codexUsable ? `codex failed: ${fr.codex && fr.codex.failureReason}` : 'codex disabled',
-      tierCounts: {
-        claude: (fr.claude && fr.claude.tierCounts) || { p0: 0, p1: 0, p2: 0 },
-        codex: codexOk ? fr.codex.tierCounts : { p0: 0, p1: 0, p2: 0 },
-      },
-      verified,
-      needsVerification,
-      refuted,
-      p2s,
-      circular,
-    }
+const engineOut = await workflow('dual-family-review', {
+  pf: {
+    repoRoot: pf.repoRoot,
+    sammyRoot: pf.sammyRoot,
+    codexAvailable: pf.codexAvailable,
+    codexVersion: pf.codexVersion,
+    headSha: pf.headSha,
+    isWorktree: pf.isWorktree,
   },
-)
+  targets,
+  config: {
+    contextNote: CONTEXT_NOTE,
+    roundNote: ROUND_NOTE,
+    skipCodex: SKIP_CODEX,
+    hardEnforce: HARD,
+    sammyRootOverride: A.sammyRoot || '',
+  },
+})
 
-const domainResults = perDomain.filter(Boolean)
+const domainResults = (engineOut && engineOut.perTarget) || []
 
 // ---------------------------------------------------------------------------
 // Phase: Consolidate (barrier — needs every domain to dedup across domains)

--- a/.claude/workflows/nereids-bug-hunt.js
+++ b/.claude/workflows/nereids-bug-hunt.js
@@ -226,6 +226,12 @@ function tierRank(t) {
 phase('Preflight')
 const domainKeys = Array.isArray(A.domains) && A.domains.length ? A.domains : ALL_DOMAINS.map((d) => d.key)
 const DOMAINS = ALL_DOMAINS.filter((d) => domainKeys.includes(d.key))
+// Fail closed on a misspelled args.domains key: an empty domain set must abort,
+// not sail through the engine to a "0 findings" all-clear report.
+if (!DOMAINS.length) {
+  log(`No domains matched ${JSON.stringify(domainKeys)} — check args.domains spelling. Aborting rather than emit a 0-findings all-clear.`)
+  return { aborted: true, reason: 'no domains matched (check args.domains)' }
+}
 
 const pf = await agent(
   `Resolve the environment for a NEREIDS bug-hunt. Run these and report via structured output:
@@ -308,7 +314,19 @@ const engineOut = await workflow('dual-family-review', {
   },
 })
 
-const domainResults = (engineOut && engineOut.perTarget) || []
+// Fail closed: the engine owns the entire Find/Verify phase, so a missing,
+// malformed, or count-mismatched result must abort loudly — never degrade to a
+// "0 findings" all-clear report the user might read as paper-ready.
+if (!engineOut || !Array.isArray(engineOut.perTarget)) {
+  throw new Error('dual-family-review returned no usable result (engineOut.perTarget missing) — aborting rather than emit a false all-clear.')
+}
+if (engineOut.perTarget.length !== targets.length) {
+  throw new Error(
+    `dual-family-review returned ${engineOut.perTarget.length} result(s) for ${targets.length} target(s)` +
+      `${engineOut.droppedTargets ? ` (${engineOut.droppedTargets} dropped to a pipeline error)` : ''} — aborting rather than under-report.`,
+  )
+}
+const domainResults = engineOut.perTarget
 
 // ---------------------------------------------------------------------------
 // Phase: Consolidate (barrier — needs every domain to dedup across domains)
@@ -318,10 +336,14 @@ phase('Consolidate')
 const allVerified = domainResults.flatMap((r) => r.verified)
 const verifiedP0 = allVerified.filter((f) => (f.verifierTier || f.tier) === 'P0').sort((a, b) => tierRank(a.tier) - tierRank(b.tier))
 const verifiedP1 = allVerified.filter((f) => (f.verifierTier || f.tier) === 'P1')
+// A cross-family-CONFIRMED finding the verifier downgraded to effective P2 is a
+// real (if low-severity) defect; fold it into the P2 backlog so it is counted,
+// not dropped between the P0/P1 buckets and r.p2s (original-tier P2s only).
+const verifiedP2 = allVerified.filter((f) => (f.verifierTier || f.tier) === 'P2')
 const needsVerification = domainResults.flatMap((r) => r.needsVerification)
 const refuted = domainResults.flatMap((r) => r.refuted)
 const circular = domainResults.flatMap((r) => r.circular)
-const p2Backlog = domainResults.flatMap((r) => r.p2s)
+const p2Backlog = [...domainResults.flatMap((r) => r.p2s), ...verifiedP2]
 
 const tierTable = domainResults.map((r) => ({
   domain: r.domainKey,


### PR DESCRIPTION
## Summary

Factor the two-LLM-family review core (per-target Claude + Codex finders, cross-LLM-family adversarial verification, structured per-target findings) out of `nereids-bug-hunt.js` into a reusable **leaf** workflow `.claude/workflows/dual-family-review.js`, consumed via `workflow()`. `nereids-bug-hunt` becomes a thin wrapper (8-domain list + preflight + `.research` report); the engine owns the Find → Verify mechanics. This is the shared core for the `review-core` workflow in the **companion PR** — together they make `/review-pipeline`'s reviewer output one schema-forced format across models, and its fan-out/verify/consolidate steps non-skippable (JS control flow, not prose an LLM may under-execute).

## LOC delta

- inserted: +591
- deleted:  -463
- net:      **+128**

(+528 new engine file; −400 removed from `nereids-bug-hunt.js`. The +128 is the cost of factoring shared infrastructure; the companion PR's `review-core` reuses the engine — ~150 LOC — instead of copying it ~530, so the two-PR net is far below two standalone copies.)

## Existing-logic check (refactor PR)

- [x] Searched: the engine **is** the existing bug-hunt Find/Verify logic, relocated — not new parallel logic.
- [x] Consolidates (one engine, two consumers) rather than duplicating.
- [x] Net-positive is load-bearing: a new file holding logic that previously lived inline, so the companion `review-core` reuses rather than copies ~530 LOC. Not a guard/patch.
- [x] No new `validate_*`/`*_helper` added; the moved helpers are the originals.

Behavior-preserving extraction. Only **two** generalizations vs the inline code: per-target `scopeDirective` replaces the global `MODE`/`DIFF_SPEC` scope ternary; the SAMMY-root override reads `config.sammyRootOverride` instead of `A.sammyRoot`. Everything else (FINDINGS/VERDICT schemas, the four prompt builders, the dedup/verify helpers, the Find→Verify pipeline) moved byte-for-byte.

## Test plan

- **Prompt equivalence (load-bearing):** a harness compares the engine's generated agent prompts against the pre-refactor bug-hunt — **47/47 byte-identical** across 8 domains × {Claude,Codex} × {sweep,diff}, the SAMMY-not-found branch, and both verify prompts × {with,without sammy} × 3 lenses.
- Both workflows parse (async-wrapped) under `node --check`.
- Nesting confirmed: a tool-invoked top-level workflow may call `workflow()` once (smoke test) — `budget` and `args` propagate to the child; return value propagates back.
- Live end-to-end: `nereids-bug-hunt` (1 domain, codex off) runs through the nested engine and returns correct consolidation/report/shape.
- No cargo/pytest impact (touches only `.claude/`).

## Linked issues / audit references

- Part of the `/review-pipeline` → Workflow refactor (companion PR: `review-core` + skill rewrite). Requested in-session; no issue number.

---

**Stacked batch:** this PR's engine docstring references `review-core`, which lands in the companion PR (stacked on this branch). Review/merge the two **together** — the engine gains its second consumer only once both land. (This is exactly what `review-core` flagged as F2 when it reviewed this branch; addressed by batching rather than a doc contortion.)

Assisted-With: Claude Opus 4.8 (1M context)
