### PR TITLE
docs: claim-accuracy pass — verify every capability claim and SAMMY citation against primary sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ output spatially resolved isotopic composition maps.
 
 ## Features
 
-- **R-matrix cross-sections** -- Reich-Moore, SLBW, R-Matrix Limited (LRF=7),
-  Unresolved Resonance Region (URR/Hauser-Feshbach), Coulomb channels
+- **R-matrix cross-sections** -- Reich-Moore, Breit-Wigner (single- and
+  multi-level), R-Matrix Limited (LRF=7), Coulomb channels
+- **Unresolved Resonance Region** -- energy-averaged Hauser-Feshbach
+  cross-sections (width-fluctuation correction planned, not yet implemented)
 - **Doppler broadening** -- Free Gas Model (crystal-lattice model planned, not yet implemented)
 - **Resolution broadening** -- Gaussian (channel width + flight path) and
   tabulated instrument functions
@@ -33,7 +35,7 @@ output spatially resolved isotopic composition maps.
 - **Detectability analysis** -- energy-window optimization for trace
   element sensitivity
 - **Python bindings** -- full API via PyO3, pip-installable
-- **Desktop GUI** -- egui application with guided workflow and studio mode
+- **Desktop GUI** -- egui application with Guided and Studio modes
 
 ## Installation
 
@@ -190,7 +192,7 @@ result = nereids.spatial_map_typed(data, energies, [u238, fe56])
 print(f"Converged: {result.n_converged}/{result.n_total} pixels")
 ```
 
-See the [examples/notebooks/](examples/notebooks/) directory for 17 tutorial
+See the [examples/notebooks/](examples/notebooks/) directory for 18 tutorial
 notebooks covering foundations, building blocks, workflows, and applications.
 
 ## Architecture
@@ -229,7 +231,7 @@ nereids-pipeline      End-to-end orchestration, spatial mapping (rayon)
 
 - **[User Guide](https://ornlneutronimaging.github.io/NEREIDS/)** -- Installation, quickstart, architecture
 - **[API Reference](https://ornlneutronimaging.github.io/NEREIDS/api/nereids_pipeline/)** -- Rustdoc for all crates
-- **[Jupyter Notebooks](examples/notebooks/)** -- 17 tutorials organized by complexity
+- **[Jupyter Notebooks](examples/notebooks/)** -- 18 tutorials organized by complexity
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ output spatially resolved isotopic composition maps.
 - **Doppler broadening** -- Free Gas Model (crystal-lattice model planned, not yet implemented)
 - **Resolution broadening** -- Gaussian (channel width + flight path) and
   tabulated instrument functions
-- **ENDF/B data** -- automatic retrieval and caching from IAEA
-  (ENDF/B-VIII.0, ENDF/B-VIII.1, JEFF-3.3, JENDL-5, TENDL-2023, CENDL-3.2)
+- **ENDF nuclear data** -- automatic retrieval and caching (ENDF/B-VIII.0
+  and VIII.1 from NNDC with IAEA fallback; JEFF-3.3, JENDL-5, TENDL-2023,
+  and CENDL-3.2 from IAEA)
 - **Spectrum fitting** -- Levenberg-Marquardt and Poisson/KL divergence
   optimizers with analytical Jacobians
 - **Spatial mapping** -- parallel per-pixel fitting via rayon for 2D

--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ output spatially resolved isotopic composition maps.
 - **Doppler broadening** -- Free Gas Model (crystal-lattice model planned, not yet implemented)
 - **Resolution broadening** -- Gaussian (channel width + flight path) and
   tabulated instrument functions
-- **ENDF/B data** -- automatic retrieval and caching from IAEA for all
-  evaluated libraries (ENDF/B-VIII.0, ENDF/B-VIII.1, JEFF-3.3, JENDL-5,
-  TENDL-2023)
+- **ENDF/B data** -- automatic retrieval and caching from IAEA
+  (ENDF/B-VIII.0, ENDF/B-VIII.1, JEFF-3.3, JENDL-5, TENDL-2023, CENDL-3.2)
 - **Spectrum fitting** -- Levenberg-Marquardt and Poisson/KL divergence
   optimizers with analytical Jacobians
 - **Spatial mapping** -- parallel per-pixel fitting via rayon for 2D

--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -1927,8 +1927,8 @@ fn fit_results_panel(ui: &mut egui::Ui, state: &AppState, result: &SpectrumFitRe
 /// the broadening grid extends beyond `[Emin − Wmin, Emax + Wmax]`,
 /// where W is the resolution width at each limit); we pick 5×FWHM so
 /// resonance shoulders just inside the boundaries are correctly
-/// broadened.  At 5×FWHM ≈ 5.9σ the Gaussian kernel is below 10⁻¹³ of
-/// peak — well past the broadening footprint.
+/// broadened.  At 5×FWHM ≈ 11.8σ (FWHM = 2.3548σ) the Gaussian kernel
+/// is ~10⁻³⁰ of peak — far past the broadening footprint.
 const FIT_RANGE_MARGIN_FWHM: f64 = 5.0;
 
 /// Resolution-kernel margin (eV) to add at energy `e_ev` when slicing

--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -1936,8 +1936,8 @@ const FIT_RANGE_MARGIN_FWHM: f64 = 5.0;
 ///
 /// - **None**: no resolution → no broadening footprint → `0.0`.
 /// - **Gaussian**: extend by `FIT_RANGE_MARGIN_FWHM × FWHM(E)`.  The
-///   kernel has infinite tails; 5×FWHM puts the residual amplitude
-///   below 10⁻¹³ of peak.
+///   kernel has infinite tails; 5×FWHM (≈ 11.8σ) puts the residual
+///   amplitude at ~10⁻³⁰ of peak (see [`FIT_RANGE_MARGIN_FWHM`]).
 /// - **Tabulated**: use `TabulatedResolution::kernel_support_ev(E)`,
 ///   the eV distance over which the discrete kernel has positive
 ///   weight at `E`.  Past this distance the kernel is exactly zero,

--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -277,7 +277,7 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState, available_height_hint: 
                  \u{03BC}s, L_scale \u{2208} [0.99, 1.01].  Mutually \
                  exclusive with Fit temperature.",
                 );
-                // SAMMY REGION-equivalent fit-energy-range restriction (#514).
+                // SAMMY EMIN/EMAX-equivalent fit-energy-range restriction (#514).
                 // The checkbox toggles the `Option<(f64, f64)>` state field;
                 // toggling on initialises from the current full grid bounds
                 // so the user can narrow incrementally.  When set, the
@@ -287,11 +287,11 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState, available_height_hint: 
                 let cb = ui
                     .checkbox(
                         &mut restrict_enabled,
-                        "Restrict fit energy range (SAMMY REGION)",
+                        "Restrict fit energy range (SAMMY EMIN/EMAX)",
                     )
                     .on_hover_text(
                         "Restrict the cost function to bins inside [min, max] eV \
-                         (SAMMY REGION / `MIN ENERGY` / `MAX ENERGY` cards).  \
+                         (equivalent to SAMMY's EMIN/EMAX analysis limits).  \
                          The resolution-kernel margin (~5×FWHM beyond each \
                          boundary) is applied automatically so resonances \
                          near the boundaries remain correctly broadened.  \
@@ -1589,7 +1589,7 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
                 );
             }
 
-            // SAMMY REGION fit-energy-range guides (#514).  Only render
+            // SAMMY EMIN/EMAX fit-energy-range guides (#514).  Only render
             // on the energy axis — the bounds are stored in eV and the
             // TOF projection would require an extra energy↔TOF
             // conversion for marginal user value.  Users can toggle to
@@ -1923,14 +1923,16 @@ fn fit_results_panel(ui: &mut egui::Ui, state: &AppState, result: &SpectrumFitRe
 
 /// Number of resolution-FWHM widths to extend the fit-energy-range
 /// slice on each side as a "kernel margin" for **Gaussian** resolution.
-/// SAMMY user manual §IIID.6 (REGION) recommends 3–5×FWHM; we pick 5×
-/// for safety so resonance shoulders just inside the boundaries are
-/// correctly broadened.  At 5×FWHM ≈ 5.9σ the Gaussian kernel is below
-/// 10⁻¹³ of peak — well past the broadening footprint.
+/// Mirrors SAMMY's auxiliary-grid construction (manual Sec. III.B.2:
+/// the broadening grid extends beyond `[Emin − Wmin, Emax + Wmax]`,
+/// where W is the resolution width at each limit); we pick 5×FWHM so
+/// resonance shoulders just inside the boundaries are correctly
+/// broadened.  At 5×FWHM ≈ 5.9σ the Gaussian kernel is below 10⁻¹³ of
+/// peak — well past the broadening footprint.
 const FIT_RANGE_MARGIN_FWHM: f64 = 5.0;
 
 /// Resolution-kernel margin (eV) to add at energy `e_ev` when slicing
-/// for the fit-energy-range filter (SAMMY REGION-equivalent, #514).
+/// for the fit-energy-range filter (SAMMY EMIN/EMAX-equivalent, #514).
 ///
 /// - **None**: no resolution → no broadening footprint → `0.0`.
 /// - **Gaussian**: extend by `FIT_RANGE_MARGIN_FWHM × FWHM(E)`.  The
@@ -2077,7 +2079,7 @@ fn build_fit_config(state: &AppState) -> Result<(UnifiedFitConfig, Range<usize>)
     // Otherwise we extend the active `[E_min, E_max]` by a kernel-FWHM
     // margin so resonance broadening at the boundaries remains correct;
     // the solver cost paths then mask residuals back to the inner
-    // active range (SAMMY REGION semantics, #514).
+    // active range (SAMMY EMIN/EMAX semantics, #514).
     let resolution = design::build_resolution_function(
         state.resolution_enabled,
         &state.resolution_mode,
@@ -2324,7 +2326,7 @@ fn fit_pixel(state: &mut AppState) {
     }
 
     // Slice per-bin data to the same `energy_range` produced by
-    // `build_fit_config` (SAMMY REGION-equivalent fit-energy-range
+    // `build_fit_config` (SAMMY EMIN/EMAX-equivalent fit-energy-range
     // restriction with kernel-margin extension, #514).  When the user
     // hasn't restricted the range, `energy_range` is `0..n_energies`,
     // so this is identical to the previous full-grid behaviour.
@@ -2495,7 +2497,7 @@ fn fit_roi(state: &mut AppState) {
     // Weighted average transmission and propagated uncertainty.
     //
     // We build the full-grid averaged arrays first, then slice to
-    // `energy_range` for the fit (SAMMY REGION-equivalent fit-energy-
+    // `energy_range` for the fit (SAMMY EMIN/EMAX-equivalent fit-energy-
     // range restriction with kernel-margin extension, #514).  The
     // ROI averaging is unaffected by the slice — it's the same
     // `n_tof` arithmetic regardless of which bins end up in the fit.
@@ -2531,7 +2533,7 @@ fn fit_roi(state: &mut AppState) {
         && let (Some(sample), Some(open_beam)) = (&state.sample_data, &state.open_beam_data)
     {
         // Counts paths slice the energy axis to `energy_range` — same
-        // SAMMY REGION semantics as the LM transmission path above.
+        // SAMMY EMIN/EMAX semantics as the LM transmission path above.
         let sample_counts: Vec<f64> = energy_range
             .clone()
             .map(|t| {
@@ -2731,7 +2733,7 @@ pub fn run_spatial_map(state: &mut AppState) {
         // Use counts-domain only when the solver is Poisson KL AND both
         // sample and open beam are available. LM always uses Transmission.
         //
-        // SAMMY REGION-equivalent fit-energy-range restriction (#514):
+        // SAMMY EMIN/EMAX-equivalent fit-energy-range restriction (#514):
         // when `state.fit_energy_range` is set, `build_fit_config` slices
         // the energy grid to `energy_range` (with kernel-margin extension);
         // here we slice the per-pixel data views to the same axis-0 range

--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -1923,12 +1923,14 @@ fn fit_results_panel(ui: &mut egui::Ui, state: &AppState, result: &SpectrumFitRe
 
 /// Number of resolution-FWHM widths to extend the fit-energy-range
 /// slice on each side as a "kernel margin" for **Gaussian** resolution.
-/// Mirrors SAMMY's auxiliary-grid construction (manual Sec. III.B.2:
-/// the broadening grid extends beyond `[Emin − Wmin, Emax + Wmax]`,
-/// where W is the resolution width at each limit); we pick 5×FWHM so
-/// resonance shoulders just inside the boundaries are correctly
-/// broadened.  At 5×FWHM ≈ 11.8σ (FWHM = 2.3548σ) the Gaussian kernel
-/// is ~10⁻³⁰ of peak — far past the broadening footprint.
+/// Follows the same endpoint-extension principle as SAMMY's auxiliary
+/// grid (general construction: manual Sec. III.A.2(c); the quantitative
+/// `[Emin − Wmin, Emax + Wmax]` statement, W = resolution width at each
+/// limit, appears in the Leal-Hwang procedure, Sec. III.B.2).  NEREIDS
+/// deliberately uses a conservative 5×FWHM margin so resonance
+/// shoulders just inside the boundaries are correctly broadened.  At
+/// 5×FWHM ≈ 11.8σ (FWHM = 2.3548σ) the Gaussian kernel is ~10⁻³⁰ of
+/// peak — far past the broadening footprint.
 const FIT_RANGE_MARGIN_FWHM: f64 = 5.0;
 
 /// Resolution-kernel margin (eV) to add at energy `e_ev` when slicing

--- a/apps/gui/src/state.rs
+++ b/apps/gui/src/state.rs
@@ -77,7 +77,7 @@ pub struct SessionCache {
     /// as free parameters.  Mutually exclusive with `fit_temperature`.
     #[serde(default)]
     pub fit_energy_scale: bool,
-    /// Fit energy range restriction (SAMMY REGION equivalent).
+    /// Fit energy range restriction (SAMMY EMIN/EMAX equivalent).
     /// `None` (default) = full grid.
     #[serde(default)]
     pub fit_energy_range: Option<(f64, f64)>,
@@ -744,8 +744,8 @@ pub struct AppState {
     /// represents the residual offset on top of the corrected grid;
     /// `L_scale` multiplies the nominal `flight_path_m`.
     pub fit_energy_scale: bool,
-    /// Restrict the fit to `[min_eV, max_eV]` (SAMMY REGION equivalent,
-    /// SAMMY user manual §IIID.6 / SAM52 `MIN ENERGY` / `MAX ENERGY`).
+    /// Restrict the fit to `[min_eV, max_eV]` (SAMMY EMIN/EMAX equivalent —
+    /// INPut-file card set 2, manual Table VI A.1).
     /// `None` = full grid (default).  Both bounds must lie inside the
     /// loaded energy grid; the resolution-kernel margin (~5×FWHM beyond
     /// each boundary) is applied automatically in `build_fit_config`

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -3375,7 +3375,7 @@ fn py_spatial_map_typed<'py>(
     // Dead pixels
     let dead_arr = dead_pixels.map(|dp| dp.as_array().to_owned());
 
-    // SAMMY REGION-equivalent fit-energy-range (#514): mask residuals
+    // SAMMY EMIN/EMAX-equivalent fit-energy-range (#514): mask residuals
     // to bins inside [E_min, E_max] in both LM and joint-Poisson per-
     // pixel cost paths.  The model is evaluated on the full grid so
     // resolution broadening at the boundaries is correct.
@@ -3703,7 +3703,7 @@ fn py_fit_counts_spectrum_typed<'py>(
         config = config.with_counts_enable_polish(Some(v));
     }
 
-    // SAMMY REGION-equivalent fit-energy-range (#514): mask residuals
+    // SAMMY EMIN/EMAX-equivalent fit-energy-range (#514): mask residuals
     // to bins inside [E_min, E_max]; the joint-Poisson cost path
     // honours the mask in deviance / gradient / Fisher loops.  No
     // Python-side data slicing required — the model is evaluated on
@@ -4203,7 +4203,7 @@ fn py_fit_spectrum_typed<'py>(
         config = config.with_tzero_jacobian_method(tzero_method);
     }
 
-    // SAMMY REGION-equivalent fit-energy-range (#514): when set, the
+    // SAMMY EMIN/EMAX-equivalent fit-energy-range (#514): when set, the
     // LM cost-function masks residuals to bins inside [E_min, E_max].
     // The Python caller is expected to pass full grid + per-bin data
     // and let the solver-side mask handle the restriction; the model

--- a/crates/nereids-endf/src/parser.rs
+++ b/crates/nereids-endf/src/parser.rs
@@ -1532,8 +1532,8 @@ fn parse_urr_range(
 
                 // All ENDF interpolation laws (INT=1..5) are now supported
                 // in the URR physics module (urr.rs).
-                // INT=1: histogram, INT=2: lin-lin, INT=3: log-lin,
-                // INT=4: lin-log, INT=5: log-log.
+                // INT=1: histogram, INT=2: lin-lin, INT=3: log-x/lin-y,
+                // INT=4: lin-x/log-y, INT=5: log-log.
                 // ENDF-6 §2.2.2.2.
 
                 let values = parse_list_values(ctx.lines, ctx.pos, n1)?;

--- a/crates/nereids-endf/src/parser.rs
+++ b/crates/nereids-endf/src/parser.rs
@@ -132,7 +132,7 @@ pub fn parse_endf_file2(endf_text: &str) -> Result<ResonanceData, EndfParseError
 
                 // NRO=range_cont.n1: if non-zero a TAB1 AP(E) record immediately follows
                 // the range CONT before the URR SPI/AP/NLS CONT.
-                // ENDF-6 §2.2.2; SAMMY unr/munr01.f90.
+                // ENDF-6 §2.2.2.
                 let nro_urr = range_cont.n1;
                 let naps_urr = range_cont.n2; // scattering radius calculation flag
                 let ap_table_urr = if nro_urr != 0 {
@@ -1413,7 +1413,7 @@ fn parse_urr_lfw1_lrf1(ctx: &mut RangeParseContext<'_>) -> Result<ResonanceRange
 /// LFW=1 / LRF=1 (energy-dependent fission widths with the shared-grid
 /// layout) is handled separately by `parse_urr_lfw1_lrf1`.
 ///
-/// Reference: ENDF-6 Formats Manual §2.2.2; SAMMY `unr/munr03.f90`
+/// Reference: ENDF-6 Formats Manual §2.2.2
 fn parse_urr_range(
     ctx: &mut RangeParseContext<'_>,
     lrf: i32,
@@ -1534,7 +1534,7 @@ fn parse_urr_range(
                 // in the URR physics module (urr.rs).
                 // INT=1: histogram, INT=2: lin-lin, INT=3: log-lin,
                 // INT=4: lin-log, INT=5: log-log.
-                // ENDF-6 §2.2.2.2; SAMMY unr/munr01.f90.
+                // ENDF-6 §2.2.2.2.
 
                 let values = parse_list_values(ctx.lines, ctx.pos, n1)?;
 

--- a/crates/nereids-endf/src/resonance.rs
+++ b/crates/nereids-endf/src/resonance.rs
@@ -184,7 +184,7 @@ pub enum ResonanceFormalism {
 // LRF=2: tabulated energy-dependent widths with an interpolation law per
 //        J-group; supported INT codes enforced by the parser at load time.
 //
-// Reference: ENDF-6 Formats Manual §2.2.2; SAMMY unr/munr03.f90 Csig3
+// Reference: ENDF-6 Formats Manual §2.2.2
 
 /// Average widths for one (L, J) combination in the Unresolved Resonance Region.
 ///
@@ -192,7 +192,7 @@ pub enum ResonanceFormalism {
 /// For LRF=2: all vectors have length NE; `int_code` selects the interpolation
 /// law (INT=2 lin-lin or INT=5 log-log).
 ///
-/// Reference: ENDF-6 Formats Manual §2.2.2; SAMMY `unr/munr03.f90`
+/// Reference: ENDF-6 Formats Manual §2.2.2
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UrrJGroup {
     /// Total angular momentum J.
@@ -241,7 +241,7 @@ pub struct UrrLGroup {
 ///
 /// Stored in `ResonanceRange::urr` when the range is an URR range.
 ///
-/// Reference: ENDF-6 Formats Manual §2.2.2; SAMMY `unr/munr03.f90`
+/// Reference: ENDF-6 Formats Manual §2.2.2
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UrrData {
     /// LRF flag: 1 = single-level BWR (energy-independent widths),

--- a/crates/nereids-endf/src/resonance.rs
+++ b/crates/nereids-endf/src/resonance.rs
@@ -216,8 +216,9 @@ pub struct UrrJGroup {
     /// Average fission width GF (eV). Single-element for LRF=1.
     pub gf: Vec<f64>,
     /// Interpolation law for the energy table (LRF=2 only).
-    /// INT=1..=5 per ENDF-6 §0.5 (1 histogram, 2 lin-lin, 3 log-lin,
-    /// 4 lin-log, 5 log-log).  Ignored for LRF=1 (no table).
+    /// INT=1..=5 per ENDF-6 §0.5 (1: histogram; 2: y linear in E;
+    /// 3: y linear in ln E; 4: ln y linear in E; 5: ln y linear in ln E).
+    /// Ignored for LRF=1 (no table).
     #[serde(default = "default_int_code")]
     pub int_code: u32,
 }

--- a/crates/nereids-endf/src/resonance.rs
+++ b/crates/nereids-endf/src/resonance.rs
@@ -190,7 +190,8 @@ pub enum ResonanceFormalism {
 ///
 /// For LRF=1: `energies` is empty; each width vector has exactly one element.
 /// For LRF=2: all vectors have length NE; `int_code` selects the interpolation
-/// law (INT=2 lin-lin or INT=5 log-log).
+/// law (INT=1..=5 per ENDF-6 §0.5; validated by the parser, dispatched in
+/// `nereids_physics::urr`).
 ///
 /// Reference: ENDF-6 Formats Manual §2.2.2
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -215,7 +216,8 @@ pub struct UrrJGroup {
     /// Average fission width GF (eV). Single-element for LRF=1.
     pub gf: Vec<f64>,
     /// Interpolation law for the energy table (LRF=2 only).
-    /// 2 = lin-lin, 5 = log-log.  Ignored for LRF=1 (no table).
+    /// INT=1..=5 per ENDF-6 §0.5 (1 histogram, 2 lin-lin, 3 log-lin,
+    /// 4 lin-log, 5 log-log).  Ignored for LRF=1 (no table).
     #[serde(default = "default_int_code")]
     pub int_code: u32,
 }

--- a/crates/nereids-fitting/src/active_mask.rs
+++ b/crates/nereids-fitting/src/active_mask.rs
@@ -1,6 +1,6 @@
 //! Active-bin masking for fit-energy-range restriction.
 //!
-//! SAMMY REGION equivalent (`MIN ENERGY` / `MAX ENERGY` SAM52 cards).
+//! SAMMY EMIN/EMAX equivalent (INPut-file card set 2, manual Table VI A.1).
 //! When a user restricts the fit to `[E_min, E_max]`, the GUI extends
 //! the energy grid by ~5×FWHM beyond each boundary so resonances near
 //! the boundaries are correctly broadened, and the cost-function paths

--- a/crates/nereids-fitting/src/joint_poisson.rs
+++ b/crates/nereids-fitting/src/joint_poisson.rs
@@ -62,7 +62,7 @@ pub struct JointPoissonObjective<'a> {
     pub s: &'a [f64],
     /// Proton-charge ratio `c = Q_s / Q_ob`.  Must be strictly positive.
     pub c: f64,
-    /// Optional per-bin active mask (SAMMY REGION-equivalent
+    /// Optional per-bin active mask (SAMMY EMIN/EMAX-equivalent
     /// fit-energy-range restriction).  When `Some(m)`, only bins where
     /// `m[i]` is `true` contribute to the deviance / gradient / Fisher
     /// information; the model is still evaluated on the full grid so
@@ -784,7 +784,7 @@ pub struct JointPoissonResult {
     /// set, or the count of `true` entries in the objective's
     /// `active_mask` otherwise.  The deviance / dof ratio uses
     /// `(n_active − n_free)` so reduced deviance is unbiased when a
-    /// fit-energy-range mask is in effect (SAMMY REGION semantics, #514).
+    /// fit-energy-range mask is in effect (SAMMY EMIN/EMAX semantics, #514).
     pub n_active: usize,
     /// Number of free parameters (k).
     pub n_free: usize,
@@ -886,7 +886,7 @@ pub fn joint_poisson_fit(
         });
     }
 
-    // SAMMY REGION-equivalent fit-energy-range (#514): zero active
+    // SAMMY EMIN/EMAX-equivalent fit-energy-range (#514): zero active
     // bins means the user's `[E_min, E_max]` does not overlap the
     // configured grid.  No data contributes to the deviance — return
     // non-converged with NaN before falling through.  Without this
@@ -1002,7 +1002,7 @@ pub fn joint_poisson_fit(
     let final_values = params.all_values();
     let final_deviance = objective.deviance(&final_values)?;
     let n_free = params.n_free();
-    // Active-bin masking (SAMMY REGION): when a fit-energy-range mask
+    // Active-bin masking (SAMMY EMIN/EMAX): when a fit-energy-range mask
     // is in effect, dof must use the count of bins that contributed to
     // the deviance — otherwise deviance-per-dof is biased low by the
     // ratio (n_active / n_data).  The `n_active < n_free` case has
@@ -2050,7 +2050,7 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // Active-bin mask (SAMMY REGION-equivalent fit-energy-range, #514).
+    // Active-bin mask (SAMMY EMIN/EMAX-equivalent fit-energy-range, #514).
     // ------------------------------------------------------------------
 
     /// `deviance_from_transmission` with `active_mask` set must equal

--- a/crates/nereids-fitting/src/lib.rs
+++ b/crates/nereids-fitting/src/lib.rs
@@ -11,7 +11,7 @@
 //! - [`transmission_model`] — Transmission forward model adapter for fitting
 //!
 //! ## SAMMY Reference
-//! - Fitting: `fit/` module, `fitAPI/`, manual Sec 4
+//! - Fitting: `fit/` module, `fitAPI/`, manual Sec. IV
 //!
 //! ## TRINIDI Reference
 //! - `trinidi/reconstruct.py` for Poisson-likelihood and APGM approach

--- a/crates/nereids-fitting/src/lm.rs
+++ b/crates/nereids-fitting/src/lm.rs
@@ -8,7 +8,7 @@
 //! and λ is the damping parameter.
 //!
 //! ## SAMMY Reference
-//! - `fit/` module, manual Sec 4 (Bayes equations / generalized least-squares)
+//! - `fit/` module, manual Sec. IV (Bayes equations / generalized least-squares)
 
 use nereids_core::constants::{LM_DIAGONAL_FLOOR, PIVOT_FLOOR};
 
@@ -190,7 +190,7 @@ impl<M: FitModel + ?Sized> FitModel for &M {
 /// matters when masked bins may contain non-finite residuals (e.g. NaN
 /// outside the user's fit-energy range): `0.0 * NaN = NaN`, so a
 /// zero-weight strategy would propagate NaN through the χ² accumulator
-/// even though the bin contributes no information.  See SAMMY REGION
+/// even though the bin contributes no information.  See SAMMY EMIN/EMAX
 /// semantics (#514) and lm.rs Fix 4.
 fn chi_squared(residuals: &[f64], weights: &[f64], active_mask: Option<&[bool]>) -> f64 {
     let mut sum = 0.0;
@@ -494,7 +494,7 @@ pub fn levenberg_marquardt(
 }
 
 /// Run the Levenberg-Marquardt optimizer with an optional per-bin
-/// active mask (SAMMY REGION-equivalent fit-energy-range restriction).
+/// active mask (SAMMY EMIN/EMAX-equivalent fit-energy-range restriction).
 ///
 /// When `active_mask` is `Some(m)`:
 /// - bins where `m[i]` is `false` are excluded from χ² and the normal
@@ -537,7 +537,7 @@ pub fn levenberg_marquardt_with_mask(
     }
     let n_active = crate::active_mask::active_count(active_mask, n_data);
 
-    // SAMMY REGION-equivalent fit-energy-range (#514): a mask with
+    // SAMMY EMIN/EMAX-equivalent fit-energy-range (#514): a mask with
     // zero active bins means the user's `[E_min, E_max]` does not
     // overlap the energy grid.  No data contributes to the cost
     // function — return non-converged with NaN χ² rather than
@@ -567,7 +567,7 @@ pub fn levenberg_marquardt_with_mask(
             .iter()
             .enumerate()
             .map(|(i, &s)| {
-                // Active-bin masking (SAMMY REGION): bins outside the
+                // Active-bin masking (SAMMY EMIN/EMAX): bins outside the
                 // user range contribute zero to χ².
                 if active_mask.is_some_and(|m| !m[i]) {
                     return 0.0;
@@ -586,7 +586,7 @@ pub fn levenberg_marquardt_with_mask(
         // Covariance/uncertainties are None because the fit did not converge —
         // an unconverged result has no meaningful covariance to report.
         //
-        // SAMMY REGION-equivalent fit-energy-range (#514): masked rows are
+        // SAMMY EMIN/EMAX-equivalent fit-energy-range (#514): masked rows are
         // skipped throughout the cost / normal-equation accumulators, so a
         // non-finite model output at a masked bin should not abort the fit
         // — only check finiteness on active rows.
@@ -616,7 +616,7 @@ pub fn levenberg_marquardt_with_mask(
         // when no mask is set) to mirror the main path and keep a single
         // visible formula.  When a fit-energy-range mask is in effect,
         // `n_active` reflects the count of bins that actually contributed
-        // to χ² (SAMMY REGION semantics).
+        // to χ² (SAMMY EMIN/EMAX semantics).
         let dof = n_active.saturating_sub(n_free);
         let reduced = if dof > 0 { chi2 / dof as f64 } else { f64::NAN };
         return Ok(LmResult {
@@ -637,7 +637,7 @@ pub fn levenberg_marquardt_with_mask(
     // we allow it and report reduced_chi_squared = NaN (0/0).
     //
     // When a fit-energy-range mask is in effect, the underdetermined
-    // check uses the active-bin count (SAMMY REGION semantics) — masked
+    // check uses the active-bin count (SAMMY EMIN/EMAX semantics) — masked
     // bins do not contribute information to the fit.
     if n_active < n_free {
         return Ok(LmResult {
@@ -657,7 +657,7 @@ pub fn levenberg_marquardt_with_mask(
     // floor instead of rejecting outright, so callers with a few zero-sigma
     // bins still get a usable fit.
     //
-    // Active-bin masking (SAMMY REGION): bins outside the user range
+    // Active-bin masking (SAMMY EMIN/EMAX): bins outside the user range
     // get weight 0 here, which propagates through χ² and the JᵀWJ /
     // JᵀWr normal-equation assembly to contribute exactly zero —
     // covering both residual and gradient masking with no further
@@ -721,7 +721,7 @@ pub fn levenberg_marquardt_with_mask(
 
         // Build normal equations: JᵀWJ and JᵀWr.
         //
-        // Active-bin masking (SAMMY REGION, #514): explicitly skip
+        // Active-bin masking (SAMMY EMIN/EMAX, #514): explicitly skip
         // masked rows rather than relying on weights[i] == 0 — the
         // model or the residual at a masked margin bin may be NaN
         // (e.g. when y_obs is NaN outside the user's fit-energy range),
@@ -783,7 +783,7 @@ pub fn levenberg_marquardt_with_mask(
 
         // #113: If the model produced NaN/Inf at any *active* bin, treat as
         // a bad step (same as chi2 increase) — increase lambda and try again.
-        // SAMMY REGION-equivalent fit-energy-range (#514): masked rows are
+        // SAMMY EMIN/EMAX-equivalent fit-energy-range (#514): masked rows are
         // skipped from χ² / JᵀWJ / JᵀWr / covariance, so a non-finite model
         // output at a masked margin bin must not penalise the trial step.
         let trial_has_active_nonfinite = y_trial
@@ -1526,7 +1526,7 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // Active-bin mask (SAMMY REGION-equivalent fit-energy-range, #514).
+    // Active-bin mask (SAMMY EMIN/EMAX-equivalent fit-energy-range, #514).
     // ------------------------------------------------------------------
 
     /// LM with an `active_mask` that restricts to a subset of bins must

--- a/crates/nereids-io/src/project.rs
+++ b/crates/nereids-io/src/project.rs
@@ -84,8 +84,8 @@ pub struct ProjectSnapshot {
     /// `L_scale`).  `Option` for backwards compatibility — projects
     /// saved before this field was introduced load as `None` (= false).
     pub fit_energy_scale: Option<bool>,
-    /// User-specified fit energy range `[min_eV, max_eV]` (SAMMY REGION
-    /// equivalent, `MIN ENERGY` / `MAX ENERGY` SAM52 cards).
+    /// User-specified fit energy range `[min_eV, max_eV]` (SAMMY EMIN/EMAX
+    /// equivalent — INPut-file card set 2, manual Table VI A.1).
     /// `None` (default) = full grid.  Projects saved before this field
     /// was introduced load as `None` via the HDF5 reader's missing-
     /// attribute handling — the bounds are stored as two scalar
@@ -579,7 +579,7 @@ fn write_config(file: &hdf5::File, snap: &ProjectSnapshot) -> Result<(), IoError
         write_bool_attr(&solver, "fit_energy_scale", fes)?;
     }
     if let Some((fr_min, fr_max)) = snap.fit_energy_range {
-        // SAMMY REGION-equivalent fit-energy-range bounds (#514).
+        // SAMMY EMIN/EMAX-equivalent fit-energy-range bounds (#514).
         // Stored as two scalar attributes so HDF5 introspection tools
         // can read the values directly without parsing a packed tuple.
         write_f64_attr(&solver, "fit_energy_range_min_ev", fr_min)?;
@@ -1265,7 +1265,7 @@ fn read_config(file: &hdf5::File, snap: &mut ProjectSnapshot) -> Result<(), IoEr
     snap.temperature_k = read_f64_attr(&solver, "temperature_k")?;
     snap.fit_temperature = read_bool_attr(&solver, "fit_temperature")?;
     snap.fit_energy_scale = read_bool_attr(&solver, "fit_energy_scale").ok();
-    // SAMMY REGION-equivalent fit-energy-range bounds (#514).  Both
+    // SAMMY EMIN/EMAX-equivalent fit-energy-range bounds (#514).  Both
     // attributes must be present to populate the field; older project
     // files load as `None` (= full-grid fit, the prior default).
     snap.fit_energy_range = match (

--- a/crates/nereids-physics/src/channel.rs
+++ b/crates/nereids-physics/src/channel.rs
@@ -6,7 +6,7 @@
 //!
 //! ## SAMMY Reference
 //! - `rml/mrml03.f` Fxradi: wave number and radius computations
-//! - SAMMY manual Section 2 (kinematics)
+//! - SAMMY manual Section II.A (scattering-theory equations and kinematics)
 //!
 //! ## Units
 //! All quantities in natural units: energies in eV, lengths in fm.

--- a/crates/nereids-physics/src/doppler.rs
+++ b/crates/nereids-physics/src/doppler.rs
@@ -1524,6 +1524,17 @@ mod tests {
         let broadened_ref = |sigma: &dyn Fn(f64) -> f64, e: f64, full: bool| -> f64 {
             let v = e.sqrt();
             let (lo, hi) = (v - 12.0 * u, v + 12.0 * u);
+            // Enforce the image-branch-omission precondition: the window must
+            // stay in positive-w territory, which also bounds the omitted
+            // image term at ≤ exp(−(v/u)²) ≤ exp(−144) — far below quadrature
+            // noise.  If the test parameters (E, T, AWR) ever change such that
+            // this fails, implement the negative-w branch instead.
+            assert!(
+                lo > 0.0,
+                "reference quadrature window crosses w = 0 (v/u = {:.1} < 12); \
+                 the omitted image branch is no longer negligible",
+                v / u
+            );
             let n = 4800usize; // even (Simpson); h = 0.005·u
             let h = (hi - lo) / n as f64;
             let f = |w: f64| -> f64 {

--- a/crates/nereids-physics/src/doppler.rs
+++ b/crates/nereids-physics/src/doppler.rs
@@ -22,12 +22,20 @@
 //!
 //! This is SAMMY Eq. III B1.7 **without** the (w/v) integrand weight the
 //! full FGM kernel carries — SAMMY's `Dopfgm` weights by w² and divides by
-//! v² (`fgm/mfgm2.f90` Modsmp/Modfpl, `mfgm4.f90`).  The omission preserves
-//! a constant cross-section exactly, whereas the full kernel yields
-//! σ·(1 + u²/2v²); the relative deviation is O(kT/(AWR·E)) — ~1.6×10⁻⁵ for
-//! U-238 at 6.67 eV / 300 K — negligible for heavy isotopes at epithermal
-//! energies and growing toward thermal energies and light targets.
-//! Exact-kernel (w²/v²) migration is planned.
+//! v² (`fgm/mfgm2.f90` Modsmp/Modfpl, `mfgm4.f90`).  Error scales of the
+//! omission, in terms of u/v = √(kT/(AWR·E)):
+//!
+//! - **Smooth cross-sections** (second order): the full kernel maps a
+//!   constant σ to σ·(1 + u²/2v²) while this kernel preserves it (up to
+//!   exponentially small e^(-(v/u)²) image terms) — relative deviation
+//!   kT/(2·AWR·E) ≈ 8.2×10⁻⁶ for U-238 at 6.67 eV / 300 K.
+//! - **Resonance line shapes** (first order): an antisymmetric flank skew
+//!   of order u/v — up to ≈ 0.4% on the Doppler-broadened flanks of the
+//!   U-238 6.67 eV resonance at 300 K, vanishing at the peak — which can
+//!   alias into fitted energy-scale and density parameters.
+//!
+//! Exact-kernel (w²/v²) migration is planned, with a flank-discriminating
+//! kernel test.
 //!
 //! The key advantage of the velocity-space formulation is that u is
 //! independent of energy, making it a true convolution.
@@ -276,8 +284,9 @@ fn erfc_val(x: f64) -> f64 {
 
 /// Apply FGM Doppler broadening to cross-section data.
 ///
-/// The cross-sections are broadened in velocity space using the exact
-/// Free Gas Model integral from SAMMY manual Eq. III B1.7.
+/// The cross-sections are broadened in velocity space via Gaussian
+/// convolution of v·σ — SAMMY manual Eq. III B1.7 without the (w/v)
+/// integrand weight; see the module docs for the error characterization.
 ///
 /// # Arguments
 /// * `energies` — Energy grid in eV. Every entry must satisfy

--- a/crates/nereids-physics/src/doppler.rs
+++ b/crates/nereids-physics/src/doppler.rs
@@ -7,17 +7,27 @@
 //!
 //! ## SAMMY Reference
 //! - Manual Section III.B.1 (Free-Gas Model of Doppler Broadening)
-//! - `fgm/` module (`FreeGasDopplerBroadening_M.f90`, subroutine `Dopfgm`)
+//! - `fgm/mfgm1.f90` subroutine `Dopfgm` (quadrature in `mfgm2.f90`
+//!   Modsmp/Modfpl)
 //!
 //! ## Method
 //!
-//! We implement the exact FGM integral in velocity space (SAMMY Eq. III B1.7):
+//! Velocity-space Gaussian broadening of v·σ:
 //!
 //!   v·σ_D(v²) = (1/(u√π)) ∫ exp(-(v-w)²/u²) · w · s(w) dw
 //!
 //! where v = √E, u = √(k_B·T / AWR), and:
 //!   s(w) =  σ(w²)  for w > 0
 //!   s(w) = -σ(w²)  for w < 0
+//!
+//! This is SAMMY Eq. III B1.7 **without** the (w/v) integrand weight the
+//! full FGM kernel carries — SAMMY's `Dopfgm` weights by w² and divides by
+//! v² (`fgm/mfgm2.f90` Modsmp/Modfpl, `mfgm4.f90`).  The omission preserves
+//! a constant cross-section exactly, whereas the full kernel yields
+//! σ·(1 + u²/2v²); the relative deviation is O(kT/(AWR·E)) — ~1.6×10⁻⁵ for
+//! U-238 at 6.67 eV / 300 K — negligible for heavy isotopes at epithermal
+//! energies and growing toward thermal energies and light targets.
+//! Exact-kernel (w²/v²) migration is planned.
 //!
 //! The key advantage of the velocity-space formulation is that u is
 //! independent of energy, making it a true convolution.

--- a/crates/nereids-physics/src/doppler.rs
+++ b/crates/nereids-physics/src/doppler.rs
@@ -7,7 +7,7 @@
 //!
 //! ## SAMMY Reference
 //! - Manual Section III.B.1 (Free-Gas Model of Doppler Broadening)
-//! - `dop/` module (Leal-Hwang implementation)
+//! - `fgm/` module (`FreeGasDopplerBroadening_M.f90`, subroutine `Dopfgm`)
 //!
 //! ## Method
 //!

--- a/crates/nereids-physics/src/doppler.rs
+++ b/crates/nereids-physics/src/doppler.rs
@@ -1483,4 +1483,133 @@ mod tests {
             "analytical vs SAMMY-style FD max rel error = {max_rel_err:.2e}, expected < 1e-3"
         );
     }
+
+    /// Pin the documented error scales of the implemented kernel (module
+    /// docs: Eq. III B1.7 WITHOUT the (w/v) integrand weight) against an
+    /// in-test full-kernel reference, so the published numbers are tested,
+    /// not free-floating.  The existing SAMMY ex001 oracle (6% tolerance)
+    /// is blind to this error class.
+    ///
+    /// (a) Smooth limit: the implemented kernel preserves a constant σ
+    ///     (quadrature-noise level), while the full kernel yields
+    ///     σ·(1 + u²/2v²) — the documented kT/(2·AWR·E) deviation.
+    /// (b) Resonance line shape (U-238-like Lorentzian: E_r = 6.674 eV,
+    ///     Γ = 0.027 eV, AWR = 236.0058, 300 K): the implemented-vs-full
+    ///     deviation at the ±Δ_D flanks is FIRST order — antisymmetric,
+    ///     within [0.1%, 1%], pinning the documented "~0.4%" — and second-
+    ///     order small at the peak.
+    /// (c) The production `doppler_broaden` agrees with the reference
+    ///     implemented-kernel quadrature at those points, so the pin holds
+    ///     for the shipping code path.
+    ///
+    /// When the exact-kernel (w²/v²) migration lands, expectation (b)
+    /// inverts: production moves to the full-kernel reference and the
+    /// flank deviation vs `sigma_full` drops to quadrature level.
+    #[test]
+    fn kernel_error_scales_pinned_vs_full_fgm_reference() {
+        use std::f64::consts::PI;
+
+        let awr = 236.0058;
+        let t_k = 300.0;
+        let e_r = 6.674; // eV
+        let gamma = 0.027; // eV (total width scale; Lorentzian discriminator)
+        let params = DopplerParams::new(t_k, awr).unwrap();
+        let u = params.u();
+
+        // Reference quadrature of the analytic integrand on [v−12u, v+12u]
+        // (Simpson).  The negative-velocity image branch is omitted: it is
+        // suppressed by exp(−(v/u)²) with v/u ≈ 247 here.  `power` selects
+        // the implemented kernel (w¹, divide by v) vs the full FGM kernel
+        // (w², divide by v²).
+        let broadened_ref = |sigma: &dyn Fn(f64) -> f64, e: f64, full: bool| -> f64 {
+            let v = e.sqrt();
+            let (lo, hi) = (v - 12.0 * u, v + 12.0 * u);
+            let n = 4800usize; // even (Simpson); h = 0.005·u
+            let h = (hi - lo) / n as f64;
+            let f = |w: f64| -> f64 {
+                let g = (-((v - w) / u).powi(2)).exp();
+                let wp = if full { w * w } else { w };
+                g * wp * sigma(w * w)
+            };
+            let mut s = f(lo) + f(hi);
+            for i in 1..n {
+                let w = lo + i as f64 * h;
+                s += f(w) * if i % 2 == 1 { 4.0 } else { 2.0 };
+            }
+            let integral = s * h / 3.0;
+            let norm = u * PI.sqrt() * if full { v * v } else { v };
+            integral / norm
+        };
+
+        // (a) Constant cross-section.
+        let const_sigma = |_e: f64| 1.0_f64;
+        let apx_const = broadened_ref(&const_sigma, e_r, false);
+        let full_const = broadened_ref(&const_sigma, e_r, true);
+        let u2_over_2v2 = u * u / (2.0 * e_r); // v² = E
+        assert!(
+            (apx_const - 1.0).abs() < 1e-8,
+            "implemented kernel must preserve constant σ (got dev {:.3e})",
+            apx_const - 1.0
+        );
+        assert!(
+            ((full_const - 1.0) - u2_over_2v2).abs() < 0.05 * u2_over_2v2,
+            "full kernel on constant σ must give 1 + u²/2v² = 1 + {:.3e} (got 1 + {:.3e})",
+            u2_over_2v2,
+            full_const - 1.0
+        );
+
+        // (b) Lorentzian line shape: first-order antisymmetric flank skew.
+        let lorentzian = |e: f64| {
+            let x = (e - e_r) / (gamma / 2.0);
+            1.0 / (1.0 + x * x)
+        };
+        let delta_d = params.doppler_width(e_r);
+        let dev_at = |e: f64| -> f64 {
+            let apx = broadened_ref(&lorentzian, e, false);
+            let full = broadened_ref(&lorentzian, e, true);
+            (full - apx) / full
+        };
+        let dev_lo = dev_at(e_r - delta_d);
+        let dev_hi = dev_at(e_r + delta_d);
+        let dev_peak = dev_at(e_r);
+        assert!(
+            dev_lo > 1.0e-3 && dev_lo < 1.0e-2,
+            "low-flank deviation must be first-order positive (~0.3%), got {dev_lo:.3e}"
+        );
+        assert!(
+            dev_hi < -1.0e-3 && dev_hi > -1.0e-2,
+            "high-flank deviation must be first-order negative (~−0.3%), got {dev_hi:.3e}"
+        );
+        assert!(
+            dev_peak.abs() < 5.0e-5,
+            "peak deviation must be second-order small, got {dev_peak:.3e}"
+        );
+
+        // (c) The shipping doppler_broaden matches the implemented-kernel
+        // reference at the same energies (grid fine enough that production
+        // quadrature error ≪ the 0.3% flank signal).
+        let n_grid = 3001usize;
+        let (e_lo, e_hi) = (e_r - 1.2, e_r + 1.2);
+        let energies: Vec<f64> = (0..n_grid)
+            .map(|i| e_lo + (e_hi - e_lo) * i as f64 / (n_grid - 1) as f64)
+            .collect();
+        let xs: Vec<f64> = energies.iter().map(|&e| lorentzian(e)).collect();
+        let broadened = doppler_broaden(&energies, &xs, &params).unwrap();
+        for target in [e_r - delta_d, e_r, e_r + delta_d] {
+            let idx = energies
+                .iter()
+                .enumerate()
+                .min_by(|(_, a), (_, b)| (*a - target).abs().total_cmp(&(*b - target).abs()))
+                .map(|(i, _)| i)
+                .unwrap();
+            let e_eval = energies[idx];
+            let ref_apx = broadened_ref(&lorentzian, e_eval, false);
+            let rel = (broadened[idx] - ref_apx).abs() / ref_apx;
+            assert!(
+                rel < 5.0e-4,
+                "production doppler_broaden vs implemented-kernel reference at \
+                 E = {e_eval:.4} eV: rel dev {rel:.3e} (must be ≪ the 3e-3 flank signal)"
+            );
+        }
+    }
 }

--- a/crates/nereids-physics/src/lib.rs
+++ b/crates/nereids-physics/src/lib.rs
@@ -4,22 +4,29 @@
 //! forward model for neutron resonance imaging.
 //!
 //! ## Modules
-//! - [`penetrability`] — Hard-sphere penetrability, shift, and phase shift functions
+//! - [`auxiliary_grid`] — Auxiliary energy-grid construction for resolution broadening
 //! - [`channel`] — Wave number, ρ parameter, statistical weight calculations
-//! - [`reich_moore`] — Reich-Moore R-matrix cross-section formalism
-//! - [`slbw`] — Single-Level Breit-Wigner formalism (validation/comparison)
+//! - [`coulomb`] — Coulomb wave functions (Steed's CF1+CF2) for charged-particle channels
 //! - [`doppler`] — Free Gas Model Doppler broadening
+//! - [`penetrability`] — Hard-sphere penetrability, shift, and phase shift functions
+//! - [`reich_moore`] — Reich-Moore R-matrix cross-section formalism
 //! - [`resolution`] — Instrument resolution broadening (Gaussian convolution)
+//! - [`rmatrix_limited`] — R-Matrix Limited (LRF=7) multi-channel formalism
+//! - [`slbw`] — Breit-Wigner formalisms, single- and multi-level (LRF=1/2)
+//! - [`surrogate`] — Forward-model surrogates for multi-isotope accelerated fits
 //! - [`transmission`] — Beer-Lambert transmission forward model
-//! - [`urr`] — Unresolved Resonance Region (LRU=2) Hauser-Feshbach cross-sections
+//! - [`urr`] — Unresolved Resonance Region (LRU=2) energy-averaged
+//!   Hauser-Feshbach cross-sections (width-fluctuation correction not yet
+//!   implemented)
 //!
 //! ## SAMMY Reference
-//! - Cross-sections: `rml/` (Reich-Moore), `mlb/` (SLBW/MLBW), manual Sec 2
+//! - Cross-sections: `rml/` (Reich-Moore), `mlb/` (SLBW/MLBW), manual Sec. II
 //! - Penetrability: `rml/mrml07.f` (Pgh, Sinsix, Pf)
 //! - Coulomb: `coulomb/mrml08.f90` (Coulfg, Steed's CF1+CF2)
-//! - Doppler: `dop/` module, manual Sec 3.1
-//! - Resolution: `convolution/` module, manual Sec 3.2
-//! - Transmission: `cro/`, `xxx/` modules, manual Sec 2, Sec 5
+//! - Doppler: `dop/` module, manual Sec. III.B.1-2
+//! - Resolution: `convolution/` module, manual Sec. III.C
+//! - Transmission: `cro/`, `xxx/` modules, manual Sec. II; transmission
+//!   experiments Sec. III.E.1
 
 pub mod auxiliary_grid;
 pub mod channel;

--- a/crates/nereids-physics/src/lib.rs
+++ b/crates/nereids-physics/src/lib.rs
@@ -23,7 +23,7 @@
 //! - Cross-sections: `rml/` (Reich-Moore), `mlb/` (SLBW/MLBW), manual Sec. II
 //! - Penetrability: `rml/mrml07.f` (Pgh, Sinsix, Pf)
 //! - Coulomb: `coulomb/mrml08.f90` (Coulfg, Steed's CF1+CF2)
-//! - Doppler: `dop/` module, manual Sec. III.B.1-2
+//! - Doppler: `fgm/` module (Dopfgm), manual Sec. III.B.1
 //! - Resolution: `convolution/` module, manual Sec. III.C
 //! - Transmission: `cro/`, `xxx/` modules, manual Sec. II; transmission
 //!   experiments Sec. III.E.1

--- a/crates/nereids-physics/src/penetrability.rs
+++ b/crates/nereids-physics/src/penetrability.rs
@@ -6,7 +6,8 @@
 //! ## SAMMY Reference
 //! - `rml/mrml07.f`: `Sinsix` (phase shifts), `Pgh` (penetrability + shift),
 //!   `Pf` (penetrability only)
-//! - SAMMY manual Section 2 (R-matrix theory)
+//! - SAMMY manual Section II.A, Table II A.1 (penetrability, level-shift, and
+//!   phase-shift formulas)
 //!
 //! ## Definitions
 //! For channel radius a and neutron wave number k:

--- a/crates/nereids-physics/src/reich_moore.rs
+++ b/crates/nereids-physics/src/reich_moore.rs
@@ -36,7 +36,7 @@
 //! - `rml/mrml09.f` Yinvrs: level matrix inversion
 //! - `rml/mrml11.f` Setxqx: X-matrix, Sectio: cross-sections
 //! - `rml/mrml03.f` Betset: ENDF widths → reduced width amplitudes
-//! - SAMMY manual Section 2.1 (R-matrix theory)
+//! - SAMMY manual Section II.B.1 (Reich-Moore approximation)
 
 use num_complex::Complex64;
 

--- a/crates/nereids-physics/src/reich_moore.rs
+++ b/crates/nereids-physics/src/reich_moore.rs
@@ -414,11 +414,6 @@ pub fn cross_sections_at_energy(data: &ResonanceData, energy_ev: f64) -> CrossSe
 /// Issue #87: the precompute is hoisted above the energy loop so that
 /// `precompute_jgroups_*` runs O(ranges) times total, not O(ranges × energies).
 ///
-/// # Limitations
-/// MLBW (Multi-Level Breit-Wigner, LRF=2) ranges use true MLBW with interference.
-/// formulas as an approximation, ignoring resonance-resonance interference.
-/// Results may be inaccurate for closely spaced or overlapping resonances.
-///
 /// # Arguments
 /// * `data` — Parsed resonance parameters from ENDF.
 /// * `energies` — Slice of neutron energies in eV.

--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -12,7 +12,8 @@
 //! - `rsl/mrsl5.f90` — Exponential tail peak shift (Shftge)
 //! - `fnc/exerfc.f90` — Scaled complementary error function
 //! - `convolution/DopplerAndResolutionBroadener.cpp` — Xcoef quadrature weights
-//! - Manual Section 3.2 (Resolution Broadening), Eq. IV B 3.8
+//! - Manual Section III.C (Resolution Broadening); quadrature Eq. IV B 3.8
+//!   (R3-revision numbering — see `broaden`)
 //!
 //! ## Physics
 //!
@@ -870,7 +871,7 @@ impl TabulatedResolution {
     /// Returns `0.0` for non-positive `e_ev`, an empty kernel set, or
     /// a non-positive flight path.  Used by the GUI's
     /// fit-energy-range slicing to extend the model-evaluation grid
-    /// beyond the user's `[E_min, E_max]` so the SAMMY REGION-
+    /// beyond the user's `[E_min, E_max]` so the SAMMY EMIN/EMAX-
     /// equivalent broadening at the boundaries is correct (#514).
     #[must_use]
     pub fn kernel_support_ev(&self, e_ev: f64) -> f64 {
@@ -3649,7 +3650,7 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // TabulatedResolution::kernel_support_ev — used by SAMMY REGION
+    // TabulatedResolution::kernel_support_ev — used by SAMMY EMIN/EMAX
     // -equivalent fit-energy-range margin computation (#514).
     // ------------------------------------------------------------------
 

--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -13,7 +13,8 @@
 //! - `fnc/exerfc.f90` — Scaled complementary error function
 //! - `convolution/DopplerAndResolutionBroadener.cpp` — Xcoef quadrature weights
 //! - Manual Section III.C (Resolution Broadening); quadrature Eq. IV B 3.8
-//!   (R3-revision numbering — see `broaden`)
+//!   (R3-revision numbering — see `compute_xcoef_weights` and the
+//!   Gaussian+exponential path in `resolution_broaden_presorted`)
 //!
 //! ## Physics
 //!

--- a/crates/nereids-physics/src/rmatrix_limited.rs
+++ b/crates/nereids-physics/src/rmatrix_limited.rs
@@ -32,7 +32,8 @@
 //! Intermediate matrix (SAMMY "XXXX"):
 //!   Ξ_cc'(E) = (√P_c / L_c) · (Ỹinv · R)_cc' · √P_c'
 //!
-//! Collision matrix (SAMMY manual eq. III.D.4):
+//! Collision matrix (eq. III.D.4 in SAMMY-manual-R3 numbering, as cited by
+//! `rml/mrml11.f`; in the R8 manual this is Eqs. (II B1.3)-(II B1.4)):
 //!   W_cc' = δ_cc' + 2i·Ξ_cc'
 //!   U_cc' = Ω_c · W_cc' · Ω_c'    where Ω_c = exp(-iφ_c)
 //!

--- a/crates/nereids-physics/src/rmatrix_limited.rs
+++ b/crates/nereids-physics/src/rmatrix_limited.rs
@@ -33,7 +33,8 @@
 //!   Ξ_cc'(E) = (√P_c / L_c) · (Ỹinv · R)_cc' · √P_c'
 //!
 //! Collision matrix (eq. III.D.4 in SAMMY-manual-R3 numbering, as cited by
-//! `rml/mrml11.f`; in the R8 manual this is Eqs. (II B1.3)-(II B1.4)):
+//! `rml/mrml11.f`; R8: W is Eqs. (II B1.3)-(II B1.4), and U = Ω·W·Ω′ is
+//! Eq. (II A.4) with Ω from Eq. (II A.5)):
 //!   W_cc' = δ_cc' + 2i·Ξ_cc'
 //!   U_cc' = Ω_c · W_cc' · Ω_c'    where Ω_c = exp(-iφ_c)
 //!

--- a/crates/nereids-physics/src/slbw.rs
+++ b/crates/nereids-physics/src/slbw.rs
@@ -24,7 +24,7 @@
 //!   accumulators consumed by Elastc_Mlb.
 //! - `xxx/mxxx9.f90` lines 68-71 (`Cs2sn2`) — confirms SAMMY's `Cs/Si` arrays
 //!   hold `cos(2φ)/sin(2φ)`, not `cos(φ)/sin(φ)`.
-//! - SAMMY manual Section 2.1.1.
+//! - SAMMY manual Section II.B.3 (Breit-Wigner approximations).
 //!
 //! ## Formulas
 //! For each resonance at energy E_r with total J, write Δ = E − E_r and

--- a/crates/nereids-physics/src/transmission.rs
+++ b/crates/nereids-physics/src/transmission.rs
@@ -20,7 +20,8 @@
 //!
 //! ## SAMMY Reference
 //! - `cro/` and `xxx/` modules — cross-section to transmission conversion
-//! - Manual Section 2 (transmission definition), Section 5 (experimental corrections)
+//! - Manual Section II (cross-section theory); transmission experiments
+//!   Section III.E.1
 
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/crates/nereids-physics/src/urr.rs
+++ b/crates/nereids-physics/src/urr.rs
@@ -12,8 +12,8 @@
 //!
 //! LRF=1: Γ_n(E) = 2 · P_L(ρ(E)) · GNO    [GNO = reduced neutron width]
 //! LRF=2: Γ_n(E) from tabulated energy grid using INT interpolation
-//!         INT=1 histogram, INT=2 lin-lin, INT=3 log-lin,
-//!         INT=4 lin-log, INT=5 log-log (all 5 ENDF codes supported)
+//!         INT=1 histogram, INT=2 lin-lin, INT=3 log-x/lin-y,
+//!         INT=4 lin-x/log-y, INT=5 log-log (all 5 ENDF codes supported)
 //!
 //! Γ_tot = Γ_n + GG + GF + GX
 //!
@@ -158,8 +158,8 @@ pub fn urr_cross_sections(urr: &UrrData, e_ev: f64, ap_fm: f64) -> (f64, f64, f6
                 (2.0 * p_l * gno, jg.d[0], 0.0_f64, jg.gg[0], gf)
             } else {
                 // LRF=2: dispatch on the stored interpolation law.
-                // ENDF-6 §0.5: INT=1 histogram, 2 lin-lin, 3 log-lin,
-                // 4 lin-log, 5 log-log.
+                // ENDF-6 §0.5: INT=1 histogram, 2 lin-lin, 3 log-x/lin-y,
+                // 4 lin-x/log-y, 5 log-log.
                 let interp: fn(&[f64], &[f64], f64) -> f64 = match jg.int_code {
                     1 => histogram_interp,
                     3 => log_lin_interp,

--- a/crates/nereids-physics/src/urr.rs
+++ b/crates/nereids-physics/src/urr.rs
@@ -33,7 +33,8 @@
 //! The kernel above is the energy-averaged Hauser-Feshbach expression in the
 //! W = 1 limit: no width-fluctuation (Porter-Thomas / Moldauer / Dresner)
 //! factor is applied.  The χ² degrees of freedom `AMUN` / `AMUF` are parsed
-//! from ENDF File 2 and stored on `UrrData`, but are not yet consumed here.
+//! from ENDF File 2 and stored on `UrrJGroup` (within `UrrData`), but are
+//! not yet consumed here.
 //! SAMMY's URR treatment (FITACS, manual Section VIII) includes the
 //! fluctuation integrals, so NEREIDS URR cross-sections will differ from
 //! SAMMY's where fluctuation effects are significant.

--- a/crates/nereids-physics/src/urr.rs
+++ b/crates/nereids-physics/src/urr.rs
@@ -137,15 +137,13 @@ pub fn urr_cross_sections(urr: &UrrData, e_ev: f64, ap_fm: f64) -> (f64, f64, f6
             // Target spin I = urr.spi, neutron spin s = 1/2.
             let g_j = channel::statistical_weight(jg.j, urr.spi);
 
-            // Obtain effective widths at energy e_ev.
+            // Obtain effective widths at energy e_ev (module formula block).
             //
-            // LRF=1: Γ_n = 2·P_L(ρ)·GNO  (GNO = reduced neutron width, eV)
+            // LRF=1: Γ_n(E) = 2·P_L(ρ(E))·GNO  (GNO = reduced neutron width, eV);
             //        D, GG, GF are energy-independent (single-element vecs).
             // LRF=2: widths interpolated from the energy table using the
-            //        INT code stored per J-group.
-            //        INT=2 (lin-lin) and INT=5 (log-log) are both supported.
-            //
-            // LRF=1: Γ_n(E) = 2 · P_L(ρ(E)) · GNO (module formula block).
+            //        INT code stored per J-group; all five ENDF INT codes
+            //        (1-5) are supported (see the dispatch below).
             let (gn_eff, d_eff, gx_eff, gg_eff, gf_eff) = if urr.lrf == 1 {
                 let gno = jg.gn[0]; // reduced neutron width (eV)
                 // LFW=1: fission widths are energy-dependent (tabulated).

--- a/crates/nereids-physics/src/urr.rs
+++ b/crates/nereids-physics/src/urr.rs
@@ -28,6 +28,16 @@
 //! returned `total` and `elastic` so that the URR band produces a physically
 //! consistent cross-section without requiring special handling at the call site.
 //!
+//! ## Width-Fluctuation Correction — not yet implemented
+//!
+//! The kernel above is the energy-averaged Hauser-Feshbach expression in the
+//! W = 1 limit: no width-fluctuation (Porter-Thomas / Moldauer / Dresner)
+//! factor is applied.  The χ² degrees of freedom `AMUN` / `AMUF` are parsed
+//! from ENDF File 2 and stored on `UrrData`, but are not yet consumed here.
+//! SAMMY's URR treatment (FITACS, manual Section VIII) includes the
+//! fluctuation integrals, so NEREIDS URR cross-sections will differ from
+//! SAMMY's where fluctuation effects are significant.
+//!
 //! ## Units
 //! All energies in eV, all lengths (AP, channel radii) in fm (true physics
 //! femtometers, 10⁻¹⁵ m), cross-sections in barns.
@@ -38,7 +48,7 @@
 //!
 //! ## SAMMY Reference
 //! - `unr/munr03.f90` Csig3 subroutine
-//! - SAMMY manual Section 4 (URR treatment)
+//! - SAMMY manual Section VIII.A (equations for the Unresolved Resonance Region)
 //!
 //! ## References
 //! - ENDF-6 Formats Manual §2.2.2
@@ -49,7 +59,9 @@ use nereids_endf::resonance::UrrData;
 use crate::channel;
 use crate::penetrability;
 
-/// Compute Hauser-Feshbach average cross-sections in the Unresolved Resonance Region.
+/// Compute energy-averaged Hauser-Feshbach cross-sections in the Unresolved
+/// Resonance Region (width-fluctuation correction not yet applied; see the
+/// module docs).
 ///
 /// Returns `(total, elastic, capture, fission)` in barns.
 /// All four are zero when `e_ev` falls outside the URR energy band

--- a/crates/nereids-physics/src/urr.rs
+++ b/crates/nereids-physics/src/urr.rs
@@ -47,8 +47,9 @@
 //! matching SAMMY's `FillSammyRmatrixFromRMat.cpp` line 422.
 //!
 //! ## SAMMY Reference
-//! - `unr/munr03.f90` Csig3 subroutine
 //! - SAMMY manual Section VIII.A (equations for the Unresolved Resonance Region)
+//! - SAMMY's URR analysis code is FITACS (`acs/` in the SAMMY source tree),
+//!   which includes the width-fluctuation corrections this module omits
 //!
 //! ## References
 //! - ENDF-6 Formats Manual §2.2.2
@@ -70,11 +71,11 @@ use crate::penetrability;
 /// `elastic` = compound-nuclear elastic + smooth potential scattering.
 /// `total`   = elastic + capture + fission + competitive (GX).
 /// Potential scattering `σ_pot = 4π·AP²/100` (AP in fm, result in barns)
-/// is folded in here rather than at the call site.
-/// SAMMY ref: `unr/munr03.f90` includes the hard-sphere background.
+/// is folded in here rather than at the call site, so the URR band yields a
+/// physically complete elastic cross-section.
 ///
 /// ## SAMMY Reference
-/// `unr/munr03.f90` Csig3 — Hauser-Feshbach cross-section kernel.
+/// SAMMY manual Section VIII.A — energy-averaged cross-section equations.
 ///
 /// # Arguments
 /// * `urr` — Parsed URR parameters (LRF=1 or LRF=2).
@@ -144,7 +145,7 @@ pub fn urr_cross_sections(urr: &UrrData, e_ev: f64, ap_fm: f64) -> (f64, f64, f6
             //        INT code stored per J-group.
             //        INT=2 (lin-lin) and INT=5 (log-log) are both supported.
             //
-            // SAMMY ref: unr/munr03.f90 Csig3 — `Gn = Two*Pene*Gno` for LRF=1.
+            // LRF=1: Γ_n(E) = 2 · P_L(ρ(E)) · GNO (module formula block).
             let (gn_eff, d_eff, gx_eff, gg_eff, gf_eff) = if urr.lrf == 1 {
                 let gno = jg.gn[0]; // reduced neutron width (eV)
                 // LFW=1: fission widths are energy-dependent (tabulated).
@@ -188,8 +189,8 @@ pub fn urr_cross_sections(urr: &UrrData, e_ev: f64, ap_fm: f64) -> (f64, f64, f6
             // Hauser-Feshbach kernel:
             //   (π/k²) · g_J · (2π · Γ_n / D) · Γ_x / Γ_tot
             //
-            // The 2π/D factor is the average level density times 2π.
-            // SAMMY ref: unr/munr03.f90 `Two*Pi*Gn/D` prefactor.
+            // The 2π/D factor is the average level density times 2π
+            // (module formula block; manual Sec. VIII.A).
             let prefactor = pi_over_k2 * g_j * (2.0 * std::f64::consts::PI * gn_eff) / d_eff;
 
             sig_cap += prefactor * gg_eff / gamma_tot;
@@ -198,20 +199,20 @@ pub fn urr_cross_sections(urr: &UrrData, e_ev: f64, ap_fm: f64) -> (f64, f64, f6
             // nucleus and re-emitted as a neutron.  The probability of re-emission
             // into the neutron channel is Γ_n / Γ_tot, giving:
             //   σ_cn = (π/k²) · g_J · (2π·Γ_n/D) · Γ_n / Γ_tot
-            // SAMMY ref: unr/munr03.f90 — `Sigxxx` uses Gn for both transmission
-            // coefficients in the neutron elastic formula.
+            // Compound-elastic: Γ_n appears as both the entrance and the exit
+            // width (module formula block).
             sig_compound_n += prefactor * gn_eff / gamma_tot;
             // Competitive (inelastic) channel: GX is included in Γ_tot but goes
             // into neither capture nor fission.  It contributes to the total
             // cross section without appearing in elastic, capture, or fission.
-            // SAMMY ref: unr/munr03.f90 — GX field in Gamma_total.
+            // GX enters Γ_tot only (module formula block).
             sig_competitive += prefactor * gx_eff / gamma_tot;
         }
     }
 
     // Smooth potential scattering: σ_pot = 4π·AP²
     // AP is in fm; 1 barn = 100 fm².
-    // SAMMY ref: unr/munr03.f90 adds hard-sphere background to elastic.
+    // Folded into `elastic` per the function contract (see fn doc).
     let sig_pot = 4.0 * std::f64::consts::PI * ap_fm * ap_fm / 100.0;
     let elastic = sig_compound_n + sig_pot;
     let total = elastic + sig_cap + sig_fiss + sig_competitive;

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -372,7 +372,7 @@ pub struct UnifiedFitConfig {
     /// `Some(_)` bypasses both the env var and the default.
     tzero_jacobian_method: Option<nereids_fitting::transmission_model::EnergyScaleJacobianMethod>,
 
-    // ── Fit energy range restriction (SAMMY REGION equivalent) ──
+    // ── Fit energy range restriction (SAMMY EMIN/EMAX equivalent) ──
     /// User-specified fit-energy-range restriction.  When `Some((min,
     /// max))`, the configured `energies` grid is expected to extend
     /// beyond `[min, max]` by a kernel-margin (~5×FWHM); the GUI / pre-
@@ -384,8 +384,11 @@ pub struct UnifiedFitConfig {
     ///
     /// `None` (default) = full grid, no masking.  Reduced χ² / dof
     /// counts are computed against the active bin count when masking
-    /// is in effect.  See SAMMY user manual §IIID.6 ("REGION") and the
-    /// `MIN ENERGY` / `MAX ENERGY` SAM52 cards.
+    /// is in effect.  SAMMY equivalent: the `EMIN` / `EMAX` analysis
+    /// limits (INPut-file card set 2, manual Table VI A.1); the kernel
+    /// margin matches the auxiliary-grid construction of manual
+    /// Sec. III.B.2, which extends the grid beyond
+    /// `[Emin − Wmin, Emax + Wmax]` (W = resolution width at the limit).
     fit_energy_range: Option<(f64, f64)>,
 
     // ── Isotope group mapping (optional) ──
@@ -519,7 +522,7 @@ impl UnifiedFitConfig {
     }
 
     /// Restrict the fit cost function to bins inside `[min_eV, max_eV]`
-    /// (SAMMY REGION equivalent).  The configured `energies` grid is
+    /// (SAMMY EMIN/EMAX equivalent).  The configured `energies` grid is
     /// expected to extend by ~5×FWHM beyond `[min, max]` on each side
     /// (the GUI / pre-processing layer handles this); the LM and
     /// joint-Poisson cost paths mask residuals outside `[min, max]` to
@@ -814,7 +817,7 @@ impl UnifiedFitConfig {
     pub fn fit_energy_scale(&self) -> bool {
         self.fit_energy_scale
     }
-    /// User-specified fit-energy-range restriction (SAMMY REGION
+    /// User-specified fit-energy-range restriction (SAMMY EMIN/EMAX
     /// equivalent), or `None` for full-grid fitting.
     /// See [`Self::with_fit_energy_range`].
     pub fn fit_energy_range(&self) -> Option<(f64, f64)> {
@@ -1133,7 +1136,7 @@ fn fit_transmission_lm(
         build_transmission_model(config, n_density_params, _temperature_index)?
     };
 
-    // Build the per-bin active mask (SAMMY REGION-equivalent fit-energy
+    // Build the per-bin active mask (SAMMY EMIN/EMAX-equivalent fit-energy
     // -range restriction).  `None` when no range is configured — the
     // LM core treats that as "all bins active".
     let active_mask = nereids_fitting::active_mask::build_active_mask(
@@ -1233,7 +1236,7 @@ fn fit_transmission_poisson(
     config: &UnifiedFitConfig,
     poisson_cfg: &PoissonConfig,
 ) -> Result<SpectrumFitResult, PipelineError> {
-    // SAMMY REGION-equivalent fit-energy-range (#514): the legacy
+    // SAMMY EMIN/EMAX-equivalent fit-energy-range (#514): the legacy
     // transmission-domain `poisson_fit` does not honour an active mask,
     // so silently routing the data here when the user set a fit range
     // would bias the fit by including out-of-range bins (margin region)
@@ -1473,7 +1476,7 @@ fn fit_counts_joint_poisson(
     // so JointPoissonObjective picks up gradients for both density and
     // background parameters without further wiring.
 
-    // Build the per-bin active mask (SAMMY REGION-equivalent fit-energy
+    // Build the per-bin active mask (SAMMY EMIN/EMAX-equivalent fit-energy
     // -range restriction).  `None` when no range is configured — the
     // JP objective treats that as "all bins active".
     let active_mask = nereids_fitting::active_mask::build_active_mask(
@@ -4890,7 +4893,7 @@ mod tests {
     /// LM fit with `fit_energy_range = Some((min, max))` on the full
     /// grid must yield the same density as the same fit run on the
     /// `[min, max]` slice directly when the residual outside the range
-    /// is negligible (SAMMY REGION semantics, paper-acceptance test).
+    /// is negligible (SAMMY EMIN/EMAX semantics, paper-acceptance test).
     #[test]
     fn test_fit_energy_range_lm_matches_subset_when_outside_negligible() {
         let data = u238_single_resonance();

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -386,9 +386,11 @@ pub struct UnifiedFitConfig {
     /// counts are computed against the active bin count when masking
     /// is in effect.  SAMMY equivalent: the `EMIN` / `EMAX` analysis
     /// limits (INPut-file card set 2, manual Table VI A.1); the kernel
-    /// margin matches the auxiliary-grid construction of manual
-    /// Sec. III.B.2, which extends the grid beyond
-    /// `[Emin − Wmin, Emax + Wmax]` (W = resolution width at the limit).
+    /// margin follows the same endpoint-extension principle as SAMMY's
+    /// auxiliary grid (general construction Sec. III.A.2(c); the
+    /// quantitative `[Emin − Wmin, Emax + Wmax]` statement is in the
+    /// Leal-Hwang procedure, Sec. III.B.2), with a deliberately
+    /// conservative 5×FWHM margin.
     fit_energy_range: Option<(f64, f64)>,
 
     // ── Isotope group mapping (optional) ──

--- a/docs/adr/0001-workspace-layout.md
+++ b/docs/adr/0001-workspace-layout.md
@@ -60,9 +60,11 @@ The decision above stands; two details have evolved since it was written:
 - A seventh core library crate, `endf-mat` (ENDF MAT-number lookup, element
   symbols, and natural isotopic abundances), was extracted from
   `nereids-endf` as a standalone, zero-dependency crate.
-- The fitting stack listed under `nereids-fitting` has evolved: the external
-  BFGS solver was removed; the current engines are Levenberg-Marquardt,
-  a transmission-domain Poisson/KL optimizer, and a counts-domain
-  joint-Poisson (conditional binomial deviance) solver.
+- The fitting stack listed under `nereids-fitting` has evolved: the
+  standalone L-BFGS-B solver path (internal to `poisson.rs`) was deleted
+  (an L-BFGS-history fallback remains inside the transmission-domain
+  Poisson/KL optimizer); the current engines are Levenberg-Marquardt, the
+  Poisson/KL optimizer, and a counts-domain joint-Poisson (conditional
+  binomial deviance) solver.
 
 The SAMMY reference document is ORNL/TM-9179/R8.

--- a/docs/adr/0001-workspace-layout.md
+++ b/docs/adr/0001-workspace-layout.md
@@ -52,3 +52,17 @@ All physics implementations reference SAMMY (ORNL/TM-9179) with:
 - GUI can be developed independently of the core library
 - Worklog directory (gitignored) prevents temp file pollution
 - Atomic commits at each phase enable early detection of issues
+
+## Addendum (2026-06)
+
+The decision above stands; two details have evolved since it was written:
+
+- A seventh core library crate, `endf-mat` (ENDF MAT-number lookup, element
+  symbols, and natural isotopic abundances), was extracted from
+  `nereids-endf` as a standalone, zero-dependency crate.
+- The fitting stack listed under `nereids-fitting` has evolved: the external
+  BFGS solver was removed; the current engines are Levenberg-Marquardt,
+  a transmission-domain Poisson/KL optimizer, and a counts-domain
+  joint-Poisson (conditional binomial deviance) solver.
+
+The SAMMY reference document is ORNL/TM-9179/R8.

--- a/docs/adr/0001-workspace-layout.md
+++ b/docs/adr/0001-workspace-layout.md
@@ -58,8 +58,10 @@ All physics implementations reference SAMMY (ORNL/TM-9179) with:
 The decision above stands; two details have evolved since it was written:
 
 - A seventh core library crate, `endf-mat` (ENDF MAT-number lookup, element
-  symbols, and natural isotopic abundances), was extracted from
-  `nereids-endf` as a standalone, zero-dependency crate.
+  symbols, and natural isotopic abundances), was created as a standalone,
+  zero-dependency crate — consolidating `nereids-core::elements` and
+  `nereids-endf`'s MAT-number table, with newly added natural-abundance
+  data.
 - The fitting stack listed under `nereids-fitting` has evolved: the
   standalone L-BFGS-B solver path (internal to `poisson.rs`) was deleted
   (an L-BFGS-history fallback remains inside the transmission-domain

--- a/docs/guide/src/gui-walkthrough.md
+++ b/docs/guide/src/gui-walkthrough.md
@@ -37,8 +37,9 @@ The landing page presents three entry points:
 After selecting **Load & Fit Data**, a short wizard asks:
 
 1. **Fitting type**: Single spectrum or spatial map
-2. **Data format**: Raw Events (HDF5/NeXus), Histogram / Pre-Normalization,
-   or Transmission (Already Normalized)
+2. **Data format**: "Raw Events (HDF5/NeXus)", "Histogram, Pre-Normalization",
+   or "Transmission (Already Normalized)" — quoted as the wizard cards
+   label them
 
 The wizard configures a dynamic pipeline with only the steps relevant to your
 data format. Six distinct pipelines are available.

--- a/docs/guide/src/gui-walkthrough.md
+++ b/docs/guide/src/gui-walkthrough.md
@@ -37,7 +37,7 @@ The landing page presents three entry points:
 After selecting **Load & Fit Data**, a short wizard asks:
 
 1. **Fitting type**: Single spectrum or spatial map
-2. **Data format**: Raw Events (HDF5/NeXus), Histogram, Pre-Normalization,
+2. **Data format**: Raw Events (HDF5/NeXus), Histogram / Pre-Normalization,
    or Transmission (Already Normalized)
 
 The wizard configures a dynamic pipeline with only the steps relevant to your
@@ -82,18 +82,18 @@ with move, select, and delete operations.
 
 ![Analyze step](images/analyze-step.png)
 
-#### Restricting the fit energy range (SAMMY REGION)
+#### Restricting the fit energy range (SAMMY EMIN/EMAX)
 
 By default NEREIDS fits the entire loaded energy grid. The advanced solver
-panel exposes a **"Restrict fit energy range"** checkbox (SAMMY REGION
-equivalent — `MIN ENERGY` / `MAX ENERGY` SAM52 cards) that limits the cost
+panel exposes a **"Restrict fit energy range"** checkbox (equivalent to
+SAMMY's EMIN/EMAX analysis limits) that limits the cost
 function to a user-specified `[E_min, E_max]` window in eV. Common uses:
 
 - **Resolved-resonance region only** — exclude the unresolved-resonance and
   high-energy tails where the model can't fit;
 - **Single resonance triplet** — focus on a specific feature for fine-grained
   density / temperature work;
-- **SAMMY parity** — match the REGION restriction used in a reference SAMMY
+- **SAMMY parity** — match the EMIN/EMAX restriction used in a reference SAMMY
   fit so the comparison is apples-to-apples.
 
 When the checkbox is on, two grey dashed vertical lines on the spectrum plot
@@ -105,8 +105,10 @@ the active range.
 contributions from outside the user range. NEREIDS handles this transparently
 by extending the data slice by ~5×FWHM on each side and masking the cost
 function back to `[E_min, E_max]` — so resonances near the boundaries are
-correctly broadened without the user picking a custom margin. SAMMY user
-manual §IIID.6 recommends 3–5×FWHM; we use 5× for safety.
+correctly broadened without the user picking a custom margin. This mirrors
+SAMMY's auxiliary-grid construction (user manual Sec. III.B.2: the broadening
+grid extends beyond `[Emin − Wmin, Emax + Wmax]`, where `W` is the resolution
+width at each limit); NEREIDS uses ~5×FWHM for safety.
 
 The setting persists in `.nrd.h5` project files (`Option<(f64, f64)>`,
 default `None` = full grid for backwards compatibility).

--- a/docs/guide/src/gui-walkthrough.md
+++ b/docs/guide/src/gui-walkthrough.md
@@ -106,10 +106,12 @@ the active range.
 contributions from outside the user range. NEREIDS handles this transparently
 by extending the data slice by ~5×FWHM on each side and masking the cost
 function back to `[E_min, E_max]` — so resonances near the boundaries are
-correctly broadened without the user picking a custom margin. This mirrors
-SAMMY's auxiliary-grid construction (user manual Sec. III.B.2: the broadening
-grid extends beyond `[Emin − Wmin, Emax + Wmax]`, where `W` is the resolution
-width at each limit); NEREIDS uses ~5×FWHM for safety.
+correctly broadened without the user picking a custom margin. This follows
+the same endpoint-extension principle as SAMMY's auxiliary grid (general
+construction: user manual Sec. III.A.2(c); the quantitative
+`[Emin − Wmin, Emax + Wmax]` statement, with `W` the resolution width at each
+limit, appears in the Leal-Hwang procedure of Sec. III.B.2); NEREIDS uses a
+deliberately conservative ~5×FWHM margin.
 
 The setting persists in `.nrd.h5` project files (`Option<(f64, f64)>`,
 default `None` = full grid for backwards compatibility).

--- a/docs/guide/src/introduction.md
+++ b/docs/guide/src/introduction.md
@@ -42,7 +42,7 @@ and equation numbers in their documentation.
 Key formalisms from SAMMY:
 
 - Reich-Moore R-matrix (LRF=3)
-- Single-Level Breit-Wigner (LRF=1/2)
+- Breit-Wigner, single- and multi-level (LRF=1/2)
 - R-Matrix Limited (LRF=7)
 - Free Gas Model Doppler broadening
 - Gaussian + exponential resolution broadening

--- a/docs/guide/src/physics.md
+++ b/docs/guide/src/physics.md
@@ -35,8 +35,10 @@ Free Gas Model (FGM) convolution accounting for thermal motion of target nuclei.
 
 - Module: [`doppler`](api/nereids_physics/doppler/)
 - SAMMY reference: `fgm/` module (Dopfgm), manual Sec. III.B.1
-- Key function: `doppler_broaden()` — exact Free Gas Model convolution
-  integral in velocity space (manual Eq. III B1.7); no psi/chi (Voigt)
+- Key function: `doppler_broaden()` — velocity-space Gaussian convolution of
+  v·σ (manual Eq. III B1.7 without the w/v integrand weight; relative
+  deviation ≲ kT/(AWR·E), negligible for heavy isotopes at epithermal
+  energies; exact-kernel migration planned); no psi/chi (Voigt)
   approximation is used
 
 ### Resolution Broadening

--- a/docs/guide/src/physics.md
+++ b/docs/guide/src/physics.md
@@ -15,7 +15,7 @@ equations and citations.
 | Reich-Moore | LRF=3 | [`reich_moore`](api/nereids_physics/reich_moore/) | Manual Sec. II, `rml/` |
 | Breit-Wigner (single- and multi-level) | LRF=1,2 | [`slbw`](api/nereids_physics/slbw/) | Manual Sec. II, `mlb/` |
 | R-Matrix Limited | LRF=7 | [`rmatrix_limited`](api/nereids_physics/rmatrix_limited/) | Manual Sec. II |
-| Unresolved Resonance Region | LRU=2 | [`urr`](api/nereids_physics/urr/) | Manual Sec. VIII.A, `unr/` |
+| Unresolved Resonance Region | LRU=2 | [`urr`](api/nereids_physics/urr/) | Manual Sec. VIII.A, `acs/` (FITACS) |
 
 The `urr` module computes energy-averaged Hauser-Feshbach cross-sections from
 the average resonance parameters. The width-fluctuation correction is not yet
@@ -34,7 +34,7 @@ and statistical spin weights.
 Free Gas Model (FGM) convolution accounting for thermal motion of target nuclei.
 
 - Module: [`doppler`](api/nereids_physics/doppler/)
-- SAMMY reference: `dop/` module, manual Sec. III.B.1-2
+- SAMMY reference: `fgm/` module (Dopfgm), manual Sec. III.B.1
 - Key function: `doppler_broaden()` — exact Free Gas Model convolution
   integral in velocity space (manual Eq. III B1.7); no psi/chi (Voigt)
   approximation is used

--- a/docs/guide/src/physics.md
+++ b/docs/guide/src/physics.md
@@ -36,10 +36,11 @@ Free Gas Model (FGM) convolution accounting for thermal motion of target nuclei.
 - Module: [`doppler`](api/nereids_physics/doppler/)
 - SAMMY reference: `fgm/` module (Dopfgm), manual Sec. III.B.1
 - Key function: `doppler_broaden()` — velocity-space Gaussian convolution of
-  v·σ (manual Eq. III B1.7 without the w/v integrand weight; relative
-  deviation ≲ kT/(AWR·E), negligible for heavy isotopes at epithermal
-  energies; exact-kernel migration planned); no psi/chi (Voigt)
-  approximation is used
+  v·σ (manual Eq. III B1.7 without the w/v integrand weight: second-order
+  kT/(2·AWR·E) deviation for smooth cross-sections, but a first-order
+  √(kT/(AWR·E)) antisymmetric flank skew on resonance line shapes, ≈ 0.4%
+  for U-238 at 6.67 eV / 300 K; exact-kernel migration planned); no psi/chi
+  (Voigt) approximation is used
 
 ### Resolution Broadening
 

--- a/docs/guide/src/physics.md
+++ b/docs/guide/src/physics.md
@@ -12,10 +12,15 @@ equations and citations.
 
 | Formalism | ENDF LRF | Module | SAMMY Reference |
 |-----------|----------|--------|-----------------|
-| Reich-Moore | LRF=3 | [`reich_moore`](api/nereids_physics/reich_moore/) | Manual Sec 2, `rml/` |
-| Single-Level Breit-Wigner | LRF=1,2 | [`slbw`](api/nereids_physics/slbw/) | Manual Sec 2, `mlb/` |
-| R-Matrix Limited | LRF=7 | [`rmatrix_limited`](api/nereids_physics/rmatrix_limited/) | Manual Sec 2 |
-| Unresolved Resonance Region | LRU=2 | [`urr`](api/nereids_physics/urr/) | Hauser-Feshbach |
+| Reich-Moore | LRF=3 | [`reich_moore`](api/nereids_physics/reich_moore/) | Manual Sec. II, `rml/` |
+| Breit-Wigner (single- and multi-level) | LRF=1,2 | [`slbw`](api/nereids_physics/slbw/) | Manual Sec. II, `mlb/` |
+| R-Matrix Limited | LRF=7 | [`rmatrix_limited`](api/nereids_physics/rmatrix_limited/) | Manual Sec. II |
+| Unresolved Resonance Region | LRU=2 | [`urr`](api/nereids_physics/urr/) | Manual Sec. VIII.A, `unr/` |
+
+The `urr` module computes energy-averaged Hauser-Feshbach cross-sections from
+the average resonance parameters. The width-fluctuation correction is not yet
+implemented: the `AMUN`/`AMUF` degrees of freedom are parsed from ENDF File 2
+but not yet used in the cross-section computation.
 
 The [`penetrability`](api/nereids_physics/penetrability/) and
 [`channel`](api/nereids_physics/channel/) modules provide the underlying
@@ -29,8 +34,10 @@ and statistical spin weights.
 Free Gas Model (FGM) convolution accounting for thermal motion of target nuclei.
 
 - Module: [`doppler`](api/nereids_physics/doppler/)
-- SAMMY reference: `dop/` module, manual Sec 3.1
-- Key function: `doppler_broaden()` using psi/chi auxiliary functions on an adaptive grid
+- SAMMY reference: `dop/` module, manual Sec. III.B.1-2
+- Key function: `doppler_broaden()` — exact Free Gas Model convolution
+  integral in velocity space (manual Eq. III B1.7); no psi/chi (Voigt)
+  approximation is used
 
 ### Resolution Broadening
 
@@ -38,7 +45,7 @@ Instrument resolution broadening from flight-path uncertainty, timing jitter,
 and moderator pulse width.
 
 - Module: [`resolution`](api/nereids_physics/resolution/)
-- SAMMY reference: `convolution/` module, manual Sec 3.2
+- SAMMY reference: `convolution/` module, manual Sec. III.C
 - Supports: Gaussian convolution, Gaussian + exponential tail, tabulated resolution functions
 
 ## Transmission Model
@@ -49,7 +56,8 @@ Where n_i is the areal density (atoms/barn) and sigma_i(E) is the broadened
 total cross-section for isotope i.
 
 - Module: [`transmission`](api/nereids_physics/transmission/)
-- SAMMY reference: `cro/`, `xxx/` modules, manual Sec 2, Sec 5
+- SAMMY reference: `cro/`, `xxx/` modules, manual Sec. II; transmission
+  experiments Sec. III.E.1
 - Handles multi-isotope samples with shared Doppler temperature
   (one global temperature parameter, optionally fitted jointly with densities)
 
@@ -60,16 +68,20 @@ total cross-section for isotope i.
 Standard nonlinear least-squares minimization for Gaussian-distributed data.
 
 - Module: [`lm`](api/nereids_fitting/lm/)
-- SAMMY reference: `fit/` module, manual Sec 4
+- SAMMY reference: `fit/` module, manual Sec. IV
 - Parameters: areal densities with optional bounds, optional temperature fitting
 
 ### Poisson KL Divergence
 
 Maximum-likelihood fitting for low-count data where Gaussian statistics break down.
 
-- Module: [`poisson`](api/nereids_fitting/poisson/)
+- Module: [`joint_poisson`](api/nereids_fitting/joint_poisson/) -- counts-domain
+  joint-Poisson fit (conditional binomial deviance); the production path for
+  counts data
+- Module: [`poisson`](api/nereids_fitting/poisson/) -- transmission-domain
+  Poisson likelihood (projected damped Gauss-Newton); used for the
+  transmission + PoissonKL combination
 - Reference: TRINIDI approach (`trinidi/reconstruct.py`)
-- Uses bounds-based preconditioning for joint density + temperature fits
 
 ## ENDF Nuclear Data
 
@@ -79,7 +91,8 @@ Resonance parameters are sourced from the ENDF/B library via the IAEA API:
 - Module: [`parser`](api/nereids_endf/parser/) -- parse ENDF-6 File 2
 - Module: [`resonance`](api/nereids_endf/resonance/) -- data structures
 
-Supported libraries: ENDF/B-VIII.0, ENDF/B-VIII.1, JEFF-3.3, JENDL-5.
+Supported libraries: ENDF/B-VIII.0, ENDF/B-VIII.1, JEFF-3.3, JENDL-5,
+TENDL-2023, CENDL-3.2.
 
 ## Further Reading
 

--- a/docs/guide/src/physics.md
+++ b/docs/guide/src/physics.md
@@ -88,7 +88,8 @@ Maximum-likelihood fitting for low-count data where Gaussian statistics break do
 
 ## ENDF Nuclear Data
 
-Resonance parameters are sourced from the ENDF/B library via the IAEA API:
+Resonance parameters are sourced from evaluated nuclear data libraries
+(ENDF/B from NNDC with IAEA fallback; the other libraries from IAEA):
 
 - Module: [`retrieval`](api/nereids_endf/retrieval/) -- download and cache
 - Module: [`parser`](api/nereids_endf/parser/) -- parse ENDF-6 File 2

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -1745,7 +1745,7 @@ class TestVenusMlbwRegression:
 
 
 class TestFitEnergyRangeBindingParameter:
-    """Tests for the SAMMY REGION-equivalent `fit_energy_range` parameter
+    """Tests for the SAMMY EMIN/EMAX-equivalent `fit_energy_range` parameter
     on `fit_spectrum_typed`.  The other two binding entry points
     (`fit_counts_spectrum_typed`, `spatial_map_typed`) share the same
     config-builder code path (`with_fit_energy_range(...).map_err(...)?`


### PR DESCRIPTION
## Summary

Claim-accuracy pass over every skimmable surface (README, mdBook guide, rendered
rustdoc, GUI strings): each capability claim and SAMMY citation was verified
against the source code, the bundled SAMMY manual (ORNL/TM-9179/R8), and the
SAMMY Fortran tree — and corrected where it overclaimed, misdescribed, or cited
something that does not exist. Docs/comments/UI strings only, **plus one new
analytic test**; zero production-logic changes.

Part of the pre-paper consolidation (stakeholder-readiness) pass; PR 1 of 3
(metadata/licensing and meta-noise scrub follow).

## Highlights

**Honest capability claims**
- URR: "URR/Hauser-Feshbach" → "energy-averaged Hauser-Feshbach cross-sections
  (width-fluctuation correction planned, not yet implemented)" — AMUN/AMUF are
  parsed but unused; `urr.rs` gains an explicit W=1-limit disclosure section
  contrasting SAMMY's FITACS.
- Doppler: the docs claimed "exact FGM integral (Eq. III B1.7)" — review
  uncovered that **the kernel omits the equation's (w/v) integrand weight**
  (SAMMY's `Dopfgm` weights by w² and divides by v²). The docs now characterize
  both error scales precisely: second-order `kT/(2·AWR·E)` for smooth
  cross-sections, and a **first-order antisymmetric flank skew**
  `√(kT/(AWR·E))` (~0.4% on the U-238 6.67 eV flanks at 300 K, vanishing at
  peak). A new test (`kernel_error_scales_pinned_vs_full_fgm_reference`) pins
  these numbers against an in-test full-kernel Simpson reference and doubles as
  the discriminating oracle for the planned exact-kernel migration (the
  6%-tolerance SAMMY ex001 oracle is blind to this error class).
- LRF=2 is Multi-Level Breit-Wigner: "SLBW" labels corrected to "Breit-Wigner
  (single- and multi-level)" across README/guide/rustdoc; `slbw` is the
  production LRF=1/2 evaluator, not "(validation/comparison)".
- Deleted `reich_moore.rs`'s stale, self-contradictory `# Limitations` block.

**Fabricated/unresolvable citations replaced with verified ones**
- "SAMMY user manual §IIID.6 (REGION)" + "MIN ENERGY / MAX ENERGY SAM52 cards"
  exist nowhere in the manual. All ~40 occurrences replaced with the real
  anchors: **EMIN/EMAX (INPut card set 2, Table VI A.1)** and the
  endpoint-extension construction (general form Sec. III.A.2(c); quantitative
  `[Emin − Wmin, Emax + Wmax]` statement in the Leal-Hwang procedure,
  Sec. III.B.2) — including a user-visible GUI checkbox label and tooltip.
- `unr/munr03.f90` / `Csig3` / `munr01.f90` exist nowhere in the SAMMY
  checkout — all 14 references removed; URR cites manual Sec. VIII.A + `acs/`
  (FITACS).
- Doppler module attribution: SAMMY's `dop/` is the **Leal-Hwang** path; the
  FGM counterpart is `fgm/mfgm1.f90` (`Dopfgm`). Fixed in three files.
- Manual section numbers migrated to real R8 numbering throughout (II.A /
  Table II A.1 / II.B.1 / II.B.3 / III.B.1 / III.C / III.E.1 / IV / VIII.A);
  R3-revision equation numbers inherited from SAMMY's own Fortran comments
  (`mrml11.f` III.D.4; quadrature IV B 3.8) are now labeled as such with R8
  equivalents.
- 5×FWHM "≈ 5.9σ … 10⁻¹³" arithmetic corrected (5×FWHM = 11.8σ, ~10⁻³⁰; the
  old figure was 5×HWHM).

**Small factual fixes**
- Notebook count 17 → 18 (×2); CENDL-3.2 added to library lists; retrieval
  attribution corrected (ENDF/B from NNDC with IAEA fallback, others IAEA);
  GUI wizard's three data formats quoted verbatim; ADR addendum (endf-mat
  provenance, L-BFGS-B history, /R8); INT=1..=5 docs spelled out unambiguously;
  AMUN/AMUF attributed to `UrrJGroup`.

## Review

Four rounds of cross-family review (Claude + Codex, both with the SAMMY manual
PDF and Fortran tree), each verifying the **new** wording, not just the old:

| Round | Blocking | Outcome |
|------:|----------|---------|
| 1 | 0 P0/P1, 11 P2 | citation residue fixed (incl. `fgm/`-vs-`dop/`, unresolvable `unr/`) |
| 2 | **1 VERIFIED P1** | "exact FGM" overclaim → kernel gap discovered, disclosed honestly |
| 3 | **1 VERIFIED P1** | error bound understated 220× for line shapes → two-scale characterization |
| 4 | **0 blocking** | converged; residual P2s fixed + the pinning test added |

The round-2/3 P1s are the headline outcome: the review process surfaced a real,
previously undocumented physics approximation in the Doppler kernel. The exact
(w²/v²) kernel migration is scheduled as the immediate next PR, with this
branch's pinning test as its oracle.

## Gates

`cargo fmt` · `clippy --workspace -D warnings` · `cargo test --workspace`
(22 binaries, +1 test) · `cargo doc -D warnings` · mdBook guide build ·
`pixi run test-python` (127 passed) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
