### PR TITLE
chore(release): 0.2.1 — repair publish pipeline, supersede yanked 0.2.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,11 +95,14 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            # manylinux_2_31 (Debian 11) ships GTK 3.24.5; rfd's gtk3
-            # backend (gtk-sys 0.18, added in #539) requires gtk+-3.0
-            # >= 3.24, which manylinux_2_28 (AlmaLinux 8, GTK 3.22)
-            # cannot satisfy — the cause of the v0.2.0 build-gui failure.
-            manylinux: "2_31"
+            # rfd's gtk3 backend (gtk-sys 0.18, added in #539) hard-requires
+            # gtk+-3.0 >= 3.24.  manylinux_2_28 (AlmaLinux 8) ships GTK 3.22 —
+            # too old — which broke the v0.2.0 build-gui job.  manylinux_2_34
+            # (AlmaLinux 9) ships GTK 3.24 AND is in maturin-action's container
+            # image map.  (manylinux_2_31 is NOT in that map, so the action
+            # silently falls back to a host build where before-script runs
+            # non-root and apt-get fails — do not use it here.)
+            manylinux: "2_34"
           - os: macos-latest
             target: aarch64-apple-darwin
 
@@ -123,11 +126,11 @@ jobs:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux || 'auto' }}
           args: --release --out dist --find-interpreter
-          # manylinux_2_31 is Debian 11 (apt), not AlmaLinux (yum).
-          # libgtk-3-dev provides gtk+-3.0.pc (3.24.5) for gtk-sys.
+          # manylinux_2_34 is AlmaLinux 9 (dnf/yum), running as root in the
+          # container.  gtk3-devel provides gtk+-3.0.pc (GTK 3.24) for gtk-sys;
+          # cmake (3.26, appstream) is needed by C build deps in the tree.
           before-script-linux: |
-            apt-get update
-            apt-get install -y --no-install-recommends cmake libgtk-3-dev
+            yum install -y gtk3-devel cmake
 
       # maturin working-directory puts output in apps/gui/dist
       - name: Upload GUI wheel

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -164,6 +164,11 @@ jobs:
         run: |
           VERSION=${GITHUB_REF_NAME:-dev}
           VERSION=${VERSION#v}
+          # On a real tag GITHUB_REF_NAME is e.g. "v0.2.1" (clean). On a
+          # workflow_dispatch dry-run it is the branch name, which may contain
+          # "/" (e.g. "fix/release-0.2.1") — that would put a slash in the DMG
+          # path and break `hdiutil create`. Sanitize so dry-runs succeed too.
+          VERSION=${VERSION//\//-}
           hdiutil create -volname "NEREIDS ${VERSION}" \
             -srcfolder target/release/bundle/osx/NEREIDS.app \
             -ov -format UDZO \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,7 +95,11 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            manylinux: "2_28"
+            # manylinux_2_31 (Debian 11) ships GTK 3.24.5; rfd's gtk3
+            # backend (gtk-sys 0.18, added in #539) requires gtk+-3.0
+            # >= 3.24, which manylinux_2_28 (AlmaLinux 8, GTK 3.22)
+            # cannot satisfy — the cause of the v0.2.0 build-gui failure.
+            manylinux: "2_31"
           - os: macos-latest
             target: aarch64-apple-darwin
 
@@ -119,10 +123,11 @@ jobs:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux || 'auto' }}
           args: --release --out dist --find-interpreter
+          # manylinux_2_31 is Debian 11 (apt), not AlmaLinux (yum).
+          # libgtk-3-dev provides gtk+-3.0.pc (3.24.5) for gtk-sys.
           before-script-linux: |
-            yum install -y cmake3 || yum install -y cmake
-            ln -sf /usr/bin/cmake3 /usr/bin/cmake || true
-            yum install -y gtk3-devel
+            apt-get update
+            apt-get install -y --no-install-recommends cmake libgtk-3-dev
 
       # maturin working-directory puts output in apps/gui/dist
       - name: Upload GUI wheel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [0.2.0] - 2026-06-16
+## [0.2.1] - 2026-06-16
+
+### Fixed
+
+- **Release packaging** — the 0.2.0 tag published only partially before
+  failing and was yanked; 0.2.1 re-publishes the complete 0.2.0 change set
+  (below) with the publish pipeline repaired:
+  - The `nereids-endf` and `nereids-physics` self dev-dependencies (which
+    expose each crate's `test-support` feature to its own integration tests)
+    are now path-only — `{ path = ".", features = [...] }` instead of carrying
+    the workspace version. The versioned form made `cargo publish` try to
+    resolve the crate's own not-yet-published current version from crates.io
+    and abort, which is what halted the 0.2.0 crates publish after `endf-mat`
+    and `nereids-core` had already gone live.
+  - The Linux GUI wheel now builds on `manylinux_2_34` (AlmaLinux 9, GTK 3.24)
+    rather than `manylinux_2_28` (AlmaLinux 8, GTK 3.22), satisfying the
+    `gtk+-3.0 >= 3.24` requirement that `gtk-sys` 0.18 (rfd's gtk3 backend,
+    added in 0.2.0) imposes. Consequently the Linux GUI wheel now requires
+    glibc ≥ 2.34 (e.g. Ubuntu 22.04+, RHEL / AlmaLinux 9+).
+
+## [0.2.0] - 2026-06-16 [YANKED]
+
+> **Yanked.** The release pipeline failed partway through: `nereids` on PyPI
+> and the `endf-mat` / `nereids-core` crates were published before a packaging
+> bug aborted the remaining crates and the Linux GUI wheel. The 0.2.0
+> artifacts that did publish have been yanked — **use 0.2.1**, which ships the
+> same change set listed here.
 
 ### Changed
 
@@ -269,7 +295,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Documentation site: mdBook user guide + rustdoc API reference on GitHub Pages
 - SAMMY validation suite: 43 test cases validated against SAMMY reference code
 
-[Unreleased]: https://github.com/ornlneutronimaging/NEREIDS/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/ornlneutronimaging/NEREIDS/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/ornlneutronimaging/NEREIDS/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/ornlneutronimaging/NEREIDS/compare/v0.1.8...v0.2.0
 [0.1.8]: https://github.com/ornlneutronimaging/NEREIDS/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/ornlneutronimaging/NEREIDS/compare/v0.1.6...v0.1.7

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ title: "NEREIDS: Neutron Resonance Resolved Imaging Data Analysis System"
 message: "If you use this software, please cite it as below."
 type: software
 license: MIT
-version: 0.2.0
+version: 0.2.1
 date-released: 2026-06-16
 doi: 10.5281/zenodo.18973054
 url: https://ornlneutronimaging.github.io/NEREIDS/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "endf-mat"
-version = "0.2.0"
+version = "0.2.1"
 
 [[package]]
 name = "endi"
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "nereids-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "endf-mat",
  "serde",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "nereids-endf"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dirs",
  "endf-mat",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "nereids-fitting"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "nereids-core",
  "nereids-endf",
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "nereids-gui"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dirs",
  "eframe",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "nereids-io"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "hdf5-metno",
  "ndarray",
@@ -2983,7 +2983,7 @@ dependencies = [
 
 [[package]]
 name = "nereids-physics"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "microlp",
  "nereids-core",
@@ -2995,7 +2995,7 @@ dependencies = [
 
 [[package]]
 name = "nereids-pipeline"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ndarray",
  "nereids-core",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "nereids-python"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ndarray",
  "nereids-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,20 +13,20 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ornlneutronimaging/NEREIDS"
 
 [workspace.dependencies]
 # Internal crates (version required for crates.io; path used locally)
-endf-mat = { version = "0.2.0", path = "crates/endf-mat" }
-nereids-core = { version = "0.2.0", path = "crates/nereids-core" }
-nereids-endf = { version = "0.2.0", path = "crates/nereids-endf" }
-nereids-physics = { version = "0.2.0", path = "crates/nereids-physics" }
-nereids-io = { version = "0.2.0", path = "crates/nereids-io" }
-nereids-fitting = { version = "0.2.0", path = "crates/nereids-fitting" }
-nereids-pipeline = { version = "0.2.0", path = "crates/nereids-pipeline" }
+endf-mat = { version = "0.2.1", path = "crates/endf-mat" }
+nereids-core = { version = "0.2.1", path = "crates/nereids-core" }
+nereids-endf = { version = "0.2.1", path = "crates/nereids-endf" }
+nereids-physics = { version = "0.2.1", path = "crates/nereids-physics" }
+nereids-io = { version = "0.2.1", path = "crates/nereids-io" }
+nereids-fitting = { version = "0.2.1", path = "crates/nereids-fitting" }
+nereids-pipeline = { version = "0.2.1", path = "crates/nereids-pipeline" }
 
 # Common external dependencies
 thiserror = "2"

--- a/apps/gui/pyproject.toml
+++ b/apps/gui/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nereids-gui"
-version = "0.2.0"
+version = "0.2.1"
 description = "GUI application for NEREIDS neutron resonance imaging"
 requires-python = ">= 3.10"
 license = "MIT"

--- a/crates/nereids-endf/Cargo.toml
+++ b/crates/nereids-endf/Cargo.toml
@@ -32,7 +32,10 @@ dirs = { workspace = true }
 tempfile = "3"
 # Self dev-dep enables in-crate `#[cfg(test)]` blocks and integration
 # tests under `crates/nereids-endf/tests/` (a separate crate boundary)
-# to consume `resonance::test_support`.  Inherits version + path from
-# `[workspace.dependencies]`, so `scripts/bump-version.sh` keeps the
-# version pin in sync automatically.
-nereids-endf = { workspace = true, features = ["test-support"] }
+# to consume `resonance::test_support`.  MUST be path-only (no version):
+# a versioned self-dep (e.g. `workspace = true`, which pins the current
+# 0.x.y) cannot be published, because `cargo publish` then tries to
+# resolve that exact version from crates.io before it exists ("failed to
+# select a version for nereids-endf = ^X").  Version-less dev-deps are
+# dropped from the published manifest, so this is safe and publishable.
+nereids-endf = { path = ".", features = ["test-support"] }

--- a/crates/nereids-physics/Cargo.toml
+++ b/crates/nereids-physics/Cargo.toml
@@ -31,12 +31,13 @@ microlp = { workspace = true }
 # `test-support` feature here exposes `resolution::test_support` to
 # the integration suite without leaking it into release builds.
 #
-# Inherits version + path from `[workspace.dependencies]` (see
-# workspace Cargo.toml) so `scripts/bump-version.sh` keeps the
-# version in sync automatically.  A path-only self-dep (without a
-# version) breaks `cargo publish` because crates.io rejects
-# manifests whose declared deps lack version constraints.
-nereids-physics = { workspace = true, features = ["test-support"] }
+# MUST be path-only (no version): a versioned self-dep (e.g.
+# `workspace = true`, which pins the current 0.x.y) cannot be
+# published, because `cargo publish` then tries to resolve that exact
+# version from crates.io before it exists ("failed to select a version
+# for nereids-physics = ^X").  Version-less dev-deps are dropped from
+# the published manifest, so this is safe and publishable.
+nereids-physics = { path = ".", features = ["test-support"] }
 # Exposes `nereids_endf::resonance::test_support` — synthetic
 # `ResonanceData` builders shared with sibling crates' tests.
 nereids-endf = { workspace = true, features = ["test-support"] }

--- a/homebrew/nereids.rb
+++ b/homebrew/nereids.rb
@@ -1,7 +1,7 @@
 # Template only — the canonical cask lives at ornlneutronimaging/homebrew-nereids.
 # CI (publish.yml update-homebrew job) substitutes version + sha256 in the tap repo.
 cask "nereids" do
-  version "0.2.0"
+  version "0.2.1"
   sha256 :no_check
 
   url "https://github.com/ornlneutronimaging/NEREIDS/releases/download/v#{version}/nereids-#{version}-macos-arm64.dmg"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nereids"
-version = "0.2.0"
+version = "0.2.1"
 description = "Neutron Resonance Resolved Imaging Data Analysis System — Python bindings"
 requires-python = ">= 3.10"
 license = "MIT"
@@ -37,7 +37,7 @@ Issues = "https://github.com/ornlneutronimaging/NEREIDS/issues"
 
 [project.optional-dependencies]
 mcp = ["fastmcp>=3.0"]
-gui = ["nereids-gui==0.2.0"]
+gui = ["nereids-gui==0.2.1"]
 
 [project.scripts]
 nereids-mcp = "nereids.mcp:main"


### PR DESCRIPTION
## Summary

Recovers the failed **v0.2.0** release. v0.2.0 published only partially before two tag-only-path bugs aborted the rest, leaving an inconsistent release. This PR repairs the publish pipeline and bumps to **0.2.1**, which re-publishes the complete 0.2.0 change set. The partial 0.2.0 artifacts will be **yanked** after 0.2.1 is live.

### What v0.2.0 published (to be yanked)
- ✅ PyPI: `nereids` 0.2.0
- ✅ crates.io: `endf-mat` 0.2.0, `nereids-core` 0.2.0
- ❌ Never published: PyPI `nereids-gui`, the other 5 crates, the GitHub Release, Homebrew

### Root causes — both are tag-only publish paths that PR CI never exercises

1. **Crates publish aborted.** The `nereids-endf` / `nereids-physics` self dev-dependencies (which expose each crate's `test-support` feature to its own integration tests) carried the workspace version. `cargo publish` then tried to resolve the crate's own not-yet-published current version from crates.io and failed — *after* `endf-mat` and `nereids-core` had already gone live. **Fix:** path-only `{ path = ".", features = [...] }`; cargo drops version-less dev-deps from the published manifest. Verified locally with `cargo package --no-verify`.

2. **Linux GUI wheel failed to build.** #539 switched rfd to its gtk3 backend, so `gtk-sys 0.18` now hard-requires `gtk+-3.0 >= 3.24`. The wheel built on `manylinux_2_28` (AlmaLinux 8, GTK **3.22**) → `pkg-config: gtk+-3.0 >= 3.24 ... not found`. **Fix:** build on `manylinux_2_34` (AlmaLinux 9, GTK **3.24**), which is in maturin-action's container image map. (`manylinux_2_31` is *not* mapped — the action silently falls back to a non-root host build where the `apt` before-script fails; that was a wrong first attempt, corrected here.) The Linux GUI wheel now requires **glibc ≥ 2.34** (Ubuntu 22.04+ / RHEL / AlmaLinux 9+).

3. **macOS DMG dry-run hygiene.** The DMG filename derives from `GITHUB_REF_NAME`; on a `workflow_dispatch` dry-run from a release branch the name contains a `/`, so `hdiutil create` failed. Sanitized `/`→`-`. No-op on real tags (which were already fine — v0.2.0's DMG built).

### Verification

Dry-ran the full publish matrix to green (`gh workflow run publish.yml -f dry_run=true`):
- All build jobs pass: sdist, library wheels (ubuntu/macos), GUI wheels (ubuntu/macos), macOS App Bundle.
- The Linux GUI wheel is produced as `nereids_gui-0.2.1-py3-none-manylinux_2_34_x86_64.whl` — a valid PyPI manylinux tag (not a downgraded `linux_x86_64`); auditwheel bundled the GTK stack (~39 MB, 64 `.so`).
- `publish-crates` / `publish-pypi` correctly **skip** in dry-run (they gate on a real tag), so FIX 1's publishability was confirmed separately via `cargo package --no-verify`.

### Changes
- `.github/workflows/publish.yml` — `build-gui` → `manylinux_2_34` + yum `gtk3-devel`; DMG version sanitize
- `crates/nereids-endf/Cargo.toml`, `crates/nereids-physics/Cargo.toml` — self dev-dep path-only
- Version `0.2.0 → 0.2.1` across Cargo manifests + inter-crate pins, both `pyproject.toml`, `CITATION.cff`, homebrew, `Cargo.lock`
- `CHANGELOG.md` — `[0.2.0]` marked `[YANKED]`; `[0.2.1]` section added

### After merge (separate, gated on your go-ahead)
1. Tag `v0.2.1` on `main` → triggers the real publish.
2. Yank the partial 0.2.0: PyPI `nereids` 0.2.0; `cargo yank --version 0.2.0` for `endf-mat` and `nereids-core`.

### Note
This release bump touches only version strings, the CHANGELOG, and a publish-only dev-dep source (build/test behavior unchanged). Gate run: `cargo fmt --all` (no Rust changes) + `cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings` (clean). The full `cargo test` run was not re-executed since no Rust logic changed and the entire workspace was just compiled green across all platforms by the dry-run — happy to run it if you'd like.
