### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-16
+
 ### Changed
 
 - License switched from BSD-3-Clause to MIT across the entire workspace —
@@ -267,7 +269,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Documentation site: mdBook user guide + rustdoc API reference on GitHub Pages
 - SAMMY validation suite: 43 test cases validated against SAMMY reference code
 
-[Unreleased]: https://github.com/ornlneutronimaging/NEREIDS/compare/v0.1.8...HEAD
+[Unreleased]: https://github.com/ornlneutronimaging/NEREIDS/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/ornlneutronimaging/NEREIDS/compare/v0.1.8...v0.2.0
 [0.1.8]: https://github.com/ornlneutronimaging/NEREIDS/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/ornlneutronimaging/NEREIDS/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/ornlneutronimaging/NEREIDS/compare/v0.1.5...v0.1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   Each publishable crate directory (and `apps/gui` for the wheel) now
   carries a copy of the LICENSE text, so published artifacts ship the MIT
   permission notice they are licensed under.
+- **Detectability tool defaults** are less pessimistic: the default matrix
+  areal density is now `0.005` at/barn (a realistic ~mm-scale sample rather
+  than a vanishingly thin one) and the default expected counts/bin (I₀) is
+  now `100_000`, so a typical first run lands near the detection boundary
+  instead of always reading "NOT DETECTABLE". The verdict math is unchanged
+  and both remain user-adjustable in the Advanced panel. (#620)
+- Input validation hardened across the public API: energy grids,
+  cross-section entry points, NeXus/IO inputs, and the spatial detector cube
+  now reject NaN / non-finite / non-physical values with typed errors in
+  release builds (not debug-assert-gated). (#559, #565, #592, #602)
+- Internal architecture refactor (net ~−1600 LOC, no behavior change):
+  dead-code and unused-API removal, test-fixture/oracle consolidation, and a
+  shared `ResolutionPlan` helper extraction. (#580–#589)
 
 ### Changed (breaking — `nereids-io`)
 
@@ -40,6 +53,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   Per semantic versioning for `0.x` crates, this is an acceptable
   breaking change at this stage of the project; no external consumers
   of this field have been identified in the workspace or sibling repos.
+
+### Fixed
+
+- **Doppler broadening** now uses the exact SAMMY Free-Gas-Model kernel
+  (manual Eq. III B1.7: a `w²`-weighted integrand divided by `E`) in both the
+  forward pass and the analytical temperature-derivative path, replacing a
+  kernel that omitted the `(w/v)` weight — a first-order antisymmetric skew on
+  resonance flanks. Includes two latent edge-case fixes (always-on low-side
+  velocity-grid padding; a SAMMY-faithful sparse-edge passthrough). SAMMY-oracle
+  errors improved across the validation suite. (#611)
+- **SLBW / MLBW cross-sections**: corrected the sign of the `Γ·sin²φ` elastic
+  interference term (#549, #550) and removed an s-wave velocity-factor
+  double-count (#577); both tighten agreement with SAMMY reference cases.
+- **R-Matrix Limited (LRF=7) KRM=3**: SAMMY-parity fixes to the APE/APT radius
+  roles, subthreshold channel widths, and the per-pair PNT penetrability flag.
+  (#589)
+- **Resolution broadening** is applied on the auxiliary (margin-extended) energy
+  grid across all transmission-model fit paths, removing edge bias near
+  fit-range boundaries. (#608)
+- Further physics/robustness fixes: phase-shift continuity, RML closed-channel
+  gating, and a sample-thickness guard (#599, #607); joint-Poisson no longer
+  reports convergence on an all-fixed-parameter fit (#575); energy-calibration
+  coverage and a zero-valid-bin guard (#563).
+- **ENDF parsing**: fixed a URR Case-B (LFW=1 / LRF=1) resonance-stream
+  misalignment (#606), and now hard-reject unsupported MF=2 NIS>1 and LRF=7
+  layouts instead of mis-parsing them (#576).
+- **NeXus I/O**: validate the `time_of_flight` `units` attribute, fixing a
+  silent 1000× rescale on files written with `units = "us"` (#561).
+
+### Security
+
+- Bumped `pyo3` and `numpy` 0.28 → 0.29, clearing two Dependabot advisories:
+  **GHSA-36hh-v3qg-5jq4** (HIGH — out-of-bounds read in `PyList`/`PyTuple`
+  `nth`/`nth_back`) and **GHSA-chgr-c6px-7xpp** (MEDIUM — missing `Sync` bound
+  on `PyCFunction::new_closure`). No binding code changes were required. (#615)
+
+### Documentation
+
+- Claim-accuracy pass: every README / guide / rustdoc capability claim and
+  SAMMY citation verified against primary sources (#610). Review-process
+  metadata scrubbed from production comments; `spatial_map_typed` and the
+  crate module lists documented; research-only scripts moved out of the tree
+  (#614). Guide screenshots refreshed for the current GUI and a stale
+  solver-settings caption corrected (#617–#619).
 
 ## [0.1.8] - 2026-04-27
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ title: "NEREIDS: Neutron Resonance Resolved Imaging Data Analysis System"
 message: "If you use this software, please cite it as below."
 type: software
 license: MIT
-version: 0.1.8
-date-released: 2026-04-27
+version: 0.2.0
+date-released: 2026-06-16
 doi: 10.5281/zenodo.18973054
 url: https://ornlneutronimaging.github.io/NEREIDS/
 repository-code: https://github.com/ornlneutronimaging/NEREIDS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "endf-mat"
-version = "0.1.8"
+version = "0.2.0"
 
 [[package]]
 name = "endi"
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "nereids-core"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "endf-mat",
  "serde",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "nereids-endf"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "dirs",
  "endf-mat",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "nereids-fitting"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "nereids-core",
  "nereids-endf",
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "nereids-gui"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "dirs",
  "eframe",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "nereids-io"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "hdf5-metno",
  "ndarray",
@@ -2983,7 +2983,7 @@ dependencies = [
 
 [[package]]
 name = "nereids-physics"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "microlp",
  "nereids-core",
@@ -2995,7 +2995,7 @@ dependencies = [
 
 [[package]]
 name = "nereids-pipeline"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "ndarray",
  "nereids-core",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "nereids-python"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "ndarray",
  "nereids-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,20 +13,20 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.8"
+version = "0.2.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ornlneutronimaging/NEREIDS"
 
 [workspace.dependencies]
 # Internal crates (version required for crates.io; path used locally)
-endf-mat = { version = "0.1.8", path = "crates/endf-mat" }
-nereids-core = { version = "0.1.8", path = "crates/nereids-core" }
-nereids-endf = { version = "0.1.8", path = "crates/nereids-endf" }
-nereids-physics = { version = "0.1.8", path = "crates/nereids-physics" }
-nereids-io = { version = "0.1.8", path = "crates/nereids-io" }
-nereids-fitting = { version = "0.1.8", path = "crates/nereids-fitting" }
-nereids-pipeline = { version = "0.1.8", path = "crates/nereids-pipeline" }
+endf-mat = { version = "0.2.0", path = "crates/endf-mat" }
+nereids-core = { version = "0.2.0", path = "crates/nereids-core" }
+nereids-endf = { version = "0.2.0", path = "crates/nereids-endf" }
+nereids-physics = { version = "0.2.0", path = "crates/nereids-physics" }
+nereids-io = { version = "0.2.0", path = "crates/nereids-io" }
+nereids-fitting = { version = "0.2.0", path = "crates/nereids-fitting" }
+nereids-pipeline = { version = "0.2.0", path = "crates/nereids-pipeline" }
 
 # Common external dependencies
 thiserror = "2"

--- a/apps/gui/pyproject.toml
+++ b/apps/gui/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nereids-gui"
-version = "0.1.8"
+version = "0.2.0"
 description = "GUI application for NEREIDS neutron resonance imaging"
 requires-python = ">= 3.10"
 license = "MIT"

--- a/homebrew/nereids.rb
+++ b/homebrew/nereids.rb
@@ -1,7 +1,7 @@
 # Template only — the canonical cask lives at ornlneutronimaging/homebrew-nereids.
 # CI (publish.yml update-homebrew job) substitutes version + sha256 in the tap repo.
 cask "nereids" do
-  version "0.1.8"
+  version "0.2.0"
   sha256 :no_check
 
   url "https://github.com/ornlneutronimaging/NEREIDS/releases/download/v#{version}/nereids-#{version}-macos-arm64.dmg"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nereids"
-version = "0.1.8"
+version = "0.2.0"
 description = "Neutron Resonance Resolved Imaging Data Analysis System — Python bindings"
 requires-python = ">= 3.10"
 license = "MIT"
@@ -37,7 +37,7 @@ Issues = "https://github.com/ornlneutronimaging/NEREIDS/issues"
 
 [project.optional-dependencies]
 mcp = ["fastmcp>=3.0"]
-gui = ["nereids-gui==0.1.8"]
+gui = ["nereids-gui==0.2.0"]
 
 [project.scripts]
 nereids-mcp = "nereids.mcp:main"


### PR DESCRIPTION
## Release v0.2.0

Minor bump **0.1.8 → 0.2.0**. The minor (not patch) reflects a breaking `nereids-io` API rename (`NexusMetadata.tof_edges_ns` → `tof_edges_us`) under 0.x semver. **First release published under MIT** (the 0.1.8 registry artifacts stay BSD-3-Clause; endf-mat 0.1.8 stays MIT OR Apache-2.0).

Two commits:
1. `docs(changelog)` — populate `[Unreleased]` with the full set of changes since v0.1.8 (April).
2. `Release v0.2.0` — `bump-version.sh`: version 0.2.0 across `Cargo.toml` (+ 7 inter-crate pins), both `pyproject.toml`, `CITATION.cff` (+ `date-released: 2026-06-16`), the homebrew template; rolls `[Unreleased]` → `[0.2.0]`; refreshes `Cargo.lock` (9 internal pins, no third-party drift).

### Headline changes (full notes in CHANGELOG)
- **Security** — pyo3/numpy 0.29 (two GHSA advisories) (#615)
- **Fixed (physics)** — exact FGM Doppler kernel (#611), SLBW/MLBW sign + velocity-factor (#549/#550/#577), LRF=7 KRM=3 SAMMY parity (#589), aux-grid resolution (#608); ENDF/NeXus parser fixes (#606/#576/#561)
- **Changed** — MIT license workspace-wide; Detectability defaults (#620); input-validation hardening; ~−1600 LOC refactor
- **Breaking** — `tof_edges_ns` → `tof_edges_us`

### Gates (all green on the bumped tree)
`cargo fmt` · `clippy -D` · **992 Rust tests** · `cargo check --examples` · **175 Python tests** · `doc-build` (mdBook + rustdoc + pdoc render).

### On merge
The signed tag `v0.2.0` goes on the merged main commit and the push triggers `publish.yml` → crates.io (7 crates), PyPI (`nereids` + `nereids-gui`), GitHub Release, and the Homebrew tap. **Irreversible** once the tag pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
