### PR TITLE
fix(gui): less-pessimistic Detectability defaults (honest, not rigged)

### DIFF
--- a/apps/gui/src/guided/detectability.rs
+++ b/apps/gui/src/guided/detectability.rs
@@ -176,7 +176,10 @@ pub(crate) fn detect_matrix_card(ui: &mut egui::Ui, state: &mut AppState, locked
                 state.periodic_table_open = true;
                 state.periodic_table_target = PeriodicTableTarget::DetectMatrix;
                 state.periodic_table_selected_z = None;
-                state.periodic_table_density = 0.001; // at/barn default
+                // ~mm-scale metal foil (~5e-3 at/barn); a realistic sample
+                // rather than a vanishingly thin one, while staying thin
+                // enough to avoid an opaque baseline for typical matrices.
+                state.periodic_table_density = 0.005; // at/barn default
             }
         });
     });
@@ -307,7 +310,10 @@ pub(crate) fn detect_advanced_config(ui: &mut egui::Ui, state: &mut AppState) {
                 );
             });
             ui.horizontal(|ui| {
-                ui.label("I\u{2080} (counts/bin):");
+                ui.label("I\u{2080} (counts/bin):").on_hover_text(
+                    "Expected counts per energy bin. Higher means better Poisson \
+                     statistics and a lower detection threshold (SNR \u{221d} \u{221a}I\u{2080}).",
+                );
                 ui.add(
                     egui::DragValue::new(&mut state.detect_i0)
                         .speed(100.0)

--- a/apps/gui/src/state.rs
+++ b/apps/gui/src/state.rs
@@ -1569,7 +1569,7 @@ impl Default for AppState {
             detect_matrix_entries: Vec::new(),
             detect_trace_entries: Vec::new(),
             detect_snr_threshold: 3.0,
-            detect_i0: 10_000.0,
+            detect_i0: 100_000.0,
             detect_energy_min: 1.0,
             detect_energy_max: 100.0,
             detect_n_energy_points: 2000,


### PR DESCRIPTION
## Problem

The Detectability tool reads **NOT DETECTABLE for essentially any first run** (hit while capturing the guide screenshot). Not a bug — the engine and wiring are correct. The defaults set an unreachable bar: with I₀=10k and matrix density 0.001 at/barn, clearing 3σ needs a resonance peak **σ > 30,000 barns** in 1–100 eV, which almost nothing has. For a pre-experiment *planning* tool, defaulting to "nothing is detectable" is poor first-impression UX.

## Change (GUI defaults only, 2 files)

- **matrix density 0.001 → 0.005 at/barn** (`detectability.rs`) — the physically honest fix: 0.001 is an unrealistically thin sample; ~mm-scale metal foil is ~5e-3 at/barn.
- **I₀ 10,000 → 100,000** (`state.rs`) — a good-statistics planning assumption (~0.3%/bin); the field stays user-adjustable in Advanced.
- I₀ field gains a hover: *expected counts per bin; higher = better statistics = lower threshold (SNR ∝ √I₀)*.

Trace ppm (1000 = 0.1%), SNR threshold (3.0), energy window, and the Forward-Model/Configure density defaults are **unchanged** — moving those would read as rigging.

## Guardrail (the important part: not over-corrected into always-DETECTABLE)

The bar drops from σ_peak > 30 kb to **~1.9 kb** — so typical resonant traces become detectable while weak ones don't. Verified empirically at the new defaults (throwaway engine check, since GUI clicks can't be driven in CI):

| trace | SNR | verdict |
|---|---|---|
| strong synthetic resonance | **312.6** | DETECTABLE |
| weak synthetic resonance | **0.01** | NOT detectable |

Consistent with the real In-115/Fe-56 **13.7σ** result in the refreshed `detectability.png` (captured at matrix 0.005). The tool stays discriminating.

GUI-only; codecov-excluded; no test pins these defaults (verified); engine detectability tests use explicit configs and are unaffected. fmt · clippy -D · 22 test binaries all green.

Ships with **0.1.9**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
