### PR TITLE
security: pin third-party GitHub Actions to commit SHAs + least-privilege permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   # ── Fast compilation gate ──────────────────────────────────────────
   check:
@@ -16,8 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install GTK 3 development headers (rfd backend)
         run: sudo apt-get update -qq && sudo apt-get install -y libgtk-3-dev
       - run: cargo check --workspace --exclude nereids-python
@@ -32,8 +37,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
+          toolchain: stable
           components: rustfmt
       - run: cargo fmt --all -- --check
 
@@ -44,10 +50,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
+          toolchain: stable
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install GTK 3 development headers (rfd backend)
         run: sudo apt-get update -qq && sudo apt-get install -y libgtk-3-dev
       - run: cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings
@@ -65,8 +72,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install GTK 3 development headers (rfd backend, Linux only)
         if: runner.os == 'Linux'
         run: sudo apt-get update -qq && sudo apt-get install -y libgtk-3-dev
@@ -82,8 +91,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install GTK 3 development headers (rfd backend)
         run: sudo apt-get update -qq && sudo apt-get install -y libgtk-3-dev
       - name: Build docs
@@ -112,10 +123,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.9.4
+        uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
         with:
           run-install: true
       - name: Build and test Python bindings
@@ -128,17 +141,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
+          toolchain: stable
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: taiki-e/install-action@50570a4fd0cb7e583e6a512c02bffb9ade28d868 # cargo-llvm-cov
+        with:
+          tool: cargo-llvm-cov
       - name: Install GTK 3 development headers (rfd backend)
         run: sudo apt-get update -qq && sudo apt-get install -y libgtk-3-dev
       - name: Generate coverage
         run: cargo llvm-cov --workspace --exclude nereids-python --lcov --output-path lcov.info
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           files: lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,15 +47,17 @@ jobs:
       - name: Check curated Python API page is in sync with .pyi stubs
         run: python scripts/check_python_api_drift.py
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install GTK 3 development headers (rfd backend)
         run: sudo apt-get update -qq && sudo apt-get install -y libgtk-3-dev
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.9.4
+        uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
         with:
           run-install: true
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
             3.13
 
       - name: Build wheel
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux || 'auto' }}
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build sdist
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           command: sdist
           args: --out dist -m bindings/python/Cargo.toml
@@ -120,7 +120,7 @@ jobs:
             3.13
 
       - name: Build GUI wheel
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           working-directory: apps/gui
           target: ${{ matrix.target }}
@@ -147,9 +147,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install cmake and cargo-bundle
         run: |
@@ -210,7 +212,7 @@ jobs:
           ls -la dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: dist/
           verbose: true
@@ -237,7 +239,7 @@ jobs:
         run: ls -la dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: dist/
 
@@ -254,7 +256,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
 
       - name: Publish crates (dependency order)
         env:
@@ -322,7 +326,7 @@ jobs:
           ls -la release/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: release/*
           generate_release_notes: true


### PR DESCRIPTION
## What

Supply-chain hardening of all GitHub Actions workflows in this repo:

- **SHA-pin every third-party action** to a full 40-char commit SHA, with the original version retained as a trailing `# version` comment. First-party `actions/*` and `github/*` actions are intentionally left tag-pinned per group convention.
- **Add a conservative top-level `permissions: contents: read`** block to pure-CI workflows that have no existing permissions block and perform no privileged operations.
- **`dtolnay/rust-toolchain`**: because this action derives the Rust channel from its git ref, a bare SHA pin would break channel selection. Every use now carries an explicit `toolchain: stable` input so behavior is unchanged.
- **`taiki-e/install-action`**: now carries an explicit `with: tool: cargo-llvm-cov` so tool selection is not ref-dependent.

## Why

Supply-chain hardening per the ORNL Neutron Imaging group convention to pin third-party GitHub Actions to commit SHAs. Produced by the 2026-06-22 workspace GitHub Actions security audit.

## Pins applied

| Action | Pinned SHA | Version |
| --- | --- | --- |
| prefix-dev/setup-pixi | a0af7a228712d6121d37aba47adf55c1332c9c2e | v0.9.4 |
| Swatinem/rust-cache | e18b497796c12c097a38f9edb9d0641fb99eee32 | v2 |
| dtolnay/rust-toolchain | 29eef336d9b2848a0b548edc03f92a220660cdb8 | stable |
| taiki-e/install-action | 50570a4fd0cb7e583e6a512c02bffb9ade28d868 | cargo-llvm-cov |
| codecov/codecov-action | 0fb7174895f61a3b6b78fc075e0cd60383518dac | v5 |
| PyO3/maturin-action | e83996d129638aa358a18fbd1dfb82f0b0fb5d3b | v1 |
| pypa/gh-action-pypi-publish | cef221092ed1bacb1cc03d23a2d87d1d172e277b | v1.14.0 |
| softprops/action-gh-release | 3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 | v2 |

## Permissions added

- `ci.yml` — added top-level `permissions: contents: read` (no existing block; no privileged operations).
- `docs.yml` and `publish.yml` — left untouched; both already declare top-level permissions blocks.

## Notes on the dtolnay/taiki-e special cases

- All 10 `dtolnay/rust-toolchain` uses (7 in `ci.yml`, 1 in `docs.yml`, 2 in `publish.yml`) gained `toolchain: stable`.
- The single `taiki-e/install-action@cargo-llvm-cov` use in `ci.yml` gained `with: tool: cargo-llvm-cov`.

No behavior change intended; CI on this PR validates.

🤖 Assisted with Claude Code
