### PR TITLE
fix(physics): resolution kernels applied as convolution, not correlation (#631) + exact support margin (#626)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Tabulated/Ikeda–Carpenter resolution kernels were applied
+  time-mirrored** (#631): the broadener gathered theory at `t + Δt`
+  (a correlation) instead of `t − Δt` (the convolution — SAMMY
+  `udr/mudr4.f90 Ud_Convolute`), putting every kernel's
+  delayed-emission tail on the wrong (high-energy) side of every
+  resonance. Consequences on strongly asymmetric kernels: mirrored
+  model asymmetry in residuals, ~2–3.7 % inflated energy-space model
+  width, fitted temperature biased low ~2.5 % at 300 K, and fitted
+  `(t0, L_scale)` absorbing the kernel centroid lag with the wrong
+  sign. **Action required: any fitted `(t0, L_scale)` energy scales and
+  any `calibrate_resolution` results (α(E), width scales) obtained with
+  earlier versions under tabulated or IC resolution are invalidated and
+  must be re-fit**, and externally maintained bit-exact baselines of
+  the broadener must be regenerated. Gaussian-resolution and
+  Doppler-only results are unaffected. New sign-pinning regression
+  tests cover both application paths in Rust and the
+  `load_resolution`/`apply_resolution` Python bindings.
+- **Fit-range resolution margin now uses the exact TOF→E map** (#626):
+  `kernel_support_ev` previously used the linear chain-rule estimate,
+  which under-covers on the high-energy side — the side the corrected
+  convolution's delayed-emission tail actually reads from. Extreme
+  tails that reach the nominal flight time now report an unbounded
+  support, which the GUI clamps to the loaded grid.
+
 - **Linux GUI wheel restored to `manylinux_2_28`** (glibc ≥ 2.28:
   RHEL/AlmaLinux 8+, Ubuntu 20.04+) — reverses 0.2.1's jump to
   `manylinux_2_34`, which made `pip install "nereids[gui]"` unresolvable

--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -1944,10 +1944,12 @@ const FIT_RANGE_MARGIN_FWHM: f64 = 5.0;
 ///   the eV distance over which the discrete kernel has positive
 ///   weight at `E`.  Past this distance the kernel is exactly zero,
 ///   so 1× the support fully captures the broadening footprint — no
-///   safety multiplier needed.  The support is computed from the
-///   actual kernel offsets via the chain-rule TOF→eV conversion (see
-///   `TabulatedResolution::kernel_support_ev`), so the margin tracks
-///   the loaded resolution file rather than a hand-picked constant.
+///   safety multiplier needed.  The support maps the actual kernel
+///   offsets through the exact TOF→E relation (see
+///   `TabulatedResolution::kernel_support_ev`; it may return
+///   `f64::INFINITY` for extreme tails, which the `partition_point`
+///   slicing below clamps to the grid), so the margin tracks the
+///   loaded resolution file rather than a hand-picked constant.
 fn kernel_margin_ev(e_ev: f64, resolution: Option<&ResolutionFunction>) -> f64 {
     match resolution {
         None => 0.0,

--- a/crates/nereids-physics/src/ikeda_carpenter.rs
+++ b/crates/nereids-physics/src/ikeda_carpenter.rs
@@ -56,10 +56,15 @@
 //!
 //! For a flight path `L`, a resonance at `E_r` has nominal TOF
 //! `t_r = TOF_FACTOR·L/√E_r`. A neutron with emission delay τ arrives at TOF
-//! `t_r+τ`, apparent energy `E' = (TOF_FACTOR·L/(t_r+τ))²`. Sampling `I(τ)` on
+//! `t_r+τ`, apparent energy `E' = (TOF_FACTOR·L/(t_r+τ))²` — that is the kernel's
+//! *definition* (its positive-τ tail is delayed emission). Sampling `I(τ)` on
 //! a τ-grid and mapping to TOF-offsets yields exactly the `(offset, weight)`
 //! kernel representation that [`crate::resolution::TabulatedResolution`]
-//! consumes — so IC rides the *same* verified broadening machinery. At apply time
+//! consumes — so IC rides the *same* verified broadening machinery, whose
+//! *application* is the convolution gather: the broadened value at measured TOF
+//! `t` reads theory at `t−τ` (a neutron measured at `t` with delay τ really flew
+//! `t−τ`; see `resolution::broaden` and SAMMY `udr/mudr4.f90` `Ud_Convolute`).
+//! At apply time
 //! `interpolated_kernel` blends the two bracketing reference kernels when they
 //! have equal point counts, else it falls back to the nearer reference; because
 //! IC trims each kernel's tail independently the point counts often differ, so the
@@ -69,9 +74,10 @@
 //! UDR file convention (peak at offset 0); `interpolated_kernel` does not
 //! re-center it. Because the IC pulse is right-skewed, its *mean* lags its mode by
 //! ~1/α(E) in TOF, so the centroid — and even the minimum — of a broadened
-//! resonance shifts in apparent energy by an α(E)-dependent amount (order 1e-2 eV,
-//! ~1e-3 relative, for α≈1.5 in the eV regime; larger toward lower energy). So it
-//! *does* move the broadened dip off the nominal energy, by a small amount.
+//! resonance shifts toward **lower apparent energy** by an α(E)-dependent amount
+//! (order 1e-2 eV, ~1e-3 relative, for α≈1.5 in the eV regime; larger toward
+//! lower energy). So it *does* move the broadened dip off the nominal energy,
+//! by a small amount.
 //!
 //! For the prompt-only law `α(E) = a0·√E + a1` with `R≈0`, the lag `~1/α(E)` is
 //! **exactly** the `1/√E` basis of a flight-path (`L_scale`) error *iff* `a1 = 0`:
@@ -877,8 +883,19 @@ mod tests {
             }
             num / den
         }
-        let shift_small_alpha = (dip_centroid_energy(0.8) - E0).abs();
-        let shift_large_alpha = (dip_centroid_energy(2.0) - E0).abs();
+        let signed_small_alpha = dip_centroid_energy(0.8) - E0;
+        let signed_large_alpha = dip_centroid_energy(2.0) - E0;
+        // The shift is toward LOWER apparent energy: the delayed-emission
+        // tail gathers theory from earlier TOF (higher E), so the theory
+        // dip at E0 surfaces at measured energies below E0. A positive
+        // shift here means the kernel was applied time-mirrored.
+        assert!(
+            signed_small_alpha < 0.0 && signed_large_alpha < 0.0,
+            "centering shift must be toward lower energy: \
+             α=0.8 {signed_small_alpha:+e}, α=2.0 {signed_large_alpha:+e}"
+        );
+        let shift_small_alpha = signed_small_alpha.abs();
+        let shift_large_alpha = signed_large_alpha.abs();
         // The bias is real (resolvable at the 1e-3 eV level)…
         assert!(
             shift_small_alpha > 1e-3,

--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -965,12 +965,21 @@ impl TabulatedResolution {
     ///
     /// 1. Find the bracketing reference kernel(s) for `e_ev` via
     ///    binary search on the sorted `ref_energies` grid.
-    /// 2. Over all bracketing kernels' entries with positive weight,
-    ///    take the extreme offsets `dt⁺ = max(dt, 0)` and
-    ///    `dt⁻ = max(−dt, 0)`.  Using both bracketing kernels (rather
-    ///    than the single nearest) is conservative — blended kernels
-    ///    are convex combinations, so their extremes are bounded by
-    ///    the bracketing extremes.
+    /// 2. Take the extreme offsets `dt⁺ = max(dt, 0)` and
+    ///    `dt⁻ = max(−dt, 0)` over the kernel entries that can carry
+    ///    weight at `e_ev`.  When the two bracketing kernels have
+    ///    equal point counts — the same condition under which
+    ///    `interpolated_kernel` blends element-wise — a blended entry
+    ///    has positive weight if EITHER endpoint's weight is
+    ///    positive, so a zero-weight padding offset in one kernel is
+    ///    activated by the other kernel's weight at the same index.
+    ///    The scan therefore uses the **joint** mask: wherever either
+    ///    kernel's weight is positive, BOTH kernels' offsets at that
+    ///    index are considered, which bounds every convex combination
+    ///    of the two offsets (and, a fortiori, the nearest-kernel
+    ///    fallback).  When the point counts differ, apply time falls
+    ///    back to the nearer reference kernel, so each kernel is
+    ///    scanned with its own positive-weight mask.
     /// 3. Map each extreme through the **exact** TOF→E relation
     ///    `E' = (TOF_FACTOR·L/(t∓dt))²` with `t = TOF_FACTOR·L/√E`
     ///    and return the larger energy excursion:
@@ -1011,12 +1020,21 @@ impl TabulatedResolution {
         let n = self.ref_energies.len();
         let mut max_dt_pos: f64 = 0.0;
         let mut max_dt_neg: f64 = 0.0;
-        let mut visit = |idx: usize| {
+        // `consider` folds one offset into the extremes; `visit` scans
+        // one kernel with its own positive-weight mask.  Both take the
+        // accumulators as explicit arguments so the joint-mask arm
+        // below can also fold offsets directly.
+        let consider = |dt: f64, pos: &mut f64, neg: &mut f64| {
+            if dt.is_finite() {
+                *pos = pos.max(dt);
+                *neg = neg.max(-dt);
+            }
+        };
+        let visit = |idx: usize, pos: &mut f64, neg: &mut f64| {
             let (offsets, weights) = &self.kernels[idx];
             for (&dt, &w) in offsets.iter().zip(weights.iter()) {
-                if w > 0.0 && dt.is_finite() {
-                    max_dt_pos = max_dt_pos.max(dt);
-                    max_dt_neg = max_dt_neg.max(-dt);
+                if w > 0.0 {
+                    consider(dt, pos, neg);
                 }
             }
         };
@@ -1025,12 +1043,36 @@ impl TabulatedResolution {
                 .partial_cmp(&e_ev)
                 .unwrap_or(std::cmp::Ordering::Equal)
         }) {
-            Ok(idx) => visit(idx),
-            Err(0) => visit(0),
-            Err(idx) if idx >= n => visit(n - 1),
+            Ok(idx) => visit(idx, &mut max_dt_pos, &mut max_dt_neg),
+            Err(0) => visit(0, &mut max_dt_pos, &mut max_dt_neg),
+            Err(idx) if idx >= n => visit(n - 1, &mut max_dt_pos, &mut max_dt_neg),
             Err(idx) => {
-                visit(idx - 1);
-                visit(idx);
+                let (off_lo, w_lo) = &self.kernels[idx - 1];
+                let (off_hi, w_hi) = &self.kernels[idx];
+                if off_lo.len() == off_hi.len() {
+                    // Element-wise blend (same condition as
+                    // `interpolated_kernel`): a blended entry carries
+                    // positive weight if EITHER endpoint weight is
+                    // positive, and its offset is a convex combination
+                    // of the two endpoint offsets — so fold BOTH
+                    // offsets wherever either weight is positive.
+                    for ((&o_lo, &wl), (&o_hi, &wh)) in off_lo
+                        .iter()
+                        .zip(w_lo.iter())
+                        .zip(off_hi.iter().zip(w_hi.iter()))
+                    {
+                        if wl > 0.0 || wh > 0.0 {
+                            consider(o_lo, &mut max_dt_pos, &mut max_dt_neg);
+                            consider(o_hi, &mut max_dt_pos, &mut max_dt_neg);
+                        }
+                    }
+                } else {
+                    // Different point counts: apply time falls back to
+                    // the nearer reference kernel, so per-kernel
+                    // positive-weight scans bound it.
+                    visit(idx - 1, &mut max_dt_pos, &mut max_dt_neg);
+                    visit(idx, &mut max_dt_pos, &mut max_dt_neg);
+                }
             }
         }
         let t = TOF_FACTOR * self.flight_path_m / e_ev.sqrt();
@@ -1668,7 +1710,15 @@ impl TabulatedResolution {
             ));
         }
 
-        // Validate strictly ascending reference energies
+        // Validate finite, strictly ascending reference energies.  The
+        // finiteness check must come first: NaN compares false against
+        // everything, so a NaN energy would slip through the ascending
+        // check below and then poison the bracketing binary search.
+        if let Some(bad) = ref_energies.iter().find(|e| !e.is_finite()) {
+            return Err(ResolutionParseError::InvalidFormat(format!(
+                "Reference energies must be finite, got {bad}"
+            )));
+        }
         for i in 1..ref_energies.len() {
             if ref_energies[i] <= ref_energies[i - 1] {
                 return Err(ResolutionParseError::InvalidFormat(format!(
@@ -1677,6 +1727,39 @@ impl TabulatedResolution {
                     ref_energies[i],
                     i - 1,
                     ref_energies[i - 1],
+                )));
+            }
+        }
+
+        // Per-block kernel invariants — the same set `from_kernels`
+        // enforces, because both constructors feed the same broadener:
+        //
+        // * non-empty: an empty block would make `broaden_presorted`
+        //   accumulate `norm == 0` and silently pass the spectrum
+        //   through;
+        // * strictly ascending offsets: the monotonic two-pointer
+        //   bracket walk and the trapezoidal `dt` widths
+        //   (`offsets[k+1] − offsets[k−1]`) both assume sorted offsets
+        //   — an unsorted block would broaden silently-wrong;
+        // * all-finite offsets and weights: a NaN weight poisons the
+        //   kernel norm and bypasses the division guard.
+        for (i, (offsets, weights)) in kernels.iter().enumerate() {
+            if offsets.is_empty() {
+                return Err(ResolutionParseError::InvalidFormat(format!(
+                    "Kernel {i} (E = {} eV) has no (offset, weight) points",
+                    ref_energies[i],
+                )));
+            }
+            if !offsets.windows(2).all(|w| w[0] < w[1]) {
+                return Err(ResolutionParseError::InvalidFormat(format!(
+                    "Kernel {i} (E = {} eV) TOF offsets must be strictly ascending",
+                    ref_energies[i],
+                )));
+            }
+            if offsets.iter().any(|v| !v.is_finite()) || weights.iter().any(|v| !v.is_finite()) {
+                return Err(ResolutionParseError::InvalidFormat(format!(
+                    "Kernel {i} (E = {} eV) contains non-finite offsets or weights",
+                    ref_energies[i],
                 )));
             }
         }
@@ -1718,6 +1801,14 @@ impl TabulatedResolution {
                 "Reference-energy count {} != kernel count {}",
                 ref_energies.len(),
                 kernels.len(),
+            )));
+        }
+        // Finiteness first: NaN compares false against everything, so a
+        // NaN energy would slip through the ascending check below and
+        // then poison the bracketing binary search.
+        if let Some(bad) = ref_energies.iter().find(|e| !e.is_finite()) {
+            return Err(ResolutionParseError::InvalidFormat(format!(
+                "Reference energies must be finite, got {bad}"
             )));
         }
         for i in 1..ref_energies.len() {
@@ -1787,6 +1878,15 @@ impl TabulatedResolution {
     /// 2. Convert TOF offsets to energy offsets using exact TOF↔energy relation
     /// 3. Convolve spectrum with interpolated kernel (trapezoidal integration)
     ///
+    /// Kernel points whose delayed-emission offset reaches the nominal
+    /// flight time at the target energy (`dt ≥ TOF(E)`) gather from
+    /// past infinite energy; they are dropped and the kernel
+    /// renormalized over the surviving points, mirroring the grid-edge
+    /// handling — see the tail-truncation note on `broaden_presorted`.
+    /// [`Self::kernel_support_ev`] returns `f64::INFINITY` in exactly
+    /// that regime, so callers consuming it as a fit-range margin
+    /// already have the signal.
+    ///
     /// # Errors
     /// Returns [`ResolutionError::LengthMismatch`] if the arrays differ in
     /// length, or [`ResolutionError::UnsortedEnergies`] if the energy grid is
@@ -1812,6 +1912,23 @@ impl TabulatedResolution {
     /// computes `Cc(Tc) = ∫Bb(τ)·Aa(Tc−τ)dτ` (the theory-segment search
     /// binds `Tc−Ta` to the kernel grid), and `Ud_Mesh_Time` (line 7)
     /// sizes the needed theory window as `[T0−UdT_last, T0−UdT_first]`.
+    ///
+    /// ## Delayed-tail truncation at short nominal flight times
+    ///
+    /// A kernel point with `dt ≥ tof_center` would gather at
+    /// `tof_prime = tof_center − dt ≤ 0`, i.e. from past infinite
+    /// energy where no theory value exists.  Such points are silently
+    /// dropped and the trapezoidal normalisation runs over the
+    /// surviving points — the same truncate-and-renormalize treatment
+    /// applied when `e_prime` falls outside the target grid
+    /// (`[e_min, e_max]`).  This engages when the nominal TOF at the
+    /// target energy is shorter than the kernel's delayed-emission
+    /// reach — very high energy and/or a short flight path — and is
+    /// reachable at *any* target energy because `interpolated_kernel`
+    /// clamps to the nearest reference kernel outside the tabulated
+    /// range.  [`Self::kernel_support_ev`] returns `f64::INFINITY` in
+    /// exactly this regime, so margin-consuming callers already have
+    /// the signal that the kernel footprint is unbounded there.
     ///
     /// ## Inner-loop optimization
     ///
@@ -2059,6 +2176,9 @@ impl TabulatedResolution {
 
                 // Convolution gather: theory at t − dt (see
                 // broaden_presorted; SAMMY mudr4.f90 Ud_Convolute).
+                // Points with dt ≥ tof_center gather from past infinite
+                // energy and are dropped, renormalizing over the
+                // survivors (see the tail-truncation note there).
                 let tof_prime = tof_center - dt;
                 if tof_prime <= 0.0 {
                     continue;
@@ -2547,6 +2667,9 @@ pub mod test_support {
 
                 // Convolution gather: theory at t − dt (see
                 // broaden_presorted; SAMMY mudr4.f90 Ud_Convolute).
+                // Points with dt ≥ tof_center gather from past infinite
+                // energy and are dropped, renormalizing over the
+                // survivors (see the tail-truncation note there).
                 let tof_prime = tof_center - dt;
                 if tof_prime <= 0.0 {
                     continue;
@@ -2777,6 +2900,115 @@ mod tests {
             25.0,
         );
         assert!(matches!(dup, Err(ResolutionParseError::InvalidFormat(_))));
+    }
+
+    #[test]
+    fn from_text_rejects_unsorted_offsets_within_block() {
+        // The second energy block has an out-of-order offset pair
+        // (1.0 followed by 0.0): the trapezoidal `dt_width` quadrature
+        // and the two-pointer bracket walk both assume sorted offsets,
+        // so the parser must error rather than construct a
+        // silently-corrupt kernel (same invariant `from_kernels`
+        // enforces).
+        let text = "\
+Resolution file
+---------------
+5.0 0.0
+-1.0 0.1
+0.0 1.0
+1.0 0.5
+
+10.0 0.0
+-1.0 0.1
+1.0 0.5
+0.0 1.0
+";
+        let err = TabulatedResolution::from_text(text, 25.0);
+        let Err(ResolutionParseError::InvalidFormat(msg)) = err else {
+            panic!("unsorted offsets must be rejected, got {err:?}");
+        };
+        assert!(
+            msg.contains("Kernel 1") && msg.contains("E = 10 eV"),
+            "error must name the offending block and reference energy: {msg}"
+        );
+        // The same file with sorted offsets parses fine.
+        let sorted = "\
+Resolution file
+---------------
+5.0 0.0
+-1.0 0.1
+0.0 1.0
+1.0 0.5
+
+10.0 0.0
+-1.0 0.1
+0.0 1.0
+1.0 0.5
+";
+        assert!(TabulatedResolution::from_text(sorted, 25.0).is_ok());
+    }
+
+    /// The remaining `from_kernels` invariants hold for parsed files too:
+    /// empty energy blocks (silent pass-through at broaden time), non-finite
+    /// kernel values (NaN norm bypasses the division guard), and non-finite
+    /// reference energies (NaN compares false, slipping through the
+    /// ascending check into the bracketing binary search) must all error.
+    #[test]
+    fn from_text_rejects_empty_block_and_non_finite_values() {
+        // Empty block: header line for E=10 with no data lines.
+        let empty_block = "\
+Resolution file
+---------------
+5.0 0.0
+-1.0 0.1
+0.0 1.0
+
+10.0 0.0
+
+";
+        let err = TabulatedResolution::from_text(empty_block, 25.0);
+        let Err(ResolutionParseError::InvalidFormat(msg)) = err else {
+            panic!("empty energy block must be rejected, got {err:?}");
+        };
+        assert!(
+            msg.contains("E = 10 eV") && msg.contains("no (offset, weight) points"),
+            "error must name the empty block: {msg}"
+        );
+
+        // Non-finite kernel weight.
+        let nan_weight = "\
+Resolution file
+---------------
+5.0 0.0
+-1.0 0.1
+0.0 NaN
+1.0 0.5
+";
+        let err = TabulatedResolution::from_text(nan_weight, 25.0);
+        let Err(ResolutionParseError::InvalidFormat(msg)) = err else {
+            panic!("non-finite weight must be rejected, got {err:?}");
+        };
+        assert!(
+            msg.contains("non-finite"),
+            "error must name the non-finite value class: {msg}"
+        );
+
+        // Non-finite reference energy.
+        let nan_energy = "\
+Resolution file
+---------------
+NaN 0.0
+-1.0 0.1
+0.0 1.0
+";
+        let err = TabulatedResolution::from_text(nan_energy, 25.0);
+        let Err(ResolutionParseError::InvalidFormat(msg)) = err else {
+            panic!("non-finite reference energy must be rejected, got {err:?}");
+        };
+        assert!(
+            msg.contains("finite"),
+            "error must name the finiteness requirement: {msg}"
+        );
     }
 
     #[test]
@@ -4296,6 +4528,111 @@ mod tests {
         assert!(
             (got - expected).abs() / expected < 1e-12,
             "support should ignore zero-weight entries: got {got}, expected {expected}"
+        );
+    }
+
+    /// Between two equal-count reference kernels, `interpolated_kernel`
+    /// blends element-wise, and a blended entry has positive weight if
+    /// EITHER endpoint's weight is positive — so a zero-weight padding
+    /// offset in one kernel is activated by the other kernel's weight
+    /// at the same index.  The support must bound the blend-activated
+    /// offset region (joint mask), not just the per-kernel
+    /// positive-weight extremes.
+    #[test]
+    fn test_tabulated_kernel_support_covers_blend_activated_offsets() {
+        // Kernel A pads its tail with zero-weight entries reaching
+        // offset 20; kernel B carries positive weight at every index.
+        // Per-kernel positive-weight maxima are 5 (A) and 12 (B), but
+        // the blend at the last index has offset `20 + frac·(12 − 20)`
+        // with weight `0 + frac·0.1 > 0` — beyond both maxima.
+        let r = TabulatedResolution {
+            ref_energies: vec![10.0, 1000.0],
+            kernels: vec![
+                (vec![0.0, 5.0, 10.0, 20.0], vec![1.0, 0.1, 0.0, 0.0]),
+                (vec![0.0, 4.0, 8.0, 12.0], vec![1.0, 0.5, 0.3, 0.1]),
+            ],
+            flight_path_m: 25.0,
+        };
+        let e: f64 = 100.0; // strictly between the reference energies
+        let expected = exact_support(e, 20.0, 0.0, 25.0);
+        let got = r.kernel_support_ev(e);
+        assert!(
+            (got - expected).abs() / expected < 1e-12,
+            "support must cover blend-activated zero-weight offsets: \
+             got {got}, expected {expected}"
+        );
+        // Non-vacuity: the joint bound strictly exceeds what the
+        // per-kernel positive-weight extremes (dt⁺ = 12) would give.
+        assert!(got > exact_support(e, 12.0, 0.0, 25.0));
+    }
+
+    /// The support must contain the footprint of the ACTUAL broadener:
+    /// broadening a flat baseline with a single narrow dip must leave
+    /// every target untouched whose window
+    /// `[e − support(e), e + support(e)]` excludes the dip.
+    /// Non-circular by construction — the oracle here is `broaden`
+    /// itself, not the `exact_support` formula mirror.
+    #[test]
+    fn test_tabulated_kernel_support_contains_broadener_footprint() {
+        // Asymmetric kernel with a dominant delayed (positive) tail.
+        let r = TabulatedResolution {
+            ref_energies: vec![100.0],
+            kernels: vec![(vec![-1.0, 0.0, 6.0], vec![0.2, 1.0, 0.7])],
+            flight_path_m: 25.0,
+        };
+        // Dense uniform grid; flat baseline with a single-point dip.
+        let de = 0.05;
+        let energies: Vec<f64> = (0..2001).map(|j| 50.0 + de * j as f64).collect();
+        let f = 1000; // dip mid-grid, at ~100 eV
+        let e_f = energies[f];
+        let mut spectrum = vec![1.0; energies.len()];
+        spectrum[f] = 0.0;
+        let out = r.broaden(&energies, &spectrum).unwrap();
+
+        // Piecewise-linear reads touch spectrum[f] only for
+        // e′ ∈ (energies[f−1], energies[f+1]); require one extra grid
+        // step of margin so bracketing/interpolation edge effects
+        // cannot straddle the window boundary.
+        let margin = 2.0 * de;
+        let (mut excluded_below, mut excluded_above) = (0usize, 0usize);
+        let mut included_differs = false;
+        let mut upside_differs = false;
+        for (&e, &o) in energies.iter().zip(out.iter()) {
+            let s = r.kernel_support_ev(e);
+            if e + s + margin < e_f || e - s - margin > e_f {
+                assert!(
+                    (o - 1.0).abs() < 1e-12,
+                    "target {e} eV (support {s}) must be untouched by a \
+                     dip at {e_f} eV outside its window; got {o}"
+                );
+                if e < e_f {
+                    excluded_below += 1;
+                } else {
+                    excluded_above += 1;
+                }
+            } else if (o - 1.0).abs() > 1e-3 {
+                included_differs = true;
+                if e < e_f - margin {
+                    upside_differs = true;
+                }
+            }
+        }
+        // Non-vacuity: both exclusion regions were exercised, the dip
+        // measurably alters at least one in-window target, and the
+        // delayed tail reaches the dip from BELOW — the direction the
+        // convolution gather loads.
+        assert!(
+            excluded_below > 0 && excluded_above > 0,
+            "grid must exercise both exclusion regions \
+             (below: {excluded_below}, above: {excluded_above})"
+        );
+        assert!(
+            included_differs,
+            "the dip must measurably alter at least one in-window target"
+        );
+        assert!(
+            upside_differs,
+            "the delayed tail must reach the dip from a target below it"
         );
     }
 }

--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -1737,12 +1737,15 @@ impl TabulatedResolution {
         // * non-empty: an empty block would make `broaden_presorted`
         //   accumulate `norm == 0` and silently pass the spectrum
         //   through;
+        // * all-finite offsets and weights (checked BEFORE sortedness:
+        //   a NaN offset fails the ascending comparison too, and the
+        //   "must be strictly ascending" message would mislead): a NaN
+        //   weight poisons the kernel norm and bypasses the division
+        //   guard;
         // * strictly ascending offsets: the monotonic two-pointer
         //   bracket walk and the trapezoidal `dt` widths
         //   (`offsets[k+1] − offsets[k−1]`) both assume sorted offsets
-        //   — an unsorted block would broaden silently-wrong;
-        // * all-finite offsets and weights: a NaN weight poisons the
-        //   kernel norm and bypasses the division guard.
+        //   — an unsorted block would broaden silently-wrong.
         for (i, (offsets, weights)) in kernels.iter().enumerate() {
             if offsets.is_empty() {
                 return Err(ResolutionParseError::InvalidFormat(format!(
@@ -1750,15 +1753,15 @@ impl TabulatedResolution {
                     ref_energies[i],
                 )));
             }
-            if !offsets.windows(2).all(|w| w[0] < w[1]) {
-                return Err(ResolutionParseError::InvalidFormat(format!(
-                    "Kernel {i} (E = {} eV) TOF offsets must be strictly ascending",
-                    ref_energies[i],
-                )));
-            }
             if offsets.iter().any(|v| !v.is_finite()) || weights.iter().any(|v| !v.is_finite()) {
                 return Err(ResolutionParseError::InvalidFormat(format!(
                     "Kernel {i} (E = {} eV) contains non-finite offsets or weights",
+                    ref_energies[i],
+                )));
+            }
+            if !offsets.windows(2).all(|w| w[0] < w[1]) {
+                return Err(ResolutionParseError::InvalidFormat(format!(
+                    "Kernel {i} (E = {} eV) TOF offsets must be strictly ascending",
                     ref_energies[i],
                 )));
             }
@@ -2991,6 +2994,27 @@ Resolution file
         assert!(
             msg.contains("non-finite"),
             "error must name the non-finite value class: {msg}"
+        );
+
+        // Non-finite kernel OFFSET: must report the finiteness problem,
+        // not the misleading "must be strictly ascending" (a NaN offset
+        // fails the ascending comparison too — finiteness is checked
+        // first so the message stays accurate).
+        let nan_offset = "\
+Resolution file
+---------------
+5.0 0.0
+-1.0 0.1
+NaN 1.0
+1.0 0.5
+";
+        let err = TabulatedResolution::from_text(nan_offset, 25.0);
+        let Err(ResolutionParseError::InvalidFormat(msg)) = err else {
+            panic!("non-finite offset must be rejected, got {err:?}");
+        };
+        assert!(
+            msg.contains("non-finite") && !msg.contains("ascending"),
+            "NaN offset must report finiteness, not sortedness: {msg}"
         );
 
         // Non-finite reference energy.

--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -822,6 +822,14 @@ pub(crate) fn resolution_broaden_presorted(
 /// TOF-offset space (μs). Kernels are interpolated between reference energies
 /// and converted from TOF to energy space when applied.
 ///
+/// ## Offset orientation
+///
+/// Positive `Δt` = delayed emission (the moderator storage tail); the
+/// kernel mode sits at `Δt = 0`. At apply time the broadener gathers
+/// theory at `t − Δt` (convolution — see [`Self::broaden`]), so the
+/// positive-`Δt` tail reads theory from earlier TOF = higher energy and
+/// broadened dips acquire their tail toward lower apparent energy.
+///
 /// ## File Format (VENUS/FTS)
 ///
 /// ```text
@@ -1768,15 +1776,31 @@ impl TabulatedResolution {
     /// Tabulated resolution broadening assuming the energy grid is already
     /// validated (sorted ascending, same length as spectrum).
     ///
+    /// ## Convolution orientation
+    ///
+    /// The broadened value at measured TOF `t` gathers theory at
+    /// `t − dt`: a neutron *measured* at `t` whose emission was delayed
+    /// by `dt` really flew for `t − dt`, i.e. it is faster than nominal,
+    /// so the kernel's positive-offset (delayed-emission) tail pulls
+    /// theory from earlier TOF = **higher** energy, and a resonance dip
+    /// acquires its tail toward lower apparent energy. This is the
+    /// convolution ∫R(τ)·S(t−τ)dτ, matching SAMMY's user-defined
+    /// resolution: `sammy/src/udr/mudr4.f90` `Ud_Convolute` (line 288)
+    /// computes `Cc(Tc) = ∫Bb(τ)·Aa(Tc−τ)dτ` (the theory-segment search
+    /// binds `Tc−Ta` to the kernel grid), and `Ud_Mesh_Time` (line 7)
+    /// sizes the needed theory window as `[T0−UdT_last, T0−UdT_first]`.
+    ///
     /// ## Inner-loop optimization
     ///
     /// The per-kernel-point spectrum interpolation uses a **two-pointer
     /// walk** instead of a binary search: `e_prime` is monotonically
-    /// decreasing in `k` (since `dt = offsets[k]` is non-decreasing,
-    /// `TOF' = tof_center + dt` is non-decreasing, and `E' = (L/TOF')²`
-    /// is non-increasing).  We maintain `bracket_hi` as the smallest
-    /// index into `energies[]` whose value is `>= e_prime`, and walk it
-    /// downward as `k` advances.  Amortized O(1) per kernel point.
+    /// increasing in `k` (since `dt = offsets[k]` is non-decreasing,
+    /// `TOF' = tof_center − dt` is non-increasing, and `E' = (L/TOF')²`
+    /// is non-decreasing).  We maintain `bracket_hi` as the smallest
+    /// index into `energies[]` whose value is `>= e_prime`; the walk is
+    /// a bidirectional fixed-point search (first kernel point descends
+    /// from `n−1`, subsequent points walk upward).  Amortized O(1) per
+    /// kernel point within a target.
     ///
     /// Math is identical to the reference implementation pinned by
     /// `broaden_presorted_reference` in the test module.
@@ -1827,7 +1851,9 @@ impl TabulatedResolution {
                     continue;
                 }
 
-                let tof_prime = tof_center + dt;
+                // Convolution gather: theory at t − dt (see docstring;
+                // SAMMY mudr4.f90 Ud_Convolute).
+                let tof_prime = tof_center - dt;
                 if tof_prime <= 0.0 {
                     continue;
                 }
@@ -2008,7 +2034,9 @@ impl TabulatedResolution {
                     continue;
                 }
 
-                let tof_prime = tof_center + dt;
+                // Convolution gather: theory at t − dt (see
+                // broaden_presorted; SAMMY mudr4.f90 Ud_Convolute).
+                let tof_prime = tof_center - dt;
                 if tof_prime <= 0.0 {
                     continue;
                 }
@@ -2494,7 +2522,9 @@ pub mod test_support {
                     continue;
                 }
 
-                let tof_prime = tof_center + dt;
+                // Convolution gather: theory at t − dt (see
+                // broaden_presorted; SAMMY mudr4.f90 Ud_Convolute).
+                let tof_prime = tof_center - dt;
                 if tof_prime <= 0.0 {
                     continue;
                 }

--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -965,18 +965,30 @@ impl TabulatedResolution {
     ///
     /// 1. Find the bracketing reference kernel(s) for `e_ev` via
     ///    binary search on the sorted `ref_energies` grid.
-    /// 2. Take `max(|tof_offset|)` over all bracketing kernels'
-    ///    entries with positive weight.  Using both bracketing
-    ///    kernels (rather than the single nearest) is conservative —
-    ///    over-estimating the margin is safer than under-estimating
-    ///    when the kernel is interpolated between references.
-    /// 3. Convert TOF offset to energy offset via
-    ///    `|ΔE| = 2·E^(3/2) / (TOF_FACTOR·L) · |Δt|`,
-    ///    the magnitude of `dE/dt` at `e_ev` along the TOF→E mapping
-    ///    `t = TOF_FACTOR·L/√E` (chain rule).
+    /// 2. Over all bracketing kernels' entries with positive weight,
+    ///    take the extreme offsets `dt⁺ = max(dt, 0)` and
+    ///    `dt⁻ = max(−dt, 0)`.  Using both bracketing kernels (rather
+    ///    than the single nearest) is conservative — blended kernels
+    ///    are convex combinations, so their extremes are bounded by
+    ///    the bracketing extremes.
+    /// 3. Map each extreme through the **exact** TOF→E relation
+    ///    `E' = (TOF_FACTOR·L/(t∓dt))²` with `t = TOF_FACTOR·L/√E`
+    ///    and return the larger energy excursion:
+    ///    `max( E·((t/(t−dt⁺))² − 1), E·(1 − (t/(t+dt⁻))²) )`.
+    ///    The convolution gather reads theory at `t − dt` (see
+    ///    [`Self::broaden`]), so the positive-offset tail reaches
+    ///    *up* in energy — and because the map is convex in `t`, the
+    ///    up-side excursion strictly exceeds the linear chain-rule
+    ///    estimate `2·E^{3/2}·dt/(TOF_FACTOR·L)` that this function
+    ///    previously returned, which under-covered exactly the side
+    ///    the delayed-emission tail loads.
     ///
     /// Returns `0.0` for non-positive `e_ev`, an empty kernel set, or
-    /// a non-positive flight path.  Used by the GUI's
+    /// a non-positive flight path, and `f64::INFINITY` when the
+    /// positive-offset extreme reaches or exceeds the nominal flight
+    /// time (`t − dt⁺ ≤ 0`: the kernel maps past infinite energy — the
+    /// caller must clamp to its grid, which the GUI's
+    /// `partition_point` slicing already does).  Used by the GUI's
     /// fit-energy-range slicing to extend the model-evaluation grid
     /// beyond the user's `[E_min, E_max]` so the SAMMY EMIN/EMAX-
     /// equivalent broadening at the boundaries is correct (#514).
@@ -997,12 +1009,14 @@ impl TabulatedResolution {
         //              (upper); clip to grid bounds when e_ev falls
         //              outside the ref range.
         let n = self.ref_energies.len();
-        let mut max_dt_us: f64 = 0.0;
-        let visit = |idx: usize, max_dt_us: &mut f64| {
+        let mut max_dt_pos: f64 = 0.0;
+        let mut max_dt_neg: f64 = 0.0;
+        let mut visit = |idx: usize| {
             let (offsets, weights) = &self.kernels[idx];
             for (&dt, &w) in offsets.iter().zip(weights.iter()) {
                 if w > 0.0 && dt.is_finite() {
-                    *max_dt_us = max_dt_us.max(dt.abs());
+                    max_dt_pos = max_dt_pos.max(dt);
+                    max_dt_neg = max_dt_neg.max(-dt);
                 }
             }
         };
@@ -1011,17 +1025,26 @@ impl TabulatedResolution {
                 .partial_cmp(&e_ev)
                 .unwrap_or(std::cmp::Ordering::Equal)
         }) {
-            Ok(idx) => visit(idx, &mut max_dt_us),
-            Err(0) => visit(0, &mut max_dt_us),
-            Err(idx) if idx >= n => visit(n - 1, &mut max_dt_us),
+            Ok(idx) => visit(idx),
+            Err(0) => visit(0),
+            Err(idx) if idx >= n => visit(n - 1),
             Err(idx) => {
-                visit(idx - 1, &mut max_dt_us);
-                visit(idx, &mut max_dt_us);
+                visit(idx - 1);
+                visit(idx);
             }
         }
-        // |dE/dt| = 2·E^(3/2)/(TOF_FACTOR·L)
-        let de_per_dt = 2.0 * e_ev.powf(1.5) / (TOF_FACTOR * self.flight_path_m);
-        de_per_dt * max_dt_us
+        let t = TOF_FACTOR * self.flight_path_m / e_ev.sqrt();
+        // Up-side excursion: the positive-offset (delayed-emission)
+        // tail gathers theory at t − dt⁺, i.e. from HIGHER energy.
+        let up = if max_dt_pos >= t {
+            return f64::INFINITY;
+        } else {
+            e_ev * ((t / (t - max_dt_pos)).powi(2) - 1.0)
+        };
+        // Down-side excursion: negative offsets gather at t + dt⁻,
+        // i.e. from lower energy (bounded below by E' → 0).
+        let down = e_ev * (1.0 - (t / (t + max_dt_neg)).powi(2));
+        up.max(down)
     }
 }
 
@@ -4131,16 +4154,28 @@ mod tests {
         half - 2.0 * half / (n - 1) as f64
     }
 
+    /// Exact-map expected support: the larger of the up-side excursion
+    /// `E·((t/(t−dt⁺))²−1)` and the down-side `E·(1−(t/(t+dt⁻))²)`
+    /// with `t = TOF_FACTOR·L/√E` — the same map the broadener applies
+    /// per kernel point, so this oracle is exact by construction.
+    fn exact_support(e: f64, dt_pos: f64, dt_neg: f64, l: f64) -> f64 {
+        let t = TOF_FACTOR * l / e.sqrt();
+        let up = e * ((t / (t - dt_pos)).powi(2) - 1.0);
+        let down = e * (1.0 - (t / (t + dt_neg)).powi(2));
+        up.max(down)
+    }
+
     /// At a reference energy with a known kernel half-width in TOF, the
-    /// support in eV must satisfy `|ΔE| = 2·E^(3/2)/(TOF_FACTOR·L)·|Δt|`.
-    /// At E = 50 eV the triangle kernel has half = 1.0 μs, n = 41, so
-    /// the largest non-zero offset is `1.0 · (1 − 1/40) = 0.975`.
+    /// support must equal the exact TOF→E excursion of the outermost
+    /// non-zero offsets.  At E = 50 eV the triangle kernel has
+    /// half = 1.0 μs, n = 41, so the largest non-zero offset is
+    /// `1.0 · (1 − 1/40) = 0.975` on both sides.
     #[test]
-    fn test_tabulated_kernel_support_at_ref_energy_matches_chain_rule() {
+    fn test_tabulated_kernel_support_at_ref_energy_matches_exact_map() {
         let r = synthetic_tab_resolution();
         let e: f64 = 50.0;
         let dt_max = triangle_dt_max(1.0, 41);
-        let expected = 2.0 * e.powf(1.5) / (TOF_FACTOR * 25.0) * dt_max;
+        let expected = exact_support(e, dt_max, dt_max, 25.0);
         let got = r.kernel_support_ev(e);
         assert!(
             (got - expected).abs() / expected < 1e-12,
@@ -4148,7 +4183,7 @@ mod tests {
         );
     }
 
-    /// Between two reference energies the support uses the larger of
+    /// Between two reference energies the support uses the extreme of
     /// the two bracketing kernels (conservative).  At E = 100 eV the
     /// brackets are 50 eV (half = 1.0, n = 41) and 500 eV (half = 2.0,
     /// n = 51); the larger non-zero offset is `2.0 · (1 − 1/50) = 1.96`.
@@ -4157,7 +4192,7 @@ mod tests {
         let r = synthetic_tab_resolution();
         let e: f64 = 100.0;
         let dt_max = triangle_dt_max(2.0, 51);
-        let expected = 2.0 * e.powf(1.5) / (TOF_FACTOR * 25.0) * dt_max;
+        let expected = exact_support(e, dt_max, dt_max, 25.0);
         let got = r.kernel_support_ev(e);
         assert!(
             (got - expected).abs() / expected < 1e-12,
@@ -4172,12 +4207,63 @@ mod tests {
         let r = synthetic_tab_resolution();
         // Below grid (ref_min = 5 eV; triangle(half=0.5, n=31)).
         let e_low: f64 = 1.0;
-        let exp_low = 2.0 * e_low.powf(1.5) / (TOF_FACTOR * 25.0) * triangle_dt_max(0.5, 31);
+        let dt_low = triangle_dt_max(0.5, 31);
+        let exp_low = exact_support(e_low, dt_low, dt_low, 25.0);
         assert!((r.kernel_support_ev(e_low) - exp_low).abs() / exp_low < 1e-12);
         // Above grid (ref_max = 500 eV; triangle(half=2.0, n=51)).
         let e_hi: f64 = 1000.0;
-        let exp_hi = 2.0 * e_hi.powf(1.5) / (TOF_FACTOR * 25.0) * triangle_dt_max(2.0, 51);
+        let dt_hi = triangle_dt_max(2.0, 51);
+        let exp_hi = exact_support(e_hi, dt_hi, dt_hi, 25.0);
         assert!((r.kernel_support_ev(e_hi) - exp_hi).abs() / exp_hi < 1e-12);
+    }
+
+    /// The exact up-side excursion strictly exceeds the linear
+    /// chain-rule estimate for a wide positive (delayed-emission) tail
+    /// at high energy — the case where the old linear margin
+    /// under-covered exactly the side the convolution gather loads.
+    #[test]
+    fn test_tabulated_kernel_support_exceeds_linear_estimate_for_wide_tail() {
+        let offsets = vec![-1.0, 0.0, 15.0];
+        let weights = vec![0.3, 1.0, 0.2];
+        let r = TabulatedResolution {
+            ref_energies: vec![100.0],
+            kernels: vec![(offsets, weights)],
+            flight_path_m: 25.0,
+        };
+        let e: f64 = 100.0;
+        let linear = 2.0 * e.powf(1.5) / (TOF_FACTOR * 25.0) * 15.0;
+        let got = r.kernel_support_ev(e);
+        assert!(
+            got > linear,
+            "exact support must exceed the linear estimate on the \
+             high-E side: got {got}, linear {linear}"
+        );
+        let expected = exact_support(e, 15.0, 1.0, 25.0);
+        assert!(
+            (got - expected).abs() / expected < 1e-12,
+            "exact support: got {got}, expected {expected}"
+        );
+    }
+
+    /// A positive-offset extreme reaching the nominal flight time maps
+    /// past infinite energy: the support is unbounded and the caller
+    /// must clamp to its grid.
+    #[test]
+    fn test_tabulated_kernel_support_infinite_when_tail_exceeds_flight_time() {
+        let offsets = vec![0.0, 10.0];
+        let weights = vec![1.0, 0.5];
+        let r = TabulatedResolution {
+            ref_energies: vec![100.0],
+            kernels: vec![(offsets, weights)],
+            flight_path_m: 25.0,
+        };
+        // Choose E high enough that t = K·L/√E ≤ 10 μs.
+        let t_at = |e: f64| TOF_FACTOR * 25.0 / e.sqrt();
+        let mut e: f64 = 100.0;
+        while t_at(e) > 10.0 {
+            e *= 10.0;
+        }
+        assert_eq!(r.kernel_support_ev(e), f64::INFINITY);
     }
 
     /// Non-positive / non-finite energy → 0.0 (no broadening footprint).
@@ -4203,9 +4289,9 @@ mod tests {
             flight_path_m: 25.0,
         };
         let e: f64 = 100.0;
-        // Expected support uses dt_max = 1.0 (the outermost zero-weight
-        // entries at ±10 are ignored), not 10.0.
-        let expected = 2.0 * e.powf(1.5) / (TOF_FACTOR * 25.0) * 1.0;
+        // Expected support uses dt = ±1.0 (the outermost zero-weight
+        // entries at ±10 are ignored), not ±10.0.
+        let expected = exact_support(e, 1.0, 1.0, 25.0);
         let got = r.kernel_support_ev(e);
         assert!(
             (got - expected).abs() / expected < 1e-12,

--- a/crates/nereids-physics/tests/kernel_orientation.rs
+++ b/crates/nereids-physics/tests/kernel_orientation.rs
@@ -1,0 +1,155 @@
+//! Sign-pinning regression for the tabulated-kernel convolution
+//! orientation (issue #631).
+//!
+//! Kernels store their delayed-emission tail at POSITIVE TOF offsets
+//! (mode at 0). A delayed neutron measured at TOF `t` really flew
+//! `t − dt` — it is faster than nominal — so broadening a symmetric
+//! absorption dip must push its tail toward later TOF = LOWER apparent
+//! energy: the broadened dip's absorption-weighted centroid shift and
+//! skew are both strictly NEGATIVE. The pre-fix code gathered at
+//! `t + dt` (a correlation, time-mirroring every kernel), which put the
+//! tail on the high-energy side; none of the earlier tests pinned the
+//! sign (the kernel-array test never applied the kernel, and the IC
+//! centering test took `.abs()` of the shift). SAMMY reference:
+//! `sammy/src/udr/mudr4.f90` `Ud_Convolute` gathers theory at `Tc − τ`.
+//!
+//! The synthetic kernel goes through [`TabulatedResolution::from_text`]
+//! so the parser is part of the pinned path, and the assertions run
+//! through BOTH the direct path (`apply_resolution`) and the plan path
+//! (`build_resolution_plan` + `apply_resolution_with_plan`).
+
+use std::fmt::Write as _;
+use std::sync::Arc;
+
+use nereids_physics::resolution::{
+    ResolutionFunction, TabulatedResolution, apply_resolution, apply_resolution_with_plan,
+    build_resolution_plan,
+};
+
+const FLIGHT_PATH_M: f64 = 25.0;
+const E0: f64 = 20.0;
+
+/// Synthetic asymmetric kernel in the VENUS/FTS text format: mode at
+/// offset 0, exponential tail at positive offsets only (identical
+/// blocks at 10 and 100 eV so `interpolated_kernel` blending is exact).
+fn asymmetric_kernel_text() -> String {
+    let n = 499;
+    let (dt_min, dt_max) = (-1.0_f64, 15.0_f64);
+    let mut text =
+        String::from("synthetic asymmetric kernel, tail at positive TOF offsets\n-----\n");
+    for eref in [10.0_f64, 100.0] {
+        writeln!(text, "   {eref:.5e}   0.00000e+000").unwrap();
+        let mut nearest = (f64::MAX, 0usize);
+        let dts: Vec<f64> = (0..n)
+            .map(|i| dt_min + (dt_max - dt_min) * i as f64 / (n - 1) as f64)
+            .collect();
+        for (i, &dt) in dts.iter().enumerate() {
+            if dt.abs() < nearest.0 {
+                nearest = (dt.abs(), i);
+            }
+        }
+        for (i, &dt) in dts.iter().enumerate() {
+            let amp = if i == nearest.1 {
+                1.0
+            } else if dt >= 0.0 {
+                (-dt / 3.0).exp()
+            } else {
+                0.0
+            };
+            writeln!(text, "{dt:.15} {amp:.15e}").unwrap();
+        }
+        text.push('\n');
+    }
+    text
+}
+
+/// Absorption-weighted centroid shift and skew of a broadened
+/// symmetric dip at `E0`.
+fn dip_moments(broadened: &[f64], energies: &[f64]) -> (f64, f64) {
+    let absorption: Vec<f64> = broadened.iter().map(|&t| (1.0 - t).max(0.0)).collect();
+    let total: f64 = absorption.iter().sum();
+    let mu = energies
+        .iter()
+        .zip(&absorption)
+        .map(|(&e, &a)| e * a)
+        .sum::<f64>()
+        / total;
+    let var = energies
+        .iter()
+        .zip(&absorption)
+        .map(|(&e, &a)| (e - mu).powi(2) * a)
+        .sum::<f64>()
+        / total;
+    let sd = var.sqrt();
+    let skew = energies
+        .iter()
+        .zip(&absorption)
+        .map(|(&e, &a)| ((e - mu) / sd).powi(3) * a)
+        .sum::<f64>()
+        / total;
+    (mu - E0, skew)
+}
+
+fn grid_and_dip() -> (Vec<f64>, Vec<f64>) {
+    let n = 8001;
+    let energies: Vec<f64> = (0..n)
+        .map(|i| (E0 - 3.0) + 6.0 * i as f64 / (n - 1) as f64)
+        .collect();
+    let spectrum: Vec<f64> = energies
+        .iter()
+        .map(|&e| 1.0 - 0.6 * (-0.5 * ((e - E0) / 0.02).powi(2)).exp())
+        .collect();
+    (energies, spectrum)
+}
+
+#[test]
+fn delayed_tail_shifts_broadened_dip_to_lower_energy() {
+    let tab = TabulatedResolution::from_text(&asymmetric_kernel_text(), FLIGHT_PATH_M)
+        .expect("synthetic kernel must parse");
+    let (energies, spectrum) = grid_and_dip();
+
+    let res = ResolutionFunction::Tabulated(Arc::new(tab));
+
+    // Direct path.
+    let direct = apply_resolution(&energies, &spectrum, &res).expect("direct broaden");
+
+    // Non-vacuity pre-check (same guard idea as
+    // `common::assert_kernel_broadens` in the VENUS USR tests): the
+    // kernel must visibly reshape the dip, or the sign assertions
+    // below pass vacuously on a no-op broadener.
+    let probe_inf = spectrum.iter().fold(0.0_f64, |m, &v| m.max(v.abs()));
+    let diff_inf = spectrum
+        .iter()
+        .zip(&direct)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0_f64, f64::max);
+    assert!(
+        diff_inf > 0.01 * probe_inf,
+        "kernel is acting as a no-op on the probe dip: \
+         ‖broadened − input‖∞ = {diff_inf:.3e} ≤ 1% of ‖input‖∞ = {probe_inf:.3e}"
+    );
+
+    let (shift, skew) = dip_moments(&direct, &energies);
+    assert!(
+        shift < 0.0,
+        "centroid must shift to LOWER energy (delayed arrival): got {shift:+.4e} eV \
+         — a positive shift means the kernel was applied time-mirrored"
+    );
+    assert!(
+        skew < 0.0,
+        "broadened dip must be skewed toward LOWER energy: got skew {skew:+.3e}"
+    );
+
+    // Plan path must agree in sign (bit-exactness with the direct path
+    // is pinned elsewhere; this guards the orientation specifically).
+    let plan = build_resolution_plan(&energies, &res)
+        .expect("plan build")
+        .expect("tabulated resolution must yield a plan");
+    let planned =
+        apply_resolution_with_plan(Some(&plan), &energies, &spectrum, &res).expect("plan broaden");
+    let (shift_p, skew_p) = dip_moments(&planned, &energies);
+    assert!(
+        shift_p < 0.0 && skew_p < 0.0,
+        "plan path orientation: shift {shift_p:+.4e}, skew {skew_p:+.3e}"
+    );
+}

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -466,6 +466,64 @@ class TestResolutionBroadening:
             nereids.resolution_broaden(e, xs, -1.0, 0.5, 0.001)
 
 
+class TestTabulatedKernelOrientation:
+    """Regression for issue #631: tabulated kernels must be applied as a
+    convolution (theory gathered at t - dt), not time-mirrored.
+
+    Kernel convention: mode at TOF offset 0, delayed-emission tail at
+    POSITIVE offsets. A delayed neutron measured at TOF t really flew
+    t - dt (it is faster than nominal), so a broadened symmetric dip
+    must acquire its tail toward later TOF = LOWER apparent energy:
+    centroid shift and skew both strictly negative. The pre-fix code
+    produced +0.297 eV / +1.53 on this exact setup.
+
+    Also the first coverage of the load_resolution / apply_resolution
+    bindings.
+    """
+
+    @staticmethod
+    def _write_kernel(path):
+        dt = np.linspace(-1.0, 15.0, 499)  # us
+        amp = np.where(dt >= 0, np.exp(-dt / 3.0), 0.0)
+        amp[np.argmin(np.abs(dt))] = 1.0  # mode at offset 0
+        lines = [
+            "synthetic asymmetric kernel, tail at positive TOF offsets",
+            "-----",
+        ]
+        for eref in (10.0, 100.0):
+            lines.append(f"   {eref:.5e}   0.00000e+000")
+            lines += [f"{d:.15f} {a:.15e}" for d, a in zip(dt, amp)]
+            lines.append("")
+        path.write_text("\n".join(lines))
+
+    def test_delayed_tail_shifts_dip_to_lower_energy(self, tmp_path):
+        kernel_path = tmp_path / "synthetic_kernel.txt"
+        self._write_kernel(kernel_path)
+        tab = nereids.load_resolution(str(kernel_path), 25.0)
+
+        e0 = 20.0
+        e = np.linspace(e0 - 3, e0 + 3, 24001)
+        spec = 1.0 - 0.6 * np.exp(-0.5 * ((e - e0) / 0.02) ** 2)
+        b = np.asarray(nereids.apply_resolution(e, spec, tab))
+
+        # Non-vacuity: the kernel must visibly reshape the dip.
+        assert np.max(np.abs(b - spec)) > 0.01 * np.max(np.abs(spec))
+
+        a = 1.0 - b
+        mu = np.sum(e * a) / np.sum(a)
+        sd = np.sqrt(np.sum((e - mu) ** 2 * a) / np.sum(a))
+        skew = np.sum(((e - mu) / sd) ** 3 * a) / np.sum(a)
+
+        assert mu - e0 < 0, (
+            f"centroid must shift to LOWER energy (delayed arrival): "
+            f"{mu - e0:+.4f} eV — positive means the kernel was applied "
+            f"time-mirrored"
+        )
+        assert skew < 0, (
+            f"broadened dip must be skewed toward LOWER energy: {skew:+.3f}"
+        )
+
+
 # ===========================================================================
 # LM fitting
 # ===========================================================================


### PR DESCRIPTION
Fixes #631. Closes #626.

## The bug

`broaden_presorted`, `plan_presorted`, and the bit-exact reference oracle gathered the source spectrum at `tof_center + dt` — the correlation ∫R(τ)S(t+τ)dτ instead of the convolution ∫R(τ)S(t−τ)dτ. Kernels (file-loaded UDR/FTS and IC-synthesized) store the delayed-emission tail at **positive** offsets with the mode at 0, so every broadened dip carried its moderator tail on the wrong (high-energy) side. Measured consequences (IPTS-37432 Ta-181): mirrored residual asymmetry around every resonance, ~2–3.7 % inflated energy-space model width, fitted temperature biased low ~2.5 % at 300 K, fitted `(t0, L_scale)` absorbing the kernel centroid lag with the wrong sign.

## Primary source

SAMMY `sammy/src/udr/mudr4.f90`:
- `Ud_Convolute` (line 288): `Cc(Tc) = ∫Bb(τ)·Aa(Tc−τ)dτ` — the theory-segment search binds `Tc−Ta` to the kernel grid throughout, with integration bounds `Tc−Ta0 → Tc−Ta1`.
- `Ud_Mesh_Time` (line 7): the needed theory window is `[T0 − UdT_last, T0 − UdT_first]` — positive kernel offsets pull theory from earlier TOF = higher energy.

Both cited in the code comments per the physics-documentation rule.

## The fix

`tof_prime = tof_center - dt` at exactly three sites (impl ×2 + oracle, verbatim-identical expression so the impl-vs-oracle bit-exact tests stay meaningful). The two-pointer bracket walk is untouched — it is a bidirectional fixed-point search, correct for the now-ascending e′ sequence; plan/direct float-op sequences remain identical (bit-exactness contract preserved).

**`kernel_support_ev` now uses the exact TOF→E map** (closes #626): the linear chain-rule margin under-covers on the high-energy side (convexity), which is exactly the side the corrected convolution's delayed-emission tail reads from. Extreme positive/negative offsets are mapped exactly: `max(E·((t/(t−dt⁺))²−1), E·(1−(t/(t+dt⁻))²))`, returning `f64::INFINITY` when the tail reaches the nominal flight time (the GUI's `partition_point` slicing clamps it; comment updated).

## Why no test caught it (and what pins it now)

| Gap | Now |
|---|---|
| Kernel-array test checked tail geometry, never application | `tests/kernel_orientation.rs`: issue #631's synthetic asymmetric kernel through `from_text` + **both** application paths, with a non-vacuity reshape pre-check, asserting centroid shift < 0 **and** skew < 0 |
| IC centering test took `.abs()` of the shift | Now pins the **sign** (both α's shifts must be negative) + keeps the ~1/α scaling |
| Calibration tests are loop-closure (orientation cancels) | Unchanged by design — they still pass untouched, as predicted |
| `load_resolution`/`apply_resolution` bindings had zero pytest coverage | `TestTabulatedKernelOrientation` ports the issue repro as a permanent pytest |
| Margin tests were circular against the chain rule | Rewritten against an exact-map oracle + new exact>linear and INFINITY-guard tests |

## Verification

- `cargo fmt` / `clippy -D warnings` / full workspace tests — green; **zero baseline edits needed** (bit-exact suites compare to the oracle, which flipped in lockstep; loop-closure calibration suites are orientation-agnostic by construction).
- `pixi run test-python` — 136 passed, 1 skipped (the skip is `test_mcp.py`, absent `fastmcp` in the default env — pre-existing, unrelated).
- **Acceptance: the issue's repro script run verbatim** now prints `centroid shift: -0.2742 eV, skew: -1.454, PASS` (pre-fix: +0.2968 eV / +1.533).
- Grep gate: exactly 3 `tof_center - dt` sites, 0 `tof_center + dt`.

## Action required for users (in CHANGELOG, prominently)

Fitted `(t0, L_scale)` energy scales and `calibrate_resolution` results (α(E), width scales) obtained with earlier versions under **tabulated or IC resolution are invalidated and must be re-fit**; externally maintained bit-exact broadener baselines must be regenerated. Gaussian-resolution and Doppler-only results are unaffected.

## Related

- #625 (mode- vs centroid-anchoring): unchanged — kernels stay mode-anchored; this PR neither helps nor hurts that open design question.
- #632 (`interpolated_kernel` over-broadening): deliberately untouched; next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
