### PR TITLE
PR-E2: physics P2 fixes — phase_shift continuity, RML closed-channel gate, aux-grid transmission, thickness guard (#599)

### DIFF
--- a/crates/nereids-physics/src/penetrability.rs
+++ b/crates/nereids-physics/src/penetrability.rs
@@ -103,7 +103,7 @@ pub fn phase_shift(l: u32, rho: f64) -> f64 {
         // difference: it computes cos φ = (C·Y + S·X)/√G and sin φ =
         // (S·Y − C·X)/√G with G = X² + Y², C = cos ρ, S = sin ρ, which are
         // continuous through Y = 0.  Recovering φ = atan2(sin φ, cos φ) gives a
-        // pole-free phase that is identical (mod 2π) to ρ − atan(X/Y) away from
+        // pole-free phase that is identical (mod π) to ρ − atan(X/Y) away from
         // the pole — the same continuous form the l > 4 path already uses.
         // l=1: φ = ρ − atan(ρ), i.e. X = ρ, Y = 1 (SAMMY uses G = 1 + X²,
         // Sinphi = (S − C·ρ)/√G, Cosphi = (C + S·ρ)/√G).  atan(ρ) has no pole,
@@ -126,7 +126,8 @@ pub fn phase_shift(l: u32, rho: f64) -> f64 {
 /// Given the orbital rational numerator `x` and denominator `y` (the SAMMY `X`
 /// and `Y` for this l), returns
 ///   φ = atan2(S·Y − C·X,  C·Y + S·X),   S = sin ρ,  C = cos ρ,
-/// which equals ρ − atan(X/Y) modulo 2π but is continuous across Y = 0.
+/// which equals ρ − atan(X/Y) for Y > 0 and differs by π for Y < 0 (so they
+/// agree modulo π), and is continuous across Y = 0.
 ///
 /// Because every consumer uses the phase only through π-invariant combinations
 /// (sin²φ, sin 2φ, |U|²), removing the −π jump leaves all cross-sections
@@ -549,7 +550,8 @@ mod tests {
     }
 
     /// The continuous Sinsix form must agree with the original
-    /// `ρ − atan(X/Y)` form modulo 2π everywhere away from the pole, so every
+    /// `ρ − atan(X/Y)` form modulo π (they coincide for Y > 0 and differ by π
+    /// for Y < 0) everywhere away from the pole, so every
     /// cross-section observable (which consumes φ only via sin²φ / sin2φ /
     /// |U|²) is bit-for-bit unchanged.  We assert the π-invariant combinations
     /// match the old closed form to round-off.

--- a/crates/nereids-physics/src/penetrability.rs
+++ b/crates/nereids-physics/src/penetrability.rs
@@ -96,21 +96,49 @@ pub fn phase_shift(l: u32, rho: f64) -> f64 {
     let rho2 = rho * rho;
     match l {
         0 => rho,
-        1 => rho - rho.atan(),
-        2 => rho - (3.0 * rho / (3.0 - rho2)).atan(),
-        3 => {
-            let num = rho * (15.0 - rho2);
-            let den = 15.0 - 6.0 * rho2;
-            rho - (num / den).atan()
-        }
+        // For l = 1..=4 the phase is conceptually φ = ρ − atan(X/Y), but
+        // forming `ρ − (X/Y).atan()` directly introduces a spurious −π jump
+        // whenever the rational denominator Y crosses zero (the atan pole at
+        // X/Y → ±∞).  SAMMY's `Sinsix` (rml/mrml07.f:254-342) never forms that
+        // difference: it computes cos φ = (C·Y + S·X)/√G and sin φ =
+        // (S·Y − C·X)/√G with G = X² + Y², C = cos ρ, S = sin ρ, which are
+        // continuous through Y = 0.  Recovering φ = atan2(sin φ, cos φ) gives a
+        // pole-free phase that is identical (mod 2π) to ρ − atan(X/Y) away from
+        // the pole — the same continuous form the l > 4 path already uses.
+        // l=1: φ = ρ − atan(ρ), i.e. X = ρ, Y = 1 (SAMMY uses G = 1 + X²,
+        // Sinphi = (S − C·ρ)/√G, Cosphi = (C + S·ρ)/√G).  atan(ρ) has no pole,
+        // so l=1 was already continuous; routing it through the same helper
+        // keeps a single code path.
+        1 => phase_shift_rational(rho, rho, 1.0),
+        2 => phase_shift_rational(rho, 3.0 * rho, 3.0 - rho2),
+        3 => phase_shift_rational(rho, rho * (15.0 - rho2), 15.0 - 6.0 * rho2),
         4 => {
             let rho4 = rho2 * rho2;
-            let num = rho * (105.0 - 10.0 * rho2);
-            let den = 105.0 - 45.0 * rho2 + rho4;
-            rho - (num / den).atan()
+            phase_shift_rational(rho, rho * (105.0 - 10.0 * rho2), 105.0 - 45.0 * rho2 + rho4)
         }
         _ => phase_shift_general(l, rho),
     }
+}
+
+/// Continuous hard-sphere phase shift from the SAMMY `Sinsix` (X, Y) rational
+/// form, avoiding the −π jump of `ρ − atan(X/Y)` at the Y = 0 pole.
+///
+/// Given the orbital rational numerator `x` and denominator `y` (the SAMMY `X`
+/// and `Y` for this l), returns
+///   φ = atan2(S·Y − C·X,  C·Y + S·X),   S = sin ρ,  C = cos ρ,
+/// which equals ρ − atan(X/Y) modulo 2π but is continuous across Y = 0.
+///
+/// Because every consumer uses the phase only through π-invariant combinations
+/// (sin²φ, sin 2φ, |U|²), removing the −π jump leaves all cross-sections
+/// unchanged; it removes a discontinuity that would corrupt any future
+/// phase-sensitive observable (e.g. angular distributions).
+///
+/// Reference: SAMMY `rml/mrml07.f` `Sinsix` (lines 254-342) —
+/// `Cosphi = (C*Y+S*X)/√G`, `Sinphi = (S*Y-C*X)/√G`.
+#[inline]
+fn phase_shift_rational(rho: f64, x: f64, y: f64) -> f64 {
+    let (s, c) = rho.sin_cos();
+    (s * y - c * x).atan2(c * y + s * x)
 }
 
 /// Shift factor at imaginary channel argument S_l(iκ) for a closed channel.
@@ -488,5 +516,88 @@ mod tests {
             p_explicit,
             p_general
         );
+    }
+
+    // ── Fix #4: phase_shift continuity across the rational-form pole ──────────
+
+    /// The old one-argument `ρ − atan(X/Y)` form jumps by −π whenever the
+    /// rational denominator Y crosses zero.  The Sinsix `atan2` form must be
+    /// continuous there.  The poles are: l=2 at ρ=√3, l=3 at ρ=√2.5,
+    /// l=4 at ρ²=(45−√1605)/2 (≈1.572) and ρ²=(45+√1605)/2 (≈6.52).
+    #[test]
+    fn test_phase_shift_continuous_across_pole() {
+        // (l, ρ_pole) pairs.
+        let poles = [
+            (2u32, 3.0_f64.sqrt()),
+            (3u32, 2.5_f64.sqrt()),
+            (4u32, ((45.0 - 1605.0_f64.sqrt()) / 2.0).sqrt()),
+            (4u32, ((45.0 + 1605.0_f64.sqrt()) / 2.0).sqrt()),
+        ];
+        for (l, rho_pole) in poles {
+            let delta = 1e-6;
+            let below = phase_shift(l, rho_pole - delta);
+            let above = phase_shift(l, rho_pole + delta);
+            let jump = (above - below).abs();
+            // A continuous φ varies by O(delta) across the pole; the buggy
+            // form jumps by ≈ π.  Require the jump to be far below π.
+            assert!(
+                jump < 1e-3,
+                "phase_shift(l={l}) discontinuous at ρ={rho_pole}: \
+                 below={below}, above={above}, jump={jump} (expected ≈ 0, not ≈ π)"
+            );
+        }
+    }
+
+    /// The continuous Sinsix form must agree with the original
+    /// `ρ − atan(X/Y)` form modulo 2π everywhere away from the pole, so every
+    /// cross-section observable (which consumes φ only via sin²φ / sin2φ /
+    /// |U|²) is bit-for-bit unchanged.  We assert the π-invariant combinations
+    /// match the old closed form to round-off.
+    #[test]
+    fn test_phase_shift_matches_old_form_on_invariants() {
+        // Old (discontinuous) reference: ρ − atan(X/Y).
+        fn old_phase(l: u32, rho: f64) -> f64 {
+            let rho2 = rho * rho;
+            match l {
+                1 => rho - rho.atan(),
+                2 => rho - (3.0 * rho / (3.0 - rho2)).atan(),
+                3 => {
+                    let num = rho * (15.0 - rho2);
+                    let den = 15.0 - 6.0 * rho2;
+                    rho - (num / den).atan()
+                }
+                4 => {
+                    let rho4 = rho2 * rho2;
+                    let num = rho * (105.0 - 10.0 * rho2);
+                    let den = 105.0 - 45.0 * rho2 + rho4;
+                    rho - (num / den).atan()
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        for l in 1u32..=4 {
+            // Sample ρ across a range that brackets every pole, skipping a
+            // tiny neighbourhood of each pole (where the OLD form is ill-defined
+            // but the NEW form is fine).
+            let poles = [3.0_f64.sqrt(), 2.5_f64.sqrt(), 1.572, 6.52];
+            for i in 1..=800 {
+                let rho = i as f64 * 0.01; // 0.01 .. 8.0
+                if poles.iter().any(|&p| (rho - p).abs() < 5e-3) {
+                    continue;
+                }
+                let new = phase_shift(l, rho);
+                let old = old_phase(l, rho);
+                // π-invariant observables consumed downstream:
+                let d_sin2 = (new.sin().powi(2) - old.sin().powi(2)).abs();
+                let d_sin2ph = ((2.0 * new).sin() - (2.0 * old).sin()).abs();
+                let d_cos2ph = ((2.0 * new).cos() - (2.0 * old).cos()).abs();
+                assert!(
+                    d_sin2 < 1e-9 && d_sin2ph < 1e-9 && d_cos2ph < 1e-9,
+                    "l={l} ρ={rho}: new φ disagrees with old on invariants \
+                     (sin²Δ={d_sin2}, sin2φΔ={d_sin2ph}, cos2φΔ={d_cos2ph})"
+                );
+            }
+        }
     }
 }

--- a/crates/nereids-physics/src/rmatrix_limited.rs
+++ b/crates/nereids-physics/src/rmatrix_limited.rs
@@ -519,8 +519,29 @@ fn spin_group_cross_sections(
             denom.inv()
         };
         for c in 0..nch {
+            // SAMMY gates the R-matrix accumulation on BOTH channels being
+            // open: rml/mrml07.f Setr lines 67-71 —
+            //   IF (Su.GT.Echan(K) .AND. Su.GT.Echan(L) .AND.
+            //     Beta(KL,Ires).NE.Zero) THEN
+            //       Rmat(1,KL) = Rmat(1,KL) + Alphar(Ires)*Beta(KL,Ires)
+            //       ...
+            // `Su.GT.Echan(K)` is exactly the open-channel test (line 118), which
+            // NEREIDS encodes as `!ws.is_closed[K]` (set in the channel-setup
+            // loop above for e_c ≤ 0 and the Coulomb-threshold case).  A channel
+            // below its threshold contributes nothing to R, including off-diagonal
+            // terms via a shared resonance width.  Skipping the whole row when c
+            // is closed avoids forming R[c,cp] for any cp.
+            if ws.is_closed[c] {
+                continue;
+            }
             let gc = ws.gamma_vals[c];
             for cp in 0..nch {
+                // Gate the off-/on-diagonal term on the partner channel cp also
+                // being open (the Su.GT.Echan(L) half of the SAMMY condition).
+                // (The Beta≠0 half is automatic: a zero width product adds 0.)
+                if ws.is_closed[cp] {
+                    continue;
+                }
                 ws.r_cplx[c * nch + cp] += gc * ws.gamma_vals[cp] * inv_denom;
             }
         }
@@ -1129,6 +1150,291 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Fix #6 (non-vacuous): a CLOSED channel must contribute nothing to the
+    /// R-matrix, even when a resonance carries a shared off-diagonal width that
+    /// couples it to an OPEN channel.
+    ///
+    /// SAMMY gates the R accumulation on both channels open (rml/mrml07.f Setr
+    /// lines 67-71: `IF (Su.GT.Echan(K) .AND. Su.GT.Echan(L) ...)`).  Before
+    /// this fix the un-gated loop formed R[open,closed] = γ_open·γ_closed/(E_n−E)
+    /// ≠ 0, which leaks into the open-channel cross-section through the level-
+    /// matrix inversion (XQ = Ỹ⁻¹·R picks up Ỹ⁻¹[0,1]·R[1,0]).
+    ///
+    /// This test (unlike the `resonances: vec![]` no-panic test, where R ≡ 0)
+    /// carries a resonance with a large off-diagonal width into a closed
+    /// channel, and asserts:
+    ///   (a) the gated cross-section equals the open-only-submatrix result
+    ///       (the same group with the closed channel's width zeroed); and
+    ///   (b) it differs from the pre-fix un-gated value (reconstructed here by
+    ///       building the full R including the closed-channel coupling and
+    ///       running the rest of the pipeline), so the gate is load-bearing.
+    #[test]
+    fn test_rml_closed_channel_excluded_from_rmatrix() {
+        use nereids_endf::resonance::{ParticlePair, RmlChannel, RmlData, RmlResonance, SpinGroup};
+
+        // Entrance: neutron (Z=0) + target (Z=74), l=0 so the open channel has
+        // full penetrability P_0 = ρ and a healthy cross-section.
+        let pp_entrance = ParticlePair {
+            ma: 1.0,
+            mb: 183.0,
+            za: 0.0,
+            zb: 74.0,
+            ia: 0.5,
+            ib: 0.0,
+            q: 0.0,
+            pnt: 1,
+            shf: 0, // l=0: shift is 0 regardless; L_0 = i·P_0 (finite, nonzero)
+            mt: 2,
+            pa: 1.0,
+            pb: 1.0,
+        };
+        // Inelastic neutron exit channel (MT=51), massive, with a very negative
+        // Q so e_c = e_cm + Q < 0 → CLOSED at the test energy.  l=1 with SHF=1 so
+        // the closed channel keeps a finite analytic shift S_1(iκ) = −1/(1−(κa)²)
+        // and L_c does NOT collapse to the 1/L_c → 1e30 decoupling sentinel.
+        // That sentinel (used for L_c ≈ 0) would otherwise numerically swamp the
+        // off-diagonal leak and make the test vacuous; a finite L_c keeps
+        // Ỹ⁻¹[0,1]·R[1,0] observable in the open channel.
+        let pp_closed = ParticlePair {
+            ma: 1.0,
+            mb: 183.0,
+            za: 0.0,
+            zb: 74.0,
+            ia: 0.5,
+            ib: 0.0,
+            // E_cm ≈ 100·183/184 ≈ 99.5 eV at E_lab=100; Q=−200 → e_c ≈ −100.5 eV
+            // (CLOSED), with |e_c| comparable so S_1(iκ) is moderate (not a pole).
+            q: -200.0,
+            pnt: 1,
+            shf: 1,
+            mt: 51,
+            pa: 1.0,
+            pb: 1.0,
+        };
+
+        let ch_open = RmlChannel {
+            particle_pair_idx: 0,
+            l: 0,
+            channel_spin: 0.5,
+            boundary: 0.0,
+            effective_radius: 8.3,
+            true_radius: 8.3,
+        };
+        let ch_closed = RmlChannel {
+            particle_pair_idx: 1,
+            l: 1,
+            channel_spin: 0.5,
+            boundary: 0.0,
+            effective_radius: 8.3,
+            true_radius: 8.3,
+        };
+
+        // KRM=2: widths ARE reduced amplitudes (copied verbatim), so the closed
+        // channel keeps a nonzero γ and the off-diagonal coupling γ_0·γ_1 is
+        // real and large pre-fix.
+        let res_full = RmlResonance {
+            energy: 120.0,
+            gamma_gamma: 0.0,       // KRM=2: no implicit capture
+            widths: vec![3.0, 5.0], // [open, closed]; large shared off-diagonal
+        };
+        // Open-only submatrix reference: zero the closed channel's width.
+        let res_open_only = RmlResonance {
+            energy: 120.0,
+            gamma_gamma: 0.0,
+            widths: vec![3.0, 0.0],
+        };
+
+        let make_rml = |res: RmlResonance| RmlData {
+            target_spin: 0.0,
+            awr: 183.0,
+            scattering_radius: 8.3,
+            krm: 2,
+            particle_pairs: vec![pp_entrance.clone(), pp_closed.clone()],
+            spin_groups: vec![SpinGroup {
+                j: 0.5,
+                parity: 1.0,
+                channels: vec![ch_open.clone(), ch_closed.clone()],
+                resonances: vec![res],
+                has_background_correction: false,
+            }],
+        };
+
+        // Evaluate off the pole (E ≠ E_n) so the result is well-conditioned.
+        let energy = 100.0;
+        let rml_full = make_rml(res_full.clone());
+        let rml_open_only = make_rml(res_open_only);
+
+        let (tot_g, elas_g, cap_g, fis_g) = cross_sections_for_rml_range(&rml_full, energy);
+        let (tot_ref, elas_ref, cap_ref, fis_ref) =
+            cross_sections_for_rml_range(&rml_open_only, energy);
+
+        // (a) Gated full-width result == open-only-submatrix result.
+        for (g, r, name) in [
+            (tot_g, tot_ref, "total"),
+            (elas_g, elas_ref, "elastic"),
+            (cap_g, cap_ref, "capture"),
+            (fis_g, fis_ref, "fission"),
+        ] {
+            assert!(
+                (g - r).abs() <= 1e-9 * r.abs().max(1.0),
+                "{name}: gated σ ({g}) must equal open-only-submatrix σ ({r}); \
+                 a closed channel must not couple into R"
+            );
+        }
+
+        // (b) The gate is load-bearing: reconstruct the PRE-FIX un-gated value
+        // by computing the full collision matrix WITHOUT the both-open gate, and
+        // confirm it differs from the gated result at the open entrance channel.
+        let ungated_tot = ungated_total_for_two_channel(&rml_full, energy);
+        // For this configuration the leak is large (gated ≈ 2.62 b vs un-gated
+        // ≈ 5.54 b, a >100% difference), so the gate is decisively load-bearing.
+        assert!(
+            (ungated_tot - tot_g).abs() > 1e-3,
+            "un-gated σ_total ({ungated_tot}) should differ from gated σ_total \
+             ({tot_g}); if equal, the off-diagonal closed-channel coupling does \
+             not affect the open channel and the test is vacuous"
+        );
+    }
+
+    /// Reconstruct the pre-fix (un-gated) σ_total for a 2-channel KRM=2 spin
+    /// group: builds the full complex R-matrix INCLUDING the closed-channel
+    /// off-diagonal coupling, then runs the same Ỹ⁻¹/XXXX/U pipeline as the
+    /// production code.  Used only to prove the Fix #6 gate is load-bearing.
+    fn ungated_total_for_two_channel(rml: &RmlData, energy_ev: f64) -> f64 {
+        use num_complex::Complex64;
+
+        let awr = rml.awr;
+        let sg = &rml.spin_groups[0];
+        let nch = sg.channels.len();
+        assert_eq!(nch, 2, "helper is specialised to 2 channels");
+        let pps = &rml.particle_pairs;
+
+        let e_cm = channel::lab_to_cm_energy(energy_ev, awr);
+        let mut p_c = vec![0.0f64; nch];
+        let mut s_c = vec![0.0f64; nch];
+        let mut phi_c = vec![0.0f64; nch];
+        let mut is_closed = vec![false; nch];
+        let mut is_entrance = vec![false; nch];
+
+        for (c, ch) in sg.channels.iter().enumerate() {
+            let pp = &pps[ch.particle_pair_idx];
+            is_entrance[c] = pp.mt == 2;
+            let e_c = e_cm + pp.q;
+            if e_c <= 0.0 {
+                // Closed channel.  Honour SHF like production (lines 338-346):
+                // SHF=1 → finite analytic shift at imaginary argument, so L_c is
+                // finite and the off-diagonal R coupling is NOT swamped by the
+                // 1/L_c → 1e30 sentinel.  This is what makes the leak observable.
+                p_c[c] = 0.0;
+                phi_c[c] = 0.0;
+                is_closed[c] = true;
+                let is_coulomb = pp.za.abs() > 0.5 && pp.zb.abs() > 0.5;
+                s_c[c] = if pp.shf == 1 && !is_coulomb {
+                    let redmas = pp.ma * pp.mb / (pp.ma + pp.mb);
+                    let kappa = channel::wave_number_from_cm(e_c.abs(), redmas);
+                    penetrability::shift_factor_closed(ch.l, kappa * ch.true_radius)
+                } else {
+                    ch.boundary
+                };
+            } else {
+                let redmas = pp.ma * pp.mb / (pp.ma + pp.mb);
+                let k_c = channel::wave_number_from_cm(e_c, redmas);
+                let rho_pen = k_c * ch.true_radius;
+                let rho_phase = k_c * ch.effective_radius;
+                p_c[c] = penetrability::penetrability(ch.l, rho_pen);
+                s_c[c] = if pp.shf == 1 {
+                    penetrability::shift_factor(ch.l, rho_pen)
+                } else {
+                    ch.boundary
+                };
+                phi_c[c] = penetrability::phase_shift(ch.l, rho_phase);
+            }
+        }
+
+        // Full R-matrix, NO both-open gate (the pre-fix behaviour).
+        let mut r = vec![Complex64::ZERO; nch * nch];
+        for res in &sg.resonances {
+            let denom = Complex64::new(res.energy, 0.0) - Complex64::new(energy_ev, 0.0);
+            let inv_denom = if denom.norm() < QUANTUM_NUMBER_EPS {
+                (denom + Complex64::new(0.0, QUANTUM_NUMBER_EPS)).inv()
+            } else {
+                denom.inv()
+            };
+            for c in 0..nch {
+                let gc = res.widths[c];
+                for cp in 0..nch {
+                    r[c * nch + cp] += gc * res.widths[cp] * inv_denom;
+                }
+            }
+        }
+
+        // L_c, Ỹ = diag(1/L_c) − R.
+        let mut y = vec![Complex64::ZERO; nch * nch];
+        for c in 0..nch {
+            let l_c = Complex64::new(s_c[c] - sg.channels[c].boundary, p_c[c]);
+            let inv_l = if l_c.norm_sqr() < NEAR_ZERO_FLOOR {
+                Complex64::new(1e30, 0.0)
+            } else {
+                Complex64::new(1.0, 0.0) / l_c
+            };
+            for cp in 0..nch {
+                let diag = if c == cp { inv_l } else { Complex64::ZERO };
+                y[c * nch + cp] = diag - r[c * nch + cp];
+            }
+        }
+
+        // Invert Ỹ (2×2 closed form).
+        let det = y[0] * y[3] - y[1] * y[2];
+        let yinv = [y[3] / det, -y[1] / det, -y[2] / det, y[0] / det];
+
+        // XQ = Ỹ⁻¹·R.
+        let mut xq = [Complex64::ZERO; 4];
+        for c in 0..nch {
+            for cp in 0..nch {
+                let mut sum = Complex64::ZERO;
+                for k in 0..nch {
+                    sum += yinv[c * nch + k] * r[k * nch + cp];
+                }
+                xq[c * nch + cp] = sum;
+            }
+        }
+
+        // XXXX, with the closed-channel √P-kill (matches production line 655).
+        let sqrt_p: Vec<Complex64> = p_c.iter().map(|&p| Complex64::new(p, 0.0).sqrt()).collect();
+        let mut xxxx = [Complex64::ZERO; 4];
+        for c in 0..nch {
+            let l_c = Complex64::new(s_c[c] - sg.channels[c].boundary, p_c[c]);
+            let sqrt_p_over_l = if is_closed[c] || l_c.norm() < PIVOT_FLOOR {
+                Complex64::ZERO
+            } else {
+                sqrt_p[c] / l_c
+            };
+            for cp in 0..nch {
+                xxxx[c * nch + cp] = sqrt_p_over_l * xq[c * nch + cp] * sqrt_p[cp];
+            }
+        }
+
+        // U and σ_total via the optical theorem on the open entrance channel.
+        let omega: Vec<Complex64> = phi_c
+            .iter()
+            .map(|&phi| Complex64::from_polar(1.0, -phi))
+            .collect();
+        let pok2 = channel::pi_over_k_squared_barns(energy_ev, awr);
+        // Use the SAME statistical weight as production so the only difference
+        // between this helper and `cross_sections_for_rml_range` is the gate.
+        let g_j = channel::statistical_weight(sg.j, rml.target_spin);
+        let mut tot = 0.0;
+        for c0 in 0..nch {
+            if !is_entrance[c0] {
+                continue;
+            }
+            let w_cc = Complex64::new(1.0, 0.0) + Complex64::new(0.0, 2.0) * xxxx[c0 * nch + c0];
+            let u_diag = omega[c0] * w_cc * omega[c0];
+            tot += 2.0 * pok2 * g_j * (1.0 - u_diag.re);
+        }
+        tot
     }
 
     /// Singular Y-matrix regularization: construct a KRM=2 spin group where

--- a/crates/nereids-physics/src/transmission.rs
+++ b/crates/nereids-physics/src/transmission.rs
@@ -144,6 +144,35 @@ fn extract_resonance_widths(resonance_data: &[&ResonanceData]) -> Vec<(f64, f64)
     pairs
 }
 
+/// Build the unbroadened cross-section vector on the extended/auxiliary grid
+/// from cached data-grid values.
+///
+/// Data-grid positions are copied verbatim from `xs_raw` (the cached
+/// unbroadened σ for this isotope); the auxiliary-only positions (boundary
+/// extension + fine-structure points) are evaluated fresh.  `is_data_point`
+/// marks which extended-grid indices are data-grid points.
+///
+/// This is the cheap reuse of cached XS that the base-XS family relies on: only
+/// the few hundred auxiliary points are recomputed, not the full grid.
+fn build_extended_xs_from_base(
+    ext_energies: &[f64],
+    data_indices: &[usize],
+    is_data_point: &[bool],
+    xs_raw: &[f64],
+    rd: &ResonanceData,
+) -> Vec<f64> {
+    let mut xs_ext = vec![0.0f64; ext_energies.len()];
+    for (data_i, &ext_i) in data_indices.iter().enumerate() {
+        xs_ext[ext_i] = xs_raw[data_i];
+    }
+    for (j, &e) in ext_energies.iter().enumerate() {
+        if !is_data_point[j] {
+            xs_ext[j] = reich_moore::cross_sections_at_energy(rd, e).total;
+        }
+    }
+    xs_ext
+}
+
 /// Errors from the transmission forward model.
 #[derive(Debug)]
 pub enum TransmissionError {
@@ -623,6 +652,15 @@ pub fn broadened_cross_sections_for_transmission(
     thickness_atoms_barn: f64,
     cancel: Option<&AtomicBool>,
 ) -> Result<Vec<Vec<f64>>, TransmissionError> {
+    // The Beer-Lambert→σ_eff inversion (step 5: σ_eff = −ln(T)/nd) divides by
+    // the thickness, so a non-positive or non-finite nd would yield ±∞/NaN
+    // cross-sections.  The docstring contract requires nd > 0; enforce it
+    // up-front before any work, matching the module's `InputMismatch` style.
+    if !thickness_atoms_barn.is_finite() || thickness_atoms_barn <= 0.0 {
+        return Err(TransmissionError::InputMismatch(format!(
+            "thickness_atoms_barn must be finite and > 0, got {thickness_atoms_barn}"
+        )));
+    }
     if !energies.windows(2).all(|w| w[0] <= w[1]) {
         return Err(ResolutionError::UnsortedEnergies.into());
     }
@@ -819,16 +857,8 @@ pub fn broadened_cross_sections_from_base(
             if let Some((ref ext_energies, ref data_indices)) = ext_grid {
                 let mask = is_data_point.as_ref().unwrap();
 
-                // Build extended XS: copy cached data-grid values, evaluate new points.
-                let mut xs_ext = vec![0.0f64; ext_energies.len()];
-                for (data_i, &ext_i) in data_indices.iter().enumerate() {
-                    xs_ext[ext_i] = xs_raw[data_i];
-                }
-                for (j, &e) in ext_energies.iter().enumerate() {
-                    if !mask[j] {
-                        xs_ext[j] = reich_moore::cross_sections_at_energy(rd, e).total;
-                    }
-                }
+                let xs_ext =
+                    build_extended_xs_from_base(ext_energies, data_indices, mask, xs_raw, rd);
 
                 let after_doppler = if temperature_k > 0.0 {
                     let params = DopplerParams::new(temperature_k, rd.awr)?;
@@ -910,16 +940,8 @@ pub fn broadened_cross_sections_with_analytical_derivative_from_base(
             if let Some((ref ext_energies, ref data_indices)) = ext_grid {
                 let mask = is_data_point.as_ref().unwrap();
 
-                // Build extended XS on auxiliary grid.
-                let mut xs_ext = vec![0.0f64; ext_energies.len()];
-                for (data_i, &ext_i) in data_indices.iter().enumerate() {
-                    xs_ext[ext_i] = xs_raw[data_i];
-                }
-                for (j, &e) in ext_energies.iter().enumerate() {
-                    if !mask[j] {
-                        xs_ext[j] = reich_moore::cross_sections_at_energy(rd, e).total;
-                    }
-                }
+                let xs_ext =
+                    build_extended_xs_from_base(ext_energies, data_indices, mask, xs_raw, rd);
 
                 // Doppler broaden + analytical derivative in one pass.
                 // Resolution is NOT applied (issue #442).
@@ -960,17 +982,27 @@ pub fn broadened_cross_sections_with_analytical_derivative_from_base(
 
 /// Compute a transmission spectrum from precomputed unbroadened cross-sections.
 ///
-/// Applies Doppler broadening and Beer-Lambert using cached base XS,
-/// then resolution broadening on the total transmission (issue #442).
-/// This skips the expensive Reich-Moore calculation, making it suitable
-/// for use inside `TransmissionFitModel::evaluate()` when temperature
-/// is a free parameter.
+/// Applies Doppler broadening and Beer-Lambert using cached base XS, then
+/// resolution broadening on the total transmission (issue #442).  This skips
+/// the expensive Reich-Moore calculation, making it suitable for use inside
+/// `TransmissionFitModel::evaluate()` when temperature is a free parameter.
+///
+/// The full pipeline runs on the **auxiliary extended grid** (boundary
+/// extension + resonance fine-structure points) so that Doppler AND resolution
+/// broadening have adequate quadrature support and correct boundary handling;
+/// the data-grid points are extracted LAST.  This mirrors the non-cached
+/// [`forward_model`] and [`broadened_cross_sections_for_transmission`] exactly
+/// — previously this cached path collapsed σ to the coarse data grid before
+/// resolution broadening, degrading the convolution near the grid edges and
+/// around narrow resonances.
 ///
 /// Pipeline:
-///   1. Doppler-broaden base σ (via `broadened_cross_sections_from_base`)
-///   2. Accumulate total attenuation: Σᵢ nᵢ·σ_{D,i}
-///   3. Beer-Lambert: T = exp(−attenuation)
-///   4. Resolution: T_broad = R ⊗ T  (when instrument is present)
+///   1. Per isotope: build σ on the extended grid (cached data-grid values +
+///      freshly-evaluated auxiliary points), Doppler-broaden on the extended grid
+///   2. Accumulate total attenuation on the extended grid: Σᵢ nᵢ·σ_{D,i}
+///   3. Beer-Lambert: T = exp(−attenuation) on the extended grid
+///   4. Resolution: T_broad = R ⊗ T on the extended grid (when instrument present)
+///   5. Extract the data-grid points
 pub fn forward_model_from_base_xs(
     energies: &[f64],
     base_xs: &[Vec<f64>],
@@ -987,36 +1019,91 @@ pub fn forward_model_from_base_xs(
             resonance_data.len(),
         )));
     }
+    for (i, row) in base_xs.iter().enumerate() {
+        if row.len() != energies.len() {
+            return Err(TransmissionError::InputMismatch(format!(
+                "base_xs[{i}] has {} energies but expected {}",
+                row.len(),
+                energies.len(),
+            )));
+        }
+    }
     let n = energies.len();
     if n == 0 {
         return Ok(vec![]);
     }
 
-    // Step 1: Doppler-only σ (resolution NOT applied — issue #442).
-    let doppler_xs = broadened_cross_sections_from_base(
-        energies,
-        base_xs,
-        resonance_data,
-        temperature_k,
-        instrument,
-    )?;
+    // Validate the data grid once before the per-isotope loop so resolution can
+    // use the presorted (unchecked) path, matching forward_model.
+    if instrument.is_some() && !energies.windows(2).all(|w| w[0] <= w[1]) {
+        return Err(ResolutionError::UnsortedEnergies.into());
+    }
 
-    // Step 2-3: accumulate attenuation, Beer-Lambert.
-    let mut total_attenuation = vec![0.0f64; n];
+    // Build the auxiliary extended grid (boundary + resonance fine-structure).
+    // SAMMY Ref: dat/mdat4.f90 Escale+Fspken+Add_Pnts.
+    let rd_refs: Vec<&ResonanceData> = resonance_data.iter().collect();
+    let ext_grid = build_aux_grid(energies, instrument, &rd_refs);
+    let is_data_point: Option<Vec<bool>> = ext_grid.as_ref().map(|(ext_e, di)| {
+        let mut mask = vec![false; ext_e.len()];
+        for &idx in di {
+            mask[idx] = true;
+        }
+        mask
+    });
+
+    // Working grid: the extended grid when available, else the data grid.
+    let (work_energies, work_len): (&[f64], usize) = if let Some((ref ext_e, _)) = ext_grid {
+        (ext_e.as_slice(), ext_e.len())
+    } else {
+        (energies, n)
+    };
+
+    // Step 1: per-isotope Doppler-broadened σ on the WORKING (extended) grid.
+    // Resolution is NOT applied here (issue #442) — it goes on total T below.
+    let doppler_xs: Result<Vec<Vec<f64>>, TransmissionError> = base_xs
+        .par_iter()
+        .zip(resonance_data.par_iter())
+        .map(|(xs_raw, rd)| {
+            let xs_ext = if let Some((ref ext_energies, ref data_indices)) = ext_grid {
+                let mask = is_data_point.as_ref().unwrap();
+                build_extended_xs_from_base(ext_energies, data_indices, mask, xs_raw, rd)
+            } else {
+                xs_raw.clone()
+            };
+            if temperature_k > 0.0 {
+                let params = DopplerParams::new(temperature_k, rd.awr)?;
+                doppler::doppler_broaden(work_energies, &xs_ext, &params).map_err(Into::into)
+            } else {
+                Ok(xs_ext)
+            }
+        })
+        .collect();
+    let doppler_xs = doppler_xs?;
+
+    // Step 2-3: accumulate attenuation on the working grid, then Beer-Lambert.
+    let mut total_attenuation = vec![0.0f64; work_len];
     for (xs, &thickness) in doppler_xs.iter().zip(thicknesses.iter()) {
         if thickness <= 0.0 {
             continue;
         }
-        for i in 0..n {
+        for i in 0..work_len {
             total_attenuation[i] += thickness * xs[i];
         }
     }
     let transmission: Vec<f64> = total_attenuation.iter().map(|&att| (-att).exp()).collect();
 
-    // Step 4: resolution broadening on total transmission.
+    // Step 4-5: resolution broadening on total transmission (on the working
+    // grid), then extract the data-grid points last.  When `instrument` is
+    // `None`, `build_aux_grid` returns `None`, so the working grid IS the data
+    // grid and `transmission` is returned directly (matching `forward_model`).
     if let Some(inst) = instrument {
-        resolution::apply_resolution(energies, &transmission, &inst.resolution)
-            .map_err(TransmissionError::from)
+        let t_broadened =
+            resolution::apply_resolution_presorted(work_energies, &transmission, &inst.resolution);
+        if let Some((_, ref data_indices)) = ext_grid {
+            Ok(data_indices.iter().map(|&i| t_broadened[i]).collect())
+        } else {
+            Ok(t_broadened)
+        }
     } else {
         Ok(transmission)
     }
@@ -1785,18 +1872,22 @@ mod tests {
         )
         .unwrap();
 
-        // Both use resolution after Beer-Lambert but may differ slightly
-        // due to extended-grid Doppler in forward_model vs data-grid Doppler
-        // in broadened_cross_sections_from_base.
+        // Both now run the IDENTICAL pipeline on the auxiliary extended grid
+        // (Doppler → Beer-Lambert → resolution, data points extracted last), so
+        // they must agree to floating-point round-off.  The cached path reuses
+        // the data-grid base XS, which is bit-identical to forward_model's fresh
+        // evaluation at those points; the auxiliary-only points are evaluated the
+        // same way in both.  (Before Fix #7 the cached path applied resolution on
+        // the coarse data grid and the two differed by ~1%.)
         let interior = 20..energies.len() - 20;
         let mut max_err = 0.0f64;
         for i in interior.clone() {
             max_err = max_err.max((t_ref[i] - t_base[i]).abs());
         }
         assert!(
-            max_err < 0.02,
-            "forward_model_from_base_xs with resolution should match \
-             forward_model.  Max error = {max_err}"
+            max_err < 1e-12,
+            "forward_model_from_base_xs with resolution must match forward_model \
+             to round-off (identical aux-grid pipeline).  Max error = {max_err}"
         );
 
         // Verify resolution actually made a difference (not a vacuous test).
@@ -1978,5 +2069,48 @@ mod tests {
         for &d in &dxs[0] {
             assert!(d.is_finite(), "∂σ/∂T must be finite");
         }
+    }
+
+    // ── Fix #8: broadened_cross_sections_for_transmission thickness guard ──
+
+    /// `broadened_cross_sections_for_transmission` divides by the thickness in
+    /// the σ_eff = −ln(T)/nd inversion, so a non-positive or non-finite
+    /// thickness must be rejected up-front (the docstring requires nd > 0).
+    #[test]
+    fn test_broadened_for_transmission_rejects_bad_thickness() {
+        let data = u238_single_resonance();
+        let energies: Vec<f64> = (0..51).map(|i| 5.0 + (i as f64) * 0.1).collect();
+        let inst = InstrumentParams {
+            resolution: resolution::ResolutionFunction::Gaussian(
+                resolution::ResolutionParams::new(25.0, 0.5, 0.005, 0.0).unwrap(),
+            ),
+        };
+
+        for bad in [0.0, -1.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let err = broadened_cross_sections_for_transmission(
+                &energies,
+                std::slice::from_ref(&data),
+                300.0,
+                &inst,
+                bad,
+                None,
+            )
+            .unwrap_err();
+            assert!(
+                matches!(err, TransmissionError::InputMismatch(_)),
+                "thickness = {bad} should be rejected with InputMismatch, got {err:?}"
+            );
+        }
+
+        // A valid positive thickness still succeeds.
+        let ok = broadened_cross_sections_for_transmission(
+            &energies,
+            std::slice::from_ref(&data),
+            300.0,
+            &inst,
+            0.001,
+            None,
+        );
+        assert!(ok.is_ok(), "valid thickness should succeed: {ok:?}");
     }
 }


### PR DESCRIPTION
Part of epic #594 · addresses the physics **P2** items of #599 (items 4, 6, 7, 8). All adjudicated against SAMMY by the cross-LLM-family pass; fix directions re-verified against the cited source.

## Fixes
| Item | File | Fix | SAMMY |
|---|---|---|---|
| #4 | `penetrability.rs` | `phase_shift(l)` l=1-4 → `atan2` (continuous across the rational-form pole) | `Sinsix` `mrml07.f:254-342` |
| #6 | `rmatrix_limited.rs` | gate level-matrix R accumulation on **both channels open** (skip closed) | `Setr` `mrml07.f:67-71` |
| #7 | `transmission.rs` | `forward_model_from_base_xs` resolves on the **aux grid** (extract data points last), mirroring its siblings; + DRY `build_extended_xs_from_base` | sibling `broadened_cross_sections_for_transmission` |
| #8 | `transmission.rs` | enforce finite/positive `thickness_atoms_barn` up front | validate-up-front |

## Observable impact: **none — zero baselines moved**
- #4 is observably invariant (consumers use `sin²φ`/`sin2φ`/`|U|²`); all 218 lib + 89 samtry + SLBW-oracle values unchanged (verified + a new-vs-old invariant-equivalence test).
- #6 is LRF=7-only (not in the paper's resolved-region cases); new **non-vacuous** test shows the gate removes a >100% off-diagonal leak (gated 2.62 b vs un-gated 5.54 b).
- #7's target function has **no production callers**, so it's baseline-neutral.
- Gates: fmt · clippy · `cargo test --workspace` · `pixi run test-python` (126 pass, **Hf-177 LM-fit baseline unchanged**).

## ⚠️ Follow-up (separate PR — baseline-affecting)
While fixing #7, the subagent found the **real** same-shape bug on the **production** path: `crates/nereids-fitting/src/transmission_model.rs:932-995` (the LM fit's cached path) applies resolution on the **coarse data grid** — no aux grid anywhere in the fit path — and the `analytical_jacobian` ∂σ/∂T (~1094-1200) likely shares it. **This is the path the Hf-177 baseline actually exercises**, so fixing it will move that baseline and needs deliberate re-derivation. Tracked separately (not in this PR).
