### PR TITLE
docs(guide): fix Configure/Analyze solver-settings caption

### DIFF
--- a/docs/guide/src/gui-walkthrough.md
+++ b/docs/guide/src/gui-walkthrough.md
@@ -67,16 +67,18 @@ Select isotopes of interest from the periodic table. ENDF nuclear data is
 fetched automatically from IAEA servers and cached locally. Each isotope shows
 a status badge (Pending, Fetching, Loaded, Failed).
 
-Configure beamline parameters (flight path, timing resolution) and solver
-settings (Levenberg-Marquardt or Poisson KL divergence).
+Configure beamline parameters (flight path, timing resolution) and toggle
+instrument-resolution broadening. (The solver choice — Levenberg-Marquardt or
+Poisson KL divergence — is set on the Analyze step.)
 
 ![Configure step](images/configure-step.png)
 
 ### Analyze
 
-Run the fit. For spatial maps, a progress bar tracks per-pixel fitting with
-rayon parallelism. Click any pixel to inspect its individual fit. Fit feedback
-shows green (good fit) or red (failed) status.
+Choose the solver (Levenberg-Marquardt or Poisson KL divergence), then run the
+fit. For spatial maps, a progress bar tracks per-pixel fitting with rayon
+parallelism. Click any pixel to inspect its individual fit. Fit feedback shows
+green (good fit) or red (failed) status.
 
 Draw regions of interest (ROI) with Shift+drag. Multiple ROIs are supported
 with move, select, and delete operations.


### PR DESCRIPTION
## What

The GUI walkthrough's **Configure** section claimed the solver method (Levenberg-Marquardt / Poisson KL divergence) is set on the Configure step. It isn't.

## Why it's wrong (verified against code + the refreshed screenshot)

- `apps/gui/src/guided/configure.rs` renders only beamline parameters, instrument-resolution broadening, and isotope selection — **no solver controls** (grep finds none).
- The solver selector lives in `apps/gui/src/guided/analyze.rs` ("-- Solver configuration --", `SolverMethod::LevenbergMarquardt`/`PoissonKL`).
- The refreshed `configure-step.png` (from #617) confirms no solver control on that screen; `analyze-step.png` shows "Method: Poisson KL".

Surfaced while auditing guide prose against the #617 screenshot refresh.

## Change

- **Configure** caption → beamline params + instrument-resolution broadening, with a pointer that solver choice is on Analyze.
- **Analyze** caption → now leads with choosing the solver, then running the fit.

Docs-only (one markdown file). `pixi run doc-guide` builds clean. No Rust touched, so the cargo gates are unaffected (CI runs the full matrix regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)