### PR TITLE
fix(physics): width-normalized kernel interpolation between reference energies (#632)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Between-reference tabulated/IC kernel widths follow the physical
+  power law** (#632): `interpolated_kernel` blended bracketing
+  reference kernels element-wise — an arithmetic width chord over the
+  convex σ_t ∝ ~E^(−1/2) law that systematically over-widened every
+  between-reference energy (+7.8 % at a synthetic 10/50 eV midpoint;
+  +4.1–7.2 % across the production VENUS 5→50 eV reference gap,
+  spanning nearly all Ta-181 thermometry resonances — fitted
+  temperatures read low as a result). Kernels are now interpolated as
+  width-normalized shape blends with geometrically interpolated widths
+  (exact for power-law files); the unequal-point-count
+  nearest-reference fallback and its ±few-% IC width sawtooth are gone.
+  This is a documented intentional departure from SAMMY, whose UDR
+  interpolation takes the same arithmetic chord (`udr/mudr3.f90`).
+  Fit-range support margins now track the true (narrower)
+  between-reference kernel. **Action required: `calibrate_resolution`
+  results and fits whose energy window lies between resolution-file
+  reference energies, obtained with earlier versions under tabulated or
+  IC resolution, are invalidated and must be re-fit**; externally
+  maintained bit-exact broadener baselines must be regenerated.
+  Gaussian-resolution and Doppler-only results are unaffected.
+
 - **Tabulated/Ikeda–Carpenter resolution kernels were applied
   time-mirrored** (#631): the broadener gathered theory at `t + Δt`
   (a correlation) instead of `t − Δt` (the convolution — SAMMY

--- a/crates/nereids-fitting/src/resolution_calib.rs
+++ b/crates/nereids-fitting/src/resolution_calib.rs
@@ -1175,9 +1175,15 @@ mod tests {
         let mkbase = || ResolutionFamily::UdrCorr {
             base: Arc::new(base.clone()),
         };
-        // Tight prior (σ=0.2 µs ≪ 1.5 µs displacement): can't reach t0, pays penalty.
+        // Tight prior: σ must be small enough that the quadratic prior
+        // curvature rivals the data-χ² curvature in t0, or the optimum
+        // sits at the displacement and the pull is invisible. The
+        // width-correct kernel interpolation sharpened the data term
+        // (narrower between-reference kernels carry more positional
+        // information than the over-wide chord blend used to), so the
+        // binding regime needs a tighter σ than it once did.
         let tight =
-            calibrate_resolution(mkbase(), &energies, &data, &unc, &sample, &mk(0.2)).unwrap();
+            calibrate_resolution(mkbase(), &energies, &data, &unc, &sample, &mk(0.005)).unwrap();
         // Loose prior (σ=100 µs): recovers the displacement, ~no penalty.
         let loose =
             calibrate_resolution(mkbase(), &energies, &data, &unc, &sample, &mk(100.0)).unwrap();

--- a/crates/nereids-physics/src/ikeda_carpenter.rs
+++ b/crates/nereids-physics/src/ikeda_carpenter.rs
@@ -65,10 +65,12 @@
 //! `t` reads theory at `t−τ` (a neutron measured at `t` with delay τ really flew
 //! `t−τ`; see `resolution::broaden` and SAMMY `udr/mudr4.f90` `Ud_Convolute`).
 //! At apply time
-//! `interpolated_kernel` blends the two bracketing reference kernels when they
-//! have equal point counts, else it falls back to the nearer reference; because
-//! IC trims each kernel's tail independently the point counts often differ, so the
-//! nearest-reference path is common. Either way IC synthesizes a dense reference
+//! `interpolated_kernel` blends the two bracketing reference kernels as a
+//! width-normalized shape blend (offsets scaled to the geometrically
+//! interpolated width, shapes merged on the union grid) — unequal point counts
+//! from IC's per-kernel tail trimming no longer trigger a nearest-reference
+//! fallback, so the between-reference width follows the physical power law
+//! smoothly. IC also synthesizes a dense reference
 //! grid (default 64 energies), so the between-reference error is negligible. The
 //! kernel is anchored with its **mode at offset 0** (peak-centering), matching the
 //! UDR file convention (peak at offset 0); `interpolated_kernel` does not

--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -1071,8 +1071,18 @@ impl TabulatedResolution {
                 let (off_hi, w_hi) = &self.kernels[idx];
                 let (_, s_lo) = trapezoidal_moments(off_lo, w_lo);
                 let (_, s_hi) = trapezoidal_moments(off_hi, w_hi);
-                if !(s_lo.is_finite() && s_lo > 0.0 && s_hi.is_finite() && s_hi > 0.0) {
-                    // Degenerate blocks take `interpolated_kernel`'s
+                let e_lo = self.ref_energies[idx - 1];
+                let e_hi = self.ref_energies[idx];
+                let frac = (e_ev.ln() - e_lo.ln()) / (e_hi.ln() - e_lo.ln());
+                if !(s_lo.is_finite()
+                    && s_lo > 0.0
+                    && s_hi.is_finite()
+                    && s_hi > 0.0
+                    && frac.is_finite())
+                {
+                    // Degenerate blocks — and a non-finite fraction
+                    // (defense-in-depth; constructors enforce positive
+                    // reference energies) — take `interpolated_kernel`'s
                     // nearest-clone fallback; bounding BOTH blocks
                     // bounds either clone.
                     visit(idx - 1, &mut max_dt_pos, &mut max_dt_neg);
@@ -1088,9 +1098,6 @@ impl TabulatedResolution {
                     // interpolated shape is positive on that fringe,
                     // and a merged point from the other block can land
                     // there with positive blended weight.
-                    let e_lo = self.ref_energies[idx - 1];
-                    let e_hi = self.ref_energies[idx];
-                    let frac = (e_ev.ln() - e_lo.ln()) / (e_hi.ln() - e_lo.ln());
                     let s_t = s_lo * (s_hi / s_lo).powf(frac);
                     let closure_extents = |offs: &[f64], ws: &[f64]| -> (f64, f64) {
                         let n_k = offs.len();
@@ -1751,13 +1758,19 @@ impl TabulatedResolution {
             ));
         }
 
-        // Validate finite, strictly ascending reference energies.  The
-        // finiteness check must come first: NaN compares false against
-        // everything, so a NaN energy would slip through the ascending
-        // check below and then poison the bracketing binary search.
-        if let Some(bad) = ref_energies.iter().find(|e| !e.is_finite()) {
+        // Validate finite, POSITIVE, strictly ascending reference
+        // energies.  The finiteness check must come first: NaN compares
+        // false against everything, so a NaN energy would slip through
+        // the ascending check below and then poison the bracketing
+        // binary search.  Positivity is load-bearing twice over: the
+        // TOF map t = TOF_FACTOR·L/√E needs E > 0, and the
+        // between-reference width interpolation takes ln(E_ref) — a
+        // non-positive reference would turn every blended weight into
+        // NaN, which bypasses the broadener's norm guard and silently
+        // disables broadening (NaN comparisons are false).
+        if let Some(bad) = ref_energies.iter().find(|e| !(e.is_finite() && **e > 0.0)) {
             return Err(ResolutionParseError::InvalidFormat(format!(
-                "Reference energies must be finite, got {bad}"
+                "Reference energies must be finite and positive, got {bad}"
             )));
         }
         for i in 1..ref_energies.len() {
@@ -1849,10 +1862,14 @@ impl TabulatedResolution {
         }
         // Finiteness first: NaN compares false against everything, so a
         // NaN energy would slip through the ascending check below and
-        // then poison the bracketing binary search.
-        if let Some(bad) = ref_energies.iter().find(|e| !e.is_finite()) {
+        // then poison the bracketing binary search.  Positivity is
+        // load-bearing twice over: the TOF map needs E > 0, and the
+        // between-reference width interpolation takes ln(E_ref) — a
+        // non-positive reference would turn every blended weight into
+        // NaN and silently disable broadening.
+        if let Some(bad) = ref_energies.iter().find(|e| !(e.is_finite() && **e > 0.0)) {
             return Err(ResolutionParseError::InvalidFormat(format!(
-                "Reference energies must be finite, got {bad}"
+                "Reference energies must be finite and positive, got {bad}"
             )));
         }
         for i in 1..ref_energies.len() {
@@ -2331,10 +2348,14 @@ impl TabulatedResolution {
     /// ## INTENTIONAL DEPARTURE from SAMMY
     ///
     /// SAMMY's user-defined resolution blends both the amplitude and
-    /// the time-point arrays element-wise, **linear in E**
-    /// (sammy/src/udr/mudr3.f90 lines 92–112: `UdR_E(J) =
-    /// a·UdR(J,I−1) + b·UdR(J,I)` and likewise `UdT_E(J)`), i.e. the
-    /// arithmetic width chord. Because the physical width law
+    /// the time-point arrays element-wise, **linear in E**: in the
+    /// active `Gen_Udr_Par` (sammy/src/udr/mudr3.f90, subroutine at
+    /// line 164; blend block at lines 241–255: `UdR_E(J,Nud) =
+    /// UdR(J,I−1,Nud)·a + UdR(J,I,Nud)·b` and likewise `UdT_E`), i.e.
+    /// the arithmetic width chord. (The file's first routine
+    /// `Gen_Udr_Par_x` holds the same blend at lines 92–112 but is
+    /// marked "never called" at line 10 — cite the live twin.)
+    /// Because the physical width law
     /// `σ_t ∝ ~E^{−1/2}` is convex, that chord systematically
     /// over-widens every between-reference energy: +7.8 % at the
     /// midpoint of synthetic 10/50 eV Gaussian blocks, +4.1…+7.2 %
@@ -2342,8 +2363,9 @@ impl TabulatedResolution {
     /// resolution-width systematic that biases fitted temperatures
     /// low. The geometric-width shape blend above removes it (and the
     /// nearest-reference width sawtooth that unequal point counts used
-    /// to produce). SAMMY additionally re-centers the blended kernel
-    /// on its trapezoidal centroid `Ct` (mudr3.f90 lines 114–140);
+    /// to produce). SAMMY additionally re-aligns the blended kernel so
+    /// its trapezoidal centroid `Ct` sits at T = 0 ("Realign so that
+    /// centroid is at T=0", mudr3.f90 lines 266–292);
     /// NEREIDS keeps kernels mode-anchored instead (deliberately
     /// unchanged here — the anchoring question is tracked separately).
     ///
@@ -2366,6 +2388,21 @@ impl TabulatedResolution {
             "ref_energies must be strictly ascending (invariant broken)"
         );
         let n_ref = self.ref_energies.len();
+
+        // NaN target energies never reach here through the validated
+        // public paths (a NaN in a multi-point grid fails the sorted
+        // check), but every comparison below is false for NaN, and the
+        // width-scaled merge would then emit NaN offsets — violating
+        // the strictly-ascending, all-finite invariants the broadener
+        // assumes. Clamp to the lowest reference so the output kernel
+        // is well-formed unconditionally (the old element-wise blend
+        // degraded to its nearest-reference fallback here by accident
+        // of its monotonicity guard; this keeps that graceful
+        // behaviour explicit). +∞ needs no guard: the high clamp
+        // below already catches it.
+        if energy.is_nan() {
+            return self.kernels[0].clone();
+        }
 
         // Clamp to nearest reference if outside range
         if energy <= self.ref_energies[0] || n_ref == 1 {
@@ -2410,7 +2447,12 @@ impl TabulatedResolution {
 
         let (_, s_lo) = trapezoidal_moments(off_lo, w_lo);
         let (_, s_hi) = trapezoidal_moments(off_hi, w_hi);
-        if !(s_lo.is_finite() && s_lo > 0.0 && s_hi.is_finite() && s_hi > 0.0) {
+        // Degenerate blocks (σ ≤ 0) cannot be width-scaled, and a
+        // non-finite fraction (constructors enforce positive reference
+        // energies, so defense-in-depth only) would poison every
+        // blended weight with NaN — both take the nearest-clone
+        // fallback so the output is well-formed unconditionally.
+        if !(s_lo.is_finite() && s_lo > 0.0 && s_hi.is_finite() && s_hi > 0.0 && frac.is_finite()) {
             return nearest();
         }
 
@@ -3203,12 +3245,61 @@ NaN 0.0
         );
     }
 
+    /// Non-positive reference energies must be rejected by BOTH
+    /// constructors: the TOF map needs E > 0, and the width
+    /// interpolation takes ln(E_ref) — a zero/negative reference would
+    /// turn every blended weight into NaN, which bypasses the
+    /// broadener's norm guard and silently disables broadening (a
+    /// stray `0.0 0.0` line after a blank line in a VENUS/FTS file
+    /// parses as an energy-block header).
+    #[test]
+    fn constructors_reject_non_positive_reference_energies() {
+        let zero_energy = "\
+Resolution file
+---------------
+0.0 0.0
+-1.0 0.1
+0.0 1.0
+1.0 0.5
+
+10.0 0.0
+-1.0 0.1
+0.0 1.0
+1.0 0.5
+";
+        let err = TabulatedResolution::from_text(zero_energy, 25.0);
+        let Err(ResolutionParseError::InvalidFormat(msg)) = err else {
+            panic!("zero reference energy must be rejected, got {err:?}");
+        };
+        assert!(
+            msg.contains("positive"),
+            "error must name the positivity requirement: {msg}"
+        );
+
+        let err = TabulatedResolution::from_kernels(
+            vec![-10.0, 10.0],
+            vec![
+                (vec![-1.0, 0.0, 1.0], vec![0.1, 1.0, 0.1]),
+                (vec![-1.0, 0.0, 1.0], vec![0.1, 1.0, 0.1]),
+            ],
+            25.0,
+        );
+        let Err(ResolutionParseError::InvalidFormat(msg)) = err else {
+            panic!("negative reference energy must be rejected, got {err:?}");
+        };
+        assert!(
+            msg.contains("positive"),
+            "error must name the positivity requirement: {msg}"
+        );
+    }
+
     #[test]
     fn interpolated_kernel_blend_stays_ascending_and_mode_anchored() {
-        // Two equal-length, mode-anchored kernels at bracketing energies (the
-        // element-wise blend path, common for IC). The blend must be strictly
-        // ascending (the sorted invariant the broadener relies on) and keep the
-        // mode at offset 0.
+        // Two equal-length, mode-anchored kernels at bracketing
+        // energies going through the width-normalized shape blend (the
+        // path every between-reference energy takes). The blend must be
+        // strictly ascending (the sorted invariant the broadener relies
+        // on) and keep the mode at offset 0.
         let off_lo = vec![-1.0, -0.4, 0.0, 0.6, 1.5, 3.0];
         let off_hi = vec![-0.5, -0.2, 0.0, 0.3, 0.8, 1.6]; // narrower, same length
         let wts = vec![0.1, 0.5, 1.0, 0.6, 0.3, 0.1]; // mode at index 2 (offset 0)
@@ -3240,6 +3331,15 @@ NaN 0.0
     /// grids coincide point-for-point in z, so the merge degenerates to
     /// the template shape at the target width). An interior reference
     /// energy must return that block bitwise (exact-hit arm).
+    ///
+    /// SCOPE NOTE: this measures the blend with the implementation's
+    /// own `trapezoidal_moments` and target formula, so it pins the
+    /// merge machinery against its coded target (plus the chord
+    /// separation below), not the physical width law independently —
+    /// that independent, end-to-end anchor lives in
+    /// `tests/kernel_width_interpolation.rs` and the pytest port,
+    /// which measure the APPLIED broadening of parsed kernels against
+    /// the analytic power law.
     #[test]
     fn interpolated_kernel_width_follows_power_law_for_self_similar_blocks() {
         let template_off = [-1.0, -0.4, 0.0, 0.8, 2.0, 4.0];
@@ -3324,6 +3424,24 @@ NaN 0.0
         for (a, b) in ws.iter().zip(&w) {
             assert_eq!(a.to_bits(), b.to_bits(), "identity weights must be bitwise");
         }
+    }
+
+    /// A NaN target energy (unreachable through validated public paths,
+    /// but defended anyway) must yield a well-formed reference clone —
+    /// never NaN offsets that break the broadener's invariants.
+    #[test]
+    fn interpolated_kernel_nan_energy_clamps_to_lowest_reference() {
+        let off = vec![-1.0, 0.0, 2.0];
+        let w = vec![0.3, 1.0, 0.2];
+        let tab = TabulatedResolution::from_kernels(
+            vec![10.0, 1000.0],
+            vec![(off.clone(), w.clone()), (off.clone(), w.clone())],
+            25.0,
+        )
+        .unwrap();
+        let (offs, ws) = test_support::interpolated_kernel(&tab, f64::NAN);
+        assert_eq!(offs, off);
+        assert_eq!(ws, w);
     }
 
     /// Degenerate blocks (single-point → σ = 0) cannot be width-scaled;
@@ -4990,6 +5108,55 @@ NaN 0.0
         assert!(
             upside_differs,
             "the delayed tail must reach the dip from a target below it"
+        );
+    }
+
+    /// Same containment property, exercised through the
+    /// BETWEEN-REFERENCES support arm: two width-scaled reference
+    /// blocks bracket the grid, so every target energy uses the
+    /// width-interpolated kernel and the closure-extent support bound.
+    /// The oracle is `broaden` itself — fully independent of both the
+    /// support formula and the interpolation implementation.
+    #[test]
+    fn test_tabulated_kernel_support_contains_broadener_footprint_between_refs() {
+        let r = TabulatedResolution {
+            ref_energies: vec![10.0, 1000.0],
+            kernels: vec![
+                (vec![-2.0, 0.0, 12.0], vec![0.2, 1.0, 0.7]),
+                (vec![-0.5, 0.0, 3.0], vec![0.2, 1.0, 0.7]),
+            ],
+            flight_path_m: 25.0,
+        };
+        let de = 0.05;
+        let energies: Vec<f64> = (0..2001).map(|j| 50.0 + de * j as f64).collect();
+        let f = 1000; // dip mid-grid, at ~100 eV — between the refs
+        let e_f = energies[f];
+        let mut spectrum = vec![1.0; energies.len()];
+        spectrum[f] = 0.0;
+        let out = r.broaden(&energies, &spectrum).unwrap();
+
+        let margin = 2.0 * de;
+        let (mut excluded, mut included_differs) = (0usize, false);
+        for (&e, &o) in energies.iter().zip(out.iter()) {
+            let s = r.kernel_support_ev(e);
+            if e + s + margin < e_f || e - s - margin > e_f {
+                assert!(
+                    (o - 1.0).abs() < 1e-12,
+                    "between-refs target {e} eV (support {s}) must be \
+                     untouched by a dip at {e_f} eV outside its window; got {o}"
+                );
+                excluded += 1;
+            } else if (o - 1.0).abs() > 1e-3 {
+                included_differs = true;
+            }
+        }
+        assert!(
+            excluded > 0,
+            "grid must exercise the exclusion region between references"
+        );
+        assert!(
+            included_differs,
+            "the dip must measurably alter at least one in-window target"
         );
     }
 }

--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -858,7 +858,10 @@ pub struct TabulatedResolution {
 /// The `dt` weights match the quadrature `broaden_presorted` integrates
 /// with (single point → 1.0; edges → one-sided span; interior → half
 /// the neighbour span), so these are the moments the broadener
-/// effectively applies. The centroid pass is byte-identical to the
+/// effectively applies: zero-weight entries contribute nothing
+/// (`tw = 0`, matching the broadener's `w <= 0` skip) and negative
+/// weights are rejected at construction, so the integration domains
+/// coincide exactly. The centroid pass is byte-identical to the
 /// accumulation `width_corrected` performed inline before this helper
 /// was factored out. Returns `(centroid, sigma)`; `sigma` is `0.0` for
 /// a single-point or zero-mass block — callers treat a non-positive or
@@ -917,6 +920,14 @@ impl TabulatedResolution {
     /// the kernel widens/narrows without moving its centroid — width and position
     /// stay orthogonal (`t0`/`L` handle absolute position). Weights are unchanged;
     /// the apply-time trapezoidal renormalization preserves unit area.
+    ///
+    /// Exactness note: the orthogonality is exact **at reference
+    /// energies**. Between references, `interpolated_kernel`'s
+    /// width-normalized blend re-scales each block about the mode
+    /// (offset 0), so the applied centroid picks up a second-order
+    /// dependence on the width exponent `p` (measured ~1 % of σ for
+    /// |p| ≤ 0.1 on widely spaced references) — absorbed by the
+    /// jointly fitted `t0` in calibration.
     ///
     /// The pivot is the **trapezoidal-weighted** centroid `Σ o·w·dt / Σ w·dt`,
     /// using the *same* `dt` quadrature weights as the broadening integral (see
@@ -1813,6 +1824,17 @@ impl TabulatedResolution {
                     ref_energies[i],
                 )));
             }
+            // Negative weights have no physical meaning (a resolution
+            // kernel is an emission-time density); the broadener skips
+            // w <= 0 entries, and the width machinery's trapezoidal
+            // moments must integrate over the same domain — reject at
+            // the door rather than let the two disagree.
+            if weights.iter().any(|&v| v < 0.0) {
+                return Err(ResolutionParseError::InvalidFormat(format!(
+                    "Kernel {i} (E = {} eV) contains negative weights",
+                    ref_energies[i],
+                )));
+            }
             if !offsets.windows(2).all(|w| w[0] < w[1]) {
                 return Err(ResolutionParseError::InvalidFormat(format!(
                     "Kernel {i} (E = {} eV) TOF offsets must be strictly ascending",
@@ -1906,6 +1928,14 @@ impl TabulatedResolution {
             if offsets.iter().chain(weights.iter()).any(|v| !v.is_finite()) {
                 return Err(ResolutionParseError::InvalidFormat(format!(
                     "Kernel {i} contains non-finite offset/weight values"
+                )));
+            }
+            // Negative weights have no physical meaning; the broadener
+            // skips w <= 0 entries and the trapezoidal width moments
+            // must integrate over the same domain (see `from_text`).
+            if weights.iter().any(|&v| v < 0.0) {
+                return Err(ResolutionParseError::InvalidFormat(format!(
+                    "Kernel {i} contains negative weights"
                 )));
             }
             // Offsets must be strictly ascending: `broaden_presorted`/`plan` walk a
@@ -2179,13 +2209,15 @@ impl TabulatedResolution {
         let e_min = energies[0];
         let e_max = energies[n - 1];
 
-        // Preallocate the entry Vecs to ~n × kernel_len so the inner
-        // pushes avoid repeated reallocations.  Real VENUS grids push
-        // ~n × 499 entries total; over-allocating by up to 2× (if some
-        // kernel points are skipped) is cheap vs. repeated grow-and-
-        // memcpy during plan build.
+        // Preallocate the entry Vecs to ~n × 2·kernel_len: the
+        // width-normalized shape blend merges the two bracketing
+        // blocks, so between-reference targets emit up to
+        // n_lo + n_hi points (~2× a single block; real VENUS grids
+        // push ~n × 998 entries). Over-allocating for at-reference
+        // targets is cheap vs. repeated grow-and-memcpy during the
+        // plan build.
         let estimated_kernel_len = self.kernels.first().map_or(0, |(off, _)| off.len());
-        let estimated_entries = n.saturating_mul(estimated_kernel_len);
+        let estimated_entries = n.saturating_mul(estimated_kernel_len.saturating_mul(2));
 
         let mut starts: Vec<u32> = Vec::with_capacity(n + 1);
         let mut lo_idx: Vec<u32> = Vec::with_capacity(estimated_entries);
@@ -3290,6 +3322,42 @@ Resolution file
         assert!(
             msg.contains("positive"),
             "error must name the positivity requirement: {msg}"
+        );
+    }
+
+    /// Negative kernel weights (no physical meaning; the broadener
+    /// skips them while the width moments would otherwise fold them
+    /// in) must be rejected by BOTH constructors.
+    #[test]
+    fn constructors_reject_negative_weights() {
+        let neg_weight = "\
+Resolution file
+---------------
+5.0 0.0
+-1.0 0.1
+0.0 1.0
+1.0 -0.2
+";
+        let err = TabulatedResolution::from_text(neg_weight, 25.0);
+        let Err(ResolutionParseError::InvalidFormat(msg)) = err else {
+            panic!("negative weight must be rejected, got {err:?}");
+        };
+        assert!(
+            msg.contains("negative weights"),
+            "error must name the negative-weight problem: {msg}"
+        );
+
+        let err = TabulatedResolution::from_kernels(
+            vec![10.0],
+            vec![(vec![-1.0, 0.0, 1.0], vec![-1.0, 0.2, -1.0])],
+            25.0,
+        );
+        let Err(ResolutionParseError::InvalidFormat(msg)) = err else {
+            panic!("negative weights must be rejected, got {err:?}");
+        };
+        assert!(
+            msg.contains("negative weights"),
+            "error must name the negative-weight problem: {msg}"
         );
     }
 

--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -853,6 +853,45 @@ pub struct TabulatedResolution {
     flight_path_m: f64,
 }
 
+/// Trapezoidal-weighted centroid and RMS width of one kernel block.
+///
+/// The `dt` weights match the quadrature `broaden_presorted` integrates
+/// with (single point → 1.0; edges → one-sided span; interior → half
+/// the neighbour span), so these are the moments the broadener
+/// effectively applies. The centroid pass is byte-identical to the
+/// accumulation `width_corrected` performed inline before this helper
+/// was factored out. Returns `(centroid, sigma)`; `sigma` is `0.0` for
+/// a single-point or zero-mass block — callers treat a non-positive or
+/// non-finite `sigma` as degenerate.
+fn trapezoidal_moments(offsets: &[f64], weights: &[f64]) -> (f64, f64) {
+    let n_k = offsets.len();
+    let dt_width = |k: usize| -> f64 {
+        if n_k <= 1 {
+            1.0
+        } else if k == 0 {
+            offsets[1] - offsets[0]
+        } else if k == n_k - 1 {
+            offsets[k] - offsets[k - 1]
+        } else {
+            (offsets[k + 1] - offsets[k - 1]) * 0.5
+        }
+    };
+    let (mut cnum, mut cden) = (0.0, 0.0);
+    for (k, (&o, &w)) in offsets.iter().zip(weights).enumerate() {
+        let tw = w * dt_width(k).abs();
+        cnum += o * tw;
+        cden += tw;
+    }
+    let centroid = if cden > 0.0 { cnum / cden } else { 0.0 };
+    let mut m2 = 0.0;
+    for (k, (&o, &w)) in offsets.iter().zip(weights).enumerate() {
+        let tw = w * dt_width(k).abs();
+        m2 += (o - centroid).powi(2) * tw;
+    }
+    let sigma = if cden > 0.0 { (m2 / cden).sqrt() } else { 0.0 };
+    (centroid, sigma)
+}
+
 impl TabulatedResolution {
     /// Reference energies (eV), sorted ascending.
     pub fn ref_energies(&self) -> &[f64] {
@@ -920,25 +959,7 @@ impl TabulatedResolution {
                 // `dt`-weighting in `broaden_presorted`), so the *integrated*
                 // centroid is preserved on non-uniform offset grids — not only on
                 // uniform grids where this reduces to the plain centroid.
-                let n_k = offsets.len();
-                let dt_width = |k: usize| -> f64 {
-                    if n_k <= 1 {
-                        1.0
-                    } else if k == 0 {
-                        offsets[1] - offsets[0]
-                    } else if k == n_k - 1 {
-                        offsets[k] - offsets[k - 1]
-                    } else {
-                        (offsets[k + 1] - offsets[k - 1]) * 0.5
-                    }
-                };
-                let (mut cnum, mut cden) = (0.0, 0.0);
-                for (k, (&o, &w)) in offsets.iter().zip(weights).enumerate() {
-                    let tw = w * dt_width(k).abs();
-                    cnum += o * tw;
-                    cden += tw;
-                }
-                let centroid = if cden > 0.0 { cnum / cden } else { 0.0 };
+                let (centroid, _) = trapezoidal_moments(offsets, weights);
                 let scaled = offsets
                     .iter()
                     .map(|&o| centroid + s * (o - centroid))
@@ -967,19 +988,18 @@ impl TabulatedResolution {
     ///    binary search on the sorted `ref_energies` grid.
     /// 2. Take the extreme offsets `dt⁺ = max(dt, 0)` and
     ///    `dt⁻ = max(−dt, 0)` over the kernel entries that can carry
-    ///    weight at `e_ev`.  When the two bracketing kernels have
-    ///    equal point counts — the same condition under which
-    ///    `interpolated_kernel` blends element-wise — a blended entry
-    ///    has positive weight if EITHER endpoint's weight is
-    ///    positive, so a zero-weight padding offset in one kernel is
-    ///    activated by the other kernel's weight at the same index.
-    ///    The scan therefore uses the **joint** mask: wherever either
-    ///    kernel's weight is positive, BOTH kernels' offsets at that
-    ///    index are considered, which bounds every convex combination
-    ///    of the two offsets (and, a fortiori, the nearest-kernel
-    ///    fallback).  When the point counts differ, apply time falls
-    ///    back to the nearer reference kernel, so each kernel is
-    ///    scanned with its own positive-weight mask.
+    ///    weight at `e_ev`.  Between references,
+    ///    [`Self::broaden`]'s width-normalized shape blend scales each
+    ///    block's support in mode-anchored `z = Δt/σ_b` to the target
+    ///    width `σ_t` and unions them — so the scan takes each block's
+    ///    **closure extremes** (the outermost `w > 0` offset, extended
+    ///    to the adjacent `w == 0` entry if one exists on that side:
+    ///    the linearly interpolated shape is positive on that fringe,
+    ///    and a merged point from the other block can land there),
+    ///    divides by that block's `σ_b`, maxes across the two blocks
+    ///    in z, and multiplies by `σ_t`.  Degenerate blocks (σ ≤ 0)
+    ///    take the nearest-clone fallback at apply time, so both
+    ///    blocks are scanned with their own positive-weight masks.
     /// 3. Map each extreme through the **exact** TOF→E relation
     ///    `E' = (TOF_FACTOR·L/(t∓dt))²` with `t = TOF_FACTOR·L/√E`
     ///    and return the larger energy excursion:
@@ -1049,29 +1069,50 @@ impl TabulatedResolution {
             Err(idx) => {
                 let (off_lo, w_lo) = &self.kernels[idx - 1];
                 let (off_hi, w_hi) = &self.kernels[idx];
-                if off_lo.len() == off_hi.len() {
-                    // Element-wise blend (same condition as
-                    // `interpolated_kernel`): a blended entry carries
-                    // positive weight if EITHER endpoint weight is
-                    // positive, and its offset is a convex combination
-                    // of the two endpoint offsets — so fold BOTH
-                    // offsets wherever either weight is positive.
-                    for ((&o_lo, &wl), (&o_hi, &wh)) in off_lo
-                        .iter()
-                        .zip(w_lo.iter())
-                        .zip(off_hi.iter().zip(w_hi.iter()))
-                    {
-                        if wl > 0.0 || wh > 0.0 {
-                            consider(o_lo, &mut max_dt_pos, &mut max_dt_neg);
-                            consider(o_hi, &mut max_dt_pos, &mut max_dt_neg);
-                        }
-                    }
-                } else {
-                    // Different point counts: apply time falls back to
-                    // the nearer reference kernel, so per-kernel
-                    // positive-weight scans bound it.
+                let (_, s_lo) = trapezoidal_moments(off_lo, w_lo);
+                let (_, s_hi) = trapezoidal_moments(off_hi, w_hi);
+                if !(s_lo.is_finite() && s_lo > 0.0 && s_hi.is_finite() && s_hi > 0.0) {
+                    // Degenerate blocks take `interpolated_kernel`'s
+                    // nearest-clone fallback; bounding BOTH blocks
+                    // bounds either clone.
                     visit(idx - 1, &mut max_dt_pos, &mut max_dt_neg);
                     visit(idx, &mut max_dt_pos, &mut max_dt_neg);
+                } else {
+                    // Width-normalized shape blend (lockstep with
+                    // `interpolated_kernel`): each block's support in
+                    // mode-anchored z = Δt/σ_b is scaled to the target
+                    // width σ_t, and the blended support is the union.
+                    // Per block use CLOSURE extremes — the outermost
+                    // w > 0 offset extended to the adjacent w == 0
+                    // entry if one exists on that side: the linearly
+                    // interpolated shape is positive on that fringe,
+                    // and a merged point from the other block can land
+                    // there with positive blended weight.
+                    let e_lo = self.ref_energies[idx - 1];
+                    let e_hi = self.ref_energies[idx];
+                    let frac = (e_ev.ln() - e_lo.ln()) / (e_hi.ln() - e_lo.ln());
+                    let s_t = s_lo * (s_hi / s_lo).powf(frac);
+                    let closure_extents = |offs: &[f64], ws: &[f64]| -> (f64, f64) {
+                        let n_k = offs.len();
+                        let mut pos = 0.0f64;
+                        let mut neg = 0.0f64;
+                        if let Some(kmax) = (0..n_k).rev().find(|&k| ws[k] > 0.0) {
+                            let k_ext = if kmax + 1 < n_k { kmax + 1 } else { kmax };
+                            pos = offs[k_ext].max(0.0);
+                            // kmax exists ⇒ a first positive-weight
+                            // index exists too.
+                            let kmin = (0..n_k).find(|&k| ws[k] > 0.0).unwrap_or(kmax);
+                            let k_ext_n = if kmin > 0 { kmin - 1 } else { kmin };
+                            neg = (-offs[k_ext_n]).max(0.0);
+                        }
+                        (pos, neg)
+                    };
+                    let (p_lo, n_lo) = closure_extents(off_lo, w_lo);
+                    let (p_hi, n_hi) = closure_extents(off_hi, w_hi);
+                    let z_pos = (p_lo / s_lo).max(p_hi / s_hi);
+                    let z_neg = (n_lo / s_lo).max(n_hi / s_hi);
+                    consider(z_pos * s_t, &mut max_dt_pos, &mut max_dt_neg);
+                    consider(-(z_neg * s_t), &mut max_dt_pos, &mut max_dt_neg);
                 }
             }
         }
@@ -2264,8 +2305,58 @@ impl TabulatedResolution {
         }
     }
 
-    /// Interpolate kernel at an arbitrary energy using log-space linear interpolation
-    /// between the two nearest reference energies.
+    /// Interpolate the kernel at an arbitrary energy as a
+    /// **width-normalized shape blend** between the two bracketing
+    /// reference kernels:
+    ///
+    /// 1. Exact hits (a reference energy, or outside the reference
+    ///    range) return that reference kernel unchanged.
+    /// 2. Each bracketing block's trapezoidal RMS width `σ_b` is
+    ///    computed ([`trapezoidal_moments`]); the target width is the
+    ///    **geometric** interpolation `σ_t = σ_lo·(σ_hi/σ_lo)^frac`
+    ///    with `frac` linear in log E — exact for the physical
+    ///    power-law width `σ_t ∝ E^p` (log σ linear in log E).
+    /// 3. Both blocks' offsets are scaled about the mode (offset 0 —
+    ///    the anchoring convention; see the `#625` discussion in
+    ///    `ikeda_carpenter`) by `σ_t/σ_b`, merged into one
+    ///    strictly-ascending grid, and the weights blended pointwise:
+    ///    `w = w_lo(x) + frac·(w_hi(x) − w_lo(x))`, each block's weight
+    ///    linearly interpolated (zero outside its support). Identical
+    ///    blocks reduce to a **bitwise identity** (the scale ratios are
+    ///    exactly 1.0 and the blend form is exact when `w_lo == w_hi`).
+    ///
+    /// Degenerate blocks (single-point, zero mass → `σ_b ≤ 0`) fall
+    /// back to the nearer reference clone.
+    ///
+    /// ## INTENTIONAL DEPARTURE from SAMMY
+    ///
+    /// SAMMY's user-defined resolution blends both the amplitude and
+    /// the time-point arrays element-wise, **linear in E**
+    /// (sammy/src/udr/mudr3.f90 lines 92–112: `UdR_E(J) =
+    /// a·UdR(J,I−1) + b·UdR(J,I)` and likewise `UdT_E(J)`), i.e. the
+    /// arithmetic width chord. Because the physical width law
+    /// `σ_t ∝ ~E^{−1/2}` is convex, that chord systematically
+    /// over-widens every between-reference energy: +7.8 % at the
+    /// midpoint of synthetic 10/50 eV Gaussian blocks, +4.1…+7.2 %
+    /// across the production VENUS 5→50 eV reference gap — a direct
+    /// resolution-width systematic that biases fitted temperatures
+    /// low. The geometric-width shape blend above removes it (and the
+    /// nearest-reference width sawtooth that unequal point counts used
+    /// to produce). SAMMY additionally re-centers the blended kernel
+    /// on its trapezoidal centroid `Ct` (mudr3.f90 lines 114–140);
+    /// NEREIDS keeps kernels mode-anchored instead (deliberately
+    /// unchanged here — the anchoring question is tracked separately).
+    ///
+    /// Exactness caveat: the blend reproduces `σ_t` exactly when the
+    /// two blocks' width-normalized shapes agree (self-similar
+    /// families, e.g. any pure power-law file). Genuinely different
+    /// bracketing shapes add a second-order mixture-spread term —
+    /// inherent to shape blending and far below the removed chord
+    /// error for real moderator files.
+    ///
+    /// Allocates the two output Vecs per call (≈ n_lo + n_hi points
+    /// between references); scratch reuse is tracked separately as a
+    /// performance follow-up.
     ///
     /// `ref_energies` is validated as strictly ascending by `from_text()` /
     /// `from_file()` at construction time, so no per-call sort check is needed.
@@ -2286,6 +2377,13 @@ impl TabulatedResolution {
 
         // Find bracketing indices
         let pos = self.ref_energies.partition_point(|&e| e < energy);
+        // Interior exact hit: return that reference unchanged, keeping
+        // this function lockstep with `kernel_support_ev`'s `Ok(idx)`
+        // arm (previously an interior hit went through the blend with
+        // `frac == 1.0`, reproducing the kernel only up to ULPs).
+        if self.ref_energies[pos] == energy {
+            return self.kernels[pos].clone();
+        }
         let idx = if pos == 0 {
             0
         } else {
@@ -2310,33 +2408,103 @@ impl TabulatedResolution {
             (k.0.clone(), k.1.clone())
         };
 
-        let (offsets, weights) = if off_lo.len() == off_hi.len() {
-            // Both kernels have the same number of points: interpolate element-wise.
-            let offsets: Vec<f64> = off_lo
-                .iter()
-                .zip(off_hi.iter())
-                .map(|(&a, &b)| a + frac * (b - a))
-                .collect();
-            // A convex blend of two strictly-ascending offset arrays stays
-            // ascending; guard defensively (e.g. a degenerate input kernel) and
-            // fall back to the nearer reference rather than emit a non-monotone
-            // kernel the two-pointer broadener assumes is sorted.
-            if offsets.windows(2).all(|w| w[0] < w[1]) {
-                let weights: Vec<f64> = w_lo
-                    .iter()
-                    .zip(w_hi.iter())
-                    .map(|(&a, &b)| a + frac * (b - a))
-                    .collect();
-                (offsets, weights)
-            } else {
-                nearest()
+        let (_, s_lo) = trapezoidal_moments(off_lo, w_lo);
+        let (_, s_hi) = trapezoidal_moments(off_hi, w_hi);
+        if !(s_lo.is_finite() && s_lo > 0.0 && s_hi.is_finite() && s_hi > 0.0) {
+            return nearest();
+        }
+
+        // Geometric width interpolation. This float form (ratio +
+        // powf) is a bitwise no-op when σ_lo == σ_hi: the ratio is
+        // exactly 1.0, powf(1.0, f) == 1.0, so both scale factors are
+        // exactly 1.0 and scaled offsets are the originals.
+        let s_t = s_lo * (s_hi / s_lo).powf(frac);
+        let r_lo = s_t / s_lo;
+        let r_hi = s_t / s_hi;
+
+        // Single-pass sorted merge of the two scaled grids. Each
+        // block's weight at a merged point is its own tabulated value
+        // when the point came from that block, else the linear
+        // interpolation of its shape (zero outside its support).
+        let n_lo = off_lo.len();
+        let n_hi = off_hi.len();
+        let mut out_off: Vec<f64> = Vec::with_capacity(n_lo + n_hi);
+        let mut out_w: Vec<f64> = Vec::with_capacity(n_lo + n_hi);
+
+        // Piecewise-linear sample of one block's shape at `x`, with a
+        // monotone cursor (merged points arrive in ascending order).
+        let sample = |offs: &[f64], ws: &[f64], r: f64, cursor: &mut usize, x: f64| -> f64 {
+            let n = offs.len();
+            if x < offs[0] * r || x > offs[n - 1] * r {
+                return 0.0;
             }
-        } else {
-            // Different point counts: fall back to the nearer reference kernel.
-            nearest()
+            while *cursor + 1 < n && offs[*cursor + 1] * r <= x {
+                *cursor += 1;
+            }
+            if *cursor + 1 >= n {
+                return ws[n - 1];
+            }
+            let x0 = offs[*cursor] * r;
+            let x1 = offs[*cursor + 1] * r;
+            let span = x1 - x0;
+            if x <= x0 || span <= 0.0 {
+                return ws[*cursor];
+            }
+            ws[*cursor] + (x - x0) / span * (ws[*cursor + 1] - ws[*cursor])
         };
 
-        (offsets, weights)
+        let (mut i, mut j) = (0usize, 0usize);
+        let (mut ci, mut cj) = (0usize, 0usize);
+        while i < n_lo || j < n_hi {
+            let xa = if i < n_lo {
+                off_lo[i] * r_lo
+            } else {
+                f64::INFINITY
+            };
+            let xb = if j < n_hi {
+                off_hi[j] * r_hi
+            } else {
+                f64::INFINITY
+            };
+            // Near-duplicate merge (covers the exact 0 == 0 mode point):
+            // emit one point carrying both blocks' exact tabulated
+            // weights, so identical blocks blend to their exact values.
+            let near_dup = i < n_lo
+                && j < n_hi
+                && (xa - xb).abs() <= 4.0 * f64::EPSILON * xa.abs().max(xb.abs());
+            let (x, wl, wh) = if near_dup {
+                let v = (xa, w_lo[i], w_hi[j]);
+                i += 1;
+                j += 1;
+                v
+            } else if xa < xb {
+                let v = (xa, w_lo[i], sample(off_hi, w_hi, r_hi, &mut cj, xa));
+                i += 1;
+                v
+            } else {
+                let v = (xb, sample(off_lo, w_lo, r_lo, &mut ci, xb), w_hi[j]);
+                j += 1;
+                v
+            };
+            // Defensive strict-ascension guard: the broadener's
+            // trapezoidal quadrature and two-pointer walk require it
+            // unconditionally, regardless of the dedup epsilon.
+            if let Some(&last) = out_off.last()
+                && x <= last
+            {
+                continue;
+            }
+            out_off.push(x);
+            // Exact when `wl == wh` (identical blocks), and exactly the
+            // endpoint values at frac → 0/1.
+            out_w.push(wl + frac * (wh - wl));
+        }
+
+        // Blended weights inherit the blocks' scale (peak-normalized by
+        // convention); the broadener renormalizes at apply time, so no
+        // re-normalization is done here — preserving the bitwise
+        // identity for identical blocks unconditionally.
+        (out_off, out_w)
     }
 }
 
@@ -3063,6 +3231,116 @@ NaN 0.0
             "mode not anchored at offset 0: {}",
             blended[kmax]
         );
+    }
+
+    /// For a self-similar family (each block a width-scaled copy of one
+    /// asymmetric template), the width-normalized shapes agree, so the
+    /// blended kernel's trapezoidal width must equal the geometric
+    /// interpolation `σ_lo·(σ_hi/σ_lo)^frac` — near-exactly (the scaled
+    /// grids coincide point-for-point in z, so the merge degenerates to
+    /// the template shape at the target width). An interior reference
+    /// energy must return that block bitwise (exact-hit arm).
+    #[test]
+    fn interpolated_kernel_width_follows_power_law_for_self_similar_blocks() {
+        let template_off = [-1.0, -0.4, 0.0, 0.8, 2.0, 4.0];
+        let template_w = vec![0.05, 0.5, 1.0, 0.6, 0.2, 0.02];
+        // σ ∝ E^{-1/2} scaling across refs 10 / 100 / 1000 eV.
+        let scale = |e: f64| (e / 10.0f64).powf(-0.5);
+        let block = |e: f64| -> (Vec<f64>, Vec<f64>) {
+            (
+                template_off.iter().map(|&o| o * scale(e)).collect(),
+                template_w.clone(),
+            )
+        };
+        let tab = TabulatedResolution::from_kernels(
+            vec![10.0, 100.0, 1000.0],
+            vec![block(10.0), block(100.0), block(1000.0)],
+            25.0,
+        )
+        .unwrap();
+
+        // Interior exact hit: the middle reference comes back bitwise.
+        let (off_ref, w_ref) = test_support::interpolated_kernel(&tab, 100.0);
+        let (exp_off, exp_w) = block(100.0);
+        assert_eq!(off_ref.len(), exp_off.len());
+        for (a, b) in off_ref.iter().zip(&exp_off) {
+            assert_eq!(
+                a.to_bits(),
+                b.to_bits(),
+                "exact-hit offsets must be bitwise"
+            );
+        }
+        for (a, b) in w_ref.iter().zip(&exp_w) {
+            assert_eq!(
+                a.to_bits(),
+                b.to_bits(),
+                "exact-hit weights must be bitwise"
+            );
+        }
+
+        // Between references: measured width equals the geometric law.
+        let (off_lo, w_lo) = block(10.0);
+        let (off_hi, w_hi) = block(100.0);
+        let (_, s_lo) = trapezoidal_moments(&off_lo, &w_lo);
+        let (_, s_hi) = trapezoidal_moments(&off_hi, &w_hi);
+        for e in [16.0f64, 25.0, 40.0, 70.0] {
+            let frac = (e.ln() - 10.0f64.ln()) / (100.0f64.ln() - 10.0f64.ln());
+            let expected = s_lo * (s_hi / s_lo).powf(frac);
+            let (offs, ws) = test_support::interpolated_kernel(&tab, e);
+            let (_, got) = trapezoidal_moments(&offs, &ws);
+            assert!(
+                (got - expected).abs() / expected < 1e-9,
+                "blended width at {e} eV: got {got}, expected {expected} \
+                 (the pre-fix arithmetic chord gave {})",
+                s_lo + frac * (s_hi - s_lo)
+            );
+            // Non-vacuity: the removed chord error is resolvable at
+            // this tolerance (σ_hi/σ_lo = 10^{-1/2} → several % apart).
+            assert!(
+                (s_lo + frac * (s_hi - s_lo) - expected).abs() / expected > 1e-2,
+                "fixture must separate chord from geometric law at {e} eV"
+            );
+        }
+    }
+
+    /// Identical bracketing blocks must come back bitwise-identical
+    /// between the references (scale ratios exactly 1.0; the blend form
+    /// `a + frac·(b − a)` is exact when a == b).
+    #[test]
+    fn interpolated_kernel_is_bitwise_identity_for_identical_blocks() {
+        let off = vec![-1.0, -0.4, 0.0, 0.8, 2.0, 4.0];
+        let w = vec![0.05, 0.5, 1.0, 0.6, 0.2, 0.02];
+        let tab = TabulatedResolution::from_kernels(
+            vec![5.0, 500.0],
+            vec![(off.clone(), w.clone()), (off.clone(), w.clone())],
+            25.0,
+        )
+        .unwrap();
+        let (offs, ws) = test_support::interpolated_kernel(&tab, 42.0);
+        assert_eq!(offs.len(), off.len());
+        for (a, b) in offs.iter().zip(&off) {
+            assert_eq!(a.to_bits(), b.to_bits(), "identity offsets must be bitwise");
+        }
+        for (a, b) in ws.iter().zip(&w) {
+            assert_eq!(a.to_bits(), b.to_bits(), "identity weights must be bitwise");
+        }
+    }
+
+    /// Degenerate blocks (single-point → σ = 0) cannot be width-scaled;
+    /// the nearer reference is cloned instead.
+    #[test]
+    fn interpolated_kernel_degenerate_blocks_fall_back_to_nearest() {
+        let tab = TabulatedResolution::from_kernels(
+            vec![10.0, 1000.0],
+            vec![(vec![0.0], vec![1.0]), (vec![0.5], vec![1.0])],
+            25.0,
+        )
+        .unwrap();
+        // frac < 0.5 → lower block; frac > 0.5 → upper block.
+        let (lo_off, _) = test_support::interpolated_kernel(&tab, 15.0);
+        assert_eq!(lo_off, vec![0.0]);
+        let (hi_off, _) = test_support::interpolated_kernel(&tab, 700.0);
+        assert_eq!(hi_off, vec![0.5]);
     }
 
     // ── Smoke tests for the test_support oracles (`interp_spectrum` +
@@ -4439,20 +4717,47 @@ NaN 0.0
         );
     }
 
-    /// Between two reference energies the support uses the extreme of
-    /// the two bracketing kernels (conservative).  At E = 100 eV the
-    /// brackets are 50 eV (half = 1.0, n = 41) and 500 eV (half = 2.0,
-    /// n = 51); the larger non-zero offset is `2.0 · (1 − 1/50) = 1.96`.
+    /// Between two reference energies the support tracks the ACTUAL
+    /// width-interpolated kernel: it must cover that kernel's non-zero
+    /// offsets (non-circular — the blend comes from
+    /// `interpolated_kernel` itself), while sitting strictly BELOW the
+    /// old take-the-wider-bracket bound (proving the interior arm
+    /// engaged rather than falling back to per-kernel extremes).
     #[test]
-    fn test_tabulated_kernel_support_uses_larger_bracketing_kernel() {
+    fn test_tabulated_kernel_support_covers_actual_blend_between_refs() {
         let r = synthetic_tab_resolution();
-        let e: f64 = 100.0;
-        let dt_max = triangle_dt_max(2.0, 51);
-        let expected = exact_support(e, dt_max, dt_max, 25.0);
+        let e: f64 = 100.0; // between the 50 eV and 500 eV references
         let got = r.kernel_support_ev(e);
+
+        // Cover: exact excursion of the blended kernel's w>0 extremes.
+        let (offs, ws) = test_support::interpolated_kernel(&r, e);
+        let dt_pos = offs
+            .iter()
+            .zip(&ws)
+            .filter(|&(_, &w)| w > 0.0)
+            .map(|(&o, _)| o)
+            .fold(0.0f64, f64::max);
+        let dt_neg = offs
+            .iter()
+            .zip(&ws)
+            .filter(|&(_, &w)| w > 0.0)
+            .map(|(&o, _)| -o)
+            .fold(0.0f64, f64::max);
+        let actual_excursion = exact_support(e, dt_pos, dt_neg, 25.0);
         assert!(
-            (got - expected).abs() / expected < 1e-12,
-            "support between refs: got {got}, expected {expected}"
+            got >= actual_excursion * (1.0 - 1e-12),
+            "support must cover the actual blended kernel: got {got}, \
+             actual excursion {actual_excursion}"
+        );
+
+        // Tightness + non-vacuity: strictly below the pre-blend bound
+        // built from the wider 500 eV bracket's extreme (1.96 µs) —
+        // the between-ref kernel is genuinely narrower.
+        let old_bound = exact_support(e, triangle_dt_max(2.0, 51), triangle_dt_max(2.0, 51), 25.0);
+        assert!(
+            got < old_bound,
+            "interior support must track the narrower interpolated \
+             kernel: got {got}, old wider-bracket bound {old_bound}"
         );
     }
 
@@ -4555,39 +4860,67 @@ NaN 0.0
         );
     }
 
-    /// Between two equal-count reference kernels, `interpolated_kernel`
-    /// blends element-wise, and a blended entry has positive weight if
-    /// EITHER endpoint's weight is positive — so a zero-weight padding
-    /// offset in one kernel is activated by the other kernel's weight
-    /// at the same index.  The support must bound the blend-activated
-    /// offset region (joint mask), not just the per-kernel
-    /// positive-weight extremes.
+    /// Between reference kernels, the blended shape is positive on the
+    /// FRINGE between a block's outermost `w > 0` entry and its
+    /// adjacent `w == 0` entry (linear interpolation), and a merged
+    /// point from the other block can land there — so the support's
+    /// closure extremes (outermost positive weight extended to the
+    /// adjacent zero-weight entry) must cover the actual blended
+    /// kernel, which reaches beyond both blocks' bare `w > 0` maxima.
     #[test]
     fn test_tabulated_kernel_support_covers_blend_activated_offsets() {
-        // Kernel A pads its tail with zero-weight entries reaching
-        // offset 20; kernel B carries positive weight at every index.
-        // Per-kernel positive-weight maxima are 5 (A) and 12 (B), but
-        // the blend at the last index has offset `20 + frac·(12 − 20)`
-        // with weight `0 + frac·0.1 > 0` — beyond both maxima.
+        // Kernel A's positive support ends at z ≈ 3.5 (offset 5,
+        // σ_A ≈ 1.44) with a zero-weight fringe out to z ≈ 7.0
+        // (offset 10). Kernel B is compact (σ_B ≈ 0.97) with a
+        // low-weight point at z ≈ 5.2 (offset 5) — inside A's fringe
+        // after width normalization — so the blended kernel is
+        // positive beyond A's bare w>0 extreme.
         let r = TabulatedResolution {
             ref_energies: vec![10.0, 1000.0],
             kernels: vec![
                 (vec![0.0, 5.0, 10.0, 20.0], vec![1.0, 0.1, 0.0, 0.0]),
-                (vec![0.0, 4.0, 8.0, 12.0], vec![1.0, 0.5, 0.3, 0.1]),
+                (vec![0.0, 1.0, 5.0, 6.0], vec![1.0, 0.8, 0.05, 0.0]),
             ],
             flight_path_m: 25.0,
         };
         let e: f64 = 100.0; // strictly between the reference energies
-        let expected = exact_support(e, 20.0, 0.0, 25.0);
         let got = r.kernel_support_ev(e);
+
+        // Non-circular cover: the actual blended kernel's w>0 extremes.
+        let (offs, ws) = test_support::interpolated_kernel(&r, e);
+        let dt_pos = offs
+            .iter()
+            .zip(&ws)
+            .filter(|&(_, &w)| w > 0.0)
+            .map(|(&o, _)| o)
+            .fold(0.0f64, f64::max);
+        let dt_neg = offs
+            .iter()
+            .zip(&ws)
+            .filter(|&(_, &w)| w > 0.0)
+            .map(|(&o, _)| -o)
+            .fold(0.0f64, f64::max);
+        let actual_excursion = exact_support(e, dt_pos, dt_neg, 25.0);
         assert!(
-            (got - expected).abs() / expected < 1e-12,
-            "support must cover blend-activated zero-weight offsets: \
-             got {got}, expected {expected}"
+            got >= actual_excursion * (1.0 - 1e-12),
+            "support must cover the actual blended kernel (incl. the \
+             zero-weight fringe): got {got}, actual {actual_excursion}"
         );
-        // Non-vacuity: the joint bound strictly exceeds what the
-        // per-kernel positive-weight extremes (dt⁺ = 12) would give.
-        assert!(got > exact_support(e, 12.0, 0.0, 25.0));
+
+        // The fringe matters: the actual blend reaches beyond block
+        // A's bare positive maximum (5 µs) scaled to the target width
+        // — assert the blend truly is wider than a no-fringe reading
+        // of block A would suggest, keeping this case load-bearing.
+        let (_, s_lo) = trapezoidal_moments(&r.kernels[0].0, &r.kernels[0].1);
+        let (_, s_hi) = trapezoidal_moments(&r.kernels[1].0, &r.kernels[1].1);
+        let frac = (e.ln() - 10.0f64.ln()) / (1000.0f64.ln() - 10.0f64.ln());
+        let s_t = s_lo * (s_hi / s_lo).powf(frac);
+        let bare_positive_bound = 5.0 / s_lo * s_t;
+        assert!(
+            dt_pos > bare_positive_bound,
+            "blend must extend into the zero-weight fringe: dt_pos {dt_pos}, \
+             bare-positive bound {bare_positive_bound}"
+        );
     }
 
     /// The support must contain the footprint of the ACTUAL broadener:

--- a/crates/nereids-physics/tests/kernel_width_interpolation.rs
+++ b/crates/nereids-physics/tests/kernel_width_interpolation.rs
@@ -1,0 +1,129 @@
+//! End-to-end width oracle for between-reference kernel interpolation
+//! (issue #632).
+//!
+//! Symmetric Gaussian kernels (mode 0, so the convolution orientation
+//! does not contaminate the width measurement) at reference energies
+//! 10 and 50 eV, with TOF-space widths following the physical
+//! σ_t ∝ E^{−1/2} law: σ_t(10 eV) = 2.0 µs, σ_t(50 eV) = 2/√5 µs. A
+//! width-correct interpolation at 20 eV must give σ_t = 2/√2 =
+//! 1.4142 µs. The pre-fix element-wise blend produced the arithmetic
+//! chord 1.523 µs (+7.8 %) — the width surplus measured at +4.1…+7.2 %
+//! across the production VENUS file's 5→50 eV reference gap.
+//!
+//! The fixture goes through [`TabulatedResolution::from_text`] and the
+//! width is measured on the APPLIED broadening (a near-delta dip's
+//! absorption-weighted σ_E mapped back to TOF space), so the whole
+//! parse → interpolate → convolve chain is the system under test —
+//! non-circular with respect to the interpolation algorithm.
+
+use std::fmt::Write as _;
+use std::sync::Arc;
+
+use nereids_physics::resolution::{
+    ResolutionFunction, TOF_FACTOR, TabulatedResolution, apply_resolution,
+    apply_resolution_with_plan, build_resolution_plan,
+};
+const FLIGHT_PATH_M: f64 = 25.0;
+const SIGMA_10EV_US: f64 = 2.0;
+
+/// Two-block Gaussian fixture in the VENUS/FTS text format with exact
+/// σ_t ∝ E^{−1/2} widths at 10 and 50 eV.
+fn gaussian_kernel_text() -> String {
+    let mut text = String::from("synthetic Gaussian kernels, sigma_t ~ E^-1/2\n-----\n");
+    for eref in [10.0f64, 50.0] {
+        let sigma = SIGMA_10EV_US * (eref / 10.0).powf(-0.5);
+        writeln!(text, "   {eref:.5e}   0.00000e+000").unwrap();
+        let n = 499;
+        for i in 0..n {
+            let d = -6.0 * sigma + 12.0 * sigma * i as f64 / (n - 1) as f64;
+            let a = (-0.5 * (d / sigma).powi(2)).exp();
+            writeln!(text, "{d:.15} {a:.15e}").unwrap();
+        }
+        text.push('\n');
+    }
+    text
+}
+
+/// Broaden a near-delta dip at `e0` and return the measured TOF-space
+/// width of the applied kernel.
+fn measured_sigma_t(tab: &TabulatedResolution, e0: f64, use_plan: bool) -> f64 {
+    let n = 30_001;
+    let energies: Vec<f64> = (0..n)
+        .map(|i| e0 * 0.7 + e0 * 0.6 * i as f64 / (n - 1) as f64)
+        .collect();
+    let spectrum: Vec<f64> = energies
+        .iter()
+        .map(|&e| 1.0 - 0.8 * (-0.5 * ((e - e0) / (e0 * 1e-4)).powi(2)).exp())
+        .collect();
+    let res = ResolutionFunction::Tabulated(Arc::new(tab.clone()));
+    let broadened = if use_plan {
+        let plan = build_resolution_plan(&energies, &res)
+            .expect("plan build")
+            .expect("tabulated resolution must yield a plan");
+        apply_resolution_with_plan(Some(&plan), &energies, &spectrum, &res).expect("plan broaden")
+    } else {
+        apply_resolution(&energies, &spectrum, &res).expect("direct broaden")
+    };
+
+    // Non-vacuity: the kernel must visibly reshape the near-delta dip.
+    let diff_inf = spectrum
+        .iter()
+        .zip(&broadened)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0_f64, f64::max);
+    assert!(
+        diff_inf > 0.01,
+        "kernel is acting as a no-op at {e0} eV: ‖broadened − input‖∞ = {diff_inf:.3e}"
+    );
+
+    let absorption: Vec<f64> = broadened.iter().map(|&t| (1.0 - t).max(0.0)).collect();
+    let total: f64 = absorption.iter().sum();
+    let mu = energies
+        .iter()
+        .zip(&absorption)
+        .map(|(&e, &a)| e * a)
+        .sum::<f64>()
+        / total;
+    let var = energies
+        .iter()
+        .zip(&absorption)
+        .map(|(&e, &a)| (e - mu).powi(2) * a)
+        .sum::<f64>()
+        / total;
+    let sigma_e = var.sqrt();
+    // |dt/dE| = t/(2E) at e0 maps the energy-space width back to TOF.
+    let tof = TOF_FACTOR * FLIGHT_PATH_M / e0.sqrt();
+    sigma_e * tof / (2.0 * e0)
+}
+
+#[test]
+fn applied_width_follows_power_law_at_and_between_references() {
+    let tab = TabulatedResolution::from_text(&gaussian_kernel_text(), FLIGHT_PATH_M)
+        .expect("synthetic Gaussian fixture must parse");
+
+    for (e0, expected) in [
+        (10.0, SIGMA_10EV_US),
+        (50.0, SIGMA_10EV_US / 5.0f64.sqrt()),
+        // The between-reference point the arithmetic chord missed by
+        // +7.8 % — width-correct interpolation must hit the power law.
+        (20.0, SIGMA_10EV_US / 2.0f64.sqrt()),
+    ] {
+        let got = measured_sigma_t(&tab, e0, false);
+        let rel = (got / expected - 1.0).abs();
+        assert!(
+            rel < 0.01,
+            "applied width at {e0} eV: measured σ_t = {got:.4} µs, power law \
+             expects {expected:.4} µs ({:+.1} % — the pre-fix chord gave +7.8 % \
+             at 20 eV)",
+            (got / expected - 1.0) * 100.0
+        );
+    }
+
+    // Plan path must agree with the direct path on the midpoint width.
+    let direct = measured_sigma_t(&tab, 20.0, false);
+    let planned = measured_sigma_t(&tab, 20.0, true);
+    assert!(
+        (direct - planned).abs() / direct < 1e-12,
+        "plan and direct widths must agree: {direct} vs {planned}"
+    );
+}

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -524,6 +524,64 @@ class TestTabulatedKernelOrientation:
         )
 
 
+class TestTabulatedKernelWidthInterpolation:
+    """Regression for issue #632: kernel width between reference energies
+    must follow the physical power law, not the arithmetic blend chord.
+
+    Symmetric Gaussian kernels (mode 0, immune to the #631 orientation)
+    at 10 and 50 eV with sigma_t ~ E^-1/2 widths: a width-correct
+    interpolation at 20 eV gives sigma_t = 2/sqrt(2) = 1.4142 us. The
+    pre-fix element-wise blend measured 1.524 us (+7.8%); the issue's
+    acceptance bar is <3% at the midpoint.
+    """
+
+    TOF_FACTOR = 72.298254398292800  # us*sqrt(eV)/m (resolution.rs)
+    L = 25.0
+    SIGMA_10EV = 2.0
+
+    @classmethod
+    def _write_kernel(cls, path):
+        lines = ["synthetic Gaussian kernels, sigma_t ~ E^-1/2", "-----"]
+        for eref in (10.0, 50.0):
+            sigma = cls.SIGMA_10EV * (eref / 10.0) ** -0.5
+            d = np.linspace(-6.0 * sigma, 6.0 * sigma, 499)
+            a = np.exp(-0.5 * (d / sigma) ** 2)
+            lines.append(f"   {eref:.5e}   0.00000e+000")
+            lines += [f"{x:.15f} {y:.15e}" for x, y in zip(d, a)]
+            lines.append("")
+        path.write_text("\n".join(lines))
+
+    def _measured_sigma_t(self, tab, e0):
+        e = np.linspace(e0 * 0.7, e0 * 1.3, 30001)
+        spec = 1.0 - 0.8 * np.exp(-0.5 * ((e - e0) / (e0 * 1e-4)) ** 2)
+        b = np.asarray(nereids.apply_resolution(e, spec, tab))
+        # Non-vacuity: the kernel must visibly reshape the dip.
+        assert np.max(np.abs(b - spec)) > 0.01
+        a = 1.0 - b
+        mu = np.sum(e * a) / np.sum(a)
+        sd_e = np.sqrt(np.sum((e - mu) ** 2 * a) / np.sum(a))
+        tof = self.TOF_FACTOR * self.L / np.sqrt(e0)
+        return sd_e * tof / (2.0 * e0)
+
+    def test_width_follows_power_law_between_references(self, tmp_path):
+        kernel_path = tmp_path / "synthetic_two_ref.txt"
+        self._write_kernel(kernel_path)
+        tab = nereids.load_resolution(str(kernel_path), self.L)
+
+        for e0, expected in [
+            (10.0, self.SIGMA_10EV),
+            (50.0, self.SIGMA_10EV / np.sqrt(5.0)),
+            (20.0, self.SIGMA_10EV / np.sqrt(2.0)),
+        ]:
+            measured = self._measured_sigma_t(tab, e0)
+            surplus = measured / expected - 1.0
+            assert abs(surplus) < 0.03, (
+                f"kernel width at {e0} eV is {surplus * 100:+.1f}% off the "
+                f"power law (measured {measured:.4f} us, expected "
+                f"{expected:.4f} us; the pre-fix blend gave +7.8% at 20 eV)"
+            )
+
+
 # ===========================================================================
 # LM fitting
 # ===========================================================================


### PR DESCRIPTION
Fixes #632. Second of the two bugs holding the v0.2.2 release.

## The bug

`interpolated_kernel` blended bracketing reference kernels element-wise (offsets and weights, linear in the log-E fraction) — an **arithmetic width chord** over the convex physical width law σ_t ∝ ~E^(−1/2). A linear chord above a convex curve always overshoots: every between-reference energy got a systematically too-wide kernel — **+7.8 %** at the issue's synthetic 10/50 eV midpoint, **+4.1–7.2 %** across the production VENUS file's 5→50 eV reference gap (spanning nearly all Ta-181 thermometry resonances). Direct resolution-width systematic; fitted temperature reads low. The unequal-point-count path (common for IC after tail trimming) skipped blending for a nearest-reference clone — a ±few-% width **sawtooth** from the same design gap.

## The fix: width-normalized shape blend

1. Per bracketing block: trapezoidal RMS width σ_b (new shared `trapezoidal_moments` helper, factored bit-exactly out of `width_corrected`).
2. Target width interpolates **geometrically**: `σ_t = σ_lo·(σ_hi/σ_lo)^frac` — exact for power-law files (1.4142 µs at the issue's 20 eV point vs the chord's 1.523), and a bitwise no-op for equal widths.
3. Both blocks' offsets scale about the mode to σ_t, merge into one strictly-ascending grid (single pass, no intermediate allocations), shapes blend pointwise.

Properties: identical blocks → **bitwise identity**; interior exact reference hits return the reference unchanged (new arm, lockstep with `kernel_support_ev`); degenerate blocks keep the nearest-clone fallback; the count-equality condition and the IC sawtooth are **gone**.

**`kernel_support_ev` lockstep**: the interior arm now unions the blocks' width-normalized **closure extremes** (outermost positive weight extended to the adjacent zero-weight entry — the interpolated shape is positive on that fringe) and scales by σ_t. Its two interior tests are rewritten **non-circularly** against the actual blended kernel's extremes, with non-vacuity guards.

## INTENTIONAL DEPARTURE from SAMMY (documented in the docstring)

SAMMY's own UDR interpolation blends the amplitude **and time-point** arrays element-wise, **linear in E** (`sammy/src/udr/mudr3.f90:92-112`, verified in the Fortran) — the same arithmetic chord this PR removes — and re-centers on the blended centroid (`:114-140`) where NEREIDS keeps mode anchoring (#625 untouched). Precedent for documented divergence: the Doppler quadrature-vs-Dopfgm note, `coulomb.rs`'s INTENTIONAL DEPARTURE block.

## Why no test ever caught it

No test checked the **absolute width of an applied kernel** against an external/analytic oracle — normalization, bit-exactness-vs-same-algorithm-oracle, and relative-scaling tests are all blind to a multiplicative width error. Now:

- `tests/kernel_width_interpolation.rs`: Gaussian σ∝E^−1/2 fixture through `from_text` + the applied broadening — measured σ_t pinned to the power law within 1 % at both references **and the midpoint**; plan path agrees to 1e-12.
- In-src: self-similar asymmetric blocks pin the blended width to the geometric law (1e-9 rel) **and separate it from the chord** (>1 % apart — non-vacuous); bitwise-identity, interior-exact-hit, and degenerate-fallback tests.
- pytest `TestTabulatedKernelWidthInterpolation`: the issue's repro through the bindings, <3 % acceptance bar.

## Verification

- **Acceptance: the issue's repro script verbatim** now prints `E=20 eV: surplus +0.0 %` (references ±0.3–0.4 % grid discretization) → **PASS**. Pre-fix: +7.8 %.
- Full workspace + clippy `-D warnings` + rustdoc clean; `pixi run test-python` 137 passed.
- One calibration test (`position_prior_penalizes_displacement`) needed a proportionally **tighter** prior σ: the corrected (narrower) kernels sharpen the data-χ² curvature in t0, so the old σ no longer bound against the data term. The recalibration re-establishes the regime the test probes (documented in the test comment) — no thresholds were loosened.

## Perf note (issue #493 interaction — not addressed here)

Between-reference kernels now carry ≈ n_lo+n_hi points (~2× for VENUS-sized blocks with distinct grids): plan entry counts and `interpolated_kernel` cost roughly double, and `plan_presorted`'s `estimated_entries` hint under-estimates accordingly. The new merge is single-pass with no intermediate allocations, and the per-block σ is a natural precompute — both make #493's scratch-reuse pass straightforward.

## Action required (CHANGELOG, prominently)

`calibrate_resolution` results and fits whose window lies **between** resolution-file reference energies, obtained with earlier versions under tabulated/IC resolution, are invalidated and must be re-fit; externally maintained bit-exact broadener baselines must be regenerated. Gaussian/Doppler-only results unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
