### PR TITLE
feat(review-pipeline): make review-core workflow the deterministic core

### DIFF
--- a/.claude/skills/review-pipeline/SKILL.md
+++ b/.claude/skills/review-pipeline/SKILL.md
@@ -15,290 +15,207 @@ The standalone `/self-review` and `/codex-review` skills have been merged
 into this single pipeline. When the user says "review", "run reviews",
 or any variation, invoke THIS skill.
 
+## Architecture: deterministic core + human-gated orchestration
+
+The non-interactive heart of each review round — **discover branches →
+two-LLM-family review → consolidate** — is the `review-core` **Workflow**
+(`.claude/workflows/review-core.js`), which runs the shared
+`dual-family-review` engine. This skill is the **orchestrator**: it invokes
+`review-core` once per round and owns everything interactive or
+state-changing (the user gates, fixes, pushes, the Copilot phase, merges,
+and issue-filing).
+
+Why this split — and why the gates live here, not in the workflow:
+
+- **Consistent format across models.** Inside `review-core`, every reviewer
+  (Claude finder, Codex finder, and every cross-family verifier) emits the
+  **same schema**; cross-confirmation and dedup are deterministic JS, not the
+  main agent eyeballing prose. Claude and Codex findings come back in one
+  shape every round.
+- **No silently-skipped steps.** discover → find(2 families) → verify →
+  consolidate is JS control flow run for every branch every round — not prose
+  an LLM may under-execute. The deferred-P2 list comes back **as data**
+  (Step 9 can no longer be "forgotten").
+- **A Workflow cannot pause for user input.** It runs unattended to
+  completion. So every mandatory STOP gate must fall on a workflow boundary —
+  which is exactly why fix/push/merge and the three gates stay in this skill,
+  with `review-core` invoked between them.
+
+Invoking `review-core` from this skill is the sanctioned Workflow opt-in
+(a skill whose instructions call the Workflow tool).
+
 ## Arguments
 
-- No arguments: auto-discover all `.claude/worktrees/*/` branches diverged from main
-- Branch name: scope to a single branch (e.g., `review-pipeline fix/my-branch`)
-- `--skip-codex`: skip the Codex external review stage
+- No arguments: `review-core` auto-discovers all `.claude/worktrees/*/`
+  branches diverged from main.
+- Branch name: scope to a single branch — pass it through as
+  `branches: ["<name>"]`.
+- `--skip-codex`: pass `skipCodex: true` (single-LLM-family; all findings
+  return as NEEDS-VERIFICATION).
 
 ## Iteration Policy
 
-- **Goal**: Zero P1s before pushing to remote
-- **Max iterations**: 4 per branch
+- **Goal**: Zero P1s before pushing to remote.
+- **Max iterations**: 4 per branch.
 - **Escalation**: If P1s persist after 4 rounds, stop and report to the user.
   Do NOT attempt a 5th round. The user must decide whether to continue,
   restructure the task, or conduct manual review.
 
-Track the current iteration number and report it in each consolidation
-(e.g., "Round 2 of 4").
+Track the current round number and report it in each consolidation
+(e.g., "Review Round 2 of 4"). Pass it to `review-core` as `round: N`.
 
 ---
 
-## Step 1: Discover Targets & Merge Order
+## Step 1: Invoke `review-core` (one round)
 
-Identify worktrees to review:
+Call the **Workflow** tool:
 
-```bash
-git worktree list
+```
+Workflow(name="review-core", args={
+  round: <N>,                      // 1 on the first round
+  base: "main",
+  branches: <["branch"] | omit to auto-discover>,
+  skipCodex: <true if --skip-codex>,
+  priorFindings: <prev round's findings, or omit on round 1>,  // see Step 5
+})
 ```
 
-For each worktree under `.claude/worktrees/`, check if the branch has diverged
-from main (`git log main..HEAD --oneline`). Skip worktrees with no new commits.
+`review-core` runs in the background and returns a structured payload:
 
-If `$ARGUMENTS` specifies a branch name, filter to just that one.
-
-### File Overlap Analysis (Merge Order)
-
-For each discovered branch, collect changed files:
-
-```bash
-cd {worktree_path} && git diff --name-only main...HEAD
+```
+{ meta: { round, base, repoRoot, headSha, codexUsable, sammyRoot, isWorktree },
+  mergeOrder: ["branch", ...],            // smallest-diff-first; parallel-safe if no overlap
+  overlaps:   [{ a, b, sharedFiles[] }],
+  perBranch:  [{ branch, crates, claudeAssessment, codexAssessment, tierCounts,
+                 verifiedP0[], verifiedP1[], needsVerification[], refuted[],
+                 p2s[] (each with .disposition: fix-now|defer), circular[], recurring[] }],
+  deferredP2s: [...],                      // P2s outside the changed crates (Step 9)
+  counts: { branches, verifiedP0, verifiedP1, needsVerification, refuted, p2, recurring } }
 ```
 
-Build a file overlap matrix and suggest merge order:
+Each finding carries `status` (VERIFIED = ≥2 LLM families agreed;
+NEEDS-VERIFICATION = single-family / split / codex unavailable; REFUTED =
+cross-family refuted), `file`, `line`, `claim`, `reasoning`, `primarySource`,
+`suggestedFix`, `confidence`, and `recurring` (matched a prior round).
 
-1. **No overlap** branches can merge in any order (parallel-safe)
-2. **Overlapping** branches should merge in order of increasing diff size
-   (smallest first — the larger diff is more likely to need rebasing)
-3. Report the suggested merge order in the Step 4 consolidation
+**Codex note:** `review-core` runs Codex as the second family via the engine.
+If `meta.codexUsable` is false (codex absent / `--skip-codex`), the round is
+single-family and *every* finding is NEEDS-VERIFICATION — say so. If codex was
+expected but consistently fails, check `codex --version` / upgrade
+(`brew upgrade codex` or `npm i -g @openai/codex@latest`); do not work around
+with model overrides. Codex is supplementary, not blocking.
 
 ---
 
-## Steps 2 + 3: Self-Audit & External Review (launch together)
+## Step 2: Consolidation Gate
 
-Launch **all** review tasks in a **single message** (background mode) so
-they run concurrently. N worktrees produce up to 2N parallel tasks
-(N Claude subagents + N Codex commands).
+Render the returned payload as a consistent per-branch report:
 
-### Self-Audit (Claude Subagents)
-
-Launch one `Agent(subagent_type="general-purpose", run_in_background=true)`
-per worktree with this prompt:
-
-> You are auditing the branch `{branch}` at `{worktree_path}`.
->
-> 1. Run `git diff main...HEAD` to see all changes
-> 2. Read each changed file in full
-> 3. Audit for:
->    - Logic bugs, panics (`unwrap`, `expect`, array indexing)
->    - Missing input validation
->    - Numerical stability (division by zero, NaN propagation, overflow)
->    - Physics correctness (for nereids-physics/nereids-endf)
->    - API consistency with existing patterns
->    - Edge cases (empty inputs, zero counts, exactly-determined systems)
-> 4. Report findings as:
->    - **P1** (must fix) — correctness bugs, panics, data corruption
->    - **P2** (should fix) — robustness, style, minor improvements
->    - Include `file:line` references for each finding
-> 5. Run `cargo test --workspace --exclude nereids-python` to verify tests pass
->    (workspace-wide, because changes often ripple across crates)
-
-### External Review (Codex CLI)
-
-Unless `--skip-codex` is in `$ARGUMENTS`, also launch one `Bash` command
-per worktree in the **same message** as the Claude self-audit so they
-run concurrently.
-
-codex-cli 0.130+ ships **both** a top-level `codex review` subcommand
-and `codex exec review` under `exec` (tracked in
-[openai/codex#6432](https://github.com/openai/codex/issues/6432)); the
-interactive `/review` slash command is separate and cannot be driven
-from `codex exec`.  Either native subcommand would work as a higher-
-level invocation, but **this skill uses the manual `codex exec` +
-explicit review prompt pattern below** because it is portable across
-all codex-cli versions (including environments stuck on older
-binaries) and gives us direct control over the prompt body, sandbox
-flags, and output capture.  Adopting the native `codex review --base
-<BRANCH>` workflow-wide is tracked as a separate follow-up.
-
-Use this pattern (one Bash call per worktree). The prompt is written to a
-temp file and fed to `codex exec` via stdin redirection (`- < "$PROMPT_FILE"`)
-to avoid the heredoc-inside-command-substitution form (`codex exec
-"$(cat <<'EOF' ... EOF)"`), which has truncated or mangled prompts on
-recent PRs under certain shell snapshots — see #536. Temp file + stdin
-delivers the body verbatim across `codex-cli` versions.
-
-```bash
-PROMPT_FILE=$(mktemp -t codex-review-{branch_slug}.XXXXXX)
-trap 'rm -f "$PROMPT_FILE"' EXIT
-cat > "$PROMPT_FILE" <<'PROMPT'
-You are reviewing the changes on the current branch (HEAD) against `main`
-in the NEREIDS repository.
-
-1. Run `git diff main...HEAD` to see all changes.
-2. Read each changed file in full.
-3. Audit for:
-   - Logic bugs, panics (unwrap, expect, array indexing)
-   - Missing input validation
-   - Numerical stability (division by zero, NaN propagation, overflow)
-   - Physics correctness (for nereids-physics / nereids-endf)
-   - API consistency with existing patterns
-   - Edge cases (empty inputs, zero counts, exactly-determined systems)
-4. Report findings as:
-   - **P1** (must fix) — correctness bugs, panics, data corruption
-   - **P2** (should fix) — robustness, style, minor improvements
-   - Include `file:line` references for each finding.
-5. If you find nothing significant, say so explicitly. Be terse.
-PROMPT
-
-codex exec --sandbox read-only --skip-git-repo-check \
-  -C {worktree_path} \
-  --output-last-message /tmp/codex-review-{branch_slug}.md \
-  - < "$PROMPT_FILE"
-```
-
-Then read the file at `/tmp/codex-review-{branch_slug}.md` for the final
-review verdict; the JSONL on stdout is the streaming transcript and is
-mostly noise for our purposes.
-
-**Why these flags:**
-- `--sandbox read-only` — review only reads code; no need for write access.
-- `--skip-git-repo-check` — defensive; we always invoke from inside a repo
-  but this avoids friction in nested-worktree edge cases.
-- `-C {worktree_path}` — sets working dir explicitly so `git diff main...HEAD`
-  resolves correctly per worktree.
-- `--output-last-message <file>` — captures the agent's final message
-  cleanly; far easier than parsing JSONL.
-
-**Known pitfalls** (verified against codex-cli 0.130, May 2026):
-
-- **Native review subcommands**: codex-cli 0.130+ ships **both**
-  `codex review --base <BRANCH>` (top-level) and `codex exec review
-  --base <BRANCH>` (under `exec`).  Either accepts the prompt via
-  stdin (`-`) and supports `--uncommitted`, `--commit <SHA>`.  This
-  was tracked in
-  [openai/codex#6432](https://github.com/openai/codex/issues/6432).
-  The error `unexpected argument '--base' found / Usage: codex
-  <PROMPT>` is from pre-0.130 codex-cli where `review` was parsed as
-  a positional prompt instead of a subcommand.  If you want to drive
-  the native `codex review --base <BRANCH>` workflow directly,
-  upgrade codex-cli to 0.130+.  **For this skill**, that upgrade is
-  not required — the manual `codex exec` + stdin prompt pattern
-  below is the canonical fallback and works across all codex-cli
-  versions (including environments where upgrading is not feasible).
-  Adopting the native subcommand workflow-wide is tracked as a
-  separate follow-up.
-- Slash commands (`/review`, `/test`, etc.) work only in interactive
-  TUI sessions; they cannot be invoked from `codex exec`.
-- **codex-cli + API model gating drift fast.** Earlier this year the
-  installed 0.46 binary was rejected by the API as *"requires a newer
-  version of Codex"* for the default `gpt-5.5` model, and overriding
-  with `-m gpt-5` failed on ChatGPT-account auth (*"not supported when
-  using Codex with a ChatGPT account"*). If you see either of those
-  errors, the fix is to upgrade codex-cli (`brew upgrade codex` or
-  `npm i -g @openai/codex@latest`). Do NOT spend time trying to work
-  around with model overrides — keep the binary current.
-- **Prompt delivery**: write the prompt to a temp file and pipe via stdin
-  (`codex exec ... - < "$PROMPT_FILE"`). The heredoc-inside-command-
-  substitution form (`codex exec "$(cat <<'EOF' ... EOF)"`) has been
-  observed to truncate/mangle prompts under certain shell snapshots —
-  see #536. Temp file + stdin is robust across versions.
-- Avoid `--full-auto` for review — it grants `workspace-write` sandbox,
-  which is broader than the read-only review needs.
-
-If Codex fails (network, license, model rejection, binary out of date),
-note the failure and continue. Codex is supplementary, not blocking. The
-Claude self-audit is the load-bearing reviewer; Codex provides
-cross-confirmation when available.
-
----
-
-## Step 4: Consolidate Findings
-
-After all reviews complete:
-
-1. Collect self-audit findings (from Agent results) and Codex findings (from Bash output)
-2. Merge into a unified report grouped by worktree/branch:
-   - **Cross-confirmed** issues (found by both Claude and Codex) — highest confidence
-   - **Claude-only** issues
-   - **Codex-only** issues
-3. For each finding, classify as:
-   - **Fix now** — P1s and high-confidence P2s
-   - **Defer** — P2s genuinely out of scope (different crate/subsystem,
-     pre-existing issue not introduced by this PR)
-   - **Dismiss** — false positives, style-only, or impossible edge cases
+1. **Per-branch table**: for each branch, Claude vs Codex tier counts and
+   VERIFIED P0 / VERIFIED P1 / NEEDS-VERIFICATION / REFUTED / P2 / RECURRING.
+2. **Findings detail**, grouped by branch and confidence:
+   - **VERIFIED** (cross-confirmed) — highest confidence, fix now.
+   - **NEEDS-VERIFICATION** (single-family) — call out that these did NOT meet
+     the ≥2-LLM-family bar.
+   - **REFUTED** — list with the refuter's reasoning so they are not
+     re-litigated.
+3. **Suggested disposition** (from each finding's `.disposition` / tier) — the
+   workflow proposes fix-now / defer / dismiss; **the user decides**:
+   - **Fix now** — VERIFIED P0/P1 and same-crate P2s.
+   - **Defer** — P2s outside the changed crate(s) (already in `deferredP2s`).
+   - **Dismiss** — false positives / impossible edge cases.
+4. **Suggested Merge Order** from `meta`/`mergeOrder` (+ any `overlaps`).
+5. Report the round: "Review Round N of 4".
+6. **RECURRING**: any finding tagged `recurring` reappeared after a prior
+   "fix" — flag it explicitly; the user must decide the approach.
 
 ### P2 Deferral Discipline
 
-**IMPORTANT**: If the PR's purpose is P2 burndown or tech debt reduction,
-the "Defer" category is restricted to findings in a *different crate or
-subsystem* than the one being fixed. Same-crate P2s MUST be classified as
-"Fix now" — otherwise P2 debt accumulates faster than it is paid down.
+If the PR's purpose is P2 burndown / tech-debt reduction, "Defer" is
+restricted to a *different crate or subsystem* than the one being fixed.
+`review-core` already marks same-crate P2s `disposition: fix-now`; honor that —
+do not defer same-crate P2s, or debt accrues faster than it is paid down.
 
-4. Report the iteration number: "Review Round N of 4"
-5. Include the **Suggested Merge Order** from Step 1
-6. **Present the consolidated report to the user and STOP.**
-
-**MANDATORY GATE**: Do NOT proceed to Step 5 without user approval.
-The user must review the consolidation and tell you which findings to fix.
+**MANDATORY GATE — present the consolidation and STOP.** Do NOT proceed to
+Step 3 without user approval. The user must tell you which findings to fix.
 End your turn after presenting the report.
 
-**Oscillating findings**: If a finding reappears after being "fixed", flag
-it as **RECURRING** — the user must decide the approach.
+---
+
+## Step 3: Fix
+
+After the user approves the fix list, launch one fix subagent per worktree
+**in parallel**, using `.claude/templates/fix-subagent-prompt.md` (it encodes
+the DRY pre-step and no-scope-dodging rules). Each fix agent must:
+
+1. Apply the approved fixes.
+2. **Check downstream consumers** — if a fix changes a public API, grep for
+   all call sites across the workspace and update them.
+3. Run `cargo fmt --all`.
+4. Run `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings`.
+5. Run `cargo test --workspace --exclude nereids-python`.
+6. For physics-correctness fixes (SLBW/MLBW/RM/RML, Doppler, resolution,
+   fitting math), also run `pixi run test-python` — `cargo test` cannot catch
+   `pytest.approx` baseline regressions.
+7. Commit with `scripts/worktree-commit.sh <worktree-name> "<msg>" [files]`
+   (GPG-signed).
 
 ---
 
-## Step 5: Fix
-
-After user approves the fix list, launch one
-`Agent(subagent_type="general-purpose")` per worktree **in parallel**.
-
-Each fix agent must:
-1. Apply the approved fixes
-2. **Check downstream consumers** — if the fix changes a public API,
-   grep for all call sites across the workspace and update them
-3. Run `cargo fmt --all`
-4. Run `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings`
-5. Run `cargo test --workspace --exclude nereids-python`
-6. Commit with `scripts/worktree-commit.sh` (GPG-signed)
-
-## Step 6: Verify & Push
+## Step 4: Verify & Push
 
 After all fix agents complete:
-1. Verify each worktree has clean `git status`
-2. Push each branch: `git push origin {branch}`
-3. Report commit hashes and branch status
+1. Verify each worktree has clean `git status`.
+2. If a fix touched a shared symbol, `cargo check` after any rebase before push.
+3. Push each branch: `git push origin {branch}`.
+4. Report commit hashes and branch status.
 
 ---
 
-## Step 7: Iteration Decision
+## Step 5: Iteration Decision
 
-After pushing, check:
+After pushing, decide:
 
-- **Zero P1s found this round?** → Phase A complete. Proceed to Phase B.
-- **P1s found and fixed, iteration < 4?** → Loop back to Step 2.
-- **Iteration == 4 and P1s still found?** → STOP. Report:
-  "Iteration limit reached (4 rounds). P1s persist — escalating to human."
+- **Zero P1s this round?** → Phase A complete. Proceed to Step 6 (Phase B).
+- **P1s found and fixed, round < 4?** → Loop back to Step 1 for round N+1.
+  Pass `priorFindings` = this round's findings (each as
+  `{branch, file, line, title}`) so `review-core` tags **RECURRING**.
+- **Round == 4 and P1s still found?** → STOP. Report: "Iteration limit
+  reached (4 rounds). P1s persist — escalating to human."
+
+**Re-run between rounds, not just once.** File overlap can appear mid-pipeline
+(a fix lands in a file another branch also touches); the fresh `mergeOrder`
+each round reflects this.
 
 ---
 
-## Step 8: Phase B — Copilot Review (after push)
+## Step 6: Phase B — Copilot Review (after push)
 
 After Phase A completes (zero P1s) and branches are pushed:
 
-1. Inform the user that Phase A is complete and branches are pushed.
-   Ask them to trigger Copilot review on GitHub. **STOP and wait.**
+1. Inform the user Phase A is complete and branches are pushed. Ask them to
+   trigger Copilot review on GitHub. **STOP and wait.**
 2. When the user says Copilot reviews are in, fetch comments:
 
-```bash
-pixi run copilot-reviews {pr_numbers...} --dedup
-```
+   ```bash
+   pixi run copilot-reviews {pr_numbers...} --dedup
+   ```
 
-3. Classify each Copilot comment as P1 or P2
+3. Classify each Copilot comment as P1 or P2.
 4. **Decision criteria**:
-   - 3+ P1s OR P1 ratio > 40% → re-iterate (back to Step 2)
-   - Otherwise → fix P2s inline, commit, push
+   - 3+ P1s OR P1 ratio > 40% → re-iterate (back to Step 1).
+   - Otherwise → fix P2s inline, commit, push.
 5. Dismiss Copilot comments that rehash already-addressed issues or flag
-   impossible edge cases
-6. Present Copilot resolution summary to the user.
+   impossible edge cases.
+6. Present the Copilot resolution summary to the user.
 
 ---
 
-## Step 9: Pre-Merge Checkpoint
+## Step 7: Pre-Merge Checkpoint
 
 **MANDATORY: End your turn here and wait for user approval.**
 
-Present the user with a concise summary table:
+Present a concise summary table:
 
 ```markdown
 ### Pre-Merge Summary — Batch {name}
@@ -307,53 +224,53 @@ Present the user with a concise summary table:
 |----|--------|-------|-------------|---------------|
 | #{n} | {branch} | #{issue} | {1-line summary} | Phase A ✓ Phase B ✓ |
 
-**Merge order**: {recommendation}
+**Merge order**: {from review-core meta.mergeOrder}
 **Review rounds**: Phase A: {N} round(s), Phase B: {N} Copilot comment(s)
 **Findings resolved**: {X} P1s fixed, {Y} P2s fixed, {Z} P2s deferred
 **Tests on branches**: {N} Rust tests — all pass
-
-Ready to merge? (User must explicitly approve.)
 ```
 
 **Do NOT run `gh pr merge` until the user responds with explicit approval.**
 
 ---
 
-## Step 10: Merge & Post-Merge
+## Step 8: Merge & Post-Merge
 
-After user approves:
+After the user approves:
 
-1. Merge PRs in recommended order using `gh pr merge --squash --delete-branch`
-2. Clean up worktrees: `git worktree remove {path} --force` for each merged branch
-3. Delete local branches: `git branch -D {branch}` for each
-4. Run `/post-merge` which handles: pull main, `cargo clean && pixi run build`,
-   workspace tests, Python tests, issue verification, memory updates
+1. Merge PRs in `mergeOrder` using `gh pr merge --squash --delete-branch`.
+2. Clean up worktrees: `git worktree remove {path} --force` per merged branch.
+3. Delete local branches: `git branch -D {branch}` per branch.
+4. Run `/post-merge` (pulls main, `cargo clean && pixi run build`, workspace
+   tests, Python tests, issue verification, memory updates).
 
-**IMPORTANT**: `pixi run build` must run first after `cargo clean`. It catches
+**IMPORTANT**: `pixi run build` must run first after `cargo clean` — it catches
 cross-PR signature mismatches that per-branch reviews miss.
 
 ---
 
-## Step 11: Track Deferred P2 Findings
+## Step 9: Track Deferred P2 Findings
 
-**Do NOT skip this step.** Create GitHub issues for every P2 finding deferred
-during consolidation:
+**Do NOT skip this step.** `review-core` returns `deferredP2s` — file them so
+nothing is lost:
 
-1. Group deferred P2s by branch/crate
-2. Create one issue per group with `file:line` references
-3. Add to project tracker (project #8)
-4. Report created issue numbers to the user
+1. Group `deferredP2s` by branch/crate.
+2. Create one issue per group with `file:line` references.
+3. Add to the project tracker (project #8).
+4. Report the created issue numbers to the user.
 
 ---
 
 ## Subagent Prompt Requirements
 
-When launching implementation or fix subagents, ALWAYS include:
+When launching fix subagents, ALWAYS include (and use
+`.claude/templates/fix-subagent-prompt.md`):
 
-- **Tooling**: "Use `pixi run build` / `pixi run test-python` — never
-  raw `maturin develop` or `pip install`."
+- **Tooling**: "Use `pixi run build` / `pixi run test-python` — never raw
+  `maturin develop` or `pip install`."
 - **Commits**: "Use `scripts/worktree-commit.sh <worktree-name> '<message>' [files]`
   for all commits."
 - **GitHub issues**: "Use `pixi run gh-issues` for issue/PR queries."
 - **Pattern matching**: "Match patterns already used in the file you're editing."
+- **DRY pre-step**: "ripgrep for existing logic before adding a new helper."
 - **Pre-commit**: "Run the pre-commit checklist from CLAUDE.md."

--- a/.claude/skills/review-pipeline/SKILL.md
+++ b/.claude/skills/review-pipeline/SKILL.md
@@ -7,7 +7,7 @@ user-invokable: true
 # Multi-Stage Review Pipeline
 
 Run an iterative review pipeline on active worktree branches. Repeats
-until zero P1s remain or the iteration limit is reached.
+until zero P0s and P1s remain or the iteration limit is reached.
 
 **This is the ONLY review mechanism.** Do not substitute with ad-hoc
 self-review agents, custom subagents, or any improvised review approach.
@@ -55,9 +55,9 @@ Invoking `review-core` from this skill is the sanctioned Workflow opt-in
 
 ## Iteration Policy
 
-- **Goal**: Zero P1s before pushing to remote.
+- **Goal**: Zero P0s and P1s before pushing to remote.
 - **Max iterations**: 4 per branch.
-- **Escalation**: If P1s persist after 4 rounds, stop and report to the user.
+- **Escalation**: If P0s/P1s persist after 4 rounds, stop and report to the user.
   Do NOT attempt a 5th round. The user must decide whether to continue,
   restructure the task, or conduct manual review.
 
@@ -100,7 +100,8 @@ cross-family refuted), `file`, `line`, `claim`, `reasoning`, `primarySource`,
 
 **Codex note:** `review-core` runs Codex as the second family via the engine.
 If `meta.codexUsable` is false (codex absent / `--skip-codex`), the round is
-single-family and *every* finding is NEEDS-VERIFICATION — say so. If codex was
+single-family and every **P0/P1** finding is NEEDS-VERIFICATION (P2s are
+single-family-reported either way) — say so. If codex was
 expected but consistently fails, check `codex --version` / upgrade
 (`brew upgrade codex` or `npm i -g @openai/codex@latest`); do not work around
 with model overrides. Codex is supplementary, not blocking.
@@ -176,12 +177,15 @@ After all fix agents complete:
 
 After pushing, decide:
 
-- **Zero P1s this round?** → Phase A complete. Proceed to Step 6 (Phase B).
-- **P1s found and fixed, round < 4?** → Loop back to Step 1 for round N+1.
+- **Zero P0s and zero P1s this round?** → Phase A complete. Proceed to Step 6 (Phase B).
+- **P0s/P1s found and fixed, round < 4?** → Loop back to Step 1 for round N+1.
   Pass `priorFindings` = this round's findings (each as
   `{branch, file, line, title}`) so `review-core` tags **RECURRING**.
-- **Round == 4 and P1s still found?** → STOP. Report: "Iteration limit
-  reached (4 rounds). P1s persist — escalating to human."
+- **Round == 4 and P0s/P1s still found?** → STOP. Report: "Iteration limit
+  reached (4 rounds). P0s/P1s persist — escalating to human."
+
+(P0 is the must-fix tier the `dual-family-review` engine assigns; the gate must
+cover P0+P1, not P1 alone — a verified P0 with zero P1s must NOT pass.)
 
 **Re-run between rounds, not just once.** File overlap can appear mid-pipeline
 (a fix lands in a file another branch also touches); the fresh `mergeOrder`
@@ -191,7 +195,7 @@ each round reflects this.
 
 ## Step 6: Phase B — Copilot Review (after push)
 
-After Phase A completes (zero P1s) and branches are pushed:
+After Phase A completes (zero P0s/P1s) and branches are pushed:
 
 1. Inform the user Phase A is complete and branches are pushed. Ask them to
    trigger Copilot review on GitHub. **STOP and wait.**
@@ -226,7 +230,7 @@ Present a concise summary table:
 
 **Merge order**: {from review-core meta.mergeOrder}
 **Review rounds**: Phase A: {N} round(s), Phase B: {N} Copilot comment(s)
-**Findings resolved**: {X} P1s fixed, {Y} P2s fixed, {Z} P2s deferred
+**Findings resolved**: {W} P0s fixed, {X} P1s fixed, {Y} P2s fixed, {Z} P2s deferred
 **Tests on branches**: {N} Rust tests — all pass
 ```
 

--- a/.claude/skills/review-pipeline/SKILL.md
+++ b/.claude/skills/review-pipeline/SKILL.md
@@ -175,17 +175,23 @@ After all fix agents complete:
 
 ## Step 5: Iteration Decision
 
-After pushing, decide:
+After pushing, decide. **"Blocking findings" this round** =
+`counts.verifiedP0 + counts.verifiedP1 + counts.needsVerification` — i.e. every
+VERIFIED **and** NEEDS-VERIFICATION P0/P1. NEEDS-VERIFICATION findings (single
+LLM family / split vote / codex unavailable) BLOCK exactly like VERIFIED ones;
+they must be fixed or **explicitly user-dismissed** before push. (P2s never block.)
 
-- **Zero P0s and zero P1s this round?** → Phase A complete. Proceed to Step 6 (Phase B).
-- **P0s/P1s found and fixed, round < 4?** → Loop back to Step 1 for round N+1.
+- **Zero blocking findings this round?** → Phase A complete. Proceed to Step 6 (Phase B).
+- **Blocking findings found and fixed, round < 4?** → Loop back to Step 1 for round N+1.
   Pass `priorFindings` = this round's findings (each as
   `{branch, file, line, title}`) so `review-core` tags **RECURRING**.
-- **Round == 4 and P0s/P1s still found?** → STOP. Report: "Iteration limit
+- **Round == 4 and blocking findings remain?** → STOP. Report: "Iteration limit
   reached (4 rounds). P0s/P1s persist — escalating to human."
 
-(P0 is the must-fix tier the `dual-family-review` engine assigns; the gate must
-cover P0+P1, not P1 alone — a verified P0 with zero P1s must NOT pass.)
+Why bind to NEEDS-VERIFICATION: P0 is the engine's must-fix tier, and in
+`--skip-codex` single-family mode every P0/P1 lands in NEEDS-VERIFICATION
+(verifiedP0/verifiedP1 are 0). Gating on verified counts alone would let
+un-cross-verified P0s pass.
 
 **Re-run between rounds, not just once.** File overlap can appear mid-pipeline
 (a fix lands in a file another branch also touches); the fresh `mergeOrder`

--- a/.claude/skills/review-pipeline/SKILL.md
+++ b/.claude/skills/review-pipeline/SKILL.md
@@ -50,8 +50,8 @@ Invoking `review-core` from this skill is the sanctioned Workflow opt-in
   branches diverged from main.
 - Branch name: scope to a single branch — pass it through as
   `branches: ["<name>"]`.
-- `--skip-codex`: pass `skipCodex: true` (single-LLM-family; all findings
-  return as NEEDS-VERIFICATION).
+- `--skip-codex`: pass `skipCodex: true` (single-LLM-family; every **P0/P1**
+  finding returns as NEEDS-VERIFICATION — P2s are single-family-reported either way).
 
 ## Iteration Policy
 
@@ -93,10 +93,12 @@ Workflow(name="review-core", args={
   counts: { branches, verifiedP0, verifiedP1, needsVerification, refuted, p2, recurring } }
 ```
 
-Each finding carries `status` (VERIFIED = ≥2 LLM families agreed;
-NEEDS-VERIFICATION = single-family / split / codex unavailable; REFUTED =
-cross-family refuted), `file`, `line`, `claim`, `reasoning`, `primarySource`,
-`suggestedFix`, `confidence`, and `recurring` (matched a prior round).
+Each VERIFIED / NEEDS-VERIFICATION / REFUTED finding carries `status` (VERIFIED
+= ≥2 LLM families agreed; NEEDS-VERIFICATION = single-family / split / codex
+unavailable; REFUTED = cross-family refuted); born-P2 findings (`p2s`) carry a
+`disposition` rather than a `status`. All findings carry `file`, `line`, `claim`,
+`reasoning`, `primarySource`, `suggestedFix`, `confidence`, and `recurring`
+(matched a prior round).
 
 **Codex note:** `review-core` runs Codex as the second family via the engine.
 If `meta.codexUsable` is false (codex absent / `--skip-codex`), the round is
@@ -113,7 +115,7 @@ with model overrides. Codex is supplementary, not blocking.
 Render the returned payload as a consistent per-branch report:
 
 1. **Per-branch table**: for each branch, Claude vs Codex tier counts and
-   VERIFIED P0 / VERIFIED P1 / NEEDS-VERIFICATION / REFUTED / P2 / RECURRING.
+   VERIFIED P0 / VERIFIED P1 / NEEDS-VERIFICATION / REFUTED / P2 / RECURRING / CIRCULAR.
 2. **Findings detail**, grouped by branch and confidence:
    - **VERIFIED** (cross-confirmed) — highest confidence, fix now.
    - **NEEDS-VERIFICATION** (single-family) — call out that these did NOT meet
@@ -125,10 +127,14 @@ Render the returned payload as a consistent per-branch report:
    - **Fix now** — VERIFIED P0/P1 and same-crate P2s.
    - **Defer** — P2s outside the changed crate(s) (already in `deferredP2s`).
    - **Dismiss** — false positives / impossible edge cases.
-4. **Suggested Merge Order** from `meta`/`mergeOrder` (+ any `overlaps`).
+4. **Suggested Merge Order** from the top-level `mergeOrder` (+ any `overlaps`).
 5. Report the round: "Review Round N of 4".
 6. **RECURRING**: any finding tagged `recurring` reappeared after a prior
    "fix" — flag it explicitly; the user must decide the approach.
+7. **Circular-validation risks**: surface every non-empty `circular[]` entry
+   (its `note`, `file:line`, family) — a test whose oracle may mirror buggy
+   behaviour is a HIGH-PRIORITY signal the engine computes but the gate must not
+   silently drop.
 
 ### P2 Deferral Discipline
 
@@ -234,7 +240,7 @@ Present a concise summary table:
 |----|--------|-------|-------------|---------------|
 | #{n} | {branch} | #{issue} | {1-line summary} | Phase A ✓ Phase B ✓ |
 
-**Merge order**: {from review-core meta.mergeOrder}
+**Merge order**: {from review-core's top-level mergeOrder}
 **Review rounds**: Phase A: {N} round(s), Phase B: {N} Copilot comment(s)
 **Findings resolved**: {W} P0s fixed, {X} P1s fixed, {Y} P2s fixed, {Z} P2s deferred
 **Tests on branches**: {N} Rust tests — all pass

--- a/.claude/workflows/dual-family-review.js
+++ b/.claude/workflows/dual-family-review.js
@@ -374,6 +374,23 @@ const LENSES = [
 // with another target's Find, explicit phase() boundaries would misrepresent the
 // interleaving. meta.phases still declares Find/Verify for the /workflows display.
 // ---------------------------------------------------------------------------
+
+// Fail loudly on a malformed target rather than degrade silently. A target
+// missing `scopeDirective` would otherwise inject the literal string "undefined"
+// into the audit prompt (missing `paths`/`lookFor` already throw in
+// buildAuditPrompt -> the pipeline drops that target -> the caller's
+// count-mismatch guard aborts; the missing-scopeDirective case is the silent one).
+// Not reachable from the current callers (both always set scopeDirective) — this
+// is defensive depth for future callers.
+for (const t of TARGETS) {
+  const key = (t && t.key) || '(unknown)'
+  if (!t || typeof t.key !== 'string' || !t.key) throw new Error('dual-family-review: a target is missing a string `key`')
+  if (typeof t.scopeDirective !== 'string' || !t.scopeDirective)
+    throw new Error(`dual-family-review: target '${key}' is missing a non-empty 'scopeDirective'`)
+  if (!Array.isArray(t.paths) || !t.paths.length) throw new Error(`dual-family-review: target '${key}' is missing non-empty 'paths'`)
+  if (!Array.isArray(t.lookFor)) throw new Error(`dual-family-review: target '${key}' 'lookFor' must be an array`)
+}
+
 const perTargetRaw = await pipeline(
   TARGETS,
 

--- a/.claude/workflows/dual-family-review.js
+++ b/.claude/workflows/dual-family-review.js
@@ -18,8 +18,9 @@ export const meta = {
 // methodology this project converged on:
 //   - 2 independent LLM families per target: Claude (agent()) + Codex (codex exec)
 //   - P0/P1/P2 tiers (P3 excluded), file:line + primary-source evidence
-//   - a cross-LLM-family confirmation pass on every SINGLE-family finding
-//     (Claude findings verified by Codex; Codex findings verified by Claude)
+//   - a cross-LLM-family confirmation pass on every SINGLE-family P0/P1 finding
+//     (Claude findings verified by Codex and vice versa; P2s are reported as-is,
+//     NOT cross-verified — verifyVotes() returns 0 for P2)
 //
 // Why the cross-family pass is load-bearing (see memory):
 //   - "parent-agent re-derivation of a subagent's claim is NOT independent
@@ -35,12 +36,18 @@ export const meta = {
 // that physically lack spawn_task/Task*/MCP/PR-issue tools — enable with
 // config.hardEnforce=true from a session started AFTER those agent defs exist.
 //
-// Generalization vs the original inline bug-hunt code (the ONLY two changes):
+// Two SEMANTIC generalizations vs the original inline bug-hunt code:
 //   - the global MODE/DIFF_SPEC scope ternary is replaced by a per-target
 //     `scopeDirective` string (each caller decides full-crate vs diff scope);
 //   - the SAMMY-root override reads config.sammyRootOverride instead of A.sammyRoot.
-// Everything else (schemas, prompt builders, dedup/verify helpers, the
-// Find->Verify pipeline) is byte-for-byte the original logic.
+// Plus behaviour-neutral re-plumbing: CONTEXT_NOTE / ROUND_NOTE / SKIP_CODEX /
+// HARD now come from the passed-in `config` (not the caller's `A.*`),
+// `codexUsable` is computed at module scope, and the engine RETURNS structured
+// per-target results instead of continuing inline to a consolidation phase
+// (preflight + consolidation now live in each wrapper).
+// The prompt builders, schemas, dedup/verify helpers, and the Find->Verify
+// pipeline are byte-for-byte the original logic (verified by a prompt-equivalence
+// harness: 47/47 byte-identical agent prompts).
 //
 // args (passed in by the calling wrapper):
 //   args.pf      : { repoRoot, sammyRoot, codexAvailable, codexVersion, headSha, isWorktree }
@@ -361,6 +368,11 @@ const LENSES = [
 // Find -> Verify (pipelined per target; no barrier between them).
 // As soon as target X's two finders complete, X's findings are cross-verified
 // while target Y is still finding.
+//
+// Progress grouping uses each agent's `phase:` opt (not top-level phase('Find')
+// / phase('Verify') calls): because the pipeline interleaves one target's Verify
+// with another target's Find, explicit phase() boundaries would misrepresent the
+// interleaving. meta.phases still declares Find/Verify for the /workflows display.
 // ---------------------------------------------------------------------------
 const perTargetRaw = await pipeline(
   TARGETS,
@@ -525,4 +537,17 @@ const perTargetRaw = await pipeline(
 // Return structured per-target findings to the calling wrapper. The wrapper
 // owns final consolidation (cross-target dedup, report writing, disposition,
 // RECURRING tagging) — this engine is detection + per-target structuring only.
-return { perTarget: perTargetRaw.filter(Boolean), codexUsable }
+//
+// Surface dropped targets (a per-target pipeline that threw -> null) so the
+// wrapper can reconcile perTarget.length against its target count and fail
+// closed rather than silently under-report. The wrapper (not the engine) owns
+// the empty-targets policy: a sweep with no matching targets is an error there,
+// while a review round with no diverged branches is a valid no-op.
+const perTarget = perTargetRaw.filter(Boolean)
+const droppedTargets = perTargetRaw.length - perTarget.length
+if (droppedTargets > 0) {
+  log(
+    `WARNING: ${droppedTargets}/${perTargetRaw.length} target(s) produced no result (pipeline error) and were dropped — the caller should fail closed.`,
+  )
+}
+return { perTarget, droppedTargets, codexUsable }

--- a/.claude/workflows/dual-family-review.js
+++ b/.claude/workflows/dual-family-review.js
@@ -1,0 +1,528 @@
+export const meta = {
+  name: 'dual-family-review',
+  description:
+    'Shared engine for two-LLM-family code review: per-target Claude + Codex finders, cross-LLM-family adversarial verification, structured per-target findings. Detection-only. A LEAF workflow (never calls workflow()).',
+  whenToUse:
+    'Not invoked directly by a human. This is the reusable core consumed via workflow() by nereids-bug-hunt (whole-crate sweep, target = crate/domain) and review-core (per-PR-diff, target = worktree branch). It runs the Find -> Verify pipeline over a generic list of audit targets and returns structured per-target findings; each caller does its own preflight (building `pf`), target construction, and final consolidation/reporting.',
+  phases: [
+    { title: 'Find', detail: 'Claude + Codex finder per target (up to 2N agents)' },
+    { title: 'Verify', detail: 'cross-LLM-family adversarial confirmation of single-family findings' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// dual-family-review — the shared two-family review engine.
+//
+// Extracted verbatim from nereids-bug-hunt.js (PR #591) so the two consumers
+// (nereids-bug-hunt + review-core) share ONE implementation of the audit
+// methodology this project converged on:
+//   - 2 independent LLM families per target: Claude (agent()) + Codex (codex exec)
+//   - P0/P1/P2 tiers (P3 excluded), file:line + primary-source evidence
+//   - a cross-LLM-family confirmation pass on every SINGLE-family finding
+//     (Claude findings verified by Codex; Codex findings verified by Claude)
+//
+// Why the cross-family pass is load-bearing (see memory):
+//   - "parent-agent re-derivation of a subagent's claim is NOT independent
+//      confirmation; same LLM family. For VERIFIED need >=2 distinct LLM
+//      families with independent access."
+//   - "the audit->fix->review cycle is non-idempotent" — so this engine
+//      DETECTS only; fixing is a separate, human-gated step.
+//
+// Detection-only is enforced two ways: (1) the DETECTION_ONLY prompt contract
+// appended to every audit-agent prompt, ALWAYS ON — this is what makes
+// behaviour consistent across models; (2) optional TOOL-LEVEL enforcement via
+// restricted custom agent types (.claude/agents/bug-hunt-{reader,runner}.md)
+// that physically lack spawn_task/Task*/MCP/PR-issue tools — enable with
+// config.hardEnforce=true from a session started AFTER those agent defs exist.
+//
+// Generalization vs the original inline bug-hunt code (the ONLY two changes):
+//   - the global MODE/DIFF_SPEC scope ternary is replaced by a per-target
+//     `scopeDirective` string (each caller decides full-crate vs diff scope);
+//   - the SAMMY-root override reads config.sammyRootOverride instead of A.sammyRoot.
+// Everything else (schemas, prompt builders, dedup/verify helpers, the
+// Find->Verify pipeline) is byte-for-byte the original logic.
+//
+// args (passed in by the calling wrapper):
+//   args.pf      : { repoRoot, sammyRoot, codexAvailable, codexVersion, headSha, isWorktree }
+//                  — the calling wrapper's preflight result.
+//   args.targets : [{ key, name, paths[], sammy, blurb, p0, lookFor[], primaryHint, scopeDirective }]
+//                  — one entry per audit unit (a crate/domain, or a branch diff).
+//   args.config  : { contextNote, roundNote, skipCodex, hardEnforce, sammyRootOverride }
+//
+// returns: { perTarget: [{ domainKey, domainName, claudeAssessment, codexAssessment,
+//            tierCounts:{claude,codex}, verified[], needsVerification[], refuted[],
+//            p2s[], circular[] }], codexUsable }
+// ---------------------------------------------------------------------------
+
+// Defensive arg unpacking — `args` should arrive as a real object, but a caller
+// may pass a JSON-encoded string; parse it rather than silently default.
+let A = {}
+if (args && typeof args === 'object') A = args
+else if (typeof args === 'string' && args.trim().startsWith('{')) {
+  try {
+    A = JSON.parse(args)
+  } catch (_e) {
+    A = {}
+  }
+}
+
+const pf = A.pf && typeof A.pf === 'object' ? A.pf : {}
+const TARGETS = Array.isArray(A.targets) ? A.targets : []
+const CONFIG = A.config && typeof A.config === 'object' ? A.config : {}
+const CONTEXT_NOTE = CONFIG.contextNote || ''
+const ROUND_NOTE = CONFIG.roundNote || 'review'
+const SKIP_CODEX = CONFIG.skipCodex === true
+const SAMMY_ROOT_OVERRIDE = CONFIG.sammyRootOverride || ''
+
+// Detection-only enforcement. Two layers: (1) the DETECTION_ONLY prompt contract
+// below, appended to every audit-agent prompt — ALWAYS ON and identical across
+// agents; (2) optional TOOL-LEVEL hard enforcement via restricted custom agent
+// types. Custom agent types load at SESSION START (not hot), so default to the
+// always-available built-in `general-purpose`; pass config.hardEnforce=true from
+// a session started AFTER those agent defs exist to switch the restriction on.
+const HARD = CONFIG.hardEnforce === true
+const READER_TYPE = HARD ? 'bug-hunt-reader' : 'general-purpose'
+const RUNNER_TYPE = HARD ? 'bug-hunt-runner' : 'general-purpose'
+
+const codexUsable = !!pf.codexAvailable && !SKIP_CODEX
+
+const DETECTION_ONLY =
+  '\n\n--- DETECTION-ONLY CONTRACT (mandatory) ---\n' +
+  'You FIND and REPORT defects; you never fix them and never advance to a fix stage. You MUST NOT:\n' +
+  '- create any task, background session, or fix-job (do NOT call spawn_task or any task-creation / scheduling tool);\n' +
+  '- open or modify any PR or issue;\n' +
+  '- edit or write repository files, or run state-changing shell commands (git commit/push/add/checkout, gh, cargo fix, installs).\n' +
+  'The only writes ever permitted are scratch /tmp files (and, for the consolidator, the one explicitly-named .research report path).\n' +
+  'Report via the structured-output tool only. Fixing is a separate, human-gated step.'
+
+// Shared checklist appended to every target (DRY — matches the project's own
+// DRY governance). Target-specific bullets (target.lookFor) are prepended.
+const CORE_CHECKLIST = [
+  'Panic-on-valid-input: `unwrap`/`expect`/`[i]` indexing/`debug_assert!` used as input validation on a public entry point.',
+  'Numerical stability: division by zero, NaN/Inf propagation, overflow, `sqrt` of negative, `NaN < x` guards that silently pass (NaN bypasses `<` comparisons — must be paired with `.is_finite()`).',
+  'Silent error masking: `Err(_) => None` in a `filter_map` for a WHOLE-CONFIG error (only acceptable for per-pixel edge cases), `.unwrap_or(default)` that hides a real failure, `max(0.0)` that converts NaN/negative to a plausible value.',
+  'Missing input validation at public entry points (validate up-front, before heavy work / rayon iterators).',
+  'Empty-collection / exactly-determined-system edge cases (`0 == 0` passes equality; guard `is_empty()` separately).',
+  'API consistency: sibling functions that should validate the same way but do not (one path hardened, the parallel path missed — a recurring NEREIDS bug class).',
+  'CIRCULAR-VALIDATION RISK (high priority): a test whose oracle mirrors the implementation, a fixture generated by the code under test, or an assertion tolerance so loose the bug would be invisible (e.g. a resolution kernel that is a no-op at the test grid spacing, a peak-energy-only test that cannot see an off-peak factor error). Flag these explicitly in `circularValidationRisk`.',
+  'Documentation/comment drift from code (rustdoc claims, SAMMY citation claims, comment arithmetic vs actual code).',
+]
+
+// ---- structured-output schemas -------------------------------------------
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    domain: { type: 'string' },
+    family: { type: 'string', enum: ['claude', 'codex'] },
+    assessment: { type: 'string', description: 'one-sentence overall assessment of the domain' },
+    codexFailed: { type: 'boolean', description: 'true only for the codex harness when codex did not run' },
+    failureReason: { type: 'string' },
+    tierCounts: {
+      type: 'object',
+      additionalProperties: false,
+      properties: { p0: { type: 'integer' }, p1: { type: 'integer' }, p2: { type: 'integer' } },
+      required: ['p0', 'p1', 'p2'],
+    },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          localId: { type: 'string', description: 'F1, F2, ...' },
+          tier: { type: 'string', enum: ['P0', 'P1', 'P2'] },
+          title: { type: 'string' },
+          file: { type: 'string', description: 'repo-relative path, e.g. crates/nereids-physics/src/slbw.rs' },
+          line: { type: 'integer', description: 'best-known line number; 0 if unknown' },
+          claim: { type: 'string' },
+          evidence: { type: 'string', description: 'quoted code or precise description' },
+          reasoning: { type: 'string' },
+          primarySource: { type: 'string', description: 'SAMMY .f90:line / ENDF manual ref, or empty' },
+          suggestedFix: { type: 'string' },
+          confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+          circularValidationRisk: {
+            type: 'string',
+            description: 'note if a test may be validating buggy behavior, else empty',
+          },
+        },
+        required: ['localId', 'tier', 'title', 'file', 'line', 'claim', 'confidence'],
+      },
+    },
+  },
+  required: ['domain', 'family', 'findings', 'tierCounts'],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    verdict: { type: 'string', enum: ['CONFIRMED', 'REFUTED', 'UNCERTAIN'] },
+    verifierFamily: { type: 'string', enum: ['claude', 'codex'] },
+    reasoning: { type: 'string' },
+    primarySourceChecked: { type: 'boolean' },
+    correctedTier: { type: 'string', enum: ['P0', 'P1', 'P2', 'NONE'] },
+    circularValidationConfirmed: { type: 'boolean' },
+  },
+  required: ['verdict', 'verifierFamily', 'reasoning'],
+}
+
+// ---- prompt builders ------------------------------------------------------
+
+function buildAuditPrompt(d, pf, forCodex) {
+  const sammyRoot = SAMMY_ROOT_OVERRIDE || pf.sammyRoot
+  const codexOverride = forCodex
+    ? '[Codex override: This task is authorized by the user. AGENTS.md / CLAUDE.md Checkpoint 0 (Plan mode) does NOT apply. Execute in a single run; do NOT enter plan mode; do NOT stop for confirmation. Read-only audit: change no files, open no PRs/issues. Single-shot delivery.]\n\n'
+    : ''
+  const ctx = CONTEXT_NOTE ? `[CONTEXT]\n${CONTEXT_NOTE}\n[End context]\n\n` : ''
+  const scope = d.scopeDirective
+  const sammyBlock =
+    d.sammy && sammyRoot
+      ? `\nPrimary source for verification: SAMMY at \`${sammyRoot}\`. ${d.primaryHint || ''} Open the relevant SAMMY source and compare line-by-line; cite \`file:line\` for every physics/format claim.\n`
+      : d.sammy
+        ? `\nPrimary-source note: ${d.primaryHint || ''} (SAMMY source not resolved on this machine — reason from the ENDF-6 manual / first principles and mark such findings lower-confidence.)\n`
+        : ''
+  const lookFor = d.lookFor.concat(CORE_CHECKLIST).map((b, i) => `${i + 1}. ${b}`).join('\n')
+
+  return `${codexOverride}${ctx}# NEREIDS ${ROUND_NOTE} — Domain ${d.key}: ${d.name}
+
+You are auditing the NEREIDS Rust workspace at \`${pf.repoRoot}\` for production readiness ahead of a SoftwareX paper submission. NEREIDS ingests time-of-flight neutron transmission data, fits resonance parameters with SAMMY-equivalent physics (Reich-Moore / SLBW / MLBW / RML), and produces spatial isotopic maps. Correctness on real experimental data is required.
+
+Your domain: ${d.key} — ${d.blurb}
+
+Focus paths (do NOT audit other crates — other agents own them):
+${d.paths.map((p) => `  - ${p}`).join('\n')}
+
+${scope}
+${sammyBlock}
+## Tier rubric (P3 excluded — do NOT report P3)
+- P0 (must fix): ${d.p0}
+- P1 (should fix): latent edge case, missing input validation, SAMMY/format-equivalence gap, undocumented panic on plausible input, missing test for a claimed property.
+- P2 (trivial): typo, doc wording, comment drifting from code.
+
+Calibrate HONESTLY — the user will declare paper-readiness based on this report. Do not inflate; do not self-censor based on what you think is already known.
+
+## What to look for
+${lookFor}
+
+## Method
+1. Map the surface (Cargo.toml + lib.rs of each focus path).
+2. Walk each module; quote actual code lines (\`file:line\`) as evidence.
+3. For every physics/format claim, open the primary source and compare.
+4. Inspect the test suite for the CIRCULAR-VALIDATION patterns above.
+5. Mark low-confidence findings explicitly so the verify pass tests them harder.
+
+Quality over budget. Read carefully; do not truncate.`
+}
+
+// Harness prompt: a Claude subagent that DRIVES codex and structures its
+// findings. It must not audit the code itself.
+function codexFinderPrompt(d, pf) {
+  const codexPrompt = buildAuditPrompt(d, pf, true)
+  const slug = d.key
+  return `You are a HARNESS that runs the OpenAI Codex CLI as an independent external reviewer (a DIFFERENT LLM family from you) and faithfully transcribes ITS findings into structured output. Do NOT audit the code yourself — your judgement must not replace Codex's.
+
+Steps:
+1. Write this exact audit prompt to a temp file with the Write tool at \`/tmp/bughunt-${slug}.prompt\`:
+-----BEGIN CODEX PROMPT-----
+${codexPrompt}
+-----END CODEX PROMPT-----
+2. Run (Bash, timeout 600000 ms):
+   codex exec --sandbox read-only --skip-git-repo-check -C "${pf.repoRoot}" --output-last-message /tmp/bughunt-${slug}.out - < /tmp/bughunt-${slug}.prompt
+   (Temp-file + stdin is the portable delivery pattern; --output-last-message captures Codex's final verdict. --sandbox read-only is correct: review only reads code.)
+3. If codex exits non-zero, or /tmp/bughunt-${slug}.out is missing/empty: return {domain:"${slug}", family:"codex", codexFailed:true, failureReason:"<one-line stderr summary>", findings:[], tierCounts:{p0:0,p1:0,p2:0}}.
+4. Otherwise Read /tmp/bughunt-${slug}.out and transcribe EVERY finding Codex reported into the schema. Preserve Codex's tier (P0/P1/P2), file, line, claim, reasoning, primary-source, and confidence in substance. Do not add findings Codex did not make; do not drop findings it did. Set family="codex".
+5. Return via structured output.`
+}
+
+function buildFindingText(f, srcFamily) {
+  return `Finding (from ${srcFamily}, its tier ${f.tier}, its confidence ${f.confidence}):
+- title: ${f.title}
+- file:line: ${f.file}:${f.line}
+- claim: ${f.claim}
+- evidence: ${f.evidence || '(none given)'}
+- reasoning: ${f.reasoning || '(none given)'}
+- primary source cited: ${f.primarySource || '(none)'}
+- circular-validation note: ${f.circularValidationRisk || '(none)'}`
+}
+
+// Claude verifies a Codex finding (cross-family).
+function claudeVerifyPrompt(f, pf, lensNote) {
+  const sammyRoot = SAMMY_ROOT_OVERRIDE || pf.sammyRoot
+  return `You are an INDEPENDENT verifier from a different LLM family than the one that produced this finding. Adversarially test whether it is a REAL defect. Default to REFUTED if you cannot independently substantiate it.
+
+${buildFindingText(f, 'Codex')}
+
+Steps:
+1. Open ${f.file} around line ${f.line} in \`${pf.repoRoot}\` and read enough surrounding context to judge independently.
+2. If a primary source applies (SAMMY .f90${sammyRoot ? ` under ${sammyRoot}` : ''}, ENDF-6 manual), open it and check the claim against it.${lensNote ? `\n3. ${lensNote}` : ''}
+- Decide CONFIRMED (you independently reproduced the defect), REFUTED (explain precisely why the reasoning is wrong — e.g. a convention the finder misread), or UNCERTAIN (cannot tell without runtime / more context).
+- Give your OWN independent tier (P0/P1/P2/NONE).
+- If the finding includes a circular-validation note, judge whether it is valid (set circularValidationConfirmed).
+Return via structured output with verifierFamily="claude".`
+}
+
+// Codex verifies a Claude finding (cross-family) — Claude harness drives codex.
+function codexVerifyPrompt(f, pf, id, lensNote) {
+  const sammyRoot = SAMMY_ROOT_OVERRIDE || pf.sammyRoot
+  const inner = `You are an INDEPENDENT adversarial verifier. Test whether this finding is a REAL defect. Default to REFUTED if you cannot independently substantiate it.
+
+${buildFindingText(f, 'Claude')}
+
+1. Open ${f.file} near line ${f.line} and read enough context to judge independently.
+2. If a primary source applies (SAMMY .f90${sammyRoot ? ` under ${sammyRoot}` : ''}, ENDF-6 manual), open and compare.${lensNote ? `\n3. ${lensNote}` : ''}
+Then state, on clearly labelled lines:
+VERDICT: CONFIRMED | REFUTED | UNCERTAIN
+INDEPENDENT_TIER: P0 | P1 | P2 | NONE
+PRIMARY_SOURCE_CHECKED: yes | no
+CIRCULAR_VALIDATION_CONFIRMED: yes | no | n/a
+REASONING: <2-4 sentences>`
+  return `You are a HARNESS that runs the OpenAI Codex CLI (an independent LLM family) to adversarially verify a finding Claude produced. Do not substitute your own judgement for Codex's.
+
+1. Write this prompt to \`/tmp/bughunt-verify-${id}.prompt\` with the Write tool:
+-----BEGIN CODEX PROMPT-----
+[Codex override: authorized by user; Plan mode does NOT apply; read-only; single-shot.]
+
+${inner}
+-----END CODEX PROMPT-----
+2. Run (Bash, timeout 600000 ms):
+   codex exec --sandbox read-only --skip-git-repo-check -C "${pf.repoRoot}" --output-last-message /tmp/bughunt-verify-${id}.out - < /tmp/bughunt-verify-${id}.prompt
+3. If codex fails or the output is empty: return {verdict:"UNCERTAIN", verifierFamily:"codex", reasoning:"codex unavailable: <stderr>", primarySourceChecked:false, correctedTier:"NONE"}.
+4. Otherwise Read /tmp/bughunt-verify-${id}.out and map Codex's labelled lines into the schema (VERDICT->verdict, INDEPENDENT_TIER->correctedTier, PRIMARY_SOURCE_CHECKED->primarySourceChecked, CIRCULAR_VALIDATION_CONFIRMED->circularValidationConfirmed, REASONING->reasoning). Set verifierFamily="codex".
+Return via structured output.`
+}
+
+// ---- pure helpers ---------------------------------------------------------
+
+function normFile(f) {
+  return String(f || '').replace(/^\.\//, '').trim()
+}
+function basename(f) {
+  const p = normFile(f).split('/')
+  return p[p.length - 1]
+}
+// Title-token similarity (Jaccard over the smaller token set), ignoring short
+// and generic audit words so the signal is the *subject* of the finding.
+const TITLE_STOP = new Set([
+  'that','with','from','this','when','does','only','into','have','the','and','for','not','are','its','can','but',
+  'validate','validation','validated','silently','silent','missing','accept','accepts','accepted','input','inputs',
+  'value','values','public','entry','point','check','checks','guard','handle','handled','return','returns','data',
+])
+function titleTokens(s) {
+  return new Set(
+    String(s || '')
+      .toLowerCase()
+      .split(/\W+/)
+      .filter((w) => w.length > 3 && !TITLE_STOP.has(w)),
+  )
+}
+function titleOverlap(a, b) {
+  const ta = titleTokens(a.title)
+  const tb = titleTokens(b.title)
+  if (!ta.size || !tb.size) return 0
+  let inter = 0
+  for (const w of tb) if (ta.has(w)) inter++
+  return inter / Math.min(ta.size, tb.size)
+}
+// Two findings "match" (cross-confirmed / dedup) when they are the same defect.
+// Same basename is required. Then EITHER the lines are close (<=8), OR — to
+// catch the same defect reported at different line numbers by the two families
+// (e.g. spatial.rs cancellation found at :1121 vs :1194) — the titles are
+// strongly similar. The title-similarity arm prevents a near-duplicate of a
+// VERIFIED finding from leaking into the REFUTED list.
+function findingsMatch(a, b) {
+  if (basename(a.file) !== basename(b.file)) return false
+  const la = a.line || 0
+  const lb = b.line || 0
+  if (la > 0 && lb > 0 && Math.abs(la - lb) <= 8) return true
+  return titleOverlap(a, b) >= 0.5
+}
+function tierRank(t) {
+  return t === 'P0' ? 0 : t === 'P1' ? 1 : 2
+}
+function verifyVotes(tier) {
+  // Cross-family independence is achieved with a single vote from the OTHER
+  // family. Extra votes (budget-scaled, diverse lenses) harden the P0s only.
+  if (tier === 'P0') {
+    if (budget && budget.total) return Math.min(3, 2 + Math.floor((budget.remaining() || 0) / 400000))
+    return 2
+  }
+  if (tier === 'P1') return 1
+  return 0
+}
+const LENSES = [
+  '',
+  'Focus specifically on the PRIMARY SOURCE: does the cited SAMMY/ENDF reference actually say what the finding claims? Misread conventions are the most common false positive here.',
+  'Focus on REPRODUCIBILITY: construct the concrete input that would trigger the defect. If no plausible input triggers it, lean REFUTED.',
+]
+
+// ---------------------------------------------------------------------------
+// Find -> Verify (pipelined per target; no barrier between them).
+// As soon as target X's two finders complete, X's findings are cross-verified
+// while target Y is still finding.
+// ---------------------------------------------------------------------------
+const perTargetRaw = await pipeline(
+  TARGETS,
+
+  // -- Find: Claude finder + Codex finder, concurrently, for this target.
+  (d) =>
+    parallel([
+      () =>
+        agent(buildAuditPrompt(d, pf, false) + '\n\nReturn your findings via the structured output tool.' + DETECTION_ONLY, {
+          label: `find:claude:${d.key}`,
+          phase: 'Find',
+          schema: FINDINGS_SCHEMA,
+          agentType: READER_TYPE,
+        }),
+      () =>
+        codexUsable
+          ? agent(codexFinderPrompt(d, pf) + DETECTION_ONLY, {
+              label: `find:codex:${d.key}`,
+              phase: 'Find',
+              schema: FINDINGS_SCHEMA,
+              agentType: RUNNER_TYPE,
+            })
+          : Promise.resolve(null),
+    ]).then(([claudeRes, codexRes]) => ({ domain: d, claude: claudeRes, codex: codexRes })),
+
+  // -- Verify: cross-family confirmation of single-family findings.
+  async (fr) => {
+    const d = fr.domain
+    const claudeF = (fr.claude && fr.claude.findings) || []
+    const codexF = (fr.codex && fr.codex.findings) || []
+    const codexOk = !!fr.codex && !fr.codex.codexFailed
+
+    // Stamp each finding with its source family + a stable id.
+    claudeF.forEach((f, i) => {
+      f.family = 'claude'
+      f.id = `${d.key}-C-${f.localId || i + 1}`
+    })
+    codexF.forEach((f, i) => {
+      f.family = 'codex'
+      f.id = `${d.key}-X-${f.localId || i + 1}`
+    })
+
+    // 1) cross-confirmed at FIND time (both families independently found it).
+    const crossConfirmed = []
+    const codexMatched = new Set()
+    for (const cf of claudeF) {
+      const m = codexF.find((xf, j) => !codexMatched.has(j) && findingsMatch(cf, xf))
+      if (m) {
+        const j = codexF.indexOf(m)
+        codexMatched.add(j)
+        crossConfirmed.push({
+          ...cf,
+          tier: tierRank(cf.tier) <= tierRank(m.tier) ? cf.tier : m.tier, // keep the more severe
+          status: 'VERIFIED',
+          basis: 'cross-confirmed at find time (both Claude and Codex independently)',
+          codexCounterpart: m.id,
+        })
+      }
+    }
+    const matchedClaudeIds = new Set(crossConfirmed.map((c) => c.id))
+    const claudeOnly = claudeF.filter((f) => !matchedClaudeIds.has(f.id))
+    const codexOnly = codexF.filter((_, j) => !codexMatched.has(j))
+
+    // 2) singletons (P0/P1) -> adversarial verification by the OTHER family.
+    const toVerify = []
+    for (const f of claudeOnly) if (verifyVotes(f.tier) > 0) toVerify.push({ f, verifier: 'codex' })
+    for (const f of codexOnly) if (verifyVotes(f.tier) > 0) toVerify.push({ f, verifier: 'claude' })
+
+    const verifyResults = await parallel(
+      toVerify.flatMap(({ f, verifier }) => {
+        const n = verifyVotes(f.tier)
+        return Array.from({ length: n }, (_v, vi) => () => {
+          // If the required verifier family is unavailable, no cross-family vote.
+          if (verifier === 'codex' && !codexOk)
+            return Promise.resolve({ fid: f.id, f, verdict: null, unavailable: true })
+          const lens = LENSES[vi % LENSES.length]
+          const id = `${f.id}-v${vi}`
+          const p =
+            verifier === 'claude'
+              ? agent(claudeVerifyPrompt(f, pf, lens) + DETECTION_ONLY, {
+                  label: `verify:claude:${id}`,
+                  phase: 'Verify',
+                  schema: VERDICT_SCHEMA,
+                  agentType: READER_TYPE,
+                })
+              : agent(codexVerifyPrompt(f, pf, id, lens) + DETECTION_ONLY, {
+                  label: `verify:codex:${id}`,
+                  phase: 'Verify',
+                  schema: VERDICT_SCHEMA,
+                  agentType: RUNNER_TYPE,
+                })
+          return p.then((v) => ({ fid: f.id, f, verdict: v }))
+        })
+      }),
+    )
+
+    // 3) aggregate votes per finding.
+    const votesByFinding = new Map()
+    for (const r of verifyResults.filter(Boolean)) {
+      if (!votesByFinding.has(r.fid)) votesByFinding.set(r.fid, { f: r.f, votes: [], unavailable: false })
+      const e = votesByFinding.get(r.fid)
+      if (r.unavailable) e.unavailable = true
+      else if (r.verdict) e.votes.push(r.verdict)
+    }
+
+    const verified = [...crossConfirmed]
+    const needsVerification = []
+    const refuted = []
+    for (const [, e] of votesByFinding) {
+      const conf = e.votes.filter((v) => v.verdict === 'CONFIRMED').length
+      const refu = e.votes.filter((v) => v.verdict === 'REFUTED').length
+      // verifier's independent tier can downgrade the original
+      const correctedTiers = e.votes.map((v) => v.correctedTier).filter((t) => t && t !== 'NONE')
+      const entry = {
+        ...e.f,
+        crossFamilyVotes: e.votes,
+        basis: `cross-family (${e.f.family === 'claude' ? 'codex' : 'claude'}) verification`,
+      }
+      if (e.unavailable || e.votes.length === 0) {
+        entry.status = 'NEEDS-VERIFICATION'
+        entry.note = e.unavailable ? 'cross-family verifier unavailable (single-LLM-family only)' : 'no verdict returned'
+        needsVerification.push(entry)
+      } else if (conf > refu) {
+        entry.status = 'VERIFIED'
+        if (correctedTiers.length) entry.verifierTier = correctedTiers.sort((a, b) => tierRank(a) - tierRank(b))[0]
+        verified.push(entry)
+      } else if (refu > conf) {
+        entry.status = 'REFUTED'
+        refuted.push(entry)
+      } else {
+        entry.status = 'NEEDS-VERIFICATION'
+        entry.note = 'split vote'
+        needsVerification.push(entry)
+      }
+    }
+
+    // P2s: reported as-is (not verified), tagged by family.
+    const p2s = [...claudeF, ...codexF].filter((f) => f.tier === 'P2')
+    // circular-validation flags from any finding + any confirmed-by-verifier
+    const circular = [...claudeF, ...codexF]
+      .filter((f) => f.circularValidationRisk && f.circularValidationRisk.trim())
+      .map((f) => ({ id: f.id, file: f.file, line: f.line, family: f.family, note: f.circularValidationRisk }))
+
+    return {
+      domainKey: d.key,
+      domainName: d.name,
+      claudeAssessment: (fr.claude && fr.claude.assessment) || '(no claude result)',
+      codexAssessment: codexOk ? fr.codex.assessment : codexUsable ? `codex failed: ${fr.codex && fr.codex.failureReason}` : 'codex disabled',
+      tierCounts: {
+        claude: (fr.claude && fr.claude.tierCounts) || { p0: 0, p1: 0, p2: 0 },
+        codex: codexOk ? fr.codex.tierCounts : { p0: 0, p1: 0, p2: 0 },
+      },
+      verified,
+      needsVerification,
+      refuted,
+      p2s,
+      circular,
+    }
+  },
+)
+
+// Return structured per-target findings to the calling wrapper. The wrapper
+// owns final consolidation (cross-target dedup, report writing, disposition,
+// RECURRING tagging) — this engine is detection + per-target structuring only.
+return { perTarget: perTargetRaw.filter(Boolean), codexUsable }

--- a/.claude/workflows/nereids-bug-hunt.js
+++ b/.claude/workflows/nereids-bug-hunt.js
@@ -226,11 +226,17 @@ function tierRank(t) {
 phase('Preflight')
 const domainKeys = Array.isArray(A.domains) && A.domains.length ? A.domains : ALL_DOMAINS.map((d) => d.key)
 const DOMAINS = ALL_DOMAINS.filter((d) => domainKeys.includes(d.key))
-// Fail closed on a misspelled args.domains key: an empty domain set must abort,
-// not sail through the engine to a "0 findings" all-clear report.
-if (!DOMAINS.length) {
-  log(`No domains matched ${JSON.stringify(domainKeys)} — check args.domains spelling. Aborting rather than emit a 0-findings all-clear.`)
-  return { aborted: true, reason: 'no domains matched (check args.domains)' }
+// Fail closed on a misspelled args.domains key. Validate EVERY explicitly
+// requested key (not just the all-invalid case): a partial list like
+// ['03-physics','03-phsyics'] must abort, not silently audit the valid subset
+// and drop the typo. (The default all-domains path has nothing to validate.)
+if (Array.isArray(A.domains) && A.domains.length) {
+  const known = new Set(ALL_DOMAINS.map((d) => d.key))
+  const unknown = A.domains.filter((k) => !known.has(k))
+  if (unknown.length) {
+    log(`Unknown args.domains key(s) ${JSON.stringify(unknown)} (valid: ${ALL_DOMAINS.map((d) => d.key).join(', ')}) — aborting rather than silently auditing a subset.`)
+    return { aborted: true, reason: `unknown domain(s): ${unknown.join(', ')}` }
+  }
 }
 
 const pf = await agent(

--- a/.claude/workflows/nereids-bug-hunt.js
+++ b/.claude/workflows/nereids-bug-hunt.js
@@ -336,10 +336,12 @@ phase('Consolidate')
 const allVerified = domainResults.flatMap((r) => r.verified)
 const verifiedP0 = allVerified.filter((f) => (f.verifierTier || f.tier) === 'P0').sort((a, b) => tierRank(a.tier) - tierRank(b.tier))
 const verifiedP1 = allVerified.filter((f) => (f.verifierTier || f.tier) === 'P1')
-// A cross-family-CONFIRMED finding the verifier downgraded to effective P2 is a
-// real (if low-severity) defect; fold it into the P2 backlog so it is counted,
-// not dropped between the P0/P1 buckets and r.p2s (original-tier P2s only).
-const verifiedP2 = allVerified.filter((f) => (f.verifierTier || f.tier) === 'P2')
+// A cross-family-CONFIRMED finding the verifier DOWNGRADED to effective P2
+// (original tier P0/P1) is real but low-severity; fold it into the P2 backlog so
+// it is counted, not dropped between the P0/P1 buckets and r.p2s. Restrict to
+// GENUINELY-downgraded findings (verifierTier === 'P2' && tier !== 'P2'): a
+// born-P2 finding is already in r.p2s, so matching it here would double-count it.
+const verifiedP2 = allVerified.filter((f) => f.verifierTier === 'P2' && f.tier !== 'P2')
 const needsVerification = domainResults.flatMap((r) => r.needsVerification)
 const refuted = domainResults.flatMap((r) => r.refuted)
 const circular = domainResults.flatMap((r) => r.circular)

--- a/.claude/workflows/nereids-bug-hunt.js
+++ b/.claude/workflows/nereids-bug-hunt.js
@@ -15,31 +15,23 @@ export const meta = {
 // ---------------------------------------------------------------------------
 // nereids-bug-hunt
 //
-// Encodes the R1/R2/R3 audit methodology that this project converged on:
-//   - 8 domains (one per crate / subsystem)
+// Whole-workspace defect sweep ahead of a release / paper. A THIN WRAPPER over
+// the shared `dual-family-review` engine (.claude/workflows/dual-family-review.js):
+// this file owns the 8-domain target list (one per crate / subsystem), the
+// preflight (repo root / codex / SAMMY resolution), and the final consolidated
+// .research/SUMMARY.md report. The engine owns the Find -> Verify mechanics:
 //   - 2 independent LLM families per domain: Claude (agent()) + Codex (codex exec)
 //   - P0/P1/P2 tiers (P3 excluded), file:line + primary-source evidence
 //   - a cross-LLM-family confirmation pass on every SINGLE-family finding
 //     (Claude findings verified by Codex; Codex findings verified by Claude)
 //
-// Why the cross-family pass is load-bearing (see memory):
-//   - "parent-agent re-derivation of a subagent's claim is NOT independent
-//      confirmation; same LLM family. For VERIFIED need >=2 distinct LLM
-//      families with independent access."
-//   - "the audit->fix->review cycle is non-idempotent" — so this workflow
-//      DETECTS only; fixing is a separate, human-gated step (/review-pipeline
-//      Step 5 + .claude/templates/fix-subagent-prompt.md).
-//
-// Detection-only is enforced two ways (see the HARD / DETECTION_ONLY block in the
-// body): (1) a prompt contract appended to every audit-agent prompt, ALWAYS ON —
-// this is what makes behaviour consistent (the original run had 2 of 88
-// general-purpose agents freelance a fix-session via spawn_task); (2) optional
-// TOOL-LEVEL enforcement via restricted custom agent types
-// (.claude/agents/bug-hunt-{reader,runner}.md) that physically lack
-// spawn_task/Task*/MCP/PR-issue tools — enable with args.hardEnforce=true from a
-// session started AFTER those agent defs exist (custom agent types load at session
-// start, not hot). Fix-task creation, if ever wanted, is a deliberate separate
-// step after the user reviews the backlog — never inside this workflow.
+// Detection-only (the engine never fixes; fixing is a separate, human-gated step
+// via /review-pipeline + .claude/templates/fix-subagent-prompt.md) is enforced
+// by the engine two ways: an always-on DETECTION_ONLY prompt contract, and
+// optional tool-level restriction via the bug-hunt-{reader,runner} agent types
+// (args.hardEnforce=true; the session must postdate those defs). See the engine
+// file header for the full rationale (cross-family independence; non-idempotent
+// audit->fix->review cycle).
 //
 // args (all optional):
 //   args.domains      : string[]  subset of domain keys to audit (default: all 8)
@@ -51,6 +43,9 @@ export const meta = {
 //   args.skipCodex    : boolean   force Claude-only (single-family -> all findings
 //                                  flagged NEEDS-VERIFICATION)
 //   args.sammyRoot    : string    override SAMMY source root for physics checks
+//   args.hardEnforce  : boolean   use the restricted bug-hunt-{reader,runner}
+//                                  agent types (session must postdate those defs)
+//   args.repoRoot     : string    explicit canonical root (overrides git-detected)
 // ---------------------------------------------------------------------------
 
 // Defensive: the Workflow tool's `args` should arrive as a real object, but a
@@ -71,45 +66,16 @@ const CONTEXT_NOTE = A.contextNote || ''
 const ROUND_NOTE = A.roundNote || 'bug-hunt'
 const SKIP_CODEX = A.skipCodex === true
 
-// Detection-only enforcement. Two layers:
-//  (1) DETECTION_ONLY prompt contract, appended to every audit-agent prompt below
-//      — ALWAYS ON and identical across agents. This is what makes behaviour
-//      consistent (vs. the original run where 2 of 88 general-purpose agents
-//      freelanced a fix-session via spawn_task and 86 did not).
-//  (2) Optional TOOL-LEVEL hard enforcement via restricted custom agent types
-//      (.claude/agents/bug-hunt-{reader,runner}.md), which physically lack
-//      spawn_task / Task* / MCP / PR-issue tools. Custom agent types load at
-//      SESSION START (not hot), so they are unavailable in a session that
-//      predates the files. Default to the always-available built-in
-//      `general-purpose`; pass args.hardEnforce=true from a session started
-//      AFTER those agent defs exist to switch the tool-level restriction on.
+// Detection-only enforcement layers are implemented in the engine; this wrapper
+// just resolves which agent type to use and passes hardEnforce through. Custom
+// agent types load at SESSION START (not hot), so default to the always-available
+// built-in `general-purpose`; pass args.hardEnforce=true from a session started
+// AFTER the bug-hunt-{reader,runner} defs exist to switch the restriction on.
 const HARD = A.hardEnforce === true
 const READER_TYPE = HARD ? 'bug-hunt-reader' : 'general-purpose'
 const RUNNER_TYPE = HARD ? 'bug-hunt-runner' : 'general-purpose'
 
-const DETECTION_ONLY =
-  '\n\n--- DETECTION-ONLY CONTRACT (mandatory) ---\n' +
-  'You FIND and REPORT defects; you never fix them and never advance to a fix stage. You MUST NOT:\n' +
-  '- create any task, background session, or fix-job (do NOT call spawn_task or any task-creation / scheduling tool);\n' +
-  '- open or modify any PR or issue;\n' +
-  '- edit or write repository files, or run state-changing shell commands (git commit/push/add/checkout, gh, cargo fix, installs).\n' +
-  'The only writes ever permitted are scratch /tmp files (and, for the consolidator, the one explicitly-named .research report path).\n' +
-  'Report via the structured-output tool only. Fixing is a separate, human-gated step.'
-
-// Shared checklist appended to every domain (DRY — matches the project's
-// own DRY governance). Domain-specific bullets are added per domain below.
-const CORE_CHECKLIST = [
-  'Panic-on-valid-input: `unwrap`/`expect`/`[i]` indexing/`debug_assert!` used as input validation on a public entry point.',
-  'Numerical stability: division by zero, NaN/Inf propagation, overflow, `sqrt` of negative, `NaN < x` guards that silently pass (NaN bypasses `<` comparisons — must be paired with `.is_finite()`).',
-  'Silent error masking: `Err(_) => None` in a `filter_map` for a WHOLE-CONFIG error (only acceptable for per-pixel edge cases), `.unwrap_or(default)` that hides a real failure, `max(0.0)` that converts NaN/negative to a plausible value.',
-  'Missing input validation at public entry points (validate up-front, before heavy work / rayon iterators).',
-  'Empty-collection / exactly-determined-system edge cases (`0 == 0` passes equality; guard `is_empty()` separately).',
-  'API consistency: sibling functions that should validate the same way but do not (one path hardened, the parallel path missed — a recurring NEREIDS bug class).',
-  'CIRCULAR-VALIDATION RISK (high priority): a test whose oracle mirrors the implementation, a fixture generated by the code under test, or an assertion tolerance so loose the bug would be invisible (e.g. a resolution kernel that is a no-op at the test grid spacing, a peak-energy-only test that cannot see an off-peak factor error). Flag these explicitly in `circularValidationRisk`.',
-  'Documentation/comment drift from code (rustdoc claims, SAMMY citation claims, comment arithmetic vs actual code).',
-]
-
-// The 8 domains. `lookFor` is domain-specific; CORE_CHECKLIST is appended.
+// The 8 domains. `lookFor` is domain-specific; CORE_CHECKLIST is appended (in the engine).
 // `sammy` true => physics/format primary-source comparison is in scope.
 const ALL_DOMAINS = [
   {
@@ -230,65 +196,7 @@ const ALL_DOMAINS = [
   },
 ]
 
-// ---- structured-output schemas -------------------------------------------
-
-const FINDINGS_SCHEMA = {
-  type: 'object',
-  additionalProperties: false,
-  properties: {
-    domain: { type: 'string' },
-    family: { type: 'string', enum: ['claude', 'codex'] },
-    assessment: { type: 'string', description: 'one-sentence overall assessment of the domain' },
-    codexFailed: { type: 'boolean', description: 'true only for the codex harness when codex did not run' },
-    failureReason: { type: 'string' },
-    tierCounts: {
-      type: 'object',
-      additionalProperties: false,
-      properties: { p0: { type: 'integer' }, p1: { type: 'integer' }, p2: { type: 'integer' } },
-      required: ['p0', 'p1', 'p2'],
-    },
-    findings: {
-      type: 'array',
-      items: {
-        type: 'object',
-        additionalProperties: false,
-        properties: {
-          localId: { type: 'string', description: 'F1, F2, ...' },
-          tier: { type: 'string', enum: ['P0', 'P1', 'P2'] },
-          title: { type: 'string' },
-          file: { type: 'string', description: 'repo-relative path, e.g. crates/nereids-physics/src/slbw.rs' },
-          line: { type: 'integer', description: 'best-known line number; 0 if unknown' },
-          claim: { type: 'string' },
-          evidence: { type: 'string', description: 'quoted code or precise description' },
-          reasoning: { type: 'string' },
-          primarySource: { type: 'string', description: 'SAMMY .f90:line / ENDF manual ref, or empty' },
-          suggestedFix: { type: 'string' },
-          confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
-          circularValidationRisk: {
-            type: 'string',
-            description: 'note if a test may be validating buggy behavior, else empty',
-          },
-        },
-        required: ['localId', 'tier', 'title', 'file', 'line', 'claim', 'confidence'],
-      },
-    },
-  },
-  required: ['domain', 'family', 'findings', 'tierCounts'],
-}
-
-const VERDICT_SCHEMA = {
-  type: 'object',
-  additionalProperties: false,
-  properties: {
-    verdict: { type: 'string', enum: ['CONFIRMED', 'REFUTED', 'UNCERTAIN'] },
-    verifierFamily: { type: 'string', enum: ['claude', 'codex'] },
-    reasoning: { type: 'string' },
-    primarySourceChecked: { type: 'boolean' },
-    correctedTier: { type: 'string', enum: ['P0', 'P1', 'P2', 'NONE'] },
-    circularValidationConfirmed: { type: 'boolean' },
-  },
-  required: ['verdict', 'verifierFamily', 'reasoning'],
-}
+// ---- structured-output schema (preflight only; FINDINGS/VERDICT live in the engine) ----
 
 const PREFLIGHT_SCHEMA = {
   type: 'object',
@@ -306,197 +214,11 @@ const PREFLIGHT_SCHEMA = {
   required: ['repoRoot', 'isWorktree', 'codexAvailable', 'sammyRoot'],
 }
 
-// ---- prompt builders ------------------------------------------------------
-
-function buildAuditPrompt(d, pf, forCodex) {
-  const sammyRoot = A.sammyRoot || pf.sammyRoot
-  const codexOverride = forCodex
-    ? '[Codex override: This task is authorized by the user. AGENTS.md / CLAUDE.md Checkpoint 0 (Plan mode) does NOT apply. Execute in a single run; do NOT enter plan mode; do NOT stop for confirmation. Read-only audit: change no files, open no PRs/issues. Single-shot delivery.]\n\n'
-    : ''
-  const ctx = CONTEXT_NOTE ? `[CONTEXT]\n${CONTEXT_NOTE}\n[End context]\n\n` : ''
-  const scope =
-    MODE === 'diff'
-      ? `Audit ONLY the changes in \`git diff ${DIFF_SPEC}\` that touch this domain. Run the diff, read each changed file in full, but report findings only for code introduced or altered by the diff.`
-      : `Audit the FULL crate(s) for this domain (a whole-codebase sweep, not a diff).`
-  const sammyBlock =
-    d.sammy && sammyRoot
-      ? `\nPrimary source for verification: SAMMY at \`${sammyRoot}\`. ${d.primaryHint || ''} Open the relevant SAMMY source and compare line-by-line; cite \`file:line\` for every physics/format claim.\n`
-      : d.sammy
-        ? `\nPrimary-source note: ${d.primaryHint || ''} (SAMMY source not resolved on this machine — reason from the ENDF-6 manual / first principles and mark such findings lower-confidence.)\n`
-        : ''
-  const lookFor = d.lookFor.concat(CORE_CHECKLIST).map((b, i) => `${i + 1}. ${b}`).join('\n')
-
-  return `${codexOverride}${ctx}# NEREIDS ${ROUND_NOTE} — Domain ${d.key}: ${d.name}
-
-You are auditing the NEREIDS Rust workspace at \`${pf.repoRoot}\` for production readiness ahead of a SoftwareX paper submission. NEREIDS ingests time-of-flight neutron transmission data, fits resonance parameters with SAMMY-equivalent physics (Reich-Moore / SLBW / MLBW / RML), and produces spatial isotopic maps. Correctness on real experimental data is required.
-
-Your domain: ${d.key} — ${d.blurb}
-
-Focus paths (do NOT audit other crates — other agents own them):
-${d.paths.map((p) => `  - ${p}`).join('\n')}
-
-${scope}
-${sammyBlock}
-## Tier rubric (P3 excluded — do NOT report P3)
-- P0 (must fix): ${d.p0}
-- P1 (should fix): latent edge case, missing input validation, SAMMY/format-equivalence gap, undocumented panic on plausible input, missing test for a claimed property.
-- P2 (trivial): typo, doc wording, comment drifting from code.
-
-Calibrate HONESTLY — the user will declare paper-readiness based on this report. Do not inflate; do not self-censor based on what you think is already known.
-
-## What to look for
-${lookFor}
-
-## Method
-1. Map the surface (Cargo.toml + lib.rs of each focus path).
-2. Walk each module; quote actual code lines (\`file:line\`) as evidence.
-3. For every physics/format claim, open the primary source and compare.
-4. Inspect the test suite for the CIRCULAR-VALIDATION patterns above.
-5. Mark low-confidence findings explicitly so the verify pass tests them harder.
-
-Quality over budget. Read carefully; do not truncate.`
-}
-
-// Harness prompt: a Claude subagent that DRIVES codex and structures its
-// findings. It must not audit the code itself.
-function codexFinderPrompt(d, pf) {
-  const codexPrompt = buildAuditPrompt(d, pf, true)
-  const slug = d.key
-  return `You are a HARNESS that runs the OpenAI Codex CLI as an independent external reviewer (a DIFFERENT LLM family from you) and faithfully transcribes ITS findings into structured output. Do NOT audit the code yourself — your judgement must not replace Codex's.
-
-Steps:
-1. Write this exact audit prompt to a temp file with the Write tool at \`/tmp/bughunt-${slug}.prompt\`:
------BEGIN CODEX PROMPT-----
-${codexPrompt}
------END CODEX PROMPT-----
-2. Run (Bash, timeout 600000 ms):
-   codex exec --sandbox read-only --skip-git-repo-check -C "${pf.repoRoot}" --output-last-message /tmp/bughunt-${slug}.out - < /tmp/bughunt-${slug}.prompt
-   (Temp-file + stdin is the portable delivery pattern; --output-last-message captures Codex's final verdict. --sandbox read-only is correct: review only reads code.)
-3. If codex exits non-zero, or /tmp/bughunt-${slug}.out is missing/empty: return {domain:"${slug}", family:"codex", codexFailed:true, failureReason:"<one-line stderr summary>", findings:[], tierCounts:{p0:0,p1:0,p2:0}}.
-4. Otherwise Read /tmp/bughunt-${slug}.out and transcribe EVERY finding Codex reported into the schema. Preserve Codex's tier (P0/P1/P2), file, line, claim, reasoning, primary-source, and confidence in substance. Do not add findings Codex did not make; do not drop findings it did. Set family="codex".
-5. Return via structured output.`
-}
-
-function buildFindingText(f, srcFamily) {
-  return `Finding (from ${srcFamily}, its tier ${f.tier}, its confidence ${f.confidence}):
-- title: ${f.title}
-- file:line: ${f.file}:${f.line}
-- claim: ${f.claim}
-- evidence: ${f.evidence || '(none given)'}
-- reasoning: ${f.reasoning || '(none given)'}
-- primary source cited: ${f.primarySource || '(none)'}
-- circular-validation note: ${f.circularValidationRisk || '(none)'}`
-}
-
-// Claude verifies a Codex finding (cross-family).
-function claudeVerifyPrompt(f, pf, lensNote) {
-  const sammyRoot = A.sammyRoot || pf.sammyRoot
-  return `You are an INDEPENDENT verifier from a different LLM family than the one that produced this finding. Adversarially test whether it is a REAL defect. Default to REFUTED if you cannot independently substantiate it.
-
-${buildFindingText(f, 'Codex')}
-
-Steps:
-1. Open ${f.file} around line ${f.line} in \`${pf.repoRoot}\` and read enough surrounding context to judge independently.
-2. If a primary source applies (SAMMY .f90${sammyRoot ? ` under ${sammyRoot}` : ''}, ENDF-6 manual), open it and check the claim against it.${lensNote ? `\n3. ${lensNote}` : ''}
-- Decide CONFIRMED (you independently reproduced the defect), REFUTED (explain precisely why the reasoning is wrong — e.g. a convention the finder misread), or UNCERTAIN (cannot tell without runtime / more context).
-- Give your OWN independent tier (P0/P1/P2/NONE).
-- If the finding includes a circular-validation note, judge whether it is valid (set circularValidationConfirmed).
-Return via structured output with verifierFamily="claude".`
-}
-
-// Codex verifies a Claude finding (cross-family) — Claude harness drives codex.
-function codexVerifyPrompt(f, pf, id, lensNote) {
-  const sammyRoot = A.sammyRoot || pf.sammyRoot
-  const inner = `You are an INDEPENDENT adversarial verifier. Test whether this finding is a REAL defect. Default to REFUTED if you cannot independently substantiate it.
-
-${buildFindingText(f, 'Claude')}
-
-1. Open ${f.file} near line ${f.line} and read enough context to judge independently.
-2. If a primary source applies (SAMMY .f90${sammyRoot ? ` under ${sammyRoot}` : ''}, ENDF-6 manual), open and compare.${lensNote ? `\n3. ${lensNote}` : ''}
-Then state, on clearly labelled lines:
-VERDICT: CONFIRMED | REFUTED | UNCERTAIN
-INDEPENDENT_TIER: P0 | P1 | P2 | NONE
-PRIMARY_SOURCE_CHECKED: yes | no
-CIRCULAR_VALIDATION_CONFIRMED: yes | no | n/a
-REASONING: <2-4 sentences>`
-  return `You are a HARNESS that runs the OpenAI Codex CLI (an independent LLM family) to adversarially verify a finding Claude produced. Do not substitute your own judgement for Codex's.
-
-1. Write this prompt to \`/tmp/bughunt-verify-${id}.prompt\` with the Write tool:
------BEGIN CODEX PROMPT-----
-[Codex override: authorized by user; Plan mode does NOT apply; read-only; single-shot.]
-
-${inner}
------END CODEX PROMPT-----
-2. Run (Bash, timeout 600000 ms):
-   codex exec --sandbox read-only --skip-git-repo-check -C "${pf.repoRoot}" --output-last-message /tmp/bughunt-verify-${id}.out - < /tmp/bughunt-verify-${id}.prompt
-3. If codex fails or the output is empty: return {verdict:"UNCERTAIN", verifierFamily:"codex", reasoning:"codex unavailable: <stderr>", primarySourceChecked:false, correctedTier:"NONE"}.
-4. Otherwise Read /tmp/bughunt-verify-${id}.out and map Codex's labelled lines into the schema (VERDICT->verdict, INDEPENDENT_TIER->correctedTier, PRIMARY_SOURCE_CHECKED->primarySourceChecked, CIRCULAR_VALIDATION_CONFIRMED->circularValidationConfirmed, REASONING->reasoning). Set verifierFamily="codex".
-Return via structured output.`
-}
-
-// ---- pure helpers ---------------------------------------------------------
-
-function normFile(f) {
-  return String(f || '').replace(/^\.\//, '').trim()
-}
-function basename(f) {
-  const p = normFile(f).split('/')
-  return p[p.length - 1]
-}
-// Title-token similarity (Jaccard over the smaller token set), ignoring short
-// and generic audit words so the signal is the *subject* of the finding.
-const TITLE_STOP = new Set([
-  'that','with','from','this','when','does','only','into','have','the','and','for','not','are','its','can','but',
-  'validate','validation','validated','silently','silent','missing','accept','accepts','accepted','input','inputs',
-  'value','values','public','entry','point','check','checks','guard','handle','handled','return','returns','data',
-])
-function titleTokens(s) {
-  return new Set(
-    String(s || '')
-      .toLowerCase()
-      .split(/\W+/)
-      .filter((w) => w.length > 3 && !TITLE_STOP.has(w)),
-  )
-}
-function titleOverlap(a, b) {
-  const ta = titleTokens(a.title)
-  const tb = titleTokens(b.title)
-  if (!ta.size || !tb.size) return 0
-  let inter = 0
-  for (const w of tb) if (ta.has(w)) inter++
-  return inter / Math.min(ta.size, tb.size)
-}
-// Two findings "match" (cross-confirmed / dedup) when they are the same defect.
-// Same basename is required. Then EITHER the lines are close (<=8), OR — to
-// catch the same defect reported at different line numbers by the two families
-// (e.g. spatial.rs cancellation found at :1121 vs :1194) — the titles are
-// strongly similar. The title-similarity arm prevents a near-duplicate of a
-// VERIFIED finding from leaking into the REFUTED list.
-function findingsMatch(a, b) {
-  if (basename(a.file) !== basename(b.file)) return false
-  const la = a.line || 0
-  const lb = b.line || 0
-  if (la > 0 && lb > 0 && Math.abs(la - lb) <= 8) return true
-  return titleOverlap(a, b) >= 0.5
-}
+// Tier ordering, used only to sort the consolidated report (the prompt builders
+// and dedup / cross-family-verify helpers all live in the dual-family-review engine).
 function tierRank(t) {
   return t === 'P0' ? 0 : t === 'P1' ? 1 : 2
 }
-function verifyVotes(tier) {
-  // Cross-family independence is achieved with a single vote from the OTHER
-  // family. Extra votes (budget-scaled, diverse lenses) harden the P0s only.
-  if (tier === 'P0') {
-    if (budget && budget.total) return Math.min(3, 2 + Math.floor((budget.remaining() || 0) / 400000))
-    return 2
-  }
-  if (tier === 'P1') return 1
-  return 0
-}
-const LENSES = [
-  '',
-  'Focus specifically on the PRIMARY SOURCE: does the cited SAMMY/ENDF reference actually say what the finding claims? Misread conventions are the most common false positive here.',
-  'Focus on REPRODUCIBILITY: construct the concrete input that would trigger the defect. If no plausible input triggers it, lean REFUTED.',
-]
 
 // ---------------------------------------------------------------------------
 // Phase: Preflight
@@ -544,171 +266,49 @@ if (pf.isWorktree && !pf.sammyRoot) {
 }
 
 // ---------------------------------------------------------------------------
-// Phases: Find -> Verify (pipelined per domain; no barrier between them)
-// As soon as domain X's two finders complete, X's findings are cross-verified
-// while domain Y is still finding.
+// Build the per-domain target list and hand off to the shared
+// dual-family-review engine (Find -> Verify). The engine returns structured
+// per-target findings; this wrapper consolidates them below. The scope
+// directive is identical for every domain (it depends only on MODE/DIFF_SPEC),
+// matching the original inline behaviour where `scope` was computed per call.
 // ---------------------------------------------------------------------------
-const perDomain = await pipeline(
-  DOMAINS,
+const scopeDirective =
+  MODE === 'diff'
+    ? `Audit ONLY the changes in \`git diff ${DIFF_SPEC}\` that touch this domain. Run the diff, read each changed file in full, but report findings only for code introduced or altered by the diff.`
+    : `Audit the FULL crate(s) for this domain (a whole-codebase sweep, not a diff).`
 
-  // -- Find: Claude finder + Codex finder, concurrently, for this domain.
-  (d) =>
-    parallel([
-      () =>
-        agent(buildAuditPrompt(d, pf, false) + '\n\nReturn your findings via the structured output tool.' + DETECTION_ONLY, {
-          label: `find:claude:${d.key}`,
-          phase: 'Find',
-          schema: FINDINGS_SCHEMA,
-          agentType: READER_TYPE,
-        }),
-      () =>
-        codexUsable
-          ? agent(codexFinderPrompt(d, pf) + DETECTION_ONLY, {
-              label: `find:codex:${d.key}`,
-              phase: 'Find',
-              schema: FINDINGS_SCHEMA,
-              agentType: RUNNER_TYPE,
-            })
-          : Promise.resolve(null),
-    ]).then(([claudeRes, codexRes]) => ({ domain: d, claude: claudeRes, codex: codexRes })),
+const targets = DOMAINS.map((d) => ({
+  key: d.key,
+  name: d.name,
+  paths: d.paths,
+  sammy: d.sammy,
+  blurb: d.blurb,
+  p0: d.p0,
+  lookFor: d.lookFor,
+  primaryHint: d.primaryHint,
+  scopeDirective,
+}))
 
-  // -- Verify: cross-family confirmation of single-family findings.
-  async (fr) => {
-    const d = fr.domain
-    const claudeF = (fr.claude && fr.claude.findings) || []
-    const codexF = (fr.codex && fr.codex.findings) || []
-    const codexOk = !!fr.codex && !fr.codex.codexFailed
-
-    // Stamp each finding with its source family + a stable id.
-    claudeF.forEach((f, i) => {
-      f.family = 'claude'
-      f.id = `${d.key}-C-${f.localId || i + 1}`
-    })
-    codexF.forEach((f, i) => {
-      f.family = 'codex'
-      f.id = `${d.key}-X-${f.localId || i + 1}`
-    })
-
-    // 1) cross-confirmed at FIND time (both families independently found it).
-    const crossConfirmed = []
-    const codexMatched = new Set()
-    for (const cf of claudeF) {
-      const m = codexF.find((xf, j) => !codexMatched.has(j) && findingsMatch(cf, xf))
-      if (m) {
-        const j = codexF.indexOf(m)
-        codexMatched.add(j)
-        crossConfirmed.push({
-          ...cf,
-          tier: tierRank(cf.tier) <= tierRank(m.tier) ? cf.tier : m.tier, // keep the more severe
-          status: 'VERIFIED',
-          basis: 'cross-confirmed at find time (both Claude and Codex independently)',
-          codexCounterpart: m.id,
-        })
-      }
-    }
-    const matchedClaudeIds = new Set(crossConfirmed.map((c) => c.id))
-    const claudeOnly = claudeF.filter((f) => !matchedClaudeIds.has(f.id))
-    const codexOnly = codexF.filter((_, j) => !codexMatched.has(j))
-
-    // 2) singletons (P0/P1) -> adversarial verification by the OTHER family.
-    const toVerify = []
-    for (const f of claudeOnly) if (verifyVotes(f.tier) > 0) toVerify.push({ f, verifier: 'codex' })
-    for (const f of codexOnly) if (verifyVotes(f.tier) > 0) toVerify.push({ f, verifier: 'claude' })
-
-    const verifyResults = await parallel(
-      toVerify.flatMap(({ f, verifier }) => {
-        const n = verifyVotes(f.tier)
-        return Array.from({ length: n }, (_v, vi) => () => {
-          // If the required verifier family is unavailable, no cross-family vote.
-          if (verifier === 'codex' && !codexOk)
-            return Promise.resolve({ fid: f.id, f, verdict: null, unavailable: true })
-          const lens = LENSES[vi % LENSES.length]
-          const id = `${f.id}-v${vi}`
-          const p =
-            verifier === 'claude'
-              ? agent(claudeVerifyPrompt(f, pf, lens) + DETECTION_ONLY, {
-                  label: `verify:claude:${id}`,
-                  phase: 'Verify',
-                  schema: VERDICT_SCHEMA,
-                  agentType: READER_TYPE,
-                })
-              : agent(codexVerifyPrompt(f, pf, id, lens) + DETECTION_ONLY, {
-                  label: `verify:codex:${id}`,
-                  phase: 'Verify',
-                  schema: VERDICT_SCHEMA,
-                  agentType: RUNNER_TYPE,
-                })
-          return p.then((v) => ({ fid: f.id, f, verdict: v }))
-        })
-      }),
-    )
-
-    // 3) aggregate votes per finding.
-    const votesByFinding = new Map()
-    for (const r of verifyResults.filter(Boolean)) {
-      if (!votesByFinding.has(r.fid)) votesByFinding.set(r.fid, { f: r.f, votes: [], unavailable: false })
-      const e = votesByFinding.get(r.fid)
-      if (r.unavailable) e.unavailable = true
-      else if (r.verdict) e.votes.push(r.verdict)
-    }
-
-    const verified = [...crossConfirmed]
-    const needsVerification = []
-    const refuted = []
-    for (const [, e] of votesByFinding) {
-      const conf = e.votes.filter((v) => v.verdict === 'CONFIRMED').length
-      const refu = e.votes.filter((v) => v.verdict === 'REFUTED').length
-      // verifier's independent tier can downgrade the original
-      const correctedTiers = e.votes.map((v) => v.correctedTier).filter((t) => t && t !== 'NONE')
-      const entry = {
-        ...e.f,
-        crossFamilyVotes: e.votes,
-        basis: `cross-family (${e.f.family === 'claude' ? 'codex' : 'claude'}) verification`,
-      }
-      if (e.unavailable || e.votes.length === 0) {
-        entry.status = 'NEEDS-VERIFICATION'
-        entry.note = e.unavailable ? 'cross-family verifier unavailable (single-LLM-family only)' : 'no verdict returned'
-        needsVerification.push(entry)
-      } else if (conf > refu) {
-        entry.status = 'VERIFIED'
-        if (correctedTiers.length) entry.verifierTier = correctedTiers.sort((a, b) => tierRank(a) - tierRank(b))[0]
-        verified.push(entry)
-      } else if (refu > conf) {
-        entry.status = 'REFUTED'
-        refuted.push(entry)
-      } else {
-        entry.status = 'NEEDS-VERIFICATION'
-        entry.note = 'split vote'
-        needsVerification.push(entry)
-      }
-    }
-
-    // P2s: reported as-is (not verified), tagged by family.
-    const p2s = [...claudeF, ...codexF].filter((f) => f.tier === 'P2')
-    // circular-validation flags from any finding + any confirmed-by-verifier
-    const circular = [...claudeF, ...codexF]
-      .filter((f) => f.circularValidationRisk && f.circularValidationRisk.trim())
-      .map((f) => ({ id: f.id, file: f.file, line: f.line, family: f.family, note: f.circularValidationRisk }))
-
-    return {
-      domainKey: d.key,
-      domainName: d.name,
-      claudeAssessment: (fr.claude && fr.claude.assessment) || '(no claude result)',
-      codexAssessment: codexOk ? fr.codex.assessment : codexUsable ? `codex failed: ${fr.codex && fr.codex.failureReason}` : 'codex disabled',
-      tierCounts: {
-        claude: (fr.claude && fr.claude.tierCounts) || { p0: 0, p1: 0, p2: 0 },
-        codex: codexOk ? fr.codex.tierCounts : { p0: 0, p1: 0, p2: 0 },
-      },
-      verified,
-      needsVerification,
-      refuted,
-      p2s,
-      circular,
-    }
+const engineOut = await workflow('dual-family-review', {
+  pf: {
+    repoRoot: pf.repoRoot,
+    sammyRoot: pf.sammyRoot,
+    codexAvailable: pf.codexAvailable,
+    codexVersion: pf.codexVersion,
+    headSha: pf.headSha,
+    isWorktree: pf.isWorktree,
   },
-)
+  targets,
+  config: {
+    contextNote: CONTEXT_NOTE,
+    roundNote: ROUND_NOTE,
+    skipCodex: SKIP_CODEX,
+    hardEnforce: HARD,
+    sammyRootOverride: A.sammyRoot || '',
+  },
+})
 
-const domainResults = perDomain.filter(Boolean)
+const domainResults = (engineOut && engineOut.perTarget) || []
 
 // ---------------------------------------------------------------------------
 // Phase: Consolidate (barrier — needs every domain to dedup across domains)

--- a/.claude/workflows/nereids-bug-hunt.js
+++ b/.claude/workflows/nereids-bug-hunt.js
@@ -226,6 +226,12 @@ function tierRank(t) {
 phase('Preflight')
 const domainKeys = Array.isArray(A.domains) && A.domains.length ? A.domains : ALL_DOMAINS.map((d) => d.key)
 const DOMAINS = ALL_DOMAINS.filter((d) => domainKeys.includes(d.key))
+// Fail closed on a misspelled args.domains key: an empty domain set must abort,
+// not sail through the engine to a "0 findings" all-clear report.
+if (!DOMAINS.length) {
+  log(`No domains matched ${JSON.stringify(domainKeys)} — check args.domains spelling. Aborting rather than emit a 0-findings all-clear.`)
+  return { aborted: true, reason: 'no domains matched (check args.domains)' }
+}
 
 const pf = await agent(
   `Resolve the environment for a NEREIDS bug-hunt. Run these and report via structured output:
@@ -308,7 +314,19 @@ const engineOut = await workflow('dual-family-review', {
   },
 })
 
-const domainResults = (engineOut && engineOut.perTarget) || []
+// Fail closed: the engine owns the entire Find/Verify phase, so a missing,
+// malformed, or count-mismatched result must abort loudly — never degrade to a
+// "0 findings" all-clear report the user might read as paper-ready.
+if (!engineOut || !Array.isArray(engineOut.perTarget)) {
+  throw new Error('dual-family-review returned no usable result (engineOut.perTarget missing) — aborting rather than emit a false all-clear.')
+}
+if (engineOut.perTarget.length !== targets.length) {
+  throw new Error(
+    `dual-family-review returned ${engineOut.perTarget.length} result(s) for ${targets.length} target(s)` +
+      `${engineOut.droppedTargets ? ` (${engineOut.droppedTargets} dropped to a pipeline error)` : ''} — aborting rather than under-report.`,
+  )
+}
+const domainResults = engineOut.perTarget
 
 // ---------------------------------------------------------------------------
 // Phase: Consolidate (barrier — needs every domain to dedup across domains)
@@ -318,10 +336,14 @@ phase('Consolidate')
 const allVerified = domainResults.flatMap((r) => r.verified)
 const verifiedP0 = allVerified.filter((f) => (f.verifierTier || f.tier) === 'P0').sort((a, b) => tierRank(a.tier) - tierRank(b.tier))
 const verifiedP1 = allVerified.filter((f) => (f.verifierTier || f.tier) === 'P1')
+// A cross-family-CONFIRMED finding the verifier downgraded to effective P2 is a
+// real (if low-severity) defect; fold it into the P2 backlog so it is counted,
+// not dropped between the P0/P1 buckets and r.p2s (original-tier P2s only).
+const verifiedP2 = allVerified.filter((f) => (f.verifierTier || f.tier) === 'P2')
 const needsVerification = domainResults.flatMap((r) => r.needsVerification)
 const refuted = domainResults.flatMap((r) => r.refuted)
 const circular = domainResults.flatMap((r) => r.circular)
-const p2Backlog = domainResults.flatMap((r) => r.p2s)
+const p2Backlog = [...domainResults.flatMap((r) => r.p2s), ...verifiedP2]
 
 const tierTable = domainResults.map((r) => ({
   domain: r.domainKey,

--- a/.claude/workflows/review-core.js
+++ b/.claude/workflows/review-core.js
@@ -8,7 +8,7 @@ export const meta = {
     { title: 'Discover', detail: 'enumerate diverged branches, diffs, file-overlap, merge order' },
     { title: 'Find', detail: 'Claude + Codex finder per branch diff (dual-family-review engine)' },
     { title: 'Verify', detail: 'cross-LLM-family confirmation (dual-family-review engine)' },
-    { title: 'Consolidate', detail: 'dedup, suggested disposition, RECURRING, merge order (deterministic JS)' },
+    { title: 'Consolidate', detail: 'suggested disposition, RECURRING tags, merge order (deterministic JS)' },
   ],
 }
 
@@ -85,11 +85,13 @@ function basename(f) {
 }
 // Slug a branch name into something safe for finding-ids and the engine's
 // `/tmp/bughunt-<slug>.prompt` codex temp path (branch names contain '/').
-// INJECTIVE: a short stable hash of the FULL name is appended so distinct
-// branches (e.g. `fix/foo-bar` vs `fix/foo/bar`) never collide to one key — a
-// collision would attach wrong crate metadata to one branch's findings and race
-// the two branches' codex temp files. djb2-style; deterministic (Date/random
-// are unavailable in workflow scripts).
+// COLLISION-RESISTANT: a short stable hash of the FULL name is appended so
+// distinct branches (e.g. `fix/foo-bar` vs `fix/foo/bar`) do not collide to one
+// key — a collision would attach wrong crate metadata to one branch's findings
+// and race the two branches' codex temp files. The 32-bit djb2 hash is not
+// provably injective (a hash CAN collide), but across the handful of branches in
+// a review batch the probability is negligible. Deterministic (Date/random are
+// unavailable in workflow scripts).
 function slug(b) {
   const s = String(b || '')
   const base = s.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'branch'
@@ -205,6 +207,20 @@ if (A.repoRoot) discover.repoRoot = A.repoRoot
 const sammyRoot = A.sammyRoot || discover.sammyRoot || ''
 const codexUsable = discover.codexAvailable && !SKIP_CODEX
 
+// Fail closed on a requested branch that discovery did not return (mistyped /
+// unresolvable ref, or a failed git command): a dropped EXPLICITLY-requested
+// branch must abort, not masquerade as "nothing to review". (Auto-discover
+// finding nothing is a valid no-op; an explicit request going missing is not.)
+if (BRANCHES) {
+  const found = new Set((discover.branches || []).map((b) => b.branch))
+  const missing = BRANCHES.filter((b) => !found.has(b))
+  if (missing.length) {
+    throw new Error(
+      `review-core: discovery did not return requested branch(es) [${missing.join(', ')}] vs base '${BASE}' — aborting rather than report a false all-clear. Check the branch name(s) and that '${BASE}' resolves.`,
+    )
+  }
+}
+
 // Only review branches that actually diverged from base (have new commits).
 const reviewable = (discover.branches || []).filter((b) => b.diverged && (b.changedFiles || []).length)
 log(
@@ -312,11 +328,13 @@ const perBranch = perTarget.map((r) => {
   const verified = (r.verified || []).map(tag)
   const verifiedP0 = verified.filter((f) => (f.verifierTier || f.tier) === 'P0')
   const verifiedP1 = verified.filter((f) => (f.verifierTier || f.tier) === 'P1')
-  // Cross-family-CONFIRMED findings the verifier downgraded to effective P2 are
-  // real defects; route them into the P2 disposition channel below so they are
-  // surfaced (with a disposition + their VERIFIED status) rather than dropped
-  // between the P0/P1 buckets and r.p2s (which holds only original-tier P2s).
-  const verifiedP2 = verified.filter((f) => (f.verifierTier || f.tier) === 'P2')
+  // Cross-family-CONFIRMED findings the verifier DOWNGRADED to effective P2
+  // (original tier P0/P1) are real defects; route them into the P2 disposition
+  // channel below so they are surfaced (with a disposition + their VERIFIED
+  // status) rather than dropped between the P0/P1 buckets and r.p2s. Restrict to
+  // GENUINELY-downgraded findings (verifierTier === 'P2' && tier !== 'P2'): a
+  // born-P2 finding is already in r.p2s, so matching it here would double-count it.
+  const verifiedP2 = verified.filter((f) => f.verifierTier === 'P2' && f.tier !== 'P2')
   const needsVerification = (r.needsVerification || []).map(tag)
   const refuted = (r.refuted || []).map(tag)
   const circular = r.circular || []
@@ -334,6 +352,12 @@ const perBranch = perTarget.map((r) => {
     return entry
   })
 
+  // Dedupe the recurring set by finding id: a verifier-downgraded P2 lives in
+  // both `verified` and the folded `p2s`, so a naive concat would count it twice.
+  const recurring = [
+    ...new Map([...verified, ...needsVerification, ...p2s].filter((f) => f.recurring).map((f) => [f.id, f])).values(),
+  ]
+
   return {
     branch,
     crates: meta.crates,
@@ -346,7 +370,7 @@ const perBranch = perTarget.map((r) => {
     refuted,
     p2s,
     circular,
-    recurring: [...verified, ...needsVerification, ...p2s].filter((f) => f.recurring),
+    recurring,
   }
 })
 

--- a/.claude/workflows/review-core.js
+++ b/.claude/workflows/review-core.js
@@ -1,0 +1,358 @@
+export const meta = {
+  name: 'review-core',
+  description:
+    'Deterministic core of /review-pipeline for ONE review round: discover diverged branches, run the two-LLM-family review engine over each branch diff, consolidate into per-branch findings + suggested disposition + merge order. Detection-only — returns structured data for the skill to gate on; never fixes, pushes, or merges.',
+  whenToUse:
+    'Invoked by the /review-pipeline skill once per review round (NOT run directly by a human). It owns the non-interactive fan-out — discover + dual-family review + consolidate — so reviewer output is one schema-forced format across models and the steps cannot be silently skipped. All user gates, fixes, pushes, merges, and issue-filing stay in the skill (a workflow cannot pause for input, so every gate must fall on a workflow boundary).',
+  phases: [
+    { title: 'Discover', detail: 'enumerate diverged branches, diffs, file-overlap, merge order' },
+    { title: 'Find', detail: 'Claude + Codex finder per branch diff (dual-family-review engine)' },
+    { title: 'Verify', detail: 'cross-LLM-family confirmation (dual-family-review engine)' },
+    { title: 'Consolidate', detail: 'dedup, suggested disposition, RECURRING, merge order (deterministic JS)' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// review-core — the deterministic heart of /review-pipeline.
+//
+// One invocation == one review round. The /review-pipeline skill calls this
+// per round (passing the previous round's findings for RECURRING detection),
+// renders the returned structured payload as a consistent per-branch table at
+// the user gate, then — only after the user approves — drives the fix / push /
+// Copilot / merge steps itself. Those are interactive or state-changing, and a
+// Workflow runs unattended to completion, so they MUST stay in the skill.
+//
+// What this workflow guarantees (the two goals of the refactor):
+//   - consistent format across models: every reviewer (Claude finder, Codex
+//     finder, and every cross-family verifier) emits the SAME schema, via the
+//     shared dual-family-review engine; cross-confirm + dedup are deterministic
+//     JS, not the main agent eyeballing prose;
+//   - no silently-skipped steps: discover -> find(2 families) -> verify ->
+//     consolidate is JS control flow, run for every branch every round.
+//
+// Detection-only: this workflow + the engine FIND and REPORT; they never fix.
+// Fixing is a separate, human-gated step (the skill's fix stage +
+// .claude/templates/fix-subagent-prompt.md). The audit->fix->review cycle is
+// non-idempotent, which is exactly why detection and fixing are separated.
+//
+// args (all optional):
+//   args.branches     : string[]  explicit branch list to review (default:
+//                                  auto-discover diverged worktree branches)
+//   args.base         : string    base ref to diff against (default 'main')
+//   args.round        : integer   review round number, for the header (default 1)
+//   args.priorFindings: object[]  last round's findings ({branch,file,line,title})
+//                                  used to tag RECURRING (default none)
+//   args.skipCodex    : boolean   Claude-only (single-family -> NEEDS-VERIFICATION)
+//   args.hardEnforce  : boolean   use restricted bug-hunt-{reader,runner} agents
+//   args.repoRoot     : string    explicit canonical root (overrides git-detected)
+//   args.sammyRoot    : string    override SAMMY source root for physics checks
+// ---------------------------------------------------------------------------
+
+// Defensive arg unpacking (a caller may pass a JSON-encoded string).
+let A = {}
+if (args && typeof args === 'object') A = args
+else if (typeof args === 'string' && args.trim().startsWith('{')) {
+  try {
+    A = JSON.parse(args)
+  } catch (_e) {
+    A = {}
+  }
+}
+const BRANCHES = Array.isArray(A.branches) && A.branches.length ? A.branches : null
+const BASE = A.base || 'main'
+const ROUND = Number.isInteger(A.round) ? A.round : 1
+const PRIOR = Array.isArray(A.priorFindings) ? A.priorFindings : []
+const SKIP_CODEX = A.skipCodex === true
+const HARD = A.hardEnforce === true
+const READER_TYPE = HARD ? 'bug-hunt-reader' : 'general-purpose'
+
+// Primary-source hints for branches that touch physics / ENDF (so the engine's
+// finder opens SAMMY / the ENDF manual). Compact on purpose — the engine's
+// CORE_CHECKLIST covers the generic bug classes; this only adds the SAMMY hook.
+const PHYSICS_HINT =
+  'SAMMY SLBW/MLBW `src/mlb/`, phase/penetrability `src/xxx/`, RML `src/rml/`, Reich-Moore `src/endf/`. Compare physics line-by-line and cite `file:line`.'
+const ENDF_HINT = 'ENDF-6 Formats Manual record layouts; SAMMY `src/endf/` for LRF=3/7 reference.'
+
+// ---- pure helpers ---------------------------------------------------------
+
+function normFile(f) {
+  return String(f || '').replace(/^\.\//, '').trim()
+}
+function basename(f) {
+  const p = normFile(f).split('/')
+  return p[p.length - 1]
+}
+// Slug a branch name into something safe for finding-ids and the engine's
+// `/tmp/bughunt-<slug>.prompt` codex temp path (branch names contain '/').
+function slug(b) {
+  return String(b || '')
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+// Which crate (top-2 path segments) a changed file belongs to, for the blurb.
+function crateOf(f) {
+  const parts = normFile(f).split('/')
+  if (parts[0] === 'crates' || parts[0] === 'bindings' || parts[0] === 'apps') return parts.slice(0, 2).join('/')
+  return parts[0] || '(root)'
+}
+function classifyBranch(changedFiles) {
+  const files = (changedFiles || []).map(normFile).filter(Boolean)
+  const touchesPhysics = files.some((f) => f.startsWith('crates/nereids-physics/'))
+  const touchesEndf = files.some((f) => f.startsWith('crates/nereids-endf/') || f.startsWith('crates/endf-mat/'))
+  const sammy = touchesPhysics || touchesEndf
+  const primaryHint = touchesPhysics ? PHYSICS_HINT : touchesEndf ? ENDF_HINT : ''
+  const crates = [...new Set(files.map(crateOf))]
+  // Focus the finder on the changed crate dirs (deduped, dir-level).
+  const focusPaths = [...new Set(files.map((f) => normFile(f).split('/').slice(0, 2).join('/') + '/'))]
+  return { sammy, primaryHint, crates, focusPaths: focusPaths.length ? focusPaths : ['(repo root)'] }
+}
+// A this-round finding "recurs" if a prior-round finding hit the same branch +
+// same file basename and either a close line or a near-identical title.
+function isRecurring(branch, f) {
+  const fl = f.line || 0
+  return PRIOR.some((p) => {
+    if (p.branch && p.branch !== branch) return false
+    if (basename(p.file) !== basename(f.file)) return false
+    const pl = p.line || 0
+    if (pl > 0 && fl > 0 && Math.abs(pl - fl) <= 8) return true
+    return String(p.title || '').trim() && String(p.title).trim() === String(f.title || '').trim()
+  })
+}
+// Branch whose changed files this finding lives in (for same-crate P2 discipline).
+function fileInChangedCrates(file, crates) {
+  const c = crateOf(file)
+  return crates.includes(c)
+}
+
+const DISCOVER_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    repoRoot: { type: 'string' },
+    isWorktree: { type: 'boolean' },
+    codexAvailable: { type: 'boolean' },
+    codexVersion: { type: 'string' },
+    sammyRoot: { type: 'string', description: 'resolved SAMMY src root, or empty if not found' },
+    headSha: { type: 'string' },
+    base: { type: 'string' },
+    branches: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          branch: { type: 'string' },
+          changedFiles: { type: 'array', items: { type: 'string' } },
+          diffLineCount: { type: 'integer', description: 'total added+deleted lines vs base; 0 if unknown' },
+          diverged: { type: 'boolean', description: 'true if the branch has commits not in base' },
+        },
+        required: ['branch', 'changedFiles', 'diverged'],
+      },
+    },
+  },
+  required: ['repoRoot', 'isWorktree', 'codexAvailable', 'base', 'branches'],
+}
+
+// ---------------------------------------------------------------------------
+// Phase: Discover — enumerate target branches + their diffs (read-only git).
+// ---------------------------------------------------------------------------
+phase('Discover')
+
+const branchInstruction = BRANCHES
+  ? `Review exactly these branches (do NOT auto-discover): ${BRANCHES.join(', ')}.`
+  : `Auto-discover targets: run \`git worktree list\` and, for each worktree under \`.claude/worktrees/\`, take its checked-out branch. Skip the base branch itself.`
+
+const discover = await agent(
+  `Resolve the environment + discover branches to review for a NEREIDS review round. Read-only git only; change nothing. Report via structured output.
+
+Base ref: \`${BASE}\`.
+${branchInstruction}
+
+Gather:
+- repoRoot: \`git rev-parse --show-toplevel\`${A.repoRoot ? ` (but report the canonical root \`${A.repoRoot}\`)` : ''}
+- isWorktree: true if repoRoot contains "/.claude/worktrees/" OR \`git rev-parse --git-common-dir\` differs from \`git rev-parse --git-dir\`
+- headSha: \`git rev-parse --short HEAD\`
+- codexAvailable / codexVersion: \`command -v codex && codex --version\` (false + empty if absent)
+- sammyRoot: first of these that exists as a directory (test -d), else empty:
+    /Users/8cz/code-int.ornl.gov/sammy/sammy/src
+    "$(git rev-parse --show-toplevel)/../SAMMY/src"
+    "$(git rev-parse --show-toplevel)/../SAMMY/sammy/src"
+- base: "${BASE}"
+- branches: for each target branch, report:
+    - branch: the branch name
+    - diverged: true if \`git rev-list --count ${BASE}..<branch>\` > 0 (it has commits not in ${BASE})
+    - changedFiles: the output of \`git diff --name-only ${BASE}...<branch>\` (the three-dot merge-base diff), as a list
+    - diffLineCount: total added+deleted lines, from \`git diff --shortstat ${BASE}...<branch>\` (sum insertions+deletions; 0 if none)
+  Use branch NAMES with git (refs are shared across worktrees); do NOT cd into sibling worktree paths and do NOT use \`git -C <other-worktree>\` (sandboxing blocks that). \`git diff ${BASE}...<branch>\` and \`git show <branch>:<path>\` resolve fine from here.
+
+Be terse; just gather facts.`,
+  { label: 'discover', phase: 'Discover', schema: DISCOVER_SCHEMA, agentType: READER_TYPE },
+)
+
+if (!discover) {
+  log('Discover was skipped — aborting review-core.')
+  return { aborted: true, reason: 'discover skipped' }
+}
+if (A.repoRoot) discover.repoRoot = A.repoRoot
+const sammyRoot = A.sammyRoot || discover.sammyRoot || ''
+const codexUsable = discover.codexAvailable && !SKIP_CODEX
+
+// Only review branches that actually diverged from base (have new commits).
+const reviewable = (discover.branches || []).filter((b) => b.diverged && (b.changedFiles || []).length)
+log(
+  `round ${ROUND} | base=${BASE} | branches=${reviewable.length}/${(discover.branches || []).length} reviewable | ` +
+    `codex=${codexUsable ? discover.codexVersion || 'yes' : 'DISABLED (single-family — findings NEEDS-VERIFICATION)'} | ` +
+    `sammy=${sammyRoot || 'NOT FOUND (physics findings lower-confidence)'}`,
+)
+
+if (!reviewable.length) {
+  log('No diverged branches with changes — nothing to review.')
+  return {
+    meta: { round: ROUND, base: BASE, repoRoot: discover.repoRoot, headSha: discover.headSha, codexUsable, sammyRoot, isWorktree: discover.isWorktree },
+    perBranch: [],
+    mergeOrder: [],
+    overlaps: [],
+    deferredP2s: [],
+    counts: { branches: 0, verifiedP0: 0, verifiedP1: 0, needsVerification: 0, refuted: 0, p2: 0, recurring: 0 },
+  }
+}
+
+// File-overlap matrix + suggested merge order (deterministic JS, not LLM-judged).
+const fileSets = new Map(reviewable.map((b) => [b.branch, new Set((b.changedFiles || []).map(normFile))]))
+const overlaps = []
+for (let i = 0; i < reviewable.length; i++) {
+  for (let j = i + 1; j < reviewable.length; j++) {
+    const a = reviewable[i].branch
+    const b = reviewable[j].branch
+    const shared = [...fileSets.get(a)].filter((f) => fileSets.get(b).has(f))
+    if (shared.length) overlaps.push({ a, b, sharedFiles: shared })
+  }
+}
+// Merge order: smallest diff first (a larger diff is likelier to need rebasing
+// after a smaller overlapping one lands). Non-overlapping branches are
+// parallel-safe and fall out of the same size sort.
+const mergeOrder = [...reviewable]
+  .sort((x, y) => (x.diffLineCount || 0) - (y.diffLineCount || 0) || x.branch.localeCompare(y.branch))
+  .map((b) => b.branch)
+
+// ---------------------------------------------------------------------------
+// Build one engine target per branch and hand off to dual-family-review.
+// ---------------------------------------------------------------------------
+const branchMeta = new Map()
+const targets = reviewable.map((b) => {
+  const cls = classifyBranch(b.changedFiles)
+  branchMeta.set(slug(b.branch), { branch: b.branch, crates: cls.crates })
+  return {
+    key: slug(b.branch),
+    name: `branch ${b.branch}`,
+    paths: cls.focusPaths,
+    sammy: cls.sammy,
+    blurb: `the changes on branch \`${b.branch}\` vs \`${BASE}\` (${(b.changedFiles || []).length} files in: ${cls.crates.join(', ') || '(root)'})`,
+    p0: 'A correctness regression introduced by this branch: a logic bug, a panic on valid input, a numerical/physics error vs SAMMY, data corruption, or a silently-masked whole-config error.',
+    lookFor: [],
+    primaryHint: cls.primaryHint,
+    scopeDirective: `Audit ONLY the changes in \`git diff ${BASE}...${b.branch}\`. Run that diff, then read each changed file IN FULL via \`git show ${b.branch}:<path>\` (the branch may not be checked out here). Report findings only for code introduced or altered by this branch's diff, plus any pre-existing call site the diff newly breaks.`,
+  }
+})
+
+const engineOut = await workflow('dual-family-review', {
+  pf: {
+    repoRoot: discover.repoRoot,
+    sammyRoot,
+    codexAvailable: discover.codexAvailable,
+    codexVersion: discover.codexVersion,
+    headSha: discover.headSha,
+    isWorktree: discover.isWorktree,
+  },
+  targets,
+  config: {
+    contextNote: `Per-PR review round ${ROUND}. Each target is one branch's diff vs ${BASE}.`,
+    roundNote: `review Round ${ROUND}`,
+    skipCodex: SKIP_CODEX,
+    hardEnforce: HARD,
+    sammyRootOverride: A.sammyRoot || '',
+  },
+})
+
+const perTarget = (engineOut && engineOut.perTarget) || []
+
+// ---------------------------------------------------------------------------
+// Phase: Consolidate (deterministic JS) — per-branch findings, suggested
+// disposition, RECURRING tags, deferred-P2 list. No file is written; the
+// structured payload goes back to the skill, which renders + gates on it.
+// ---------------------------------------------------------------------------
+phase('Consolidate')
+
+const deferredP2s = []
+const perBranch = perTarget.map((r) => {
+  const meta = branchMeta.get(r.domainKey) || { branch: r.domainKey, crates: [] }
+  const branch = meta.branch
+  const tag = (f) => ({ ...f, branch, recurring: isRecurring(branch, f) })
+
+  const verified = (r.verified || []).map(tag)
+  const verifiedP0 = verified.filter((f) => (f.verifierTier || f.tier) === 'P0')
+  const verifiedP1 = verified.filter((f) => (f.verifierTier || f.tier) === 'P1')
+  const needsVerification = (r.needsVerification || []).map(tag)
+  const refuted = (r.refuted || []).map(tag)
+  const circular = r.circular || []
+
+  // Suggested disposition (the skill presents these; the USER decides at the gate):
+  //  - verified P0/P1  -> fix-now
+  //  - P2 in a crate this branch already changes -> fix-now (same-crate P2 discipline)
+  //  - P2 elsewhere    -> defer (collected into deferredP2s for issue-filing)
+  //  - refuted         -> dismiss
+  const p2s = (r.p2s || []).map((f) => {
+    const sameCrate = fileInChangedCrates(f.file, meta.crates)
+    const disposition = sameCrate ? 'fix-now' : 'defer'
+    const entry = { ...f, branch, recurring: isRecurring(branch, f), disposition }
+    if (disposition === 'defer') deferredP2s.push(entry)
+    return entry
+  })
+
+  return {
+    branch,
+    crates: meta.crates,
+    claudeAssessment: r.claudeAssessment,
+    codexAssessment: r.codexAssessment,
+    tierCounts: r.tierCounts,
+    verifiedP0,
+    verifiedP1,
+    needsVerification,
+    refuted,
+    p2s,
+    circular,
+    recurring: [...verified, ...needsVerification].filter((f) => f.recurring),
+  }
+})
+
+const counts = {
+  branches: perBranch.length,
+  verifiedP0: perBranch.reduce((n, b) => n + b.verifiedP0.length, 0),
+  verifiedP1: perBranch.reduce((n, b) => n + b.verifiedP1.length, 0),
+  needsVerification: perBranch.reduce((n, b) => n + b.needsVerification.length, 0),
+  refuted: perBranch.reduce((n, b) => n + b.refuted.length, 0),
+  p2: perBranch.reduce((n, b) => n + b.p2s.length, 0),
+  recurring: perBranch.reduce((n, b) => n + b.recurring.length, 0),
+}
+
+log(
+  `round ${ROUND} consolidated: ${counts.verifiedP0} VERIFIED P0, ${counts.verifiedP1} VERIFIED P1, ` +
+    `${counts.needsVerification} NEEDS-VERIFICATION, ${counts.refuted} refuted, ${counts.p2} P2, ${counts.recurring} RECURRING.`,
+)
+
+return {
+  meta: {
+    round: ROUND,
+    base: BASE,
+    repoRoot: discover.repoRoot,
+    headSha: discover.headSha,
+    codexUsable,
+    sammyRoot: sammyRoot || '(not found)',
+    isWorktree: discover.isWorktree,
+  },
+  mergeOrder,
+  overlaps,
+  perBranch,
+  deferredP2s, // the skill files these as issues at the end (no longer a skippable plea)
+  counts,
+}

--- a/.claude/workflows/review-core.js
+++ b/.claude/workflows/review-core.js
@@ -221,8 +221,14 @@ if (BRANCHES) {
   }
 }
 
-// Only review branches that actually diverged from base (have new commits).
-const reviewable = (discover.branches || []).filter((b) => b.diverged && (b.changedFiles || []).length)
+// Dedupe discovered branches by name before filtering: if the discover agent
+// emits a branch twice (e.g. the same branch checked out in two worktrees with
+// shared refs), two same-`slug` targets would slip past the engine's
+// count-mismatch guard (N in, N out) and the branch would be presented + counted
+// twice. Only review branches that actually diverged from base (have new commits).
+const reviewable = [...new Map((discover.branches || []).map((b) => [b.branch, b])).values()].filter(
+  (b) => b.diverged && (b.changedFiles || []).length,
+)
 log(
   `round ${ROUND} | base=${BASE} | branches=${reviewable.length}/${(discover.branches || []).length} reviewable | ` +
     `codex=${codexUsable ? discover.codexVersion || 'yes' : 'DISABLED (single-family — P0/P1 findings NEEDS-VERIFICATION)'} | ` +

--- a/.claude/workflows/review-core.js
+++ b/.claude/workflows/review-core.js
@@ -42,7 +42,8 @@ export const meta = {
 //   args.round        : integer   review round number, for the header (default 1)
 //   args.priorFindings: object[]  last round's findings ({branch,file,line,title})
 //                                  used to tag RECURRING (default none)
-//   args.skipCodex    : boolean   Claude-only (single-family -> NEEDS-VERIFICATION)
+//   args.skipCodex    : boolean   Claude-only (single-family -> P0/P1 NEEDS-VERIFICATION;
+//                                  P2s are single-family-reported either way)
 //   args.hardEnforce  : boolean   use restricted bug-hunt-{reader,runner} agents
 //   args.repoRoot     : string    explicit canonical root (overrides git-detected)
 //   args.sammyRoot    : string    override SAMMY source root for physics checks
@@ -84,10 +85,17 @@ function basename(f) {
 }
 // Slug a branch name into something safe for finding-ids and the engine's
 // `/tmp/bughunt-<slug>.prompt` codex temp path (branch names contain '/').
+// INJECTIVE: a short stable hash of the FULL name is appended so distinct
+// branches (e.g. `fix/foo-bar` vs `fix/foo/bar`) never collide to one key — a
+// collision would attach wrong crate metadata to one branch's findings and race
+// the two branches' codex temp files. djb2-style; deterministic (Date/random
+// are unavailable in workflow scripts).
 function slug(b) {
-  return String(b || '')
-    .replace(/[^A-Za-z0-9._-]+/g, '-')
-    .replace(/^-+|-+$/g, '')
+  const s = String(b || '')
+  const base = s.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'branch'
+  let h = 5381
+  for (let i = 0; i < s.length; i++) h = (((h << 5) + h) ^ s.charCodeAt(i)) | 0
+  return `${base}-${(h >>> 0).toString(36)}`
 }
 // Which crate (top-2 path segments) a changed file belongs to, for the blurb.
 function crateOf(f) {
@@ -201,14 +209,14 @@ const codexUsable = discover.codexAvailable && !SKIP_CODEX
 const reviewable = (discover.branches || []).filter((b) => b.diverged && (b.changedFiles || []).length)
 log(
   `round ${ROUND} | base=${BASE} | branches=${reviewable.length}/${(discover.branches || []).length} reviewable | ` +
-    `codex=${codexUsable ? discover.codexVersion || 'yes' : 'DISABLED (single-family — findings NEEDS-VERIFICATION)'} | ` +
+    `codex=${codexUsable ? discover.codexVersion || 'yes' : 'DISABLED (single-family — P0/P1 findings NEEDS-VERIFICATION)'} | ` +
     `sammy=${sammyRoot || 'NOT FOUND (physics findings lower-confidence)'}`,
 )
 
 if (!reviewable.length) {
   log('No diverged branches with changes — nothing to review.')
   return {
-    meta: { round: ROUND, base: BASE, repoRoot: discover.repoRoot, headSha: discover.headSha, codexUsable, sammyRoot, isWorktree: discover.isWorktree },
+    meta: { round: ROUND, base: BASE, repoRoot: discover.repoRoot, headSha: discover.headSha, codexUsable, sammyRoot: sammyRoot || '(not found)', isWorktree: discover.isWorktree },
     perBranch: [],
     mergeOrder: [],
     overlaps: [],
@@ -274,7 +282,19 @@ const engineOut = await workflow('dual-family-review', {
   },
 })
 
-const perTarget = (engineOut && engineOut.perTarget) || []
+// Fail closed: a missing/malformed or count-mismatched engine result must abort,
+// not silently become "zero reviewed branches". The engine surfaces droppedTargets
+// (a per-target pipeline that threw) so we reconcile against the target count.
+if (!engineOut || !Array.isArray(engineOut.perTarget)) {
+  throw new Error('dual-family-review returned no usable result (engineOut.perTarget missing) — aborting rather than report zero reviewed branches.')
+}
+if (engineOut.perTarget.length !== targets.length) {
+  throw new Error(
+    `dual-family-review returned ${engineOut.perTarget.length} result(s) for ${targets.length} target(s)` +
+      `${engineOut.droppedTargets ? ` (${engineOut.droppedTargets} dropped to a pipeline error)` : ''} — aborting rather than under-report.`,
+  )
+}
+const perTarget = engineOut.perTarget
 
 // ---------------------------------------------------------------------------
 // Phase: Consolidate (deterministic JS) — per-branch findings, suggested
@@ -292,6 +312,11 @@ const perBranch = perTarget.map((r) => {
   const verified = (r.verified || []).map(tag)
   const verifiedP0 = verified.filter((f) => (f.verifierTier || f.tier) === 'P0')
   const verifiedP1 = verified.filter((f) => (f.verifierTier || f.tier) === 'P1')
+  // Cross-family-CONFIRMED findings the verifier downgraded to effective P2 are
+  // real defects; route them into the P2 disposition channel below so they are
+  // surfaced (with a disposition + their VERIFIED status) rather than dropped
+  // between the P0/P1 buckets and r.p2s (which holds only original-tier P2s).
+  const verifiedP2 = verified.filter((f) => (f.verifierTier || f.tier) === 'P2')
   const needsVerification = (r.needsVerification || []).map(tag)
   const refuted = (r.refuted || []).map(tag)
   const circular = r.circular || []
@@ -301,7 +326,7 @@ const perBranch = perTarget.map((r) => {
   //  - P2 in a crate this branch already changes -> fix-now (same-crate P2 discipline)
   //  - P2 elsewhere    -> defer (collected into deferredP2s for issue-filing)
   //  - refuted         -> dismiss
-  const p2s = (r.p2s || []).map((f) => {
+  const p2s = [...(r.p2s || []), ...verifiedP2].map((f) => {
     const sameCrate = fileInChangedCrates(f.file, meta.crates)
     const disposition = sameCrate ? 'fix-now' : 'defer'
     const entry = { ...f, branch, recurring: isRecurring(branch, f), disposition }
@@ -321,7 +346,7 @@ const perBranch = perTarget.map((r) => {
     refuted,
     p2s,
     circular,
-    recurring: [...verified, ...needsVerification].filter((f) => f.recurring),
+    recurring: [...verified, ...needsVerification, ...p2s].filter((f) => f.recurring),
   }
 })
 


### PR DESCRIPTION
## Summary

Make `review-core` (`.claude/workflows/review-core.js`) the deterministic heart of one `/review-pipeline` round, and rewrite the skill into a thin orchestrator around it. `review-core` discovers diverged branches, builds one `dual-family-review` target per branch diff, runs the shared engine (Claude + Codex finders + cross-LLM-family verification — from #603), and consolidates into per-branch findings with suggested disposition (fix-now/defer/dismiss), RECURRING tags (vs the prior round), a file-overlap matrix, and a suggested merge order. It **returns structured data and writes nothing**; the skill renders + gates on it.

**Stacked on #603** (the shared engine). `review-core` is the engine's second consumer — review/merge the two as a batch.

This delivers the two goals: reviewer output is **one schema-forced format across models** (Claude/Codex/verifiers all emit the engine's schema; cross-confirm + dedup are deterministic JS, not the main agent eyeballing prose), and discover → find(2 families) → verify → consolidate **cannot be silently skipped** (JS control flow). The deferred-P2 list returns as data, so "track deferred P2s" is no longer a skippable plea.

The skill keeps every human gate and state-changing action in the main loop (fix dispatch, push, Copilot phase, merge, issue-filing): a Workflow runs unattended and cannot pause for input, so each mandatory STOP gate falls on a workflow boundary, with `review-core` invoked between them. All three STOP gates preserved.

## LOC delta

(vs the stacked base `wf/dual-family-review-engine`, i.e. this PR's own contribution)

- inserted: +522
- deleted:  -247
- net:      **+275**

(`review-core.js` +358 new; `SKILL.md` 359 → 276, a rewrite that nets −83 but rewrites most lines.)

## Existing-logic check (feature PR)

- [x] Searched: `review-core` **reuses** the `dual-family-review` engine via `workflow()` — it does not re-implement Find/Verify/consolidation.
- [x] No duplication of the engine; its helpers (`slug`, `classifyBranch`, `isRecurring`, same-crate-P2 disposition) are review-specific (branch classification + cross-round recurrence), distinct from the engine's intra-round cross-family dedup.
- [x] Net-positive is load-bearing: `review-core` is a new feature workflow (the deterministic core the issue asked for) + a skill that shrinks. Not a guard/patch.
- [x] No redundant `validate_*`/`*_helper`.

## Test plan

- `review-core.js` parses (async-wrapped) under `node --check`.
- **18/18 unit tests** on the pure consolidation helpers (`slug`, branch classification + SAMMY detection, RECURRING matching, same-crate-P2 disposition).
- **Live end-to-end** (1 branch = #603's branch, codex off): discover → engine → consolidate completes and returns the exact structured payload the skill consumes (`mergeOrder`, `overlaps`, `perBranch`, `deferredP2s`, `counts`); the single P2 was correctly classified `disposition: fix-now` (same-crate) and the merge order/overlap computed in JS.
- **Dogfooding:** that same live run, reviewing the engine PR (#603), surfaced two findings about #603:
  - **F1 (P1):** the engine reads the `budget` global only on the never-exercised P0 verify arm. Investigated with a targeted nested-workflow probe → **REFUTED**: the harness injects `budget` into child workflows (`type=object`, `remaining()` present), so the engine's existing use is correct. No code change.
  - **F2 (P2):** the engine docstring forward-references `review-core`. Addressed by shipping #603 + this PR as a **merge-together batch**.
- No cargo/pytest impact (touches only `.claude/`).

## Linked issues / audit references

- Stacked on #603 (shared `dual-family-review` engine). Requested in-session; no issue number.

---

Assisted-With: Claude Opus 4.8 (1M context)
