### PR TITLE
feat(fitting): fit_energy_scale + fit_temperature jointly; corrected_energies(); calibrate_energy via LM (#634)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,14 +46,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- **`calibrate_energy` is orders of magnitude faster** (#634): the
-  three-phase (L, t₀) grid + per-candidate golden-section density search
-  (~35 000 forward evaluations; >10 min on production windows) is
-  replaced by a multi-start descent built on the `fit_energy_scale` LM
-  path (peak-match-seeded alignment with the density frozen, exact 1-D
-  golden-section density at each alignment, joint LM polish, argmin-χ²
-  across log-spaced density starts). The public signature,
-  `CalibrationResult` fields, density band `[1e-5, 1e-2]`,
+- **`calibrate_energy` rebuilt on the `fit_energy_scale` LM path**
+  (#634): the three-phase (L, t₀) grid + per-candidate golden-section
+  density search (~35 000 forward evaluations; >10 min on production
+  windows) is replaced by a staged search — coarse joint (t₀, L_scale)
+  scan with exact per-candidate density, a plateau-robust dip-match
+  anchor (handles saturated flat-bottom dips), fine joint pit-scans
+  around each anchor, then a multi-start LM descent scored by the
+  original valid-bins χ² (argmin). ~4× fewer forward evaluations on
+  production windows, and the LM refinement removes the old grid's
+  resolution floor (the optimum is continuous rather than quantized to
+  0.001 % L / 0.05 µs t₀). New wide-offset round-trip regression tests
+  pin recovery at production-scale offsets (0.3–1.2 % L, 1–6 µs t₀)
+  across trace, mid-band, and saturated-foil densities. The public
+  signature, `CalibrationResult` fields, density band `[1e-5, 1e-2]`,
   boundary-saturation and no-finite-χ² error contracts, and the
   `dof = n_valid − 3` reduced-χ² convention are unchanged; all existing
   calibration tests pass unmodified.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`fit_energy_scale` + `fit_temperature` jointly, in every fitter**
+  (#634): the flag combination resonance thermometry needs — calibrate
+  the SAMMY energy scale (t₀, L_scale) *and* fit temperature in one
+  fit — is now supported across the LM, transmission-KL, and counts
+  joint-Poisson paths and `spatial_map_typed` (the four guards that
+  rejected it are gone). `EnergyScaleTransmissionModel` carries a fitted
+  temperature column (central finite difference, validated against the
+  analytic ∂σ/∂T column to <1e-4 relative; an independent (JᵀWJ)⁻¹
+  reconstruction reproduces the reported temperature σ to <0.1 %).
+- **`corrected_energies()` accessor** (#634): `SpectrumFitResult` (Rust)
+  and `FitResult` (Python) expose the exact energy-scale transform the
+  fit used — `corrected_energies(nominal_energies, flight_path_m)` maps
+  a nominal grid through the fitted `(t0_us, l_scale)` with the SAMMY
+  `−t0` sign convention (`dat/mdat0.f90:189`), returning `None` when the
+  energy scale was not fitted. Hand-deriving this transform (with a
+  `+t0` slip) previously caused a silent +400 K temperature bias.
+
 - **Per-parameter density freeze in every fitter** (#633): areal
   densities can now be held fixed while other parameters (temperature,
   energy scale, background) are fit. `UnifiedFitConfig` gains
@@ -26,6 +43,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   uncertainties reflect only the parameters actually varied (a frozen
   density's reported 1-σ is `NaN`). This enables temperature-only
   thermometry fits against a known sample density.
+
+### Changed
+
+- **`calibrate_energy` is orders of magnitude faster** (#634): the
+  three-phase (L, t₀) grid + per-candidate golden-section density search
+  (~35 000 forward evaluations; >10 min on production windows) is
+  replaced by a multi-start descent built on the `fit_energy_scale` LM
+  path (peak-match-seeded alignment with the density frozen, exact 1-D
+  golden-section density at each alignment, joint LM polish, argmin-χ²
+  across log-spaced density starts). The public signature,
+  `CalibrationResult` fields, density band `[1e-5, 1e-2]`,
+  boundary-saturation and no-finite-χ² error contracts, and the
+  `dof = n_valid − 3` reduced-χ² convention are unchanged; all existing
+  calibration tests pass unmodified.
 
 ## [0.2.2] - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   reconstruction reproduces the reported temperature σ to <0.1 %).
 - **`corrected_energies()` accessor** (#634): `SpectrumFitResult` (Rust)
   and `FitResult` (Python) expose the exact energy-scale transform the
-  fit used — `corrected_energies(nominal_energies, flight_path_m)` maps
-  a nominal grid through the fitted `(t0_us, l_scale)` with the SAMMY
+  fit used — `corrected_energies(nominal_energies)` maps a nominal grid
+  through the fitted `(t0_us, l_scale)`, using the flight path stored on
+  the result at fit time, with the SAMMY
   `−t0` sign convention (`dat/mdat0.f90:189`), returning `None` when the
   energy scale was not fitted. Hand-deriving this transform (with a
   `+t0` slip) previously caused a silent +400 K temperature bias.

--- a/apps/gui/src/file_dialog.rs
+++ b/apps/gui/src/file_dialog.rs
@@ -945,6 +945,7 @@ mod tests {
             back_f_map: None,
             t0_us_map: None,
             l_scale_map: None,
+            energy_scale_flight_path_m: None,
             n_converged: 4,
             n_total: 4,
             n_failed: 0,

--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -247,24 +247,17 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState, available_height_hint: 
 
         let draw_advanced_solver = |ui: &mut egui::Ui, state: &mut AppState| {
             ui.indent("advanced_solver", |ui| {
-                // Fit temperature and Fit energy scale are mutually exclusive
-                // (pipeline returns a hard error if both are true — see
-                // `pipeline.rs` ~L977).  Grey out each when the other is on so
-                // the constraint is visible in the UI rather than only at fit
-                // time.
-                ui.add_enabled(
-                    !state.fit_energy_scale,
-                    egui::Checkbox::new(
-                        &mut state.fit_temperature,
-                        "Fit temperature (slow for Spatial Map)",
-                    ),
+                // Fit temperature and Fit energy scale can be combined since
+                // issue #634 (the energy-scale model carries a fitted
+                // temperature column) — the joint (t\u{2080}, L_scale, T) fit
+                // is the standard resonance-thermometry workflow.
+                ui.checkbox(
+                    &mut state.fit_temperature,
+                    "Fit temperature (slow for Spatial Map)",
                 );
-                ui.add_enabled(
-                    !state.fit_temperature,
-                    egui::Checkbox::new(
-                        &mut state.fit_energy_scale,
-                        "Fit energy scale (TZERO t\u{2080} + L_scale, SAMMY equivalent)",
-                    ),
+                ui.checkbox(
+                    &mut state.fit_energy_scale,
+                    "Fit energy scale (TZERO t\u{2080} + L_scale, SAMMY equivalent)",
                 )
                 .on_hover_text(
                     "Adds the residual time-zero offset t\u{2080} (\u{03BC}s) \
@@ -274,8 +267,9 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState, available_height_hint: 
                  has already been subtracted when building the energy \
                  grid, and L_scale multiplies the configured Flight \
                  Path.  Optimiser bound: t\u{2080} \u{2208} \u{00B1}10 \
-                 \u{03BC}s, L_scale \u{2208} [0.99, 1.01].  Mutually \
-                 exclusive with Fit temperature.",
+                 \u{03BC}s, L_scale \u{2208} [0.99, 1.01].  Can be \
+                 combined with Fit temperature (issue #634) for joint \
+                 energy-scale + temperature thermometry.",
                 );
                 // SAMMY EMIN/EMAX-equivalent fit-energy-range restriction (#514).
                 // The checkbox toggles the `Option<(f64, f64)>` state field;
@@ -1144,13 +1138,11 @@ fn selected_pixel_fit_result_for_overlay(
         back_f: result.back_f_map.as_ref().map(|map| map[[y, x]]),
         t0_us: result.t0_us_map.as_ref().map(|map| map[[y, x]]),
         l_scale: result.l_scale_map.as_ref().map(|map| map[[y, x]]),
-        // The spatial fit was configured with the beamline flight path (see
-        // `build_fit_config`'s `with_energy_scale` call), so the overlay
-        // result carries the same value when the energy scale was fitted.
-        energy_scale_flight_path_m: result
-            .t0_us_map
-            .as_ref()
-            .map(|_| state.beamline.flight_path_m),
+        // Use the flight path RECORDED AT FIT TIME on the spatial result —
+        // not the live beamline setting, which the user may have edited
+        // since the fit (issue #634 review: a stale-state flight path would
+        // reopen the mismatch channel the stored field exists to close).
+        energy_scale_flight_path_m: result.energy_scale_flight_path_m,
         deviance_per_dof: result.deviance_per_dof_map.as_ref().map(|map| map[[y, x]]),
     })
 }
@@ -2230,9 +2222,8 @@ fn build_fit_config(state: &AppState) -> Result<(UnifiedFitConfig, Range<usize>)
     }
 
     // Energy-scale calibration: TZERO t₀ (μs) + flight-path L_scale
-    // (dimensionless) as free parameters.  Pipeline rejects the
-    // combination with fit_temperature; the UI grey-out should
-    // prevent that path.
+    // (dimensionless) as free parameters.  Composes with
+    // fit_temperature since issue #634 (joint thermometry fit).
     //
     // **Why `t0_init_us = 0.0`** (not `state.beamline.delay_us`):
     // `tof_edges_to_energy` (`nereids-io::tof`) already subtracts

--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -1144,6 +1144,13 @@ fn selected_pixel_fit_result_for_overlay(
         back_f: result.back_f_map.as_ref().map(|map| map[[y, x]]),
         t0_us: result.t0_us_map.as_ref().map(|map| map[[y, x]]),
         l_scale: result.l_scale_map.as_ref().map(|map| map[[y, x]]),
+        // The spatial fit was configured with the beamline flight path (see
+        // `build_fit_config`'s `with_energy_scale` call), so the overlay
+        // result carries the same value when the energy scale was fitted.
+        energy_scale_flight_path_m: result
+            .t0_us_map
+            .as_ref()
+            .map(|_| state.beamline.flight_path_m),
         deviance_per_dof: result.deviance_per_dof_map.as_ref().map(|map| map[[y, x]]),
     })
 }

--- a/apps/gui/src/project.rs
+++ b/apps/gui/src/project.rs
@@ -1120,6 +1120,7 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
             back_f: None,
             t0_us: None,
             l_scale: None,
+            energy_scale_flight_path_m: None,
             deviance_per_dof: None,
         };
         // Rebuild FitFeedback from the restored result

--- a/apps/gui/src/project.rs
+++ b/apps/gui/src/project.rs
@@ -1090,6 +1090,9 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
             // restore.  Re-running spatial_map_typed regenerates them.
             t0_us_map: None,
             l_scale_map: None,
+            // Snapshots don't persist the energy-scale flight path yet; the
+            // overlay accessor treats `None` as "energy scale not fitted".
+            energy_scale_flight_path_m: None,
             n_converged: snap.n_converged.unwrap_or(0),
             n_total: snap.n_total.unwrap_or(0),
             n_failed: snap.n_failed.unwrap_or(0),

--- a/apps/gui/src/state.rs
+++ b/apps/gui/src/state.rs
@@ -74,7 +74,7 @@ pub struct SessionCache {
     #[serde(default)]
     pub kl_enable_polish_override: Option<bool>,
     /// Fit energy-scale calibration (TZERO `t₀` + flight-path `L_scale`)
-    /// as free parameters.  Mutually exclusive with `fit_temperature`.
+    /// as free parameters.  Composes with `fit_temperature` (issue #634).
     #[serde(default)]
     pub fit_energy_scale: bool,
     /// Fit energy range restriction (SAMMY EMIN/EMAX equivalent).
@@ -734,9 +734,9 @@ pub struct AppState {
     pub solver_method: SolverMethod,
     pub fit_temperature: bool,
     /// Fit residual energy-scale calibration (TZERO `t₀` μs + flight-path
-    /// `L_scale`) as free parameters per SAMMY equivalent.  Mutually
-    /// exclusive with `fit_temperature` — pipeline returns a hard error
-    /// if both are set (`pipeline.rs` ~L977).
+    /// `L_scale`) as free parameters per SAMMY equivalent.  Composes with
+    /// `fit_temperature` since issue #634 — the energy-scale model carries
+    /// a fitted temperature column (joint thermometry).
     ///
     /// Initial values: `t₀ = 0.0` and `L_scale = 1.0` (identity seeds).
     /// The configured Delay has already been subtracted when the energy

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -159,6 +159,19 @@ class FitResult:
         """Fitted flight-path scale factor (SAMMY TZERO L0), or None."""
         ...
 
+    def corrected_energies(
+        self, nominal_energies: NDArray[np.float64], flight_path_m: float
+    ) -> NDArray[np.float64] | None:
+        """Map a nominal energy grid through the fitted ``(t0_us, l_scale)``
+        energy scale to the corrected (calibrated) energies the fit used
+        (issue #634), using the exact SAMMY −t0 convention.
+
+        Returns ``None`` when energy-scale fitting was not enabled; raises
+        ``ValueError`` on a degenerate calibration (t0 past the shortest
+        flight time).
+        """
+        ...
+
     @property
     def deviance_per_dof(self) -> float | None:
         """Conditional binomial deviance / (n - k) from the counts-KL

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -160,14 +160,16 @@ class FitResult:
         ...
 
     def corrected_energies(
-        self, nominal_energies: NDArray[np.float64], flight_path_m: float
+        self, nominal_energies: NDArray[np.float64]
     ) -> NDArray[np.float64] | None:
         """Map a nominal energy grid through the fitted ``(t0_us, l_scale)``
         energy scale to the corrected (calibrated) energies the fit used
-        (issue #634), using the exact SAMMY −t0 convention.
+        (issue #634), using the exact SAMMY −t0 convention and the SAME
+        flight path the fit was configured with (stored on the result).
 
         Returns ``None`` when energy-scale fitting was not enabled; raises
-        ``ValueError`` on a degenerate calibration (t0 past the shortest
+        ``ValueError`` on an invalid nominal grid (non-finite, non-positive,
+        or non-ascending) or a degenerate calibration (t0 past the shortest
         flight time).
         """
         ...

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -431,6 +431,10 @@ struct PyFitResult {
     /// Fitted flight-path scale factor (SAMMY TZERO L₀, dimensionless).
     /// None when energy-scale fitting is not enabled.
     l_scale: Option<f64>,
+    /// Nominal flight path (m) the energy-scale fit was configured with;
+    /// consumed by `corrected_energies` so the transform is reproduced with
+    /// the SAME flight path the fit used (issue #634).
+    energy_scale_flight_path_m: Option<f64>,
     /// Conditional binomial deviance / (n − k).  `Some(...)` only for the
     /// counts-KL dispatch (`solver="kl"` on counts input).
     deviance_per_dof: Option<f64>,
@@ -533,23 +537,27 @@ impl PyFitResult {
     /// Map a nominal energy grid through the fitted ``(t0_us, l_scale)`` energy
     /// scale to the corrected (calibrated) energies the fit evaluated the
     /// physics on (issue #634). Reuses the exact SAMMY-convention transform
-    /// (``dat/mdat0.f90:189``, −t0 sign) the fitter used, so the corrected
-    /// axis is never re-derived by hand (a +t0 slip caused a silent +400 K
-    /// temperature bias in the field).
+    /// (``dat/mdat0.f90:189``, −t0 sign) with the SAME flight path the fit
+    /// was configured with (stored on the result), so the corrected axis is
+    /// never re-derived by hand (a +t0 slip caused a silent +400 K
+    /// temperature bias in the field) and a mismatched caller-supplied
+    /// flight path cannot silently skew the t₀ term.
     ///
-    /// Returns ``None`` when energy-scale fitting was not enabled (``t0_us`` or
-    /// ``l_scale`` is ``None``). Raises ``ValueError`` on a degenerate
-    /// calibration (a ``t0`` past the shortest flight time on this grid).
-    #[pyo3(signature = (nominal_energies, flight_path_m))]
+    /// Returns ``None`` when energy-scale fitting was not enabled. Raises
+    /// ``ValueError`` on an invalid nominal grid (non-finite / non-positive /
+    /// non-ascending — the binding's standard energy-grid validation) or a
+    /// degenerate calibration (a ``t0`` past the shortest flight time).
+    #[pyo3(signature = (nominal_energies))]
     fn corrected_energies<'py>(
         &self,
         py: Python<'py>,
         nominal_energies: PyReadonlyArray1<'py, f64>,
-        flight_path_m: f64,
     ) -> PyResult<Option<Bound<'py, PyArray1<f64>>>> {
-        match (self.t0_us, self.l_scale) {
-            (Some(t0), Some(l_scale)) => {
+        match (self.t0_us, self.l_scale, self.energy_scale_flight_path_m) {
+            (Some(t0), Some(l_scale), Some(flight_path_m)) => {
                 let e = nominal_energies.as_slice()?;
+                require_non_empty_energy_grid(e)?;
+                validate_energy_grid(e)?;
                 let corr = nereids_fitting::resolution_calib::corrected_energy_grid(
                     e,
                     t0,
@@ -4279,6 +4287,7 @@ fn py_fit_counts_spectrum_typed<'py>(
         },
         t0_us: result.t0_us,
         l_scale: result.l_scale,
+        energy_scale_flight_path_m: result.energy_scale_flight_path_m,
         deviance_per_dof: result.deviance_per_dof,
     })
 }
@@ -4820,6 +4829,7 @@ fn py_fit_spectrum_typed<'py>(
         },
         t0_us: result.t0_us,
         l_scale: result.l_scale,
+        energy_scale_flight_path_m: result.energy_scale_flight_path_m,
         deviance_per_dof: result.deviance_per_dof,
     })
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -530,6 +530,39 @@ impl PyFitResult {
         self.l_scale
     }
 
+    /// Map a nominal energy grid through the fitted ``(t0_us, l_scale)`` energy
+    /// scale to the corrected (calibrated) energies the fit evaluated the
+    /// physics on (issue #634). Reuses the exact SAMMY-convention transform
+    /// (``dat/mdat0.f90:189``, −t0 sign) the fitter used, so the corrected
+    /// axis is never re-derived by hand (a +t0 slip caused a silent +400 K
+    /// temperature bias in the field).
+    ///
+    /// Returns ``None`` when energy-scale fitting was not enabled (``t0_us`` or
+    /// ``l_scale`` is ``None``). Raises ``ValueError`` on a degenerate
+    /// calibration (a ``t0`` past the shortest flight time on this grid).
+    #[pyo3(signature = (nominal_energies, flight_path_m))]
+    fn corrected_energies<'py>(
+        &self,
+        py: Python<'py>,
+        nominal_energies: PyReadonlyArray1<'py, f64>,
+        flight_path_m: f64,
+    ) -> PyResult<Option<Bound<'py, PyArray1<f64>>>> {
+        match (self.t0_us, self.l_scale) {
+            (Some(t0), Some(l_scale)) => {
+                let e = nominal_energies.as_slice()?;
+                let corr = nereids_fitting::resolution_calib::corrected_energy_grid(
+                    e,
+                    t0,
+                    l_scale,
+                    flight_path_m,
+                )
+                .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
+                Ok(Some(PyArray1::from_vec(py, corr)))
+            }
+            _ => Ok(None),
+        }
+    }
+
     /// Conditional binomial deviance divided by (n − k) from the counts-KL
     /// dispatch (joint-Poisson profile-deviance fitter).
     ///

--- a/crates/nereids-endf/src/resonance.rs
+++ b/crates/nereids-endf/src/resonance.rs
@@ -1104,6 +1104,36 @@ pub mod test_support {
         )
     }
 
+    /// U-238 with three well-separated s-wave resonances (6.674, 20.87,
+    /// 36.68 eV), Reich-Moore.  Multiple dips at different energies break the
+    /// (t0, L_scale) degeneracy that a single resonance leaves — a single dip
+    /// cannot separate a TOF offset from a flight-path scale.  Used by the
+    /// energy-scale calibration and joint temperature-recovery tests (#634),
+    /// mirroring the Python `TestFitEnergyScaleRecovery` fixture.
+    pub fn u238_three_resonances() -> ResonanceData {
+        wrap(
+            92,
+            238,
+            236.006,
+            make_range(
+                1e-6,
+                1e5,
+                ResonanceFormalism::ReichMoore,
+                0.0,
+                9.4285,
+                1,
+                0,
+                236.006,
+                0.0,
+                vec![
+                    res(6.674, 0.5, 1.493e-3, 23.0e-3),
+                    res(20.87, 0.5, 10.3e-3, 26.0e-3),
+                    res(36.68, 0.5, 34.4e-3, 27.0e-3),
+                ],
+            ),
+        )
+    }
+
     /// Fully-parameterized U-238 ZA single-resonance, Reich-Moore.  For the
     /// RM-harness tests that vary (E_r, Γn, Γγ, J, L, AWR, I, AP) per case.
     pub fn single_resonance(p: SingleResonanceParams) -> ResonanceData {

--- a/crates/nereids-endf/src/resonance.rs
+++ b/crates/nereids-endf/src/resonance.rs
@@ -1108,8 +1108,9 @@ pub mod test_support {
     /// 36.68 eV), Reich-Moore.  Multiple dips at different energies break the
     /// (t0, L_scale) degeneracy that a single resonance leaves — a single dip
     /// cannot separate a TOF offset from a flight-path scale.  Used by the
-    /// energy-scale calibration and joint temperature-recovery tests (#634),
-    /// mirroring the Python `TestFitEnergyScaleRecovery` fixture.
+    /// energy-scale calibration and joint temperature-recovery tests (#634);
+    /// analogous to (not numerically identical with) the Python
+    /// `TestFitEnergyScaleRecovery` fixture.
     pub fn u238_three_resonances() -> ResonanceData {
         wrap(
             92,

--- a/crates/nereids-fitting/src/resolution_calib.rs
+++ b/crates/nereids-fitting/src/resolution_calib.rs
@@ -127,6 +127,17 @@ pub fn corrected_energy_grid(
              got {flight_path_m}"
         )));
     }
+    // Per-bin grid validation runs BEFORE the identity shortcut so the
+    // Ok/Err contract is uniform: previously (t0=0, l_scale=1) returned a
+    // NaN/non-positive grid verbatim while any other transform rejected the
+    // same grid via the denominator guard (#634 review).
+    for (i, &e) in energies.iter().enumerate() {
+        if !e.is_finite() || e <= 0.0 {
+            return Err(FittingError::EvaluationFailed(format!(
+                "corrected_energy_grid: energies[{i}] must be finite and positive, got {e}"
+            )));
+        }
+    }
     if t0_us == 0.0 && l_scale == 1.0 {
         return Ok(energies.to_vec());
     }

--- a/crates/nereids-fitting/src/resolution_calib.rs
+++ b/crates/nereids-fitting/src/resolution_calib.rs
@@ -101,6 +101,32 @@ pub fn corrected_energy_grid(
     l_scale: f64,
     flight_path_m: f64,
 ) -> Result<Vec<f64>, FittingError> {
+    // Validate scale inputs up front (issue #634 review): the transform is
+    // EVEN in `l_scale` (`(kl·l_scale/denom)²`), so a negative `l_scale`
+    // would silently return the identical plausible grid as its positive
+    // counterpart, a NaN `l_scale` would pass the denominator-only guard and
+    // return `Ok(vec![NaN])` ("NaN bypasses guards"), and
+    // `flight_path_m = 0` with a negative fitted `t0` would return an
+    // all-zeros grid as `Ok`.  Matches the sibling fit entry points'
+    // `validate_energy_scale_params` rejection (issue #458) — this is the
+    // canonical public transform, so it must not hand back plausible
+    // garbage for invalid inputs.
+    if !t0_us.is_finite() {
+        return Err(FittingError::EvaluationFailed(format!(
+            "corrected_energy_grid: t0_us must be finite, got {t0_us}"
+        )));
+    }
+    if !l_scale.is_finite() || l_scale <= 0.0 {
+        return Err(FittingError::EvaluationFailed(format!(
+            "corrected_energy_grid: l_scale must be finite and positive, got {l_scale}"
+        )));
+    }
+    if !flight_path_m.is_finite() || flight_path_m <= 0.0 {
+        return Err(FittingError::EvaluationFailed(format!(
+            "corrected_energy_grid: flight_path_m must be finite and positive, \
+             got {flight_path_m}"
+        )));
+    }
     if t0_us == 0.0 && l_scale == 1.0 {
         return Ok(energies.to_vec());
     }

--- a/crates/nereids-fitting/src/resolution_calib.rs
+++ b/crates/nereids-fitting/src/resolution_calib.rs
@@ -130,7 +130,14 @@ pub fn corrected_energy_grid(
     // Per-bin grid validation runs BEFORE the identity shortcut so the
     // Ok/Err contract is uniform: previously (t0=0, l_scale=1) returned a
     // NaN/non-positive grid verbatim while any other transform rejected the
-    // same grid via the denominator guard (#634 review).
+    // same grid via the denominator guard (#634 review).  Empty grids are
+    // rejected for the same uniformity (the Python binding already errors
+    // on them; a per-bin loop is vacuous on an empty slice).
+    if energies.is_empty() {
+        return Err(FittingError::EvaluationFailed(
+            "corrected_energy_grid: energies must not be empty".into(),
+        ));
+    }
     for (i, &e) in energies.iter().enumerate() {
         if !e.is_finite() || e <= 0.0 {
             return Err(FittingError::EvaluationFailed(format!(

--- a/crates/nereids-fitting/src/resolution_calib.rs
+++ b/crates/nereids-fitting/src/resolution_calib.rs
@@ -144,6 +144,17 @@ pub fn corrected_energy_grid(
                 "corrected_energy_grid: energies[{i}] must be finite and positive, got {e}"
             )));
         }
+        // Strict ascending order, matching the Python binding's standard
+        // energy-grid validation (issue #634 review): a non-monotone input
+        // would otherwise map to a plausible but non-monotone corrected axis.
+        if i > 0 && e <= energies[i - 1] {
+            return Err(FittingError::EvaluationFailed(format!(
+                "corrected_energy_grid: energies must be strictly ascending; \
+                 energies[{i}] = {e} <= energies[{}] = {}",
+                i - 1,
+                energies[i - 1],
+            )));
+        }
     }
     if t0_us == 0.0 && l_scale == 1.0 {
         return Ok(energies.to_vec());

--- a/crates/nereids-fitting/src/resolution_calib.rs
+++ b/crates/nereids-fitting/src/resolution_calib.rs
@@ -86,11 +86,16 @@ const POSITION_L_SCALE_MAX: f64 = 1.02;
 /// opposite to the `+t0` form used by the retired position nuisance. Errors if any
 /// corrected TOF `tof − t0 ≤ 0` (a `t0` past the shortest flight time).
 ///
-/// `pub(crate)` so the equivalence to the runtime
-/// [`EnergyScaleTransmissionModel::corrected_energies`] is *pinned by a test*
-/// (`corrected_energy_grid_matches_energy_scale_model`) rather than only asserted
-/// in prose — a future edit to either convention then fails fast.
-pub(crate) fn corrected_energy_grid(
+/// SAMMY reference for the `−t0` sign convention: `dat/mdat0.f90:189`
+/// (`etzero = ee*(Elzero/(1−Tzero·√ee/Tttzzz))²`) — the measured TOF has TZERO
+/// subtracted before the energy conversion, so a positive `t0` raises the
+/// corrected energy. This is the canonical NEREIDS implementation of the
+/// formula; the runtime
+/// `EnergyScaleTransmissionModel::corrected_energies` is pinned bit-for-bit
+/// to it by `corrected_energy_grid_matches_energy_scale_model`, and
+/// `SpectrumFitResult::corrected_energies` (issue #634) reuses it so callers
+/// never re-derive the transform (a `+t0` slip caused a silent +400 K bias).
+pub fn corrected_energy_grid(
     energies: &[f64],
     t0_us: f64,
     l_scale: f64,

--- a/crates/nereids-fitting/src/transmission_model.rs
+++ b/crates/nereids-fitting/src/transmission_model.rs
@@ -1667,7 +1667,25 @@ pub struct EnergyScaleTransmissionModel {
     /// thickness is `params[density_indices[i]] * density_ratios[i]`.
     density_ratios: Arc<Vec<f64>>,
     /// Sample temperature (K) for Doppler broadening at the corrected energies.
+    /// Used as the fixed temperature when `temperature_index` is `None`, and as
+    /// the fallback / initial value otherwise.
     temperature_k: f64,
+    /// If `Some(idx)`, `params[idx]` is the sample temperature (K) fitted as a
+    /// free parameter jointly with the energy scale (issue #634); σ is rebuilt
+    /// at that T on each evaluate. `None` ⇒ the fixed `temperature_k` is used.
+    /// Mirrors `PrecomputedTransmissionModel::temperature_index`.
+    ///
+    /// The temperature Jacobian column is computed by central finite
+    /// difference (like this model's t0 column), not by the analytic ∂σ/∂T
+    /// that the fixed-grid `PrecomputedTransmissionModel` uses. The forward σ
+    /// stays exact — FD only sets the descent direction / covariance, and it
+    /// is validated against the analytic column to `<1e-4` relative. Porting
+    /// analytic ∂σ/∂T here is a deliberate FUTURE optimization: it is
+    /// evaluated on the *corrected* grid (which moves with t0/L_scale), so it
+    /// would need a new physics helper plus a third `(t0,L_scale,T)`-keyed
+    /// derivative cache — not worth it until profiling shows the FD probes
+    /// dominate.
+    temperature_index: Option<usize>,
     /// Nominal energy grid (eV, ascending).
     nominal_energies: Vec<f64>,
     /// Flight path length in meters (used for TOF↔energy conversion).
@@ -1718,10 +1736,12 @@ pub struct EnergyScaleTransmissionModel {
     jacobian_method: EnergyScaleJacobianMethod,
 }
 
-/// Capacity-1 working-grid σ cache entry, keyed on `(t0_bits, l_scale_bits)`.
-/// Named alias to keep the field type within clippy's `type_complexity` budget
-/// (issue #608).
-type CachedWorkXs = Option<((u64, u64), Rc<transmission::WorkingGridXs>)>;
+/// Capacity-1 working-grid σ cache entry, keyed on
+/// `(t0_bits, l_scale_bits, temperature_bits)` — the temperature bits (issue
+/// #634) keep a T-only perturbation (same t0/L_scale) from incorrectly hitting
+/// a σ built at the base temperature. Named alias to keep the field type within
+/// clippy's `type_complexity` budget (issue #608).
+type CachedWorkXs = Option<((u64, u64, u64), Rc<transmission::WorkingGridXs>)>;
 
 /// One `(t0_bits, l_scale_bits)` → `ResolutionPlan` entry.  Named
 /// struct to keep the cache field type within clippy's
@@ -1895,6 +1915,9 @@ impl EnergyScaleTransmissionModel {
             density_indices,
             density_ratios,
             temperature_k,
+            // Default: temperature fixed. `with_temperature_index` opts into
+            // joint temperature fitting (issue #634).
+            temperature_index: None,
             nominal_energies,
             flight_path_m,
             tof_factor,
@@ -1913,6 +1936,25 @@ impl EnergyScaleTransmissionModel {
     pub fn with_jacobian_method(mut self, method: EnergyScaleJacobianMethod) -> Self {
         self.jacobian_method = method;
         self
+    }
+
+    /// Fit the sample temperature jointly with the energy scale (issue #634).
+    /// `Some(idx)` makes `params[idx]` the free temperature (K); `None` keeps
+    /// temperature fixed at the constructor's `temperature_k`.
+    #[must_use]
+    pub fn with_temperature_index(mut self, temperature_index: Option<usize>) -> Self {
+        self.temperature_index = temperature_index;
+        self
+    }
+
+    /// Sample temperature (K) for the current parameter vector: the fitted
+    /// `params[temperature_index]` when temperature is free, else the fixed
+    /// `temperature_k`. Mirrors `PrecomputedTransmissionModel`.
+    fn temperature_for(&self, params: &[f64]) -> f64 {
+        match self.temperature_index {
+            Some(idx) => params[idx],
+            None => self.temperature_k,
+        }
     }
 
     /// Build or reuse the broadening plan for the current `(t0, L_scale)`
@@ -2025,7 +2067,11 @@ impl EnergyScaleTransmissionModel {
     /// the only way to reproduce SAMMY's σ(E_corr) under the energy-scale shift
     /// (boundary + fine-structure fidelity).  For tabulated / no resolution the
     /// working grid is `e_corr` itself with an identity layout.
-    fn working_xs(&self, e_corr: &[f64]) -> Result<transmission::WorkingGridXs, FittingError> {
+    fn working_xs(
+        &self,
+        e_corr: &[f64],
+        temperature_k: f64,
+    ) -> Result<transmission::WorkingGridXs, FittingError> {
         // Issue #608: a degenerate calibration can drive corrected energies to
         // 0 (l_scale → 0) or non-finite (l_scale → ∞).  `reich_moore` asserts
         // positive finite energy (an always-on `assert!`), so without this guard
@@ -2050,7 +2096,7 @@ impl EnergyScaleTransmissionModel {
         transmission::broadened_cross_sections_on_working_grid(
             e_corr,
             &self.resonance_data,
-            self.temperature_k,
+            temperature_k,
             self.instrument.as_deref(),
             None,
         )
@@ -2067,9 +2113,11 @@ impl EnergyScaleTransmissionModel {
         params: &[f64],
         e_corr: &[f64],
     ) -> Result<Rc<transmission::WorkingGridXs>, FittingError> {
+        let temperature_k = self.temperature_for(params);
         let key = (
             params[self.t0_index].to_bits(),
             params[self.l_scale_index].to_bits(),
+            temperature_k.to_bits(),
         );
         let hit = self
             .cached_work_xs
@@ -2079,7 +2127,7 @@ impl EnergyScaleTransmissionModel {
         if let Some(xs) = hit {
             return Ok(xs);
         }
-        let xs = Rc::new(self.working_xs(e_corr)?);
+        let xs = Rc::new(self.working_xs(e_corr, temperature_k)?);
         *self.cached_work_xs.borrow_mut() = Some((key, Rc::clone(&xs)));
         Ok(xs)
     }
@@ -2306,7 +2354,13 @@ impl FitModel for EnergyScaleTransmissionModel {
         let density_plan = self.cached_resolution_plan(t0, l_scale, work_e);
 
         for (col, &fp_idx) in free_param_indices.iter().enumerate() {
-            if fp_idx == self.t0_index || fp_idx == self.l_scale_index {
+            // Temperature (issue #634), when free, is differentiated by the
+            // per-coordinate central FD arm below — it is neither t0 nor
+            // L_scale, so the PartialGal block never fires for it. Perturbing
+            // T changes σ (via `working_xs` at the T-widened cache key) but not
+            // the corrected grid, so its ±h probes share `e_corr`.
+            let is_temperature = Some(fp_idx) == self.temperature_index;
+            if fp_idx == self.t0_index || fp_idx == self.l_scale_index || is_temperature {
                 // partial-GAL: when both t0 and L_scale are free, the t0
                 // column comes from a single pre-computed FD pair (above),
                 // and the L_scale column is the per-bin rank-1 derivation
@@ -2382,7 +2436,20 @@ impl FitModel for EnergyScaleTransmissionModel {
                 // use the cache for the many-uses-per-probe callers
                 // (KL solver's deviance + gradient + Fisher at the
                 // current probe).  Issue #483 A1.
-                let h = if fp_idx == self.t0_index { 1e-4 } else { 1e-7 };
+                // FD step per coordinate: t0 in μs → absolute 1e-4; L_scale
+                // dimensionless → absolute 1e-7; temperature in K → a RELATIVE
+                // step (1e-4·T, i.e. ~0.03 K at 300 K, matching L_scale's
+                // relative scale) since T is O(300 K) and an absolute 1e-7 K
+                // would be pure round-off. Central differences make the
+                // truncation error O((h/T)²) ~ 1e-9, far below the analytic
+                // column it is validated against (see the FD-vs-analytic test).
+                let h = if fp_idx == self.t0_index {
+                    1e-4
+                } else if is_temperature {
+                    1e-4 * params[fp_idx].max(1.0)
+                } else {
+                    1e-7
+                };
                 let mut p_plus = params.to_vec();
                 let mut p_minus = params.to_vec();
                 p_plus[fp_idx] += h;
@@ -4806,6 +4873,94 @@ mod tests {
             err_old > 1e-4 && err_old > 1e4 * err_fixed.max(1e-15),
             "old coarse-grid path should differ from forward_model far more than \
              the fixed path (old={err_old:.3e}, fixed={err_fixed:.3e})"
+        );
+    }
+
+    /// Issue #634: the energy-scale model's FINITE-DIFFERENCE temperature
+    /// column must match the ANALYTIC ∂σ/∂T column that the fixed-grid
+    /// `TransmissionFitModel` produces on the SAME corrected grid, to <1e-4
+    /// relative. This validates the FD choice (correct index, sign, magnitude)
+    /// against the exact analytic derivative the non-energy-scale path uses.
+    /// The non-zero assertions guard against a silently mis-wired T index
+    /// (which would yield a zero column a loose recovery test could miss).
+    #[test]
+    fn energy_scale_temperature_jacobian_matches_analytic() {
+        let data = u238_single_resonance();
+        let energies: Vec<f64> = (0..401).map(|i| 4.0 + (i as f64) * 0.015).collect();
+        let temperature = 320.0;
+        let density = 0.0006;
+        // Non-trivial energy scale so the corrected grid differs from nominal.
+        let t0 = 0.7_f64;
+        let l_scale = 1.004_f64;
+        let flight_path = 25.0;
+
+        // Param layout mirrors the pipeline: [density, temperature, t0, l_scale]
+        // (temperature appended before the energy-scale params).
+        let (d_idx, t_idx, t0_idx, ls_idx) = (0usize, 1usize, 2usize, 3usize);
+        let params = [density, temperature, t0, l_scale];
+
+        // Energy-scale model with temperature fitting (FD T column). No
+        // resolution keeps the corrected-grid physics identical to the oracle.
+        let es = EnergyScaleTransmissionModel::new(
+            Arc::new(vec![data.clone()]),
+            Arc::new(vec![d_idx]),
+            Arc::new(vec![1.0]),
+            temperature,
+            energies.clone(),
+            flight_path,
+            t0_idx,
+            ls_idx,
+            None,
+        )
+        .with_temperature_index(Some(t_idx));
+
+        let free = [d_idx, t_idx, t0_idx, ls_idx];
+        let y = es.evaluate(&params).unwrap();
+        let jac = es
+            .analytical_jacobian(&params, &free, &y)
+            .expect("energy-scale jacobian available");
+        let t_col_fd: Vec<f64> = (0..energies.len()).map(|i| jac.get(i, 1)).collect();
+
+        // Analytic oracle: TransmissionFitModel on the SAME corrected grid.
+        let e_corr = es.corrected_energies(t0, l_scale);
+        let oracle = TransmissionFitModel::new(
+            e_corr,
+            vec![data],
+            temperature,
+            None,
+            (vec![d_idx], vec![1.0]),
+            Some(t_idx),
+            None,
+        )
+        .unwrap();
+        // Oracle params: [density, temperature] (no t0/l_scale); T at index 1.
+        let oracle_params = [density, temperature];
+        let y_o = oracle.evaluate(&oracle_params).unwrap();
+        let jac_o = oracle
+            .analytical_jacobian(&oracle_params, &[d_idx, t_idx], &y_o)
+            .expect("oracle analytic jacobian available");
+        let t_col_an: Vec<f64> = (0..energies.len()).map(|i| jac_o.get(i, 1)).collect();
+
+        let mut scale = 0.0f64;
+        let mut max_err = 0.0f64;
+        for i in 0..energies.len() {
+            scale = scale.max(t_col_an[i].abs());
+            max_err = max_err.max((t_col_fd[i] - t_col_an[i]).abs());
+        }
+        assert!(
+            scale > 1e-6,
+            "analytic T column must be non-trivially non-zero (scale {scale:.3e})"
+        );
+        let fd_scale = t_col_fd.iter().fold(0.0f64, |a, &v| a.max(v.abs()));
+        assert!(
+            fd_scale > 1e-6,
+            "FD T column must be non-zero — a mis-wired T index gives a silent zero"
+        );
+        let rel = max_err / scale;
+        assert!(
+            rel < 1e-4,
+            "energy-scale FD ∂T/∂temperature must match the analytic column to \
+             <1e-4 relative, got {rel:.3e}"
         );
     }
 

--- a/crates/nereids-fitting/src/transmission_model.rs
+++ b/crates/nereids-fitting/src/transmission_model.rs
@@ -2072,6 +2072,20 @@ impl EnergyScaleTransmissionModel {
         e_corr: &[f64],
         temperature_k: f64,
     ) -> Result<transmission::WorkingGridXs, FittingError> {
+        // Issue #634 review: validate the (possibly fitted) temperature at
+        // the point of consumption, mirroring
+        // `PrecomputedTransmissionModel::evaluate`.  Without this, a NaN or
+        // negative `params[temperature_index]` flows into
+        // `broadened_cross_sections_on_working_grid`, whose
+        // `temperature_k > 0.0` branch silently SKIPS Doppler broadening and
+        // returns plausible unbroadened σ as `Ok` ("NaN bypasses guards").
+        // The production fitter bounds T ∈ [1, 5000] K, so this guard fires
+        // only for direct model API misuse — but the model is public.
+        if !temperature_k.is_finite() || temperature_k < 0.0 {
+            return Err(FittingError::EvaluationFailed(format!(
+                "temperature must be finite and non-negative, got {temperature_k}"
+            )));
+        }
         // Issue #608: a degenerate calibration can drive corrected energies to
         // 0 (l_scale → 0) or non-finite (l_scale → ∞).  `reich_moore` asserts
         // positive finite energy (an always-on `assert!`), so without this guard

--- a/crates/nereids-fitting/src/transmission_model.rs
+++ b/crates/nereids-fitting/src/transmission_model.rs
@@ -1941,16 +1941,41 @@ impl EnergyScaleTransmissionModel {
     /// Fit the sample temperature jointly with the energy scale (issue #634).
     /// `Some(idx)` makes `params[idx]` the free temperature (K); `None` keeps
     /// temperature fixed at the constructor's `temperature_k`.
-    #[must_use]
-    pub fn with_temperature_index(mut self, temperature_index: Option<usize>) -> Self {
+    ///
+    /// # Errors
+    /// `FittingError::InvalidConfig` if `Some(idx)` collides with `t0_index`,
+    /// `l_scale_index`, or any density index — a mis-wired index would
+    /// otherwise Doppler-broaden at a nonsense "temperature" (e.g. the t0
+    /// value) with no error.  Mirrors `TransmissionFitModel::new`'s
+    /// density-overlap rejection (issue #634 review, sibling-parity class).
+    pub fn with_temperature_index(
+        mut self,
+        temperature_index: Option<usize>,
+    ) -> Result<Self, FittingError> {
+        if let Some(idx) = temperature_index
+            && (idx == self.t0_index
+                || idx == self.l_scale_index
+                || self.density_indices.contains(&idx))
+        {
+            return Err(FittingError::InvalidConfig(format!(
+                "temperature_index {idx} must not overlap t0_index \
+                 ({}), l_scale_index ({}), or the density indices",
+                self.t0_index, self.l_scale_index,
+            )));
+        }
         self.temperature_index = temperature_index;
-        self
+        Ok(self)
     }
 
     /// Sample temperature (K) for the current parameter vector: the fitted
     /// `params[temperature_index]` when temperature is free, else the fixed
     /// `temperature_k`. Mirrors `PrecomputedTransmissionModel`.
     fn temperature_for(&self, params: &[f64]) -> f64 {
+        debug_assert!(
+            self.temperature_index.is_none_or(|i| i < params.len()),
+            "temperature_index out of bounds for params (len={})",
+            params.len()
+        );
         match self.temperature_index {
             Some(idx) => params[idx],
             None => self.temperature_k,
@@ -4926,7 +4951,8 @@ mod tests {
             ls_idx,
             None,
         )
-        .with_temperature_index(Some(t_idx));
+        .with_temperature_index(Some(t_idx))
+        .expect("distinct temperature index");
 
         let free = [d_idx, t_idx, t0_idx, ls_idx];
         let y = es.evaluate(&params).unwrap();

--- a/crates/nereids-pipeline/src/calibration.rs
+++ b/crates/nereids-pipeline/src/calibration.rs
@@ -438,6 +438,16 @@ pub fn calibrate_energy(
             "assumed_flight_path_m must be finite and positive, got {assumed_flight_path_m}",
         )));
     }
+    // Reject an invalid temperature at the entry (issue #634 review): the
+    // sibling `UnifiedFitConfig::new` validates it, and without this guard a
+    // NaN/negative temperature is only caught deep inside the repeated
+    // search/LM stages (or silently converted to an all-INFINITY chi²).
+    if !temperature_k.is_finite() || temperature_k < 0.0 {
+        return Err(PipelineError::InvalidParameter(format!(
+            "calibrate_energy: temperature_k must be finite and non-negative, \
+             got {temperature_k}",
+        )));
+    }
     for (i, &e) in energies_nominal.iter().enumerate() {
         if !e.is_finite() || e <= 0.0 {
             return Err(PipelineError::InvalidParameter(format!(
@@ -516,9 +526,10 @@ pub fn calibrate_energy(
 
     // ── Local helpers ────────────────────────────────────────────────────
     // `run_lm`: one LM energy-scale fit on `grid`, cold-seeded at
-    // `(t0, L_scale) = (0, 1)` (the peak-match seed inside the fitter
-    // improves on that when it can), with the grouped density either free
-    // or frozen (#633) at `d_init`.
+    // `(t0, L_scale) = (0, 1)` — the fitters' internal peak-match seed is
+    // deliberately DISABLED for these fits (see the
+    // `with_energy_scale_seed(false)` call and its rationale below) — with
+    // the grouped density either free or frozen (#633) at `d_init`.
     let run_lm = |grid: &[f64],
                   d_init: f64,
                   freeze_density: bool|
@@ -616,7 +627,16 @@ pub fn calibrate_energy(
     let mut t0_tot = 0.0_f64;
     let mut ls_tot = 1.0_f64;
     let mut anchor_n = n_seed;
-    let mut anchor_chi2 = seed_chi2;
+    // NaN-safe latch init (issue #634 review): a NaN identity chi² would
+    // make every `chi2_c < anchor_chi2` comparison false and silently
+    // discard the whole joint scan — the same NaN-latch pattern the winner
+    // latch below is hardened against.  The old grid was immune
+    // (`best_chi2 = INFINITY` with no privileged identity candidate).
+    let mut anchor_chi2 = if seed_chi2.is_finite() {
+        seed_chi2
+    } else {
+        f64::INFINITY
+    };
     for i_l in -3..=3_i32 {
         let ls = 1.0 + f64::from(i_l) * 0.005;
         for i_t in 0..=6_i32 {

--- a/crates/nereids-pipeline/src/calibration.rs
+++ b/crates/nereids-pipeline/src/calibration.rs
@@ -19,6 +19,7 @@ use nereids_core::types::IsotopeGroup;
 use nereids_endf::resonance::ResonanceData;
 use nereids_fitting::lm::LmConfig;
 use nereids_fitting::resolution_calib::corrected_energy_grid;
+use nereids_physics::resolution::TOF_FACTOR;
 use nereids_physics::transmission::{self, InstrumentParams, SampleParams};
 
 use crate::error::PipelineError;
@@ -148,6 +149,143 @@ where
     }
 }
 
+/// Plateau-robust dip-position anchor (issue #634 review P0).
+///
+/// The dip POSITIONS carry the complete (t₀, L_scale) information: with the
+/// resonance energies known, matching each measured dip to its resonance and
+/// solving the 2-parameter affine TOF map `u_dip = t₀ + L_scale · u_res` by
+/// least squares recovers the energy scale directly — no grid search.  This
+/// is the same idea as the fitters' peak-match seed, with one critical
+/// difference: dip positions are the depth-weighted centres of contiguous
+/// below-threshold RUNS, so saturated flat-bottomed dips (transmission ≈ 0
+/// over several bins — the SoftwareX foil regime), which fail the strict
+/// local-minimum test of `detect_transmission_dips`, are located robustly.
+///
+/// Used as one CANDIDATE for the stage-2 anchor (scored by the same exact
+/// golden-section density as the lattice candidates); the coarse lattice
+/// remains the fallback when fewer than two dips are detectable.  Restricted
+/// to the plausible window (|t₀| ≤ 10 µs, L_scale ∈ [0.98, 1.02]) — wider
+/// offsets are out of this function's documented band.
+fn dip_match_anchor(
+    energies_nominal: &[f64],
+    transmission: &[f64],
+    valid: &[bool],
+    isotopes: &[ResonanceData],
+    abundances: &[f64],
+    assumed_flight_path_m: f64,
+) -> Option<(f64, f64)> {
+    let n = energies_nominal.len();
+    // Baseline = 90th percentile of valid transmission; depth threshold at
+    // 25 % of the maximum depth (matches the fitters' seed conventions).
+    let mut vals: Vec<f64> = transmission
+        .iter()
+        .zip(valid.iter())
+        .filter(|&(_, &v)| v)
+        .map(|(&t, _)| t)
+        .collect();
+    if vals.len() < 5 {
+        return None;
+    }
+    vals.sort_by(f64::total_cmp);
+    let baseline = vals[(vals.len() * 9) / 10];
+    let max_depth = baseline - vals[0];
+    if !(max_depth.is_finite() && max_depth > 1e-6) {
+        return None;
+    }
+    let threshold = baseline - 0.25 * max_depth;
+
+    // Depth-weighted centre of each contiguous below-threshold run.
+    let mut dips: Vec<f64> = Vec::new();
+    let mut i = 0;
+    while i < n {
+        if valid[i] && transmission[i] < threshold {
+            let mut wsum = 0.0_f64;
+            let mut ewsum = 0.0_f64;
+            while i < n && valid[i] && transmission[i] < threshold {
+                let w = (baseline - transmission[i]).max(0.0);
+                wsum += w;
+                ewsum += w * energies_nominal[i];
+                i += 1;
+            }
+            if wsum > 0.0 {
+                dips.push(ewsum / wsum);
+            }
+        } else {
+            i += 1;
+        }
+    }
+    if dips.len() < 2 {
+        return None;
+    }
+
+    // Resonance energies of contributing isotopes inside the window.
+    let e_lo = energies_nominal[0];
+    let e_hi = energies_nominal[n - 1];
+    let mut res_e: Vec<f64> = Vec::new();
+    for (rd, &abd) in isotopes.iter().zip(abundances.iter()) {
+        if abd <= 0.0 {
+            continue;
+        }
+        for range in &rd.ranges {
+            for lg in &range.l_groups {
+                for r in &lg.resonances {
+                    if r.energy > e_lo && r.energy < e_hi {
+                        res_e.push(r.energy);
+                    }
+                }
+            }
+        }
+    }
+    res_e.sort_by(f64::total_cmp);
+    res_e.dedup_by(|a, b| (*a - *b).abs() < 1e-9);
+    if res_e.len() < 2 {
+        return None;
+    }
+
+    // Match each resonance to its nearest dip within half the minimum
+    // resonance spacing (floored at twice the grid resolution).
+    let min_spacing = res_e
+        .windows(2)
+        .map(|w| w[1] - w[0])
+        .fold(f64::INFINITY, f64::min);
+    let grid_res = (e_hi - e_lo) / (n as f64 - 1.0);
+    let tol = (0.5 * min_spacing).max(2.0 * grid_res);
+    let kl = TOF_FACTOR * assumed_flight_path_m;
+    let mut pairs: Vec<(f64, f64)> = Vec::new(); // (u_dip, u_res) in µs
+    for &er in &res_e {
+        let mut best: Option<f64> = None;
+        for &d in &dips {
+            let dist = (d - er).abs();
+            if dist < tol && best.is_none_or(|b: f64| dist < (b - er).abs()) {
+                best = Some(d);
+            }
+        }
+        if let Some(d) = best {
+            pairs.push((kl / d.sqrt(), kl / er.sqrt()));
+        }
+    }
+    if pairs.len() < 2 {
+        return None;
+    }
+
+    // Least squares for u_dip = t0 + ls · u_res.
+    let m = pairs.len() as f64;
+    let su: f64 = pairs.iter().map(|p| p.0).sum();
+    let sv: f64 = pairs.iter().map(|p| p.1).sum();
+    let svv: f64 = pairs.iter().map(|p| p.1 * p.1).sum();
+    let suv: f64 = pairs.iter().map(|p| p.0 * p.1).sum();
+    let sxx = svv - sv * sv / m;
+    if !(sxx.is_finite() && sxx > 0.0) {
+        return None;
+    }
+    let ls = (suv - su * sv / m) / sxx;
+    let t0 = (su - ls * sv) / m;
+    if !(t0.is_finite() && ls.is_finite()) || t0.abs() > 10.0 || !(0.98..=1.02).contains(&ls) {
+        return None;
+    }
+    Some((t0, ls))
+}
+
 /// Result of energy calibration.
 #[derive(Debug, Clone)]
 pub struct CalibrationResult {
@@ -174,24 +312,39 @@ pub struct CalibrationResult {
 /// Issue #634: the former three-phase `(L, t₀)` grid scan — ~900 (L, t₀)
 /// candidates × a ~25-evaluation golden-section density search each,
 /// i.e. ~35 000 forward evaluations, >10 min on production windows — is
-/// replaced by the
-/// **`fit_energy_scale` Levenberg–Marquardt path** — the same
-/// peak-match-seeded machinery `fit_spectrum_typed` uses — which solves
-/// the identical 3-parameter `(t₀, L_scale, n_total)` problem in seconds.
+/// replaced by a staged global-then-local search built on the
+/// **`fit_energy_scale` Levenberg–Marquardt path**:
 ///
-/// The density `n_total` (total areal density, atoms/barn) is seeded by a
-/// **golden-section search in `log10(n)` space** over the documented
-/// user-supported interval `[1e-5, 1e-2]` atoms/barn, evaluated once at
-/// the identity energy scale; the LM then refines all three parameters
-/// jointly (density fitted as a single grouped parameter with the
-/// normalised abundances as fixed ratios).  Searching the seed in log
-/// space gives uniform relative resolution across the three-decade band
-/// (~1e-5 trace samples to ~1e-2 for 1 mm metal foils).
+/// 1. a coarse joint `(t₀, L_scale)` scan (7 × 7 candidates, each with an
+///    exact golden-section density in `log10(n)` over the documented
+///    `[1e-5, 1e-2]` atoms/barn band — the per-candidate density is what
+///    keeps the anchor JOINT, like the old grid);
+/// 2. a direct **dip-match anchor**: measured dip positions (plateau-robust
+///    depth-weighted run centres, so saturated flat-bottom dips locate
+///    correctly) matched to the known resonance energies and solved as an
+///    affine TOF map by least squares — the discriminating anchor along
+///    the `(t₀, L_scale)` degeneracy valley;
+/// 3. a fine joint pit-scan (11 × 11 at 0.25 µs / 0.05 % steps, narrow-band
+///    golden density) around EACH anchor — the compact descendant of the
+///    old Phase-2/3 grids, needed because the chi² landscape's sub-bin
+///    aliasing pits are ~±0.3 µs wide;
+/// 4. a multi-start descent from both fine anchors (per anchor: its own
+///    density plus log-spaced starts; per start: a direct joint LM AND an
+///    exact-density ↔ alignment-only-LM alternation), with every candidate
+///    scored by the original valid-bins chi² and the argmin returned.
+///
+/// Net cost is ~4× fewer forward evaluations than the old grid on
+/// production windows, and the LM refinement removes the old grid's
+/// resolution floor (0.001 % L, 0.05 µs t₀) — the optimum is continuous.
+/// The internal LM fits disable the fitters' peak-match seed
+/// (`with_energy_scale_seed(false)`): stages 1–3 already provide a
+/// stronger anchor, and the seed's strict-local-minimum dip detector
+/// mislocates saturated flat-bottom dips.
 ///
 /// Each LM fit constrains `L_scale` to ±1 % (`ENERGY_SCALE_L_SCALE_*`);
 /// when a fit rails on that box (a larger true offset), the search
 /// re-anchors on the corrected grid and composes the affine TOF maps, so
-/// the documented ±1.5 % flight-path band remains covered (≤ 3 rounds).
+/// the documented ±1.5 % flight-path band remains covered.
 ///
 /// The golden-section seed runs on a slightly wider band (~5e-6 to
 /// ~2e-2), and if the **fitted** density optimum saturates that band —
@@ -381,8 +534,23 @@ pub fn calibrate_energy(
         .map_err(|e| PipelineError::InvalidParameter(format!("calibrate_energy: {e}")))?
         .with_groups(&group_pairs, vec![d_init])
         .map_err(|e| PipelineError::InvalidParameter(format!("calibrate_energy: {e}")))?
-        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig::default()))
-        .with_energy_scale(0.0, 1.0, assumed_flight_path_m);
+        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig {
+            // Small first steps (issue #634): at saturated sharp dips the
+            // true (t0, L_scale) pit is sub-0.3 µs narrow while the
+            // along-valley Jacobian is near-singular — the default
+            // lambda_init = 1e-3 lets the first LM step overshoot the
+            // basin (observed: a start 0.12 µs from truth walking to a
+            // 7 µs-wrong valley pit).  A large initial damping keeps the
+            // early steps gradient-like and short; the LM anneals lambda
+            // back down once inside the basin.
+            lambda_init: 1.0e2,
+            ..LmConfig::default()
+        }))
+        .with_energy_scale(0.0, 1.0, assumed_flight_path_m)
+        // The anchor stages already seed (t0, L_scale); the fitters' internal
+        // peak-match seed mislocates saturated flat-bottom dips and would
+        // overwrite the anchor with an in-bounds wrong seed (issue #634).
+        .with_energy_scale_seed(false);
         if freeze_density {
             config = config.with_fix_densities(true);
         }
@@ -430,194 +598,297 @@ pub fn calibrate_energy(
         10f64.powf(0.5 * (CALIBRATION_LOG10_N_LO + CALIBRATION_LOG10_N_HI))
     };
 
-    // ── Stage 2: coarse global alignment anchor ─────────────────────────
+    // ── Stage 2: coarse global JOINT alignment anchor ────────────────────
     // A compact descendant of the old Phase-1 scan: 7 L_scale (±1.5 % in
     // 0.5 % steps) × 7 t₀ (−5…+10 µs in 2.5 µs steps) candidates, each
-    // scored by chi² at the COMMON density `n_seed` (49 forward
-    // evaluations — no per-candidate density optimisation, which was the
-    // expensive part of the old grid).  This keeps the global-basin
-    // robustness for wide offsets that a purely local method would lose
-    // when the peak-match seed cannot fire (e.g. trace densities in noise).
+    // scored with its OWN exact golden-section density — the per-candidate
+    // density optimisation is what makes the anchor JOINT, exactly like the
+    // old grid.  Scoring all candidates at one common density is NOT
+    // sufficient (issue #634 review, empirically demonstrated): on
+    // saturated (5e-3) or trace (2e-5) landscapes with production-scale
+    // offsets (0.3–1.2 % L, the module header's own VENUS example
+    // magnitude), the identity-seeded common density corrupts the candidate
+    // ranking, every descent start then inherits a wrong-basin anchor, and
+    // the calibration returns Ok with a density up to 139× off — at trace
+    // density with chi²_r ≈ 1e-4, i.e. no user-visible failure signal.
+    // ~49 golden sections ≈ 1 200 forward evaluations, still ~30× cheaper
+    // than the old three-phase grid's ~35 000.
     let mut t0_tot = 0.0_f64;
     let mut ls_tot = 1.0_f64;
+    let mut anchor_n = n_seed;
     let mut anchor_chi2 = seed_chi2;
     for i_l in -3..=3_i32 {
         let ls = 1.0 + f64::from(i_l) * 0.005;
         for i_t in 0..=6_i32 {
             let t0 = -5.0 + 2.5 * f64::from(i_t);
             if i_l == 0 && i_t == 2 {
-                continue; // the identity candidate is `seed_chi2` above
+                continue; // the identity candidate is (n_seed, seed_chi2) above
             }
             let Ok(e_c) = corrected_energy_grid(energies_nominal, t0, ls, assumed_flight_path_m)
             else {
                 continue; // degenerate candidate (t0 past the shortest TOF)
             };
-            let c = compute_chi2(
-                &e_c,
-                transmission,
-                uncertainty,
-                isotopes,
-                abundances,
-                n_seed,
-                temperature_k,
-                &valid,
-                resolution,
-            );
-            if c < anchor_chi2 {
-                anchor_chi2 = c;
+            let (n_c, chi2_c) = golden_at(&e_c);
+            if chi2_c < anchor_chi2 {
+                anchor_chi2 = chi2_c;
                 t0_tot = t0;
                 ls_tot = ls;
+                anchor_n = n_c;
             }
         }
     }
-    let grid = if t0_tot == 0.0 && ls_tot == 1.0 {
-        energies_nominal.to_vec()
-    } else {
-        corrected_energy_grid(energies_nominal, t0_tot, ls_tot, assumed_flight_path_m).map_err(
-            |e| {
-                PipelineError::InvalidParameter(format!(
-                    "calibrate_energy: degenerate anchor grid: {e}"
-                ))
-            },
-        )?
+
+    // ── Stage 2b: fine joint pit-scan around each anchor ────────────────
+    // The coarse 2.5 µs / 0.5 % cell — and the dip-match solve at saturated
+    // dips (its centroid is the bin-quantized saturation interval, biased up
+    // to ~0.5 µs) — are both coarser than the (t0, L_scale) landscape's
+    // sub-bin aliasing pits (~±0.3 µs wide, ~2 µs apart on the 0.2 eV test
+    // grid), so a descent seeded from either can converge into a
+    // NEIGHBOURING pit (observed: chi² 3.3 at 1.85 µs from the chi² ≈ 0 true
+    // pit, with the LM reporting converged).  This fine scan — 11 × 11
+    // candidates at 0.25 µs / 0.05 % steps spanning one coarse cell, each
+    // with its own golden-section density on a ±0.5-decade band around the
+    // coarse anchor density — is the compact descendant of the old
+    // Phase-2/3 refinement grids and deterministically lands inside the
+    // true pit, from which the descent below converges.  It runs around
+    // BOTH anchors (lattice winner and dip-match).
+    let fine_scan = |t0_a: f64, ls_a: f64, n_a: f64| -> (f64, f64, f64, f64) {
+        let fine_lo = (n_a.log10() - 0.5).max(CALIBRATION_LOG10_N_LO);
+        let fine_hi = (n_a.log10() + 0.5).min(CALIBRATION_LOG10_N_HI);
+        let mut best = (t0_a, ls_a, n_a, f64::INFINITY);
+        for i_l in -5..=5_i32 {
+            let ls = ls_a + f64::from(i_l) * 0.0005;
+            for i_t in -5..=5_i32 {
+                let t0 = t0_a + f64::from(i_t) * 0.25;
+                let Ok(e_c) =
+                    corrected_energy_grid(energies_nominal, t0, ls, assumed_flight_path_m)
+                else {
+                    continue;
+                };
+                let (n_c, chi2_c) =
+                    golden_section_n_total(fine_lo, fine_hi, CALIBRATION_LOG10_N_TOL, |log_n| {
+                        compute_chi2(
+                            &e_c,
+                            transmission,
+                            uncertainty,
+                            isotopes,
+                            abundances,
+                            10f64.powf(log_n),
+                            temperature_k,
+                            &valid,
+                            resolution,
+                        )
+                    });
+                if chi2_c < best.3 {
+                    best = (t0, ls, n_c, chi2_c);
+                }
+            }
+        }
+        best
     };
 
-    // ── Stages 3+4: multi-start descent — the sparse-grid degeneracy ────
-    // On coarse energy grids (dip width < bin spacing) the chi² landscape
-    // has aliasing local minima: with each dip sampled by ~1 point, a
-    // wrong density can trade off against a sub-bin (t₀, L_scale) shift
-    // almost perfectly.  A single local descent seeded from a
-    // misalignment-biased density can converge there (observed: n 14× low
-    // at chi² 0.17 on the 0.2 eV test fixture, while the true basin sits
-    // at chi² ≈ 0).  The old grid escaped this by JOINTLY sweeping
-    // (L, t₀) × exact density; the local-method equivalent is a small
-    // multi-start over log-spaced density seeds with argmin-chi²
-    // selection — the true basin always wins the comparison.
-    //
-    // Each start runs the same two stages from the stage-2 anchor:
-    //
-    //   Stage 3 — coordinate descent: the density is optimised EXACTLY
-    //   (1-D golden section) at the current alignment, and the alignment
-    //   is refined with the density FROZEN (#633), so the two cannot
-    //   trade off inside one ill-conditioned joint step.  Alignment-only
-    //   LM is the safe direction: at fixed density, dip POSITION mismatch
-    //   is the only signal, exactly what (t₀, L_scale) control.  Each
-    //   cycle re-anchors the grid at the composed transform (affine TOF
-    //   maps compose as t₀ ← t₀ + ls·t₀ₖ, ls ← ls·lsₖ), so a fit railed
-    //   on its ±1 % L_scale box extends its reach next cycle — covering
-    //   this function's documented ±1.5 % band.
-    //
-    //   Stage 4 — joint (t₀, L_scale, n) LM refinement: from inside the
-    //   basin the LM only accepts chi²-improving steps, so it cannot
-    //   degrade the alternation's solution; it captures the residual
-    //   density↔alignment coupling the alternation alone cannot.
-    let anchor = (t0_tot, ls_tot);
-    let anchor_grid = grid;
-    let mut seeds = vec![n_seed];
-    for exp in [-4.5_f64, -3.5, -2.5] {
-        let s = 10f64.powf(exp);
-        // Skip seeds within 2× of an existing one — same basin.
-        if seeds.iter().all(|&e| (s / e).log10().abs() > 0.301) {
-            seeds.push(s);
+    // Anchor set for the descent: the fine-scanned lattice winner PLUS the
+    // fine-scanned dip-match solve (see `dip_match_anchor`).  The dip-match
+    // anchor is deliberately NOT ranked against the lattice winner by a
+    // single chi² comparison: at sub-bin misalignment of sharp saturated
+    // dips, chi²(n) is multimodal — the steep dip edges make a nearly-right
+    // deep model score WORSE than a shallow one — so a chi² ranking can
+    // discard the one anchor whose fine neighbourhood contains the true pit
+    // (observed: dip-match landed 0.12 µs from truth yet scored chi² 1 809
+    // vs the lattice winner's 124).  Running the full multi-start descent
+    // from BOTH fine anchors and letting the final argmin-chi² decide is
+    // robust to that ranking failure.
+    let lattice_fine = fine_scan(t0_tot, ls_tot, anchor_n);
+    let mut anchor_list: Vec<(f64, f64, f64)> =
+        vec![(lattice_fine.0, lattice_fine.1, lattice_fine.2)];
+    if let Some((t0_d, ls_d)) = dip_match_anchor(
+        energies_nominal,
+        transmission,
+        &valid,
+        isotopes,
+        abundances,
+        assumed_flight_path_m,
+    ) {
+        // Density context for the dip anchor's narrow golden band: the
+        // lattice anchor's density is the best available estimate.
+        let dip_fine = fine_scan(t0_d, ls_d, anchor_n);
+        // Skip a duplicate anchor (both scans converged on the same pit).
+        if (dip_fine.0 - lattice_fine.0).abs() > 0.05 || (dip_fine.1 - lattice_fine.1).abs() > 1e-4
+        {
+            anchor_list.push((dip_fine.0, dip_fine.1, dip_fine.2));
         }
     }
+
     // (t0_tot, ls_tot, n_total, chi2 over valid bins, LM converged flag)
     let mut winner: Option<(f64, f64, f64, f64, bool)> = None;
-    for &start_n in &seeds {
-        let mut t0_tot = anchor.0;
-        let mut ls_tot = anchor.1;
-        let mut grid = anchor_grid.clone();
-        let mut n_cur = start_n;
+    // Last LM error across all starts: per-seed failures are skippable, but
+    // when EVERY start fails (a config-class error — bad resolution kernel,
+    // config rejection — fails all seeds identically) the no-winner
+    // diagnostic must carry the actual root cause instead of misattributing
+    // it to non-finite residuals (issue #634 review).
+    let mut last_lm_err: Option<PipelineError> = None;
+    for &(a_t0, a_ls, a_n) in &anchor_list {
+        let anchor_grid = if a_t0 == 0.0 && a_ls == 1.0 {
+            energies_nominal.to_vec()
+        } else {
+            match corrected_energy_grid(energies_nominal, a_t0, a_ls, assumed_flight_path_m) {
+                Ok(g) => g,
+                // Degenerate anchor — the other anchor still runs; if every
+                // anchor is degenerate the no-winner guard below reports it.
+                Err(_) => continue,
+            }
+        };
+        // Density seeds: this anchor's own fine-scan density (the joint
+        // optimum of its pit) plus log-spaced starts across the band (the
+        // aliasing/multimodality guard).
+        let mut seeds = vec![a_n];
+        for exp in [-4.5_f64, -3.5, -2.5] {
+            let sd = 10f64.powf(exp);
+            // Skip seeds within 2× of an existing one — same basin.
+            if seeds.iter().all(|&e| (sd / e).log10().abs() > 0.301) {
+                seeds.push(sd);
+            }
+        }
+        for &start_n in &seeds {
+            // Two descent variants per (anchor, seed); both feed the same
+            // final argmin:
+            //
+            //  (a) DIRECT joint LM from the anchor — robust at saturated
+            //      dips, where the alternation below fails: a frozen
+            //      slightly-wrong density has its alignment optimum in a
+            //      COMPENSATING pit, so the alternation walks away from a
+            //      good anchor before its joint stage ever runs (observed:
+            //      an anchor 0.12 µs from truth descending to a chi² 3.3
+            //      pit while the direct joint fit rolls into the chi² ≈ 0
+            //      true pit).
+            //
+            //  (b) alternation (exact density ↔ alignment-only LM, then
+            //      joint LM) — robust when the density seed is decades off,
+            //      where a direct joint fit would trade density against a
+            //      sub-bin shift (the aliasing degeneracy).
+            let mut candidates: Vec<(f64, f64, SpectrumFitResult)> = Vec::new();
 
-        // Stage 3: exact density ↔ alignment-only LM.
-        let mut failed = false;
-        for cycle in 0..3 {
-            // First cycle keeps the start density (the whole point of the
-            // multi-start); later cycles re-optimise it at the improved
-            // alignment.
-            if cycle > 0 {
-                let (n_new, chi2_n) = golden_at(&grid);
-                if chi2_n.is_finite() {
-                    n_cur = n_new;
+            // (a) direct joint fit from the anchor.
+            match run_lm(&anchor_grid, start_n * total_abundance, false) {
+                Ok(fit) => {
+                    let t0_c = a_t0 + a_ls * fit.t0_us.unwrap_or(0.0);
+                    let ls_c = a_ls * fit.l_scale.unwrap_or(1.0);
+                    candidates.push((t0_c, ls_c, fit));
                 }
+                Err(e) => last_lm_err = Some(e),
             }
-            let Ok(align) = run_lm(&grid, n_cur * total_abundance, true) else {
-                failed = true;
-                break;
-            };
-            let t0_k = align.t0_us.unwrap_or(0.0);
-            let ls_k = align.l_scale.unwrap_or(1.0);
-            t0_tot += ls_tot * t0_k;
-            ls_tot *= ls_k;
-            // Alignment converged (no further shift found) → stop.
-            if t0_k.abs() < 1e-6 && (ls_k - 1.0).abs() < 1e-9 {
-                break;
-            }
-            match corrected_energy_grid(energies_nominal, t0_tot, ls_tot, assumed_flight_path_m) {
-                Ok(g) => grid = g,
-                Err(_) => {
-                    failed = true;
+
+            // (b) alternation.
+            let mut t0_tot = a_t0;
+            let mut ls_tot = a_ls;
+            let mut grid = anchor_grid.clone();
+            let mut n_cur = start_n;
+            let mut failed = false;
+            for cycle in 0..3 {
+                // First cycle keeps the start density (the whole point of the
+                // multi-start); later cycles re-optimise it at the improved
+                // alignment.
+                if cycle > 0 {
+                    let (n_new, chi2_n) = golden_at(&grid);
+                    if chi2_n.is_finite() {
+                        n_cur = n_new;
+                    }
+                }
+                let align = match run_lm(&grid, n_cur * total_abundance, true) {
+                    Ok(a) => a,
+                    Err(e) => {
+                        last_lm_err = Some(e);
+                        failed = true;
+                        break;
+                    }
+                };
+                let t0_k = align.t0_us.unwrap_or(0.0);
+                let ls_k = align.l_scale.unwrap_or(1.0);
+                t0_tot += ls_tot * t0_k;
+                ls_tot *= ls_k;
+                // Alignment converged (no further shift found) → stop.
+                if t0_k.abs() < 1e-6 && (ls_k - 1.0).abs() < 1e-9 {
                     break;
                 }
+                match corrected_energy_grid(energies_nominal, t0_tot, ls_tot, assumed_flight_path_m)
+                {
+                    Ok(g) => grid = g,
+                    Err(_) => {
+                        failed = true;
+                        break;
+                    }
+                }
             }
-        }
-        if failed {
-            continue;
-        }
+            if !failed {
+                // Joint refinement of the alternation result.
+                let (n_stage, chi2_stage) = golden_at(&grid);
+                if chi2_stage.is_finite() {
+                    n_cur = n_stage;
+                }
+                match run_lm(&grid, n_cur * total_abundance, false) {
+                    Ok(fit) => {
+                        let t0_c = t0_tot + ls_tot * fit.t0_us.unwrap_or(0.0);
+                        let ls_c = ls_tot * fit.l_scale.unwrap_or(1.0);
+                        candidates.push((t0_c, ls_c, fit));
+                    }
+                    Err(e) => last_lm_err = Some(e),
+                }
+            }
 
-        // Stage 4: joint refinement with the density free.
-        let (n_stage, chi2_stage) = golden_at(&grid);
-        if chi2_stage.is_finite() {
-            n_cur = n_stage;
-        }
-        let Ok(fit) = run_lm(&grid, n_cur * total_abundance, false) else {
-            continue;
-        };
-        let t0_c = t0_tot + ls_tot * fit.t0_us.unwrap_or(0.0);
-        let ls_c = ls_tot * fit.l_scale.unwrap_or(1.0);
-        let n_c = fit.densities.first().copied().unwrap_or(f64::NAN) / total_abundance;
-
-        // Score this start with the ORIGINAL valid-bins objective at its
-        // solution; keep the argmin.  The latch is gated on finiteness: a
-        // bare `None => true` first-start arm would let a NaN chi² latch
-        // (bypassing the `<` comparison), and every later start would then
-        // compare `chi2 < NaN` (always false) — a valid later calibration
-        // could never displace a NaN first start and the function would
-        // return the no-finite-chi² error for a calibratable spectrum.
-        // Mirrors the old grid's `best_chi2 = INFINITY` + `<` behaviour,
-        // where non-finite candidates could never latch (issue #634 review).
-        let Ok(e_c) = corrected_energy_grid(energies_nominal, t0_c, ls_c, assumed_flight_path_m)
-        else {
-            continue;
-        };
-        let chi2_c = compute_chi2(
-            &e_c,
-            transmission,
-            uncertainty,
-            isotopes,
-            abundances,
-            n_c,
-            temperature_k,
-            &valid,
-            resolution,
-        );
-        let better = chi2_c.is_finite()
-            && match &winner {
-                None => true,
-                Some((_, _, _, best, _)) => chi2_c < *best,
-            };
-        if better {
-            winner = Some((t0_c, ls_c, n_c, chi2_c, fit.converged));
+            // Score every candidate with the ORIGINAL valid-bins objective at
+            // its solution; keep the argmin.  The latch is gated on
+            // finiteness: a bare `None => true` first-candidate arm would let
+            // a NaN chi² latch (bypassing the `<` comparison), and every
+            // later candidate would then compare `chi2 < NaN` (always false)
+            // — a valid later calibration could never displace a NaN first
+            // one and the function would return the no-finite-chi² error for
+            // a calibratable spectrum.  Mirrors the old grid's
+            // `best_chi2 = INFINITY` + `<` behaviour, where non-finite
+            // candidates could never latch (issue #634 review).
+            for (t0_c, ls_c, fit) in candidates {
+                let n_c = fit.densities.first().copied().unwrap_or(f64::NAN) / total_abundance;
+                let Ok(e_c) =
+                    corrected_energy_grid(energies_nominal, t0_c, ls_c, assumed_flight_path_m)
+                else {
+                    continue;
+                };
+                let chi2_c = compute_chi2(
+                    &e_c,
+                    transmission,
+                    uncertainty,
+                    isotopes,
+                    abundances,
+                    n_c,
+                    temperature_k,
+                    &valid,
+                    resolution,
+                );
+                let better = chi2_c.is_finite()
+                    && match &winner {
+                        None => true,
+                        Some((_, _, _, best, _)) => chi2_c < *best,
+                    };
+                if better {
+                    winner = Some((t0_c, ls_c, n_c, chi2_c, fit.converged));
+                }
+            }
         }
     }
     let Some((t0_tot, ls_tot, best_n, _, lm_converged)) = winner else {
-        return Err(PipelineError::InvalidParameter(
+        // Preserve the root cause: a config-class LM error fails every seed
+        // identically, and its message is the actionable diagnostic — the
+        // generic non-finite-residuals guess applies only when no LM error
+        // occurred.
+        let detail = match last_lm_err {
+            Some(e) => format!("last LM error: {e}"),
+            None => "likely cause is forward-model failure or non-finite \
+                     residuals (e.g. wildly out-of-scale transmission)"
+                .to_string(),
+        };
+        return Err(PipelineError::InvalidParameter(format!(
             "calibrate_energy: calibration produced no finite chi² from any \
-             density start (best_chi2 = inf) — likely cause is forward-model \
-             failure or non-finite residuals (e.g. wildly out-of-scale \
-             transmission)"
-                .into(),
-        ));
+             density start (best_chi2 = inf) — {detail}"
+        )));
     };
 
     // Boundary-saturation guard: if the fitted n_total lies within
@@ -1219,19 +1490,19 @@ mod tests {
     // the old reachable max) plus the explicit boundary-failure
     // diagnostic at densities outside the band.
 
-    /// Synthetic round-trip helper parameterised on `true_n`.  Builds
-    /// data with two well-separated Hf-style resonances at the given
-    /// true density, runs `calibrate_energy`, and on success returns
-    /// `(result, e_true, assumed_l)` so individual tests can assert on
-    /// density recovery and chi² finiteness (most callers) or on
-    /// corrected-energy accuracy against `e_true` (the
-    /// `test_calibrate_round_trip_synthetic` smoke test).
-    fn calibrate_round_trip_at_density(
+    /// Fully-parameterised synthetic round-trip helper.  Builds data with
+    /// two well-separated Hf-style resonances at the given true density and
+    /// injected `(true_l = assumed_l · true_l_factor, true_t0_us)` offsets,
+    /// runs `calibrate_energy`, and on success returns
+    /// `(result, e_true, assumed_l)` so tests can assert on parameter
+    /// recovery and corrected-energy accuracy against `e_true`.
+    fn calibrate_round_trip(
+        true_l_factor: f64,
+        true_t0_us: f64,
         true_n: f64,
     ) -> Result<(CalibrationResult, Vec<f64>, f64), PipelineError> {
-        let true_l = 25.0125;
         let assumed_l = 25.0;
-        let true_t0_us = 0.5;
+        let true_l = assumed_l * true_l_factor;
         let temperature_k = 293.6;
 
         let iso_a = synthetic_single_resonance(72, 178, 176.4, 7.8);
@@ -1271,6 +1542,89 @@ mod tests {
             None,
         )?;
         Ok((result, e_true, assumed_l))
+    }
+
+    /// Synthetic round-trip helper parameterised on `true_n` at the small
+    /// legacy offsets (`+0.05 % L`, `+0.5 µs`) — the easy regime.  The
+    /// wide-offset production regime is covered separately by
+    /// `assert_wide_offset_recovery` (issue #634 review P0).
+    fn calibrate_round_trip_at_density(
+        true_n: f64,
+    ) -> Result<(CalibrationResult, Vec<f64>, f64), PipelineError> {
+        calibrate_round_trip(25.0125 / 25.0, 0.5, true_n)
+    }
+
+    /// Issue #634 review P0 regression: production-scale offsets — the
+    /// module header's own VENUS correction magnitude (0.3 % L) and
+    /// beyond-one-±1 %-L_scale-box offsets (1.2 % L, 6 µs, which also pin
+    /// the affine re-anchoring composition `t0 ← t0 + ls·t0_k, ls ← ls·ls_k`)
+    /// — must recover `(L, t0, n)` and the corrected energy grid.  The
+    /// single-common-density anchor variant returned Ok in the WRONG basin
+    /// here (density up to 139× off; at trace density with chi²_r ≈ 1e-4,
+    /// no visible failure signal); the per-candidate golden-section density
+    /// in the stage-2 anchor is what defeats it.
+    fn assert_wide_offset_recovery(
+        true_l_factor: f64,
+        true_t0_us: f64,
+        true_n: f64,
+        n_rel_tol: f64,
+    ) {
+        let (result, e_true, assumed_l) = calibrate_round_trip(true_l_factor, true_t0_us, true_n)
+            .expect("wide-offset calibration must succeed");
+        let true_l = assumed_l * true_l_factor;
+        assert!(
+            (result.flight_path_m - true_l).abs() / true_l < 2e-3,
+            "L: got {}, expected {true_l}",
+            result.flight_path_m,
+        );
+        assert!(
+            (result.t0_us - true_t0_us).abs() < 0.5,
+            "t0: got {}, expected {true_t0_us}",
+            result.t0_us,
+        );
+        assert!(
+            (result.total_density - true_n).abs() / true_n < n_rel_tol,
+            "n: got {}, expected {true_n}",
+            result.total_density,
+        );
+        // The deliverable: the corrected energy grid tracks the truth.
+        let mut rel: Vec<f64> = result
+            .energies_corrected
+            .iter()
+            .zip(e_true.iter())
+            .map(|(&c, &t)| (c - t).abs() / t)
+            .collect();
+        rel.sort_by(f64::total_cmp);
+        let med = rel[rel.len() / 2];
+        assert!(
+            med < 5e-3,
+            "median corrected-energy rel err {med:.3e} exceeds 5e-3"
+        );
+    }
+
+    #[test]
+    fn test_calibrate_wide_offset_venus_scale_at_paper_density() {
+        // 0.3 % L + 1 µs at the SoftwareX U-238 foil density.
+        assert_wide_offset_recovery(1.003, 1.0, 5e-3, 0.15);
+    }
+
+    #[test]
+    fn test_calibrate_wide_offset_venus_scale_at_trace_density() {
+        // Same offsets at trace density — the silent-failure regime
+        // (wrong answer previously carried chi²_r ≈ 1e-4).
+        assert_wide_offset_recovery(1.003, 1.0, 2e-5, 0.3);
+    }
+
+    #[test]
+    fn test_calibrate_wide_offset_beyond_one_box_at_paper_density() {
+        // 1.2 % L exceeds the per-fit ±1 % L_scale box → exercises the
+        // re-anchoring composition; 6 µs t0 is mid coarse-grid.
+        assert_wide_offset_recovery(1.012, 6.0, 5e-3, 0.15);
+    }
+
+    #[test]
+    fn test_calibrate_wide_offset_beyond_one_box_at_midband_density() {
+        assert_wide_offset_recovery(1.012, 6.0, 1.5e-4, 0.15);
     }
 
     /// Near-lower-edge density: `true_n = 2e-5` sits just inside the

--- a/crates/nereids-pipeline/src/calibration.rs
+++ b/crates/nereids-pipeline/src/calibration.rs
@@ -171,8 +171,10 @@ pub struct CalibrationResult {
 ///
 /// # Search strategy
 ///
-/// Issue #634: the former three-phase `(L, t₀)` grid scan (~900 forward
-/// evaluations, >10 min on production windows) is replaced by the
+/// Issue #634: the former three-phase `(L, t₀)` grid scan — ~900 (L, t₀)
+/// candidates × a ~25-evaluation golden-section density search each,
+/// i.e. ~35 000 forward evaluations, >10 min on production windows — is
+/// replaced by the
 /// **`fit_energy_scale` Levenberg–Marquardt path** — the same
 /// peak-match-seeded machinery `fit_spectrum_typed` uses — which solves
 /// the identical 3-parameter `(t₀, L_scale, n_total)` problem in seconds.
@@ -576,7 +578,14 @@ pub fn calibrate_energy(
         let n_c = fit.densities.first().copied().unwrap_or(f64::NAN) / total_abundance;
 
         // Score this start with the ORIGINAL valid-bins objective at its
-        // solution; keep the argmin.  (NaN chi² never wins: `<` is false.)
+        // solution; keep the argmin.  The latch is gated on finiteness: a
+        // bare `None => true` first-start arm would let a NaN chi² latch
+        // (bypassing the `<` comparison), and every later start would then
+        // compare `chi2 < NaN` (always false) — a valid later calibration
+        // could never displace a NaN first start and the function would
+        // return the no-finite-chi² error for a calibratable spectrum.
+        // Mirrors the old grid's `best_chi2 = INFINITY` + `<` behaviour,
+        // where non-finite candidates could never latch (issue #634 review).
         let Ok(e_c) = corrected_energy_grid(energies_nominal, t0_c, ls_c, assumed_flight_path_m)
         else {
             continue;
@@ -592,10 +601,11 @@ pub fn calibrate_energy(
             &valid,
             resolution,
         );
-        let better = match &winner {
-            None => true,
-            Some((_, _, _, best, _)) => chi2_c < *best,
-        };
+        let better = chi2_c.is_finite()
+            && match &winner {
+                None => true,
+                Some((_, _, _, best, _)) => chi2_c < *best,
+            };
         if better {
             winner = Some((t0_c, ls_c, n_c, chi2_c, fit.converged));
         }

--- a/crates/nereids-pipeline/src/calibration.rs
+++ b/crates/nereids-pipeline/src/calibration.rs
@@ -242,8 +242,13 @@ fn dip_match_anchor(
         return None;
     }
 
-    // Match each resonance to its nearest dip within half the minimum
-    // resonance spacing (floored at twice the grid resolution).
+    // Match resonances to dips ONE-TO-ONE within half the minimum resonance
+    // spacing (floored at twice the grid resolution).  Greedy assignment on
+    // globally ascending distance: matching each resonance to its nearest
+    // dip independently would let one dip serve several resonances,
+    // duplicating `u_dip` rows in the affine least squares below — which
+    // biases the fit and, in the two-resonance case, degenerates it toward
+    // `sxx → 0` (Copilot review, PR #644).
     let min_spacing = res_e
         .windows(2)
         .map(|w| w[1] - w[0])
@@ -251,18 +256,26 @@ fn dip_match_anchor(
     let grid_res = (e_hi - e_lo) / (n as f64 - 1.0);
     let tol = (0.5 * min_spacing).max(2.0 * grid_res);
     let kl = TOF_FACTOR * assumed_flight_path_m;
-    let mut pairs: Vec<(f64, f64)> = Vec::new(); // (u_dip, u_res) in µs
-    for &er in &res_e {
-        let mut best: Option<f64> = None;
-        for &d in &dips {
+    let mut candidates: Vec<(f64, usize, usize)> = Vec::new(); // (dist, res idx, dip idx)
+    for (ri, &er) in res_e.iter().enumerate() {
+        for (di, &d) in dips.iter().enumerate() {
             let dist = (d - er).abs();
-            if dist < tol && best.is_none_or(|b: f64| dist < (b - er).abs()) {
-                best = Some(d);
+            if dist < tol {
+                candidates.push((dist, ri, di));
             }
         }
-        if let Some(d) = best {
-            pairs.push((kl / d.sqrt(), kl / er.sqrt()));
+    }
+    candidates.sort_by(|a, b| a.0.total_cmp(&b.0));
+    let mut res_used = vec![false; res_e.len()];
+    let mut dip_used = vec![false; dips.len()];
+    let mut pairs: Vec<(f64, f64)> = Vec::new(); // (u_dip, u_res) in µs
+    for &(_, ri, di) in &candidates {
+        if res_used[ri] || dip_used[di] {
+            continue;
         }
+        res_used[ri] = true;
+        dip_used[di] = true;
+        pairs.push((kl / dips[di].sqrt(), kl / res_e[ri].sqrt()));
     }
     if pairs.len() < 2 {
         return None;

--- a/crates/nereids-pipeline/src/calibration.rs
+++ b/crates/nereids-pipeline/src/calibration.rs
@@ -13,11 +13,18 @@
 //! resonance positions shift in the energy domain, causing catastrophic
 //! chi² degradation (e.g. 436 → 2.7 for a 0.3% L correction on VENUS).
 
+#[cfg(test)]
 use nereids_core::constants::{EV_TO_JOULES, NEUTRON_MASS_KG};
+use nereids_core::types::IsotopeGroup;
 use nereids_endf::resonance::ResonanceData;
+use nereids_fitting::lm::LmConfig;
+use nereids_fitting::resolution_calib::corrected_energy_grid;
 use nereids_physics::transmission::{self, InstrumentParams, SampleParams};
 
 use crate::error::PipelineError;
+use crate::pipeline::{
+    InputData, SolverConfig, SpectrumFitResult, UnifiedFitConfig, fit_spectrum_typed,
+};
 
 /// Neutron mass constant: C = m_n / (2 · eV) ≈ 5.2276e-9 eV·s²/m².
 ///
@@ -25,7 +32,11 @@ use crate::error::PipelineError;
 ///
 /// Uses the CODATA 2018 values from `nereids_core::constants` so that
 /// this calibration path, `EnergyScaleTransmissionModel`, and
-/// `core::tof_to_energy` all agree to machine precision.
+/// `core::tof_to_energy` all agree to machine precision.  Production
+/// code now routes the TOF↔energy transform through
+/// `resolution_calib::corrected_energy_grid` (issue #634); this const
+/// remains for the test fixtures that synthesize ground-truth grids.
+#[cfg(test)]
 const NEUTRON_MASS_CONSTANT: f64 = 0.5 * NEUTRON_MASS_KG / EV_TO_JOULES;
 
 /// Lower / upper bounds (log10) on the `n_total` (areal density,
@@ -160,23 +171,31 @@ pub struct CalibrationResult {
 ///
 /// # Search strategy
 ///
-/// The optimisation runs as three nested coarse → fine → ultra-fine
-/// grid scans on `(L, t₀)`.  At each `(L, t₀)` candidate, the third
-/// parameter `n_total` (total areal density, atoms/barn) is
-/// optimised by **golden-section search in `log10(n)` space** over
-/// the documented user-supported interval `[1e-5, 1e-2]`
-/// atoms/barn.  Searching in log space gives uniform relative
-/// resolution across the three-decade band, which is necessary
-/// because realistic samples span from ~1e-5 (trace) to ~1e-2
-/// (1 mm metal foils).
+/// Issue #634: the former three-phase `(L, t₀)` grid scan (~900 forward
+/// evaluations, >10 min on production windows) is replaced by the
+/// **`fit_energy_scale` Levenberg–Marquardt path** — the same
+/// peak-match-seeded machinery `fit_spectrum_typed` uses — which solves
+/// the identical 3-parameter `(t₀, L_scale, n_total)` problem in seconds.
 ///
-/// Internally the golden section runs on a slightly wider band
-/// (~5e-6 to ~2e-2) so the boundary-saturation guard's ~5 % linear
-/// tolerance does not exclude a true optimum at the documented
-/// edges; if the optimum lands inside the tolerance window — i.e.
-/// effectively at `1e-5` or `1e-2` — the function returns
-/// `Err(PipelineError::InvalidParameter)` rather than a silent
-/// boundary-saturated answer, because a true minimum at the edge
+/// The density `n_total` (total areal density, atoms/barn) is seeded by a
+/// **golden-section search in `log10(n)` space** over the documented
+/// user-supported interval `[1e-5, 1e-2]` atoms/barn, evaluated once at
+/// the identity energy scale; the LM then refines all three parameters
+/// jointly (density fitted as a single grouped parameter with the
+/// normalised abundances as fixed ratios).  Searching the seed in log
+/// space gives uniform relative resolution across the three-decade band
+/// (~1e-5 trace samples to ~1e-2 for 1 mm metal foils).
+///
+/// Each LM fit constrains `L_scale` to ±1 % (`ENERGY_SCALE_L_SCALE_*`);
+/// when a fit rails on that box (a larger true offset), the search
+/// re-anchors on the corrected grid and composes the affine TOF maps, so
+/// the documented ±1.5 % flight-path band remains covered (≤ 3 rounds).
+///
+/// The golden-section seed runs on a slightly wider band (~5e-6 to
+/// ~2e-2), and if the **fitted** density optimum saturates that band —
+/// effectively at `1e-5` or `1e-2`, or anywhere beyond — the function
+/// returns `Err(PipelineError::InvalidParameter)` rather than a silent
+/// boundary-saturated answer, because a true minimum at or past the edge
 /// almost always means the real optimum lies outside the supported
 /// interval and the caller should supply a better initial estimate
 /// or check the sample composition.
@@ -280,12 +299,6 @@ pub fn calibrate_energy(
         }
     }
 
-    // Recover TOF from nominal energies: t = L_assumed · √(C / E)
-    let tof_s: Vec<f64> = energies_nominal
-        .iter()
-        .map(|&e| assumed_flight_path_m * (NEUTRON_MASS_CONSTANT / e).sqrt())
-        .collect();
-
     // Pre-filter valid bins (finite T, positive sigma)
     let valid: Vec<bool> = transmission
         .iter()
@@ -308,237 +321,321 @@ pub fn calibrate_energy(
         )));
     }
 
-    // ── Phase 1: Coarse grid search over (L, t₀) ───────────────────
-    // L: ±1.5 % around assumed (0.1 % steps → 31 points)
-    // t₀: -5 to +10 µs (1 µs steps → 16 points)
-    // n_total: at each (L, t₀), golden-section search in log10(n)
-    //          on the full `[1e-5, 1e-2]` density band.  The
-    //          previous implementation used a 5-point hard-coded
-    //          scan `{5e-5, 1e-4, 1.5e-4, 2e-4, 3e-4}` followed by
-    //          multiplicative refinements, which left the final
-    //          density anchored inside a `[2.25e-5, 4.95e-4]` band
-    //          — incompatible with the 1 mm metal-foil densities
-    //          (U/W/Ni at ~5e-3) the paper relies on.
-
-    let l_center = assumed_flight_path_m;
-    let mut best_chi2 = f64::INFINITY;
-    let mut best_l = l_center;
-    let mut best_t0_us = 0.0f64;
-    let mut best_n = 1e-4;
-
-    // Coarse L: 0.2% steps, ±1.5%
-    let l_steps: Vec<f64> = (-15..=15)
-        .map(|i| l_center * (1.0 + i as f64 * 0.001))
-        .collect();
-    // Coarse t₀: 1 µs steps, -5 to +10 µs
-    let t0_steps: Vec<f64> = (-5..=10).map(|i| i as f64).collect();
-
-    for &l in &l_steps {
-        for &t0 in &t0_steps {
-            let t0_s = t0 * 1e-6;
-            // Correct energies
-            let e_corr: Vec<f64> = tof_s
-                .iter()
-                .map(|&t| {
-                    let t_corr = t - t0_s;
-                    if t_corr <= 0.0 {
-                        f64::NAN
-                    } else {
-                        NEUTRON_MASS_CONSTANT * (l / t_corr).powi(2)
-                    }
-                })
-                .collect();
-
-            // Skip if any NaN
-            if e_corr.iter().any(|e| !e.is_finite() || *e <= 0.0) {
-                continue;
-            }
-
-            // Optimise n_total at this (L, t₀) by golden section in
-            // log10(n) over the full configured search band.
-            let (n_opt, chi2_opt) = golden_section_n_total(
-                CALIBRATION_LOG10_N_LO,
-                CALIBRATION_LOG10_N_HI,
-                CALIBRATION_LOG10_N_TOL,
-                |log_n| {
-                    compute_chi2(
-                        &e_corr,
-                        transmission,
-                        uncertainty,
-                        isotopes,
-                        abundances,
-                        10f64.powf(log_n),
-                        temperature_k,
-                        &valid,
-                        resolution,
-                    )
-                },
-            );
-            if chi2_opt < best_chi2 {
-                best_chi2 = chi2_opt;
-                best_l = l;
-                best_t0_us = t0;
-                best_n = n_opt;
-            }
+    // ── Neutralise invalid bins for the LM ──────────────────────────────
+    // The grid search masked invalid bins out of its chi² sum; the LM cost
+    // has no per-bin validity mask (its active-mask is an energy-window
+    // mask only), and a NaN transmission at an active bin poisons the
+    // normal equations.  Replace invalid bins with a finite dummy and a
+    // huge σ (weight ~1e-60 — numerically zero) so the energy grid stays
+    // intact for resolution broadening while the bins carry no influence
+    // on the fit.  The reported chi²_r below is still computed over VALID
+    // bins only, preserving the original `dof = n_valid − 3` contract.
+    let mut t_fit = transmission.to_vec();
+    let mut sigma_fit = uncertainty.to_vec();
+    for (i, &ok) in valid.iter().enumerate() {
+        if !ok {
+            t_fit[i] = 1.0;
+            sigma_fit[i] = 1.0e30;
         }
     }
 
-    // ── Phase 2: Fine grid search around coarse (L, t₀) best ───────
-    // L: ±0.05%, 0.01% steps
-    // t₀: ±2 µs, 0.25 µs steps
-    // n_total: golden-section in log10(n) on the full search band
-    //          at each (L, t₀) candidate, same as Phase 1.  Running
-    //          the same minimiser over the full band — rather than
-    //          a ±50 % window around the Phase-1 winner — guards
-    //          against the chi² landscape's coupling between
-    //          (L, t₀) and density: a coarse-grid winner can sit on
-    //          a slightly biased density that the Phase-2 (L, t₀)
-    //          refinement should be allowed to walk away from.
+    // ── One fitted density parameter via an isotope group ───────────────
+    // The grid fitted a single n_total with per-isotope densities
+    // `abundance_i · n_total`.  Reproduce that exactly with one group whose
+    // ratios are the normalised abundances: the fitted per-isotope density
+    // is `D · abundance_i / S`, so `n_total = D / S` (S = Σ abundances).
+    // Zero-abundance isotopes contribute nothing to the model (exactly as
+    // in `compute_chi2`) and `IsotopeGroup` rejects non-positive ratios,
+    // so they are dropped from the group.
+    let mut members = Vec::new();
+    let mut rd_list: Vec<ResonanceData> = Vec::new();
+    for (rd, &abd) in isotopes.iter().zip(abundances.iter()) {
+        if abd > 0.0 {
+            members.push((rd.isotope, abd / total_abundance));
+            rd_list.push(rd.clone());
+        }
+    }
+    let group = IsotopeGroup::custom("calibration".into(), members)
+        .map_err(|e| PipelineError::InvalidParameter(format!("calibrate_energy: {e}")))?;
+    let group_pairs: [(&IsotopeGroup, &[ResonanceData]); 1] = [(&group, rd_list.as_slice())];
 
-    let l_fine: Vec<f64> = (-5..=5)
-        .map(|i| best_l * (1.0 + i as f64 * 0.0001))
-        .collect();
-    let t0_fine: Vec<f64> = (-8..=8).map(|i| best_t0_us + i as f64 * 0.25).collect();
+    // ── Local helpers ────────────────────────────────────────────────────
+    // `run_lm`: one LM energy-scale fit on `grid`, cold-seeded at
+    // `(t0, L_scale) = (0, 1)` (the peak-match seed inside the fitter
+    // improves on that when it can), with the grouped density either free
+    // or frozen (#633) at `d_init`.
+    let run_lm = |grid: &[f64],
+                  d_init: f64,
+                  freeze_density: bool|
+     -> Result<SpectrumFitResult, PipelineError> {
+        let mut config = UnifiedFitConfig::new(
+            grid.to_vec(),
+            vec![rd_list[0].clone()],
+            vec!["calibration".into()],
+            temperature_k,
+            resolution.map(|r| r.resolution.clone()),
+            vec![d_init],
+        )
+        .map_err(|e| PipelineError::InvalidParameter(format!("calibrate_energy: {e}")))?
+        .with_groups(&group_pairs, vec![d_init])
+        .map_err(|e| PipelineError::InvalidParameter(format!("calibrate_energy: {e}")))?
+        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig::default()))
+        .with_energy_scale(0.0, 1.0, assumed_flight_path_m);
+        if freeze_density {
+            config = config.with_fix_densities(true);
+        }
+        let input = InputData::Transmission {
+            transmission: t_fit.clone(),
+            uncertainty: sigma_fit.clone(),
+        };
+        fit_spectrum_typed(&input, &config).map_err(|e| {
+            PipelineError::InvalidParameter(format!(
+                "calibrate_energy: LM energy-scale fit failed: {e}"
+            ))
+        })
+    };
+    // `golden_at`: the ORIGINAL exact 1-D density optimisation (golden
+    // section in log10 n against `compute_chi2`) at a given corrected grid.
+    let golden_at = |e_corr: &[f64]| {
+        golden_section_n_total(
+            CALIBRATION_LOG10_N_LO,
+            CALIBRATION_LOG10_N_HI,
+            CALIBRATION_LOG10_N_TOL,
+            |log_n| {
+                compute_chi2(
+                    e_corr,
+                    transmission,
+                    uncertainty,
+                    isotopes,
+                    abundances,
+                    10f64.powf(log_n),
+                    temperature_k,
+                    &valid,
+                    resolution,
+                )
+            },
+        )
+    };
 
-    for &l in &l_fine {
-        for &t0 in &t0_fine {
-            let t0_s = t0 * 1e-6;
-            let e_corr: Vec<f64> = tof_s
-                .iter()
-                .map(|&t| {
-                    let t_corr = t - t0_s;
-                    if t_corr <= 0.0 {
-                        f64::NAN
-                    } else {
-                        NEUTRON_MASS_CONSTANT * (l / t_corr).powi(2)
-                    }
-                })
-                .collect();
-            if e_corr.iter().any(|e| !e.is_finite() || *e <= 0.0) {
-                continue;
+    // ── Stage 1: density seed at the identity energy scale ──────────────
+    // If no candidate yields a finite chi² (wildly out-of-scale data), fall
+    // back to the band midpoint — the no-finite-chi² guard below reports
+    // the failure.
+    let (n_seed, seed_chi2) = golden_at(energies_nominal);
+    let n_seed = if seed_chi2.is_finite() {
+        n_seed
+    } else {
+        10f64.powf(0.5 * (CALIBRATION_LOG10_N_LO + CALIBRATION_LOG10_N_HI))
+    };
+
+    // ── Stage 2: coarse global alignment anchor ─────────────────────────
+    // A compact descendant of the old Phase-1 scan: 7 L_scale (±1.5 % in
+    // 0.5 % steps) × 7 t₀ (−5…+10 µs in 2.5 µs steps) candidates, each
+    // scored by chi² at the COMMON density `n_seed` (49 forward
+    // evaluations — no per-candidate density optimisation, which was the
+    // expensive part of the old grid).  This keeps the global-basin
+    // robustness for wide offsets that a purely local method would lose
+    // when the peak-match seed cannot fire (e.g. trace densities in noise).
+    let mut t0_tot = 0.0_f64;
+    let mut ls_tot = 1.0_f64;
+    let mut anchor_chi2 = seed_chi2;
+    for i_l in -3..=3_i32 {
+        let ls = 1.0 + f64::from(i_l) * 0.005;
+        for i_t in 0..=6_i32 {
+            let t0 = -5.0 + 2.5 * f64::from(i_t);
+            if i_l == 0 && i_t == 2 {
+                continue; // the identity candidate is `seed_chi2` above
             }
-            let (n_opt, chi2_opt) = golden_section_n_total(
-                CALIBRATION_LOG10_N_LO,
-                CALIBRATION_LOG10_N_HI,
-                CALIBRATION_LOG10_N_TOL,
-                |log_n| {
-                    compute_chi2(
-                        &e_corr,
-                        transmission,
-                        uncertainty,
-                        isotopes,
-                        abundances,
-                        10f64.powf(log_n),
-                        temperature_k,
-                        &valid,
-                        resolution,
-                    )
-                },
+            let Ok(e_c) = corrected_energy_grid(energies_nominal, t0, ls, assumed_flight_path_m)
+            else {
+                continue; // degenerate candidate (t0 past the shortest TOF)
+            };
+            let c = compute_chi2(
+                &e_c,
+                transmission,
+                uncertainty,
+                isotopes,
+                abundances,
+                n_seed,
+                temperature_k,
+                &valid,
+                resolution,
             );
-            if chi2_opt < best_chi2 {
-                best_chi2 = chi2_opt;
-                best_l = l;
-                best_t0_us = t0;
-                best_n = n_opt;
+            if c < anchor_chi2 {
+                anchor_chi2 = c;
+                t0_tot = t0;
+                ls_tot = ls;
             }
         }
     }
+    let grid = if t0_tot == 0.0 && ls_tot == 1.0 {
+        energies_nominal.to_vec()
+    } else {
+        corrected_energy_grid(energies_nominal, t0_tot, ls_tot, assumed_flight_path_m).map_err(
+            |e| {
+                PipelineError::InvalidParameter(format!(
+                    "calibrate_energy: degenerate anchor grid: {e}"
+                ))
+            },
+        )?
+    };
 
-    // ── Phase 3: Ultra-fine refinement ──────────────────────────────
-    // L: ±0.005%, 0.001% steps
-    // t₀: ±0.5 µs, 0.05 µs steps
-    // n_total: golden-section in log10(n) on the full search band
-    //          at each (L, t₀) candidate.
-
-    let l_ultra: Vec<f64> = (-5..=5)
-        .map(|i| best_l * (1.0 + i as f64 * 0.00001))
-        .collect();
-    let t0_ultra: Vec<f64> = (-10..=10).map(|i| best_t0_us + i as f64 * 0.05).collect();
-
-    for &l in &l_ultra {
-        for &t0 in &t0_ultra {
-            let t0_s = t0 * 1e-6;
-            let e_corr: Vec<f64> = tof_s
-                .iter()
-                .map(|&t| {
-                    let t_corr = t - t0_s;
-                    if t_corr <= 0.0 {
-                        f64::NAN
-                    } else {
-                        NEUTRON_MASS_CONSTANT * (l / t_corr).powi(2)
-                    }
-                })
-                .collect();
-            if e_corr.iter().any(|e| !e.is_finite() || *e <= 0.0) {
-                continue;
-            }
-            let (n_opt, chi2_opt) = golden_section_n_total(
-                CALIBRATION_LOG10_N_LO,
-                CALIBRATION_LOG10_N_HI,
-                CALIBRATION_LOG10_N_TOL,
-                |log_n| {
-                    compute_chi2(
-                        &e_corr,
-                        transmission,
-                        uncertainty,
-                        isotopes,
-                        abundances,
-                        10f64.powf(log_n),
-                        temperature_k,
-                        &valid,
-                        resolution,
-                    )
-                },
-            );
-            if chi2_opt < best_chi2 {
-                best_chi2 = chi2_opt;
-                best_l = l;
-                best_t0_us = t0;
-                best_n = n_opt;
-            }
+    // ── Stages 3+4: multi-start descent — the sparse-grid degeneracy ────
+    // On coarse energy grids (dip width < bin spacing) the chi² landscape
+    // has aliasing local minima: with each dip sampled by ~1 point, a
+    // wrong density can trade off against a sub-bin (t₀, L_scale) shift
+    // almost perfectly.  A single local descent seeded from a
+    // misalignment-biased density can converge there (observed: n 14× low
+    // at chi² 0.17 on the 0.2 eV test fixture, while the true basin sits
+    // at chi² ≈ 0).  The old grid escaped this by JOINTLY sweeping
+    // (L, t₀) × exact density; the local-method equivalent is a small
+    // multi-start over log-spaced density seeds with argmin-chi²
+    // selection — the true basin always wins the comparison.
+    //
+    // Each start runs the same two stages from the stage-2 anchor:
+    //
+    //   Stage 3 — coordinate descent: the density is optimised EXACTLY
+    //   (1-D golden section) at the current alignment, and the alignment
+    //   is refined with the density FROZEN (#633), so the two cannot
+    //   trade off inside one ill-conditioned joint step.  Alignment-only
+    //   LM is the safe direction: at fixed density, dip POSITION mismatch
+    //   is the only signal, exactly what (t₀, L_scale) control.  Each
+    //   cycle re-anchors the grid at the composed transform (affine TOF
+    //   maps compose as t₀ ← t₀ + ls·t₀ₖ, ls ← ls·lsₖ), so a fit railed
+    //   on its ±1 % L_scale box extends its reach next cycle — covering
+    //   this function's documented ±1.5 % band.
+    //
+    //   Stage 4 — joint (t₀, L_scale, n) LM refinement: from inside the
+    //   basin the LM only accepts chi²-improving steps, so it cannot
+    //   degrade the alternation's solution; it captures the residual
+    //   density↔alignment coupling the alternation alone cannot.
+    let anchor = (t0_tot, ls_tot);
+    let anchor_grid = grid;
+    let mut seeds = vec![n_seed];
+    for exp in [-4.5_f64, -3.5, -2.5] {
+        let s = 10f64.powf(exp);
+        // Skip seeds within 2× of an existing one — same basin.
+        if seeds.iter().all(|&e| (s / e).log10().abs() > 0.301) {
+            seeds.push(s);
         }
     }
+    // (t0_tot, ls_tot, n_total, chi2 over valid bins, LM converged flag)
+    let mut winner: Option<(f64, f64, f64, f64, bool)> = None;
+    for &start_n in &seeds {
+        let mut t0_tot = anchor.0;
+        let mut ls_tot = anchor.1;
+        let mut grid = anchor_grid.clone();
+        let mut n_cur = start_n;
 
-    // Post-grid-search sanity check: if every `compute_chi2` call along
-    // the entire 3-phase grid returned `f64::INFINITY` (e.g. because
-    // `SampleParams::new` or `forward_model` failed at every candidate,
-    // or because the residuals overflowed for non-finite-but-passing
-    // transmission values such as 1e308), `best_chi2` remains
-    // `INFINITY` and the caller would otherwise receive a
-    // `CalibrationResult { reduced_chi_squared: inf, .. }` — the same
-    // silent-failure class as the zero-valid-bins case the up-front
-    // guard now rejects.  Reject explicitly here so calibration
-    // failure is always an `Err`, never an `Ok` with a sentinel chi².
-    if !best_chi2.is_finite() {
-        return Err(PipelineError::InvalidParameter(format!(
-            "calibrate_energy: grid search produced no finite chi² across all \
-             (L, t₀, n_total) candidates — likely cause is forward-model failure \
-             or non-finite residuals (e.g. wildly out-of-scale transmission); \
-             best_chi2 = {best_chi2}",
-        )));
+        // Stage 3: exact density ↔ alignment-only LM.
+        let mut failed = false;
+        for cycle in 0..3 {
+            // First cycle keeps the start density (the whole point of the
+            // multi-start); later cycles re-optimise it at the improved
+            // alignment.
+            if cycle > 0 {
+                let (n_new, chi2_n) = golden_at(&grid);
+                if chi2_n.is_finite() {
+                    n_cur = n_new;
+                }
+            }
+            let Ok(align) = run_lm(&grid, n_cur * total_abundance, true) else {
+                failed = true;
+                break;
+            };
+            let t0_k = align.t0_us.unwrap_or(0.0);
+            let ls_k = align.l_scale.unwrap_or(1.0);
+            t0_tot += ls_tot * t0_k;
+            ls_tot *= ls_k;
+            // Alignment converged (no further shift found) → stop.
+            if t0_k.abs() < 1e-6 && (ls_k - 1.0).abs() < 1e-9 {
+                break;
+            }
+            match corrected_energy_grid(energies_nominal, t0_tot, ls_tot, assumed_flight_path_m) {
+                Ok(g) => grid = g,
+                Err(_) => {
+                    failed = true;
+                    break;
+                }
+            }
+        }
+        if failed {
+            continue;
+        }
+
+        // Stage 4: joint refinement with the density free.
+        let (n_stage, chi2_stage) = golden_at(&grid);
+        if chi2_stage.is_finite() {
+            n_cur = n_stage;
+        }
+        let Ok(fit) = run_lm(&grid, n_cur * total_abundance, false) else {
+            continue;
+        };
+        let t0_c = t0_tot + ls_tot * fit.t0_us.unwrap_or(0.0);
+        let ls_c = ls_tot * fit.l_scale.unwrap_or(1.0);
+        let n_c = fit.densities.first().copied().unwrap_or(f64::NAN) / total_abundance;
+
+        // Score this start with the ORIGINAL valid-bins objective at its
+        // solution; keep the argmin.  (NaN chi² never wins: `<` is false.)
+        let Ok(e_c) = corrected_energy_grid(energies_nominal, t0_c, ls_c, assumed_flight_path_m)
+        else {
+            continue;
+        };
+        let chi2_c = compute_chi2(
+            &e_c,
+            transmission,
+            uncertainty,
+            isotopes,
+            abundances,
+            n_c,
+            temperature_k,
+            &valid,
+            resolution,
+        );
+        let better = match &winner {
+            None => true,
+            Some((_, _, _, best, _)) => chi2_c < *best,
+        };
+        if better {
+            winner = Some((t0_c, ls_c, n_c, chi2_c, fit.converged));
+        }
     }
+    let Some((t0_tot, ls_tot, best_n, _, lm_converged)) = winner else {
+        return Err(PipelineError::InvalidParameter(
+            "calibrate_energy: calibration produced no finite chi² from any \
+             density start (best_chi2 = inf) — likely cause is forward-model \
+             failure or non-finite residuals (e.g. wildly out-of-scale \
+             transmission)"
+                .into(),
+        ));
+    };
 
-    // Boundary-saturation guard: if the n_total optimum lies within
-    // tolerance of either density bound, the true minimum almost
-    // certainly sits outside the supported range and the
+    // Boundary-saturation guard: if the fitted n_total lies within
+    // tolerance of either density-band edge — or anywhere beyond it (the
+    // LM density is unbounded above, unlike the old grid) — the true
+    // minimum almost certainly sits outside the supported range and the
     // calibration is unreliable.  Returning `Ok` with `best_n` ≈
     // boundary would silently rail the density and let the (L, t₀)
     // parameters absorb the missing density freedom by compensating
-    // bias — exactly the silent-failure pattern the post-search
-    // chi² guard above also defends against, but with a boundary-
-    // specific diagnostic.
+    // bias — exactly the silent-failure pattern the no-finite-chi²
+    // guard below also defends against, but with a boundary-specific
+    // diagnostic.
     //
-    // The internal search band is `[~5e-6, ~2e-2]`; the documented
-    // edges are `[1e-5, 1e-2]`.  Densities at the documented edges
-    // lie outside the tolerance window (a true optimum at `1e-5`
-    // sits ~0.3 decades above the internal lower bound, comfortably
-    // past the ~0.02-log10 tolerance) so the guard fires only when
-    // the optimum has actually saturated against the wider buffer.
+    // The seed band is `[~5e-6, ~2e-2]`; the documented edges are
+    // `[1e-5, 1e-2]`.  Fits at the documented edges lie outside the
+    // tolerance window (a true optimum at `1e-5` sits ~0.3 decades
+    // above the internal lower bound, comfortably past the ~0.02-log10
+    // tolerance) so the guard fires only when the optimum has actually
+    // saturated against — or escaped — the wider buffer.  One-sided
+    // comparisons (≤ / ≥ rather than the former |·|) so a far
+    // out-of-band LM optimum (e.g. n ≈ 1) fires the same diagnostic; a
+    // NaN density falls through (NaN comparisons are false) to the
+    // no-finite-chi² guard below.
     let log_best_n = best_n.log10();
     let n_lo = 10f64.powf(CALIBRATION_LOG10_N_LO_DOC);
     let n_hi = 10f64.powf(CALIBRATION_LOG10_N_HI_DOC);
-    if (log_best_n - CALIBRATION_LOG10_N_LO).abs() < CALIBRATION_LOG10_BOUNDARY_TOL
-        || (CALIBRATION_LOG10_N_HI - log_best_n).abs() < CALIBRATION_LOG10_BOUNDARY_TOL
+    if log_best_n <= CALIBRATION_LOG10_N_LO + CALIBRATION_LOG10_BOUNDARY_TOL
+        || log_best_n >= CALIBRATION_LOG10_N_HI - CALIBRATION_LOG10_BOUNDARY_TOL
     {
         return Err(PipelineError::InvalidParameter(format!(
             "calibrate_energy: n_total optimum {best_n:.3e} atoms/barn is at the \
@@ -548,12 +645,58 @@ pub fn calibrate_energy(
         )));
     }
 
-    // Compute corrected energy grid at the best parameters
-    let t0_best_s = best_t0_us * 1e-6;
-    let energies_corrected: Vec<f64> = tof_s
-        .iter()
-        .map(|&t| NEUTRON_MASS_CONSTANT * (best_l / (t - t0_best_s)).powi(2))
-        .collect();
+    // Corrected energy grid at the composed (t0_tot, ls_tot): the same
+    // canonical transform the LM evaluated (SAMMY −t0 convention,
+    // `resolution_calib::corrected_energy_grid`), expressed relative to
+    // the caller's ORIGINAL nominal grid and assumed flight path — the
+    // pre-#634 output convention.
+    let energies_corrected =
+        corrected_energy_grid(energies_nominal, t0_tot, ls_tot, assumed_flight_path_m).map_err(
+            |e| {
+                PipelineError::InvalidParameter(format!(
+                    "calibrate_energy: degenerate calibration: {e}"
+                ))
+            },
+        )?;
+
+    // Final chi² over VALID bins with the original grid objective
+    // (`compute_chi2`), preserving the pre-#634 chi²_r semantics exactly:
+    // invalid bins excluded, `dof = n_valid − 3` clamped to ≥ 1 for the
+    // exact-fit edge case.  If the final chi² is non-finite
+    // (forward-model failure, or residual overflow for
+    // non-finite-but-passing transmission values such as 1e308), reject
+    // explicitly so calibration failure is always an `Err`, never an
+    // `Ok` with a sentinel chi² — the same contract as the old
+    // post-grid-search guard.
+    //
+    // Note the gate is the chi², NOT the LM `converged` flag: the grid
+    // search this replaced had no convergence concept — it reported the
+    // best candidate found, quality-gated only by finite chi² and the
+    // density boundary.  The LM matches that contract; its parameters at
+    // lambda-breakout are the best point found (a stall is common for
+    // trace densities, where the energy-scale Jacobian columns are nearly
+    // zero and the step control gives up AFTER the density has already
+    // converged).  The reported chi²_r carries the fit quality either way.
+    let best_chi2 = compute_chi2(
+        &energies_corrected,
+        transmission,
+        uncertainty,
+        isotopes,
+        abundances,
+        best_n,
+        temperature_k,
+        &valid,
+        resolution,
+    );
+    if !best_chi2.is_finite() {
+        return Err(PipelineError::InvalidParameter(format!(
+            "calibrate_energy: calibration produced no finite chi² \
+             (LM converged = {converged}, best_chi2 = {best_chi2}) — likely cause is \
+             forward-model failure or non-finite residuals (e.g. wildly \
+             out-of-scale transmission)",
+            converged = lm_converged,
+        )));
+    }
 
     // Final chi2r (reduced).  The up-front guard ensures
     // `n_valid >= N_FITTED_PARAMS`, so we always have a non-negative
@@ -564,8 +707,8 @@ pub fn calibrate_energy(
     let chi2r = best_chi2 / dof as f64;
 
     Ok(CalibrationResult {
-        flight_path_m: best_l,
-        t0_us: best_t0_us,
+        flight_path_m: assumed_flight_path_m * ls_tot,
+        t0_us: t0_tot,
         total_density: best_n,
         reduced_chi_squared: chi2r,
         energies_corrected,

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -4514,6 +4514,16 @@ mod tests {
     /// on the TRUE corrected grid at the true T, report on the nominal grid,
     /// then fit from a cold energy-scale seed (0, 1) with T seeded 40 K off —
     /// so a no-op fit cannot pass (non-vacuity).
+    ///
+    /// Oracle-dependency note: the truth grid is built with the SAME
+    /// `corrected_energy_grid` transform the fitter is pinned to, so a
+    /// sign/convention error in that shared transform would cancel here.
+    /// The convention itself is covered independently: the Python
+    /// `TestFitEnergyScaleRecovery` derives measured energies through a
+    /// hand-written inverse TOF map, and the `−t0` form is verified against
+    /// SAMMY `dat/mdat0.f90:189`. This test targets the JOINT-recovery
+    /// property (temperature wiring, FD column, index mapping), which the
+    /// shared transform cannot mask.
     #[test]
     fn test_energy_scale_with_temperature_recovers_all_three() {
         // Three well-separated resonances break the (t0, L_scale) degeneracy
@@ -4573,6 +4583,150 @@ mod tests {
         assert!(
             (temp - true_temp).abs() < 3.0,
             "temperature: fitted={temp}, true={true_temp}"
+        );
+    }
+
+    /// Issue #634: the joint combination must also work on the
+    /// transmission-PoissonKL path — its guard was lifted too, and the KL
+    /// solver consumes the model Jacobian through a different route
+    /// (deviance gradient plus Fisher) than the LM normal equations,
+    /// exactly the seam where wrong-slot σ bugs have hidden before (#641).
+    /// Same closed loop as the LM test; also pins a finite positive
+    /// temperature σ.
+    #[test]
+    fn test_energy_scale_with_temperature_recovers_all_three_kl() {
+        let data = u238_three_resonances();
+        let flight_path = 25.0_f64;
+        let true_density = 0.002;
+        let true_temp = 340.0;
+        let true_t0 = 0.6_f64;
+        let true_l_scale = 1.004_f64;
+        let nominal: Vec<f64> = (0..801).map(|i| 4.0 + (i as f64) * 0.05).collect();
+        let e_true = nereids_fitting::resolution_calib::corrected_energy_grid(
+            &nominal,
+            true_t0,
+            true_l_scale,
+            flight_path,
+        )
+        .unwrap();
+        let (t_obs, sigma) =
+            synthetic_transmission_at_temp(&data, true_density, true_temp, &e_true);
+
+        let config = UnifiedFitConfig::new(
+            nominal,
+            vec![data],
+            vec!["U-238".into()],
+            true_temp - 40.0,
+            None,
+            vec![true_density],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::PoissonKL(PoissonConfig::default()))
+        .with_fit_temperature(true)
+        .with_energy_scale(0.0, 1.0, flight_path);
+
+        let result = fit_spectrum_typed(
+            &InputData::Transmission {
+                transmission: t_obs,
+                uncertainty: sigma,
+            },
+            &config,
+        )
+        .expect("KL joint fit runs");
+        assert!(result.converged, "KL joint fit should converge");
+        let t0 = result.t0_us.expect("t0_us populated");
+        let ls = result.l_scale.expect("l_scale populated");
+        let temp = result.temperature_k.expect("temperature_k populated");
+        assert!(
+            (t0 - true_t0).abs() < 0.1,
+            "KL t0: fitted={t0}, true={true_t0}"
+        );
+        assert!(
+            (ls - true_l_scale).abs() / true_l_scale < 2e-3,
+            "KL l_scale: fitted={ls}, true={true_l_scale}"
+        );
+        assert!(
+            (temp - true_temp).abs() < 5.0,
+            "KL temperature: fitted={temp}, true={true_temp}"
+        );
+        let t_unc = result
+            .temperature_k_unc
+            .expect("KL joint fit must report a temperature σ");
+        assert!(
+            t_unc.is_finite() && t_unc > 0.0,
+            "KL joint temperature σ must be finite positive, got {t_unc}"
+        );
+    }
+
+    /// Issue #634: the joint combination on the COUNTS joint-Poisson path —
+    /// the third lifted guard. Deterministic counts (no sampling noise) at
+    /// the true corrected grid; the joint fit must recover (t0, L_scale, T)
+    /// and report a finite temperature σ through the joint-Poisson
+    /// uncertainty extraction.
+    #[test]
+    fn test_energy_scale_with_temperature_recovers_all_three_counts() {
+        let data = u238_three_resonances();
+        let flight_path = 25.0_f64;
+        let true_density = 0.002;
+        let true_temp = 340.0;
+        let true_t0 = 0.6_f64;
+        let true_l_scale = 1.004_f64;
+        let flux = 1.0e4_f64;
+        let nominal: Vec<f64> = (0..801).map(|i| 4.0 + (i as f64) * 0.05).collect();
+        let e_true = nereids_fitting::resolution_calib::corrected_energy_grid(
+            &nominal,
+            true_t0,
+            true_l_scale,
+            flight_path,
+        )
+        .unwrap();
+        let (t_true, _) = synthetic_transmission_at_temp(&data, true_density, true_temp, &e_true);
+        let open_beam = vec![flux; t_true.len()];
+        let sample_counts: Vec<f64> = t_true.iter().map(|&t| flux * t).collect();
+
+        let config = UnifiedFitConfig::new(
+            nominal,
+            vec![data],
+            vec!["U-238".into()],
+            true_temp - 40.0,
+            None,
+            vec![true_density],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::PoissonKL(PoissonConfig::default()))
+        .with_fit_temperature(true)
+        .with_energy_scale(0.0, 1.0, flight_path);
+
+        let result = fit_spectrum_typed(
+            &InputData::Counts {
+                sample_counts,
+                open_beam_counts: open_beam,
+            },
+            &config,
+        )
+        .expect("counts joint-Poisson joint fit runs");
+        assert!(result.converged, "counts joint fit should converge");
+        let t0 = result.t0_us.expect("t0_us populated");
+        let ls = result.l_scale.expect("l_scale populated");
+        let temp = result.temperature_k.expect("temperature_k populated");
+        assert!(
+            (t0 - true_t0).abs() < 0.1,
+            "counts t0: fitted={t0}, true={true_t0}"
+        );
+        assert!(
+            (ls - true_l_scale).abs() / true_l_scale < 2e-3,
+            "counts l_scale: fitted={ls}, true={true_l_scale}"
+        );
+        assert!(
+            (temp - true_temp).abs() < 5.0,
+            "counts temperature: fitted={temp}, true={true_temp}"
+        );
+        let t_unc = result
+            .temperature_k_unc
+            .expect("counts joint fit must report a temperature σ");
+        assert!(
+            t_unc.is_finite() && t_unc > 0.0,
+            "counts joint temperature σ must be finite positive, got {t_unc}"
         );
     }
 
@@ -4786,6 +4940,27 @@ mod tests {
             mk(Some(t0), None)
                 .corrected_energies(&nominal, flight_path)
                 .is_none()
+        );
+
+        // Invalid scale inputs are REJECTED, not squared into plausible
+        // grids (#634 review): the transform is even in l_scale (a negative
+        // l_scale would silently return the same grid as its positive
+        // counterpart), flight_path_m = 0 with t0 < 0 would return all
+        // zeros, and a NaN l_scale would return Ok(NaN).
+        let fitted = mk(Some(t0), Some(ls));
+        assert!(fitted.corrected_energies(&nominal, 0.0).unwrap().is_err());
+        assert!(fitted.corrected_energies(&nominal, -25.0).unwrap().is_err());
+        assert!(
+            mk(Some(t0), Some(-1.0))
+                .corrected_energies(&nominal, flight_path)
+                .unwrap()
+                .is_err()
+        );
+        assert!(
+            mk(Some(t0), Some(f64::NAN))
+                .corrected_energies(&nominal, flight_path)
+                .unwrap()
+                .is_err()
         );
     }
 

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -873,6 +873,10 @@ impl UnifiedFitConfig {
     pub fn fit_energy_scale(&self) -> bool {
         self.fit_energy_scale
     }
+    /// Nominal flight path (m) configured via [`Self::with_energy_scale`].
+    pub fn flight_path_m(&self) -> f64 {
+        self.flight_path_m
+    }
     /// User-specified fit-energy-range restriction (SAMMY EMIN/EMAX
     /// equivalent), or `None` for full-grid fitting.
     /// See [`Self::with_fit_energy_range`].
@@ -4866,7 +4870,13 @@ mod tests {
         .unwrap();
         let sigma_t_ref = reference.temperature_k_unc.expect("reference σ_T");
 
-        // (c1) strict physical invariant.
+        // (c1) strict inequality.  NOTE: this compares σ_T across two
+        // DIFFERENT models (4-param energy-scale on the nominal grid vs
+        // 2-param fixed-grid on the true corrected grid), so the nested-
+        // model Fisher argument does not make it a theorem — it is an
+        // empirical property of THIS fixture (verified robust here). If a
+        // future fixture change flips it, convert to the same-model form
+        // (t0/L_scale frozen vs free), where the inequality is guaranteed.
         assert!(sigma_t_joint.is_finite() && sigma_t_joint > 0.0);
         assert!(sigma_t_ref.is_finite() && sigma_t_ref > 0.0);
         assert!(
@@ -4945,9 +4955,19 @@ mod tests {
         let nominal: Vec<f64> = (0..50).map(|i| 5.0 + i as f64 * 0.3).collect();
         let flight_path = 25.0;
         let (t0, ls) = (0.4_f64, 1.003_f64);
-        let expected =
-            nereids_fitting::resolution_calib::corrected_energy_grid(&nominal, t0, ls, flight_path)
-                .unwrap();
+        // Hand-computed oracle — deliberately NOT `corrected_energy_grid`
+        // (the very helper the accessor delegates to), so a sign flip,
+        // argument swap, or wrong flight-path source in the accessor wiring
+        // cannot cancel (issue #634 review: circular-oracle gap).  Formula
+        // per SAMMY dat/mdat0.f90:189: E' = (kl·ls / (kl/√E − t0))².
+        let kl = nereids_physics::resolution::TOF_FACTOR * flight_path;
+        let expected: Vec<f64> = nominal
+            .iter()
+            .map(|&e| {
+                let tof = kl / e.sqrt();
+                (kl * ls / (tof - t0)).powi(2)
+            })
+            .collect();
 
         let mk = |t0: Option<f64>, ls: Option<f64>, fp: Option<f64>| SpectrumFitResult {
             densities: vec![0.001],

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -1942,6 +1942,17 @@ fn seed_energy_scale_in_params(
     }
 }
 
+/// Optimizer box bound on the TZERO offset: `t_0 ∈ [−T0, +T0]` µs.
+/// `calibrate_energy` (calibration.rs) composes multiple fits when an
+/// offset exceeds one box (issue #634); each individual fit is bounded here.
+const ENERGY_SCALE_T0_BOUND_US: f64 = 10.0;
+/// Optimizer box bounds on the flight-path scale `L_scale` (dimensionless,
+/// ±1 %).  `calibrate_energy` re-anchors across cycles to cover its wider
+/// documented band (issue #634); each individual fit is bounded here.
+const ENERGY_SCALE_L_SCALE_LO: f64 = 0.99;
+/// Upper `L_scale` bound; see [`ENERGY_SCALE_L_SCALE_LO`].
+const ENERGY_SCALE_L_SCALE_HI: f64 = 1.01;
+
 /// Append SAMMY TZERO energy-scale parameters (t_0 and L_scale) when
 /// `config.fit_energy_scale` is `true`.  Returns `(t0_idx, l_scale_idx)`.
 ///
@@ -1958,16 +1969,16 @@ fn append_energy_scale_params(
     param_vec.push(FitParameter {
         name: "t0_us".into(),
         value: config.t0_init_us,
-        lower: -10.0,
-        upper: 10.0,
+        lower: -ENERGY_SCALE_T0_BOUND_US,
+        upper: ENERGY_SCALE_T0_BOUND_US,
         fixed: false,
     });
     let ls_idx = param_vec.len();
     param_vec.push(FitParameter {
         name: "l_scale".into(),
         value: config.l_scale_init,
-        lower: 0.99,
-        upper: 1.01,
+        lower: ENERGY_SCALE_L_SCALE_LO,
+        upper: ENERGY_SCALE_L_SCALE_HI,
         fixed: false,
     });
     Some((t0_idx, ls_idx))

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -1216,17 +1216,7 @@ fn fit_transmission_lm(
     // Build parameter vector
     let mut param_vec = build_density_params(config);
 
-    // Guard: energy-scale + temperature fitting is not yet supported.
-    // The EnergyScaleTransmissionModel does not wire the temperature parameter.
-    if config.fit_energy_scale && config.fit_temperature {
-        return Err(PipelineError::InvalidParameter(
-            "fit_energy_scale and fit_temperature cannot both be true: \
-             EnergyScaleTransmissionModel does not support temperature fitting yet"
-                .into(),
-        ));
-    }
-
-    let _temperature_index = append_temperature_param(&mut param_vec, config);
+    let temperature_index = append_temperature_param(&mut param_vec, config);
     let energy_scale_indices = append_energy_scale_params(&mut param_vec, config);
 
     // Issue #608: seed (t0, L_scale) via resonance peak-matching so the
@@ -1250,9 +1240,9 @@ fn fit_transmission_lm(
 
     // Build model — use EnergyScaleTransmissionModel when energy-scale is enabled
     let model: Box<dyn FitModel> = if let Some((t0_idx, ls_idx)) = energy_scale_indices {
-        build_energy_scale_transmission_model(config, t0_idx, ls_idx)?
+        build_energy_scale_transmission_model(config, t0_idx, ls_idx, temperature_index)?
     } else {
-        build_transmission_model(config, n_density_params, _temperature_index)?
+        build_transmission_model(config, n_density_params, temperature_index)?
     };
 
     // Build the per-bin active mask (SAMMY EMIN/EMAX-equivalent fit-energy
@@ -1379,13 +1369,6 @@ fn fit_transmission_poisson(
     let n_density_params = config.n_density_params();
     let mut param_vec = build_density_params(config);
 
-    if config.fit_temperature && config.fit_energy_scale {
-        return Err(PipelineError::InvalidParameter(
-            "fit_energy_scale and fit_temperature cannot both be true: \
-             EnergyScaleTransmissionModel does not support temperature fitting yet"
-                .into(),
-        ));
-    }
     let temperature_index = append_temperature_param(&mut param_vec, config);
     let energy_scale_indices = append_energy_scale_params(&mut param_vec, config);
 
@@ -1406,7 +1389,7 @@ fn fit_transmission_poisson(
 
     // Build inner model (energy-scale or precomputed)
     let model: Box<dyn FitModel> = if let Some((t0_idx, ls_idx)) = energy_scale_indices {
-        build_energy_scale_transmission_model(config, t0_idx, ls_idx)?
+        build_energy_scale_transmission_model(config, t0_idx, ls_idx, temperature_index)?
     } else {
         build_transmission_model(config, n_density_params, temperature_index)?
     };
@@ -1536,13 +1519,6 @@ fn fit_counts_joint_poisson(
     let n_density_params = config.n_density_params();
     let mut param_vec = build_density_params(config);
 
-    if config.fit_temperature && config.fit_energy_scale {
-        return Err(PipelineError::InvalidParameter(
-            "fit_energy_scale and fit_temperature cannot both be true: \
-             EnergyScaleTransmissionModel does not support temperature fitting yet"
-                .into(),
-        ));
-    }
     let temperature_index = append_temperature_param(&mut param_vec, config);
     let energy_scale_indices = append_energy_scale_params(&mut param_vec, config);
 
@@ -1579,7 +1555,7 @@ fn fit_counts_joint_poisson(
 
     // ── Build pure transmission model ──
     let t_model: Box<dyn FitModel> = if let Some((t0_idx, ls_idx)) = energy_scale_indices {
-        build_energy_scale_transmission_model(config, t0_idx, ls_idx)?
+        build_energy_scale_transmission_model(config, t0_idx, ls_idx, temperature_index)?
     } else {
         build_transmission_model(config, n_density_params, temperature_index)?
     };
@@ -2374,6 +2350,7 @@ fn build_energy_scale_transmission_model(
     config: &UnifiedFitConfig,
     t0_idx: usize,
     ls_idx: usize,
+    temperature_index: Option<usize>,
 ) -> Result<Box<dyn FitModel>, PipelineError> {
     let instrument = config
         .resolution
@@ -2403,7 +2380,11 @@ fn build_energy_scale_transmission_model(
         t0_idx,
         ls_idx,
         instrument,
-    );
+    )
+    // Issue #634: when temperature is also fit, wire its parameter index in
+    // so the model rebuilds σ at the free temperature and emits a T Jacobian
+    // column. `None` keeps temperature fixed (unchanged behavior).
+    .with_temperature_index(temperature_index);
     if let Some(method) = config.tzero_jacobian_method {
         es_model = es_model.with_jacobian_method(method);
     }
@@ -3145,14 +3126,96 @@ pub struct SpectrumFitResult {
     pub deviance_per_dof: Option<f64>,
 }
 
+impl SpectrumFitResult {
+    /// Map a nominal energy grid through the fitted SAMMY energy scale
+    /// `(t0_us, l_scale)` to the corrected (calibrated) energies the fit
+    /// actually evaluated the physics on (issue #634).
+    ///
+    /// This exposes the exact transform the fitter used so downstream code
+    /// never has to re-derive it — replicating it by hand with a `+t0` sign
+    /// (instead of the correct `−t0`) caused a silent +400 K temperature bias
+    /// in the field. It reuses the canonical
+    /// [`corrected_energy_grid`](nereids_fitting::resolution_calib::corrected_energy_grid)
+    /// (SAMMY `dat/mdat0.f90:189`, −t0 convention).
+    ///
+    /// Returns `None` when energy-scale fitting was not enabled (`t0_us` or
+    /// `l_scale` is `None`) — the corrected grid would equal the input, but
+    /// `None` distinguishes "not fitted" from "fitted to the identity".
+    /// Returns `Some(Err(_))` for a degenerate calibration (a `t0` past the
+    /// shortest flight time on the given grid).
+    pub fn corrected_energies(
+        &self,
+        nominal_energies: &[f64],
+        flight_path_m: f64,
+    ) -> Option<Result<Vec<f64>, PipelineError>> {
+        match (self.t0_us, self.l_scale) {
+            (Some(t0), Some(l_scale)) => Some(
+                nereids_fitting::resolution_calib::corrected_energy_grid(
+                    nominal_energies,
+                    t0,
+                    l_scale,
+                    flight_path_m,
+                )
+                .map_err(|e| PipelineError::InvalidParameter(e.to_string())),
+            ),
+            _ => None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use nereids_endf::resonance::test_support::{
         hf178_mlbw_two_resonances, synthetic_single_resonance, u238_single_resonance,
+        u238_three_resonances,
     };
     use nereids_fitting::lm::FitModel;
+    use nereids_fitting::transmission_model::{
+        EnergyScaleJacobianMethod, EnergyScaleTransmissionModel,
+    };
     use nereids_physics::transmission as phys_transmission;
+
+    /// Gauss–Jordan inverse of a small dense matrix (test-only; the crate's
+    /// `invert_matrix` is `pub(crate)` in nereids-fitting and unreachable here).
+    /// Returns `None` on a singular pivot.
+    fn invert_dense(a: &[Vec<f64>]) -> Option<Vec<Vec<f64>>> {
+        let n = a.len();
+        let mut m: Vec<Vec<f64>> = a.to_vec();
+        let mut inv: Vec<Vec<f64>> = (0..n)
+            .map(|i| (0..n).map(|j| if i == j { 1.0 } else { 0.0 }).collect())
+            .collect();
+        for col in 0..n {
+            // Partial pivot.
+            let mut piv = col;
+            for r in (col + 1)..n {
+                if m[r][col].abs() > m[piv][col].abs() {
+                    piv = r;
+                }
+            }
+            if m[piv][col].abs() < 1e-300 {
+                return None;
+            }
+            m.swap(col, piv);
+            inv.swap(col, piv);
+            let d = m[col][col];
+            for j in 0..n {
+                m[col][j] /= d;
+                inv[col][j] /= d;
+            }
+            for r in 0..n {
+                if r == col {
+                    continue;
+                }
+                let f = m[r][col];
+                for j in 0..n {
+                    m[r][j] -= f * m[col][j];
+                    inv[r][j] -= f * inv[col][j];
+                }
+            }
+        }
+        Some(inv)
+    }
 
     /// Issue #608: the dip detector finds the resonance signatures (local
     /// transmission minima) the energy-scale peak-match seed needs.
@@ -3946,6 +4009,25 @@ mod tests {
     }
 
     /// Helper: build synthetic transmission at a given temperature.
+    /// Deterministic ~N(0,1) samples via an LCG + Box–Muller. Test-only, so a
+    /// fixed seed gives reproducible noise (no `rand` dev-dependency).
+    fn seeded_gaussian(n: usize, seed: u64) -> Vec<f64> {
+        let mut state = seed | 1;
+        let mut unif = || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (((state >> 11) as f64) / ((1u64 << 53) as f64)).clamp(1e-12, 1.0 - 1e-12)
+        };
+        (0..n)
+            .map(|_| {
+                let u1 = unif();
+                let u2 = unif();
+                (-2.0 * u1.ln()).sqrt() * (std::f64::consts::TAU * u2).cos()
+            })
+            .collect()
+    }
+
     fn synthetic_transmission_at_temp(
         data: &ResonanceData,
         true_density: f64,
@@ -4416,36 +4498,283 @@ mod tests {
 
     // ── Energy-scale fitting tests ──
 
-    /// fit_energy_scale + fit_temperature must be rejected.
+    /// Issue #634: fit_energy_scale + fit_temperature JOINTLY recovers the
+    /// injected (t0, L_scale, T) in a single LM fit. Closed loop: synthesize
+    /// on the TRUE corrected grid at the true T, report on the nominal grid,
+    /// then fit from a cold energy-scale seed (0, 1) with T seeded 40 K off —
+    /// so a no-op fit cannot pass (non-vacuity).
     #[test]
-    fn test_energy_scale_rejects_temperature() {
-        let data = u238_single_resonance();
-        let energies: Vec<f64> = (0..101).map(|i| 1.0 + (i as f64) * 0.1).collect();
-        let (t_obs, sigma) = synthetic_transmission(&data, 0.002, &energies);
+    fn test_energy_scale_with_temperature_recovers_all_three() {
+        // Three well-separated resonances break the (t0, L_scale) degeneracy
+        // that a single dip leaves.
+        let data = u238_three_resonances();
+        let flight_path = 25.0_f64;
+        let true_density = 0.002;
+        let true_temp = 340.0;
+        let true_t0 = 0.6_f64; // µs
+        let true_l_scale = 1.004_f64;
+        // Fine grid spanning all three resonances (6.674, 20.87, 36.68 eV).
+        let nominal: Vec<f64> = (0..801).map(|i| 4.0 + (i as f64) * 0.05).collect();
+
+        // TRUE corrected energies: each nominal bin's true physical energy.
+        let e_true = nereids_fitting::resolution_calib::corrected_energy_grid(
+            &nominal,
+            true_t0,
+            true_l_scale,
+            flight_path,
+        )
+        .unwrap();
+        // Clean transmission at the true energies + true T, indexed by bin.
+        let (t_obs, sigma) =
+            synthetic_transmission_at_temp(&data, true_density, true_temp, &e_true);
 
         let config = UnifiedFitConfig::new(
-            energies,
+            nominal,
             vec![data],
             vec!["U-238".into()],
-            293.6,
+            true_temp - 40.0, // temperature seeded 40 K low
             None,
-            vec![0.001],
+            vec![true_density],
         )
         .unwrap()
         .with_solver(SolverConfig::LevenbergMarquardt(Default::default()))
         .with_fit_temperature(true)
-        .with_energy_scale(0.0, 1.0, 25.0);
+        .with_energy_scale(0.0, 1.0, flight_path); // cold energy-scale seed
 
         let input = InputData::Transmission {
             transmission: t_obs,
             uncertainty: sigma,
         };
-        let err = fit_spectrum_typed(&input, &config);
-        assert!(err.is_err(), "energy_scale + temperature should fail");
-        let msg = err.unwrap_err().to_string();
+        let result = fit_spectrum_typed(&input, &config).expect("joint fit runs");
+        assert!(result.converged, "joint (t0,L_scale,T) fit should converge");
+
+        let t0 = result.t0_us.expect("t0_us populated");
+        let ls = result.l_scale.expect("l_scale populated");
+        let temp = result.temperature_k.expect("temperature_k populated");
         assert!(
-            msg.contains("fit_energy_scale") && msg.contains("fit_temperature"),
-            "error should mention both flags: {msg}"
+            (t0 - true_t0).abs() < 0.05,
+            "t0: fitted={t0}, true={true_t0}"
+        );
+        assert!(
+            (ls - true_l_scale).abs() / true_l_scale < 1e-3,
+            "l_scale: fitted={ls}, true={true_l_scale}"
+        );
+        assert!(
+            (temp - true_temp).abs() < 3.0,
+            "temperature: fitted={temp}, true={true_temp}"
+        );
+    }
+
+    /// Issue #634 (acceptance c, revised): two guarantees on the joint fit's
+    /// temperature uncertainty.
+    ///
+    /// (c1) Physical invariant, no arbitrary threshold: on identical data the
+    /// joint (T + t0 + L_scale) fit's σ_T is strictly LARGER than a
+    /// no-energy-scale (T-only) fit's σ_T — the extra energy-scale parameters
+    /// are not orthogonal to temperature. (The magnitude of the excess is
+    /// dataset-dependent coupling, so pinning a % against a different model
+    /// protects nothing; hence a strict inequality, not a bound.)
+    ///
+    /// (c2) Covariance plumbing, same model: at the joint solution, an
+    /// INDEPENDENT reconstruction of the covariance — finite-difference the
+    /// SAME model's predictions with the model's own steps, form (JᵀWJ)⁻¹ by
+    /// hand, read the temperature diagonal, scale by reduced χ² — reproduces
+    /// the solver-reported σ_T to <0.1%. This is the assertion that catches
+    /// the #641-class bug where σ_T is read from the wrong free-parameter slot.
+    /// Full-FD Jacobian so the reconstruction's steps match the solver's.
+    #[test]
+    fn test_energy_scale_temperature_sigma_covariance_plumbing() {
+        let data = u238_three_resonances();
+        let flight_path = 25.0_f64;
+        let true_density = 0.002;
+        let true_temp = 340.0;
+        let true_t0 = 0.6_f64;
+        let true_l_scale = 1.004_f64;
+        let nominal: Vec<f64> = (0..801).map(|i| 4.0 + (i as f64) * 0.05).collect();
+        let e_true = nereids_fitting::resolution_calib::corrected_energy_grid(
+            &nominal,
+            true_t0,
+            true_l_scale,
+            flight_path,
+        )
+        .unwrap();
+        let (t_clean, sigma) =
+            synthetic_transmission_at_temp(&data, true_density, true_temp, &e_true);
+        // Matched Gaussian noise so both fits reach reduced_chi²≈1 and σ_T
+        // reflects the Jacobian covariance (not a ~0 residual).
+        let noise = seeded_gaussian(t_clean.len(), 0x6340_0000_0000_0634);
+        let t_obs: Vec<f64> = t_clean
+            .iter()
+            .zip(sigma.iter())
+            .zip(noise.iter())
+            .map(|((&t, &s), &g)| t + s * g)
+            .collect();
+
+        // Joint fit — full-FD Jacobian so the independent reconstruction below
+        // uses matching per-coordinate central differences (PartialGal would
+        // derive the L_scale column by a rank-1 identity we do not replicate).
+        let joint_cfg = UnifiedFitConfig::new(
+            nominal.clone(),
+            vec![data.clone()],
+            vec!["U-238".into()],
+            true_temp - 40.0,
+            None,
+            vec![true_density],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::LevenbergMarquardt(Default::default()))
+        .with_fit_temperature(true)
+        .with_energy_scale(0.0, 1.0, flight_path)
+        .with_tzero_jacobian_method(Some(EnergyScaleJacobianMethod::FiniteDifference));
+        let joint = fit_spectrum_typed(
+            &InputData::Transmission {
+                transmission: t_obs.clone(),
+                uncertainty: sigma.clone(),
+            },
+            &joint_cfg,
+        )
+        .unwrap();
+        let sigma_t_joint = joint.temperature_k_unc.expect("joint σ_T");
+
+        // Reference: temperature-only fit on the TRUE corrected grid (analytic
+        // ∂σ/∂T path, no energy scale) — same data, same noise.
+        let ref_cfg = UnifiedFitConfig::new(
+            e_true,
+            vec![data.clone()],
+            vec!["U-238".into()],
+            true_temp - 40.0,
+            None,
+            vec![true_density],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::LevenbergMarquardt(Default::default()))
+        .with_fit_temperature(true);
+        let reference = fit_spectrum_typed(
+            &InputData::Transmission {
+                transmission: t_obs,
+                uncertainty: sigma.clone(),
+            },
+            &ref_cfg,
+        )
+        .unwrap();
+        let sigma_t_ref = reference.temperature_k_unc.expect("reference σ_T");
+
+        // (c1) strict physical invariant.
+        assert!(sigma_t_joint.is_finite() && sigma_t_joint > 0.0);
+        assert!(sigma_t_ref.is_finite() && sigma_t_ref > 0.0);
+        assert!(
+            sigma_t_joint > sigma_t_ref,
+            "joint σ_T ({sigma_t_joint:.5}) must strictly exceed no-energy-scale \
+             σ_T ({sigma_t_ref:.5}): the extra t0/L_scale params are not \
+             orthogonal to temperature"
+        );
+
+        // (c2) independent covariance reconstruction at the joint solution.
+        // Param layout: [density(0), temperature(1), t0(2), l_scale(3)].
+        let p = [
+            joint.densities[0],
+            joint.temperature_k.unwrap(),
+            joint.t0_us.unwrap(),
+            joint.l_scale.unwrap(),
+        ];
+        let model = EnergyScaleTransmissionModel::new(
+            Arc::new(vec![data]),
+            Arc::new(vec![0]),
+            Arc::new(vec![1.0]),
+            true_temp - 40.0,
+            nominal.clone(),
+            flight_path,
+            2,
+            3,
+            None,
+        )
+        .with_temperature_index(Some(1))
+        .with_jacobian_method(EnergyScaleJacobianMethod::FiniteDifference);
+
+        // Central FD of the model predictions, per-coordinate steps matching
+        // the model (t0 abs 1e-4, temperature rel 1e-4, L_scale abs 1e-7;
+        // density is analytic in the model — FD it here with a tiny relative
+        // step, its off-diagonal contribution to cov_TT is negligible).
+        let steps = [1e-4 * p[0].max(1e-6), 1e-4 * p[1].max(1.0), 1e-4, 1e-7];
+        let n_e = nominal.len();
+        let mut jac = vec![[0.0f64; 4]; n_e];
+        for (j, &h) in steps.iter().enumerate() {
+            let mut pp = p;
+            let mut pm = p;
+            pp[j] += h;
+            pm[j] -= h;
+            let yp = model.evaluate(&pp).unwrap();
+            let ym = model.evaluate(&pm).unwrap();
+            for i in 0..n_e {
+                jac[i][j] = (yp[i] - ym[i]) / (2.0 * h);
+            }
+        }
+        // A = JᵀWJ, W = diag(1/σ²).
+        let mut a = vec![vec![0.0f64; 4]; 4];
+        for i in 0..n_e {
+            let w = 1.0 / (sigma[i] * sigma[i]);
+            for r in 0..4 {
+                for c in 0..4 {
+                    a[r][c] += jac[i][r] * w * jac[i][c];
+                }
+            }
+        }
+        let cov = invert_dense(&a).expect("covariance invertible");
+        // #108.1: covariance is scaled by reduced χ².
+        let sigma_t_recon = (cov[1][1] * joint.reduced_chi_squared).sqrt();
+        let rel = (sigma_t_recon - sigma_t_joint).abs() / sigma_t_joint;
+        assert!(
+            rel < 1e-3,
+            "independent covariance reconstruction σ_T={sigma_t_recon:.5} must match \
+             the solver-reported σ_T={sigma_t_joint:.5} to <0.1%, got {rel:.3e} \
+             (a mismatch means the solver read T's σ from the wrong covariance slot)"
+        );
+    }
+
+    /// Issue #634: `SpectrumFitResult::corrected_energies` reuses the canonical
+    /// transform and returns `None` when the energy scale was not fitted.
+    #[test]
+    fn test_spectrum_result_corrected_energies() {
+        let nominal: Vec<f64> = (0..50).map(|i| 5.0 + i as f64 * 0.3).collect();
+        let flight_path = 25.0;
+        let (t0, ls) = (0.4_f64, 1.003_f64);
+        let expected =
+            nereids_fitting::resolution_calib::corrected_energy_grid(&nominal, t0, ls, flight_path)
+                .unwrap();
+
+        let mk = |t0: Option<f64>, ls: Option<f64>| SpectrumFitResult {
+            densities: vec![0.001],
+            uncertainties: None,
+            reduced_chi_squared: 1.0,
+            converged: true,
+            iterations: 1,
+            temperature_k: None,
+            temperature_k_unc: None,
+            anorm: 1.0,
+            background: [0.0; 3],
+            back_d: None,
+            back_f: None,
+            t0_us: t0,
+            l_scale: ls,
+            deviance_per_dof: None,
+        };
+
+        // Fitted energy scale → Some(corrected grid) == the canonical transform.
+        let got = mk(Some(t0), Some(ls))
+            .corrected_energies(&nominal, flight_path)
+            .expect("Some when energy scale fitted")
+            .unwrap();
+        assert_eq!(got, expected);
+        // Not fitted → None (distinguishes "unfit" from "fitted to identity").
+        assert!(
+            mk(None, None)
+                .corrected_energies(&nominal, flight_path)
+                .is_none()
+        );
+        assert!(
+            mk(Some(t0), None)
+                .corrected_energies(&nominal, flight_path)
+                .is_none()
         );
     }
 

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -2428,7 +2428,8 @@ fn build_energy_scale_transmission_model(
     // Issue #634: when temperature is also fit, wire its parameter index in
     // so the model rebuilds σ at the free temperature and emits a T Jacobian
     // column. `None` keeps temperature fixed (unchanged behavior).
-    .with_temperature_index(temperature_index);
+    .with_temperature_index(temperature_index)
+    .map_err(|e| PipelineError::InvalidParameter(format!("energy-scale model: {e}")))?;
     if let Some(method) = config.tzero_jacobian_method {
         es_model = es_model.with_jacobian_method(method);
     }
@@ -4906,6 +4907,7 @@ mod tests {
             None,
         )
         .with_temperature_index(Some(1))
+        .expect("distinct temperature index")
         .with_jacobian_method(EnergyScaleJacobianMethod::FiniteDifference);
 
         // Central FD of the model predictions, per-coordinate steps matching
@@ -5043,6 +5045,14 @@ mod tests {
         assert!(
             mk(Some(t0), Some(ls), Some(flight_path))
                 .corrected_energies(&[0.0, 1.0])
+                .unwrap()
+                .is_err()
+        );
+        // Non-ascending grids are rejected on the Rust surface too, matching
+        // the Python binding's standard validation (#634 review R4).
+        assert!(
+            mk(Some(t0), Some(ls), Some(flight_path))
+                .corrected_energies(&[5.0, 4.0, 6.0])
                 .unwrap()
                 .is_err()
         );

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -372,6 +372,14 @@ pub struct UnifiedFitConfig {
     /// back to `PartialGal` (the default since issue #489).
     /// `Some(_)` bypasses both the env var and the default.
     tzero_jacobian_method: Option<nereids_fitting::transmission_model::EnergyScaleJacobianMethod>,
+    /// Whether the resonance peak-match seed runs before an energy-scale fit
+    /// (default `true`).  `calibrate_energy` disables it (issue #634): its
+    /// global anchor stages already seed `(t0, L_scale)`, and the peak-match
+    /// dip detector mislocates saturated flat-bottom dips (a strict
+    /// local-minimum test on a ≈0 plateau), producing an in-bounds but wrong
+    /// least-squares seed that OVERWRITES the caller's anchor — observed
+    /// driving a fit from 0.12 µs off truth to a 7 µs-wrong pit.
+    energy_scale_seed_enabled: bool,
 
     // ── Fit energy range restriction (SAMMY EMIN/EMAX equivalent) ──
     /// User-specified fit-energy-range restriction.  When `Some((min,
@@ -486,6 +494,7 @@ impl UnifiedFitConfig {
             n_density_params: None,
             density_free: None,
             tzero_jacobian_method: None,
+            energy_scale_seed_enabled: true,
             fit_energy_range: None,
         })
     }
@@ -501,6 +510,18 @@ impl UnifiedFitConfig {
         method: Option<nereids_fitting::transmission_model::EnergyScaleJacobianMethod>,
     ) -> Self {
         self.tzero_jacobian_method = method;
+        self
+    }
+
+    /// Enable/disable the resonance peak-match `(t0, L_scale)` seed that
+    /// normally runs before an energy-scale fit (default `true`).  Callers
+    /// that supply their own, stronger alignment anchor — `calibrate_energy`
+    /// (issue #634) — disable it: the seed's dip detector mislocates
+    /// saturated flat-bottom dips and its in-bounds least-squares result
+    /// would overwrite the anchor.
+    #[must_use]
+    pub fn with_energy_scale_seed(mut self, enabled: bool) -> Self {
+        self.energy_scale_seed_enabled = enabled;
         self
     }
 
@@ -1329,6 +1350,7 @@ fn fit_transmission_lm(
     if let Some((t0_idx, ls_idx)) = energy_scale_indices {
         sr.t0_us = Some(result.params[t0_idx]);
         sr.l_scale = Some(result.params[ls_idx]);
+        sr.energy_scale_flight_path_m = Some(config.flight_path_m);
     }
 
     Ok(sr)
@@ -1437,6 +1459,7 @@ fn fit_transmission_poisson(
     if let Some((t0_idx, ls_idx)) = energy_scale_indices {
         sr.t0_us = Some(result.params[t0_idx]);
         sr.l_scale = Some(result.params[ls_idx]);
+        sr.energy_scale_flight_path_m = Some(config.flight_path_m);
     }
 
     Ok(sr)
@@ -1699,6 +1722,7 @@ fn fit_counts_joint_poisson(
         back_f: None,
         t0_us: energy_scale_indices.map(|(t0_idx, _)| result.params[t0_idx]),
         l_scale: energy_scale_indices.map(|(_, ls_idx)| result.params[ls_idx]),
+        energy_scale_flight_path_m: energy_scale_indices.map(|_| config.flight_path_m),
         deviance_per_dof: Some(result.deviance_per_dof),
     })
 }
@@ -1924,6 +1948,11 @@ fn seed_energy_scale_in_params(
     measured_transmission: &[f64],
     config: &UnifiedFitConfig,
 ) {
+    // Issue #634: callers with their own alignment anchor (calibrate_energy)
+    // disable the seed — see `with_energy_scale_seed`.
+    if !config.energy_scale_seed_enabled {
+        return;
+    }
     let Some((t0_idx, ls_idx)) = energy_scale_indices else {
         return;
     };
@@ -2665,6 +2694,7 @@ fn extract_result(
         back_f,
         t0_us: None,
         l_scale: None,
+        energy_scale_flight_path_m: None,
         deviance_per_dof: None,
     })
 }
@@ -3126,6 +3156,13 @@ pub struct SpectrumFitResult {
     /// Fitted flight-path scale factor (SAMMY TZERO L₀, dimensionless).
     /// `None` when energy-scale fitting is not enabled.
     pub l_scale: Option<f64>,
+    /// The nominal flight path (m) the energy-scale fit was configured
+    /// with — stored so [`Self::corrected_energies`] reproduces the
+    /// transform with the SAME flight path the fit used, closing the
+    /// caller-resupplied-mismatch channel (issue #634 review: a wrong but
+    /// positive flight path silently changes the t₀ term).  `None` when
+    /// energy-scale fitting is not enabled.
+    pub energy_scale_flight_path_m: Option<f64>,
     /// Conditional binomial deviance divided by `(n − k)`
     /// (primary GOF for the counts-KL dispatch, i.e.
     /// `SolverConfig::PoissonKL` on `InputData::Counts` or
@@ -3140,27 +3177,32 @@ pub struct SpectrumFitResult {
 impl SpectrumFitResult {
     /// Map a nominal energy grid through the fitted SAMMY energy scale
     /// `(t0_us, l_scale)` to the corrected (calibrated) energies the fit
-    /// actually evaluated the physics on (issue #634).
+    /// evaluated the physics on (issue #634).
     ///
-    /// This exposes the exact transform the fitter used so downstream code
-    /// never has to re-derive it — replicating it by hand with a `+t0` sign
+    /// This exposes the transform the fitter used so downstream code never
+    /// has to re-derive it — replicating it by hand with a `+t0` sign
     /// (instead of the correct `−t0`) caused a silent +400 K temperature bias
     /// in the field. It reuses the canonical
     /// [`corrected_energy_grid`](nereids_fitting::resolution_calib::corrected_energy_grid)
-    /// (SAMMY `dat/mdat0.f90:189`, −t0 convention).
+    /// (SAMMY `dat/mdat0.f90:189`, −t0 convention) with the SAME flight path
+    /// the fit was configured with (stored on the result), so a mismatched
+    /// caller-supplied flight path cannot silently skew the t₀ term.
     ///
-    /// Returns `None` when energy-scale fitting was not enabled (`t0_us` or
-    /// `l_scale` is `None`) — the corrected grid would equal the input, but
-    /// `None` distinguishes "not fitted" from "fitted to the identity".
-    /// Returns `Some(Err(_))` for a degenerate calibration (a `t0` past the
-    /// shortest flight time on the given grid).
+    /// One divergence from the fit's internal evaluation: at a DEGENERATE
+    /// `t0` at/past the grid's shortest flight time, the model clamps `t0`
+    /// just below the limit and keeps evaluating, while this accessor
+    /// returns `Some(Err(_))` — a degenerate calibration should be
+    /// re-examined, not silently reproduced.
+    ///
+    /// Returns `None` when energy-scale fitting was not enabled — the
+    /// corrected grid would equal the input, but `None` distinguishes
+    /// "not fitted" from "fitted to the identity".
     pub fn corrected_energies(
         &self,
         nominal_energies: &[f64],
-        flight_path_m: f64,
     ) -> Option<Result<Vec<f64>, PipelineError>> {
-        match (self.t0_us, self.l_scale) {
-            (Some(t0), Some(l_scale)) => Some(
+        match (self.t0_us, self.l_scale, self.energy_scale_flight_path_m) {
+            (Some(t0), Some(l_scale), Some(flight_path_m)) => Some(
                 nereids_fitting::resolution_calib::corrected_energy_grid(
                     nominal_energies,
                     t0,
@@ -4907,7 +4949,7 @@ mod tests {
             nereids_fitting::resolution_calib::corrected_energy_grid(&nominal, t0, ls, flight_path)
                 .unwrap();
 
-        let mk = |t0: Option<f64>, ls: Option<f64>| SpectrumFitResult {
+        let mk = |t0: Option<f64>, ls: Option<f64>, fp: Option<f64>| SpectrumFitResult {
             densities: vec![0.001],
             uncertainties: None,
             reduced_chi_squared: 1.0,
@@ -4921,44 +4963,66 @@ mod tests {
             back_f: None,
             t0_us: t0,
             l_scale: ls,
+            energy_scale_flight_path_m: fp,
             deviance_per_dof: None,
         };
 
-        // Fitted energy scale → Some(corrected grid) == the canonical transform.
-        let got = mk(Some(t0), Some(ls))
-            .corrected_energies(&nominal, flight_path)
+        // Fitted energy scale → Some(corrected grid) == the canonical
+        // transform at the STORED flight path.
+        let got = mk(Some(t0), Some(ls), Some(flight_path))
+            .corrected_energies(&nominal)
             .expect("Some when energy scale fitted")
             .unwrap();
         assert_eq!(got, expected);
         // Not fitted → None (distinguishes "unfit" from "fitted to identity").
+        assert!(mk(None, None, None).corrected_energies(&nominal).is_none());
         assert!(
-            mk(None, None)
-                .corrected_energies(&nominal, flight_path)
-                .is_none()
-        );
-        assert!(
-            mk(Some(t0), None)
-                .corrected_energies(&nominal, flight_path)
+            mk(Some(t0), None, None)
+                .corrected_energies(&nominal)
                 .is_none()
         );
 
-        // Invalid scale inputs are REJECTED, not squared into plausible
+        // Invalid scale values are REJECTED, not squared into plausible
         // grids (#634 review): the transform is even in l_scale (a negative
         // l_scale would silently return the same grid as its positive
         // counterpart), flight_path_m = 0 with t0 < 0 would return all
         // zeros, and a NaN l_scale would return Ok(NaN).
-        let fitted = mk(Some(t0), Some(ls));
-        assert!(fitted.corrected_energies(&nominal, 0.0).unwrap().is_err());
-        assert!(fitted.corrected_energies(&nominal, -25.0).unwrap().is_err());
         assert!(
-            mk(Some(t0), Some(-1.0))
-                .corrected_energies(&nominal, flight_path)
+            mk(Some(t0), Some(ls), Some(0.0))
+                .corrected_energies(&nominal)
                 .unwrap()
                 .is_err()
         );
         assert!(
-            mk(Some(t0), Some(f64::NAN))
-                .corrected_energies(&nominal, flight_path)
+            mk(Some(t0), Some(ls), Some(-25.0))
+                .corrected_energies(&nominal)
+                .unwrap()
+                .is_err()
+        );
+        assert!(
+            mk(Some(t0), Some(-1.0), Some(flight_path))
+                .corrected_energies(&nominal)
+                .unwrap()
+                .is_err()
+        );
+        assert!(
+            mk(Some(t0), Some(f64::NAN), Some(flight_path))
+                .corrected_energies(&nominal)
+                .unwrap()
+                .is_err()
+        );
+        // A garbage NOMINAL grid is rejected too — including at the exact
+        // identity (t0=0, ls=1), which previously passed the grid through
+        // verbatim (#634 review: inconsistent Ok/Err contract).
+        assert!(
+            mk(Some(0.0), Some(1.0), Some(flight_path))
+                .corrected_energies(&[1.0, f64::NAN, 3.0])
+                .unwrap()
+                .is_err()
+        );
+        assert!(
+            mk(Some(t0), Some(ls), Some(flight_path))
+                .corrected_energies(&[0.0, 1.0])
                 .unwrap()
                 .is_err()
         );

--- a/crates/nereids-pipeline/src/spatial.rs
+++ b/crates/nereids-pipeline/src/spatial.rs
@@ -712,22 +712,11 @@ pub fn spatial_map_typed(
         ));
     }
 
-    // Issue #458: `fit_energy_scale` + `fit_temperature`
-    // is not a supported combination — `EnergyScaleTransmissionModel`
-    // and the temperature-fitting path are mutually exclusive in every
-    // solver dispatch arm of `fit_spectrum_typed`.  Without
-    // this spatial-layer guard, every per-pixel call would error and
-    // `spatial_map_typed` would report `n_failed == n_total` with an
-    // all-NaN map — a silently-failed map is worse than a clear error.
-    if config.fit_energy_scale() && config.fit_temperature() {
-        return Err(PipelineError::InvalidParameter(
-            "spatial_map_typed: fit_energy_scale=true and fit_temperature=true cannot \
-             both be set — EnergyScaleTransmissionModel does not support temperature \
-             fitting. Choose one: either calibrate TZERO with a fixed temperature, or \
-             fit temperature on the nominal energy grid."
-                .into(),
-        ));
-    }
+    // Issue #634: `fit_energy_scale` + `fit_temperature` is now supported —
+    // `EnergyScaleTransmissionModel` wires a fitted temperature column, so
+    // per-pixel `fit_spectrum_typed` handles the combination and no spatial
+    // guard is needed. (The #458 B3 guard above — LM + fit_energy_scale on
+    // counts — is a separate, still-active numerical-stability restriction.)
 
     // `fit_spectrum_typed` rejects `CountsWithNuisance + LM` per-pixel
     // (see `validate_input_solver` in `pipeline.rs` — "CountsWithNuisance
@@ -3831,14 +3820,12 @@ mod tests {
         assert!(result.t0_us_map.is_some());
     }
 
-    /// `fit_energy_scale + fit_temperature` must be rejected at
-    /// spatial entry (follow-up to #458).  The
-    /// single-spectrum fitter errors on this combination, but without
-    /// a spatial-layer guard every pixel would error and
-    /// `spatial_map_typed` would silently return `n_failed == n_total`
-    /// with an all-NaN map instead of a clear error.
+    /// Issue #634: `fit_energy_scale + fit_temperature` is now SUPPORTED at
+    /// spatial entry (the per-pixel fitter wires a temperature column into the
+    /// energy-scale model). `spatial_map_typed` must run without the old guard
+    /// error and allocate both the temperature and t0/L_scale maps.
     #[test]
-    fn test_spatial_map_typed_rejects_energy_scale_with_temperature() {
+    fn test_spatial_map_typed_allows_energy_scale_with_temperature() {
         let rd = u238_single_resonance();
         let energies: Vec<f64> = (0..51).map(|i| 1.0 + (i as f64) * 0.2).collect();
         let (t_3d, u_3d) = synthetic_4x4_transmission(&rd, 0.001, &energies);
@@ -3859,13 +3846,18 @@ mod tests {
         .with_fit_temperature(true)
         .with_energy_scale(0.0, 1.0, 25.0);
 
-        let err = spatial_map_typed(&data, &config, None, None, None)
-            .expect_err("fit_energy_scale + fit_temperature must be rejected");
-        let msg = err.to_string();
+        let result = spatial_map_typed(&data, &config, None, None, None)
+            .expect("fit_energy_scale + fit_temperature is now supported (#634)");
+        // Both flag families allocate their maps.
         assert!(
-            msg.contains("fit_energy_scale") && msg.contains("fit_temperature"),
-            "error message should name both culprits, got: {msg}"
+            result.temperature_map.is_some(),
+            "temperature map allocated when fit_temperature=true"
         );
+        assert!(
+            result.t0_us_map.is_some() && result.l_scale_map.is_some(),
+            "energy-scale maps allocated when fit_energy_scale=true"
+        );
+        assert_eq!(result.n_total, 16, "4×4 map");
     }
 
     /// `(Transmission + LM + fit_energy_scale=true)` is allowed —

--- a/crates/nereids-pipeline/src/spatial.rs
+++ b/crates/nereids-pipeline/src/spatial.rs
@@ -107,6 +107,13 @@ pub struct SpatialResult {
     /// `Some` when `config.fit_energy_scale` is true; `None` otherwise.
     /// NaN at pixels where `converged_map` is `false`.
     pub l_scale_map: Option<Array2<f64>>,
+    /// Nominal flight path (m) the energy-scale fit was configured with —
+    /// recorded AT FIT TIME so downstream consumers (e.g. the GUI overlay's
+    /// per-pixel `SpectrumFitResult::corrected_energies`) reproduce the
+    /// transform with the fit's own flight path even if the live beamline
+    /// setting is edited afterwards (issue #634 review).  `Some` when
+    /// `config.fit_energy_scale` is true; `None` otherwise.
+    pub energy_scale_flight_path_m: Option<f64>,
     /// Number of pixels that converged.
     pub n_converged: usize,
     /// Total number of pixels fitted.
@@ -925,6 +932,7 @@ pub fn spatial_map_typed(
             } else {
                 None
             },
+            energy_scale_flight_path_m: config.fit_energy_scale().then(|| config.flight_path_m()),
             n_converged: 0,
             n_total: 0,
             n_failed: 0,
@@ -1737,6 +1745,7 @@ pub fn spatial_map_typed(
         back_f_map,
         t0_us_map,
         l_scale_map,
+        energy_scale_flight_path_m: config.fit_energy_scale().then(|| config.flight_path_m()),
         n_converged,
         n_total: pixel_coords.len(),
         n_failed: failed_count.load(Ordering::Relaxed),

--- a/crates/nereids-pipeline/src/spatial.rs
+++ b/crates/nereids-pipeline/src/spatial.rs
@@ -582,11 +582,12 @@ fn validate_spatial_data_values(
 /// * Known-degenerate configurations are rejected with a diagnostic
 ///   rather than letting every pixel fail into an all-NaN map:
 ///   counts + LM + `fit_energy_scale` (numerically ill-conditioned
-///   per-pixel — issue #458 B3), `fit_energy_scale` together with
-///   `fit_temperature` (mutually exclusive model paths), and
-///   `CountsWithNuisance` with an LM solver (requires a counts-domain
-///   solver).  `transmission_background` settings are validated here
-///   for the same reason.
+///   per-pixel — issue #458 B3) and `CountsWithNuisance` with an LM
+///   solver (requires a counts-domain solver).
+///   `transmission_background` settings are validated here for the
+///   same reason.  (`fit_energy_scale` together with `fit_temperature`
+///   is SUPPORTED since issue #634 — the energy-scale model carries a
+///   fitted temperature column.)
 ///
 /// Per-pixel fit *failures* after validation are not errors: the pixel
 /// is recorded as NaN in the maps, `converged_map` is `false` there,
@@ -800,8 +801,8 @@ pub fn spatial_map_typed(
     //
     // Ordering note: the preflight runs *after* the dispatch /
     // solver-compatibility guards above (CountsWithNuisance + LM,
-    // fit_energy_scale + fit_temperature, transmission_background
-    // BackD/BackF interlocks, …).  The fit-range, temperature and
+    // transmission_background BackD/BackF interlocks, …).  The
+    // fit-range, temperature and
     // alpha gates inside the preflight only meaningfully apply once
     // the input → solver dispatch is known to be valid; otherwise
     // a downstream "LM transmission active-bin" message would
@@ -3823,7 +3824,11 @@ mod tests {
     /// Issue #634: `fit_energy_scale + fit_temperature` is now SUPPORTED at
     /// spatial entry (the per-pixel fitter wires a temperature column into the
     /// energy-scale model). `spatial_map_typed` must run without the old guard
-    /// error and allocate both the temperature and t0/L_scale maps.
+    /// error, actually CONVERGE per pixel, and write finite values into both
+    /// the temperature and t0/L_scale maps.  Some-ness alone is vacuous — the
+    /// maps are pre-allocated as `Some(NaN-filled)` from the config flags, so
+    /// an all-pixels-failed run (the exact hazard the replaced guard's doc
+    /// comment warned about) would still pass a Some-only assertion.
     #[test]
     fn test_spatial_map_typed_allows_energy_scale_with_temperature() {
         let rd = u238_single_resonance();
@@ -3848,16 +3853,36 @@ mod tests {
 
         let result = spatial_map_typed(&data, &config, None, None, None)
             .expect("fit_energy_scale + fit_temperature is now supported (#634)");
-        // Both flag families allocate their maps.
-        assert!(
-            result.temperature_map.is_some(),
-            "temperature map allocated when fit_temperature=true"
-        );
-        assert!(
-            result.t0_us_map.is_some() && result.l_scale_map.is_some(),
-            "energy-scale maps allocated when fit_energy_scale=true"
-        );
         assert_eq!(result.n_total, 16, "4×4 map");
+        // Real acceptance: the joint per-pixel fits must actually converge
+        // (neighbouring-spatial-test convention), not merely be dispatched.
+        assert!(
+            result.n_converged >= 14,
+            "joint fit should converge on (nearly) all pixels, got {}/16",
+            result.n_converged
+        );
+        // Converged pixels write FINITE values into all three maps — this is
+        // what distinguishes success from the pre-allocated NaN fill.
+        let finite_count = |m: &Option<ndarray::Array2<f64>>| {
+            m.as_ref()
+                .expect("map allocated when its flag is set")
+                .iter()
+                .filter(|v| v.is_finite())
+                .count()
+        };
+        for (name, map) in [
+            ("temperature_map", &result.temperature_map),
+            ("t0_us_map", &result.t0_us_map),
+            ("l_scale_map", &result.l_scale_map),
+        ] {
+            let n_finite = finite_count(map);
+            assert!(
+                n_finite >= result.n_converged,
+                "{name}: {n_finite} finite entries < {} converged pixels — \
+                 converged pixels must write finite values",
+                result.n_converged
+            );
+        }
     }
 
     /// `(Transmission + LM + fit_energy_scale=true)` is allowed —

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -2807,6 +2807,13 @@ class TestFitEnergyScaleRecovery:
         )
         assert r_plain.corrected_energies(energies, L_NOM) is None
 
+        # Invalid flight path is rejected, not squared into a plausible
+        # (all-zero / garbage) grid (#634 review).
+        with pytest.raises(ValueError):
+            r_es.corrected_energies(energies, 0.0)
+        with pytest.raises(ValueError):
+            r_es.corrected_energies(energies, -25.0)
+
 
 # ===========================================================================
 # Issue #558 — energy-grid validation at the PyO3 boundary

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -2690,6 +2690,123 @@ class TestFitEnergyScaleRecovery:
             f"got {float(r.l_scale):.6f}, truth {L_SCALE_TRUE}"
         )
 
+    def test_recovers_t0_l_scale_and_temperature_jointly(self):
+        """Issue #634: fit_energy_scale + fit_temperature recover the injected
+        (t0, L_scale, T) in ONE fit through the Python binding — the flag
+        combination the binding used to reject. Gate on the observables
+        (L_scale + temperature), seeding T 60 K off so a no-op cannot pass."""
+        L_NOM = 25.0
+        T0_TRUE = 0.5
+        L_SCALE_TRUE = 1.005
+        TRUE_DENSITY = 3.0e-4
+        TRUE_TEMP = 450.0
+
+        u238 = nereids.create_resonance_data(
+            z=92,
+            a=238,
+            awr=236.006,
+            scattering_radius=9.48,
+            resonances=[
+                (6.67, 0.5, 0.0015, 0.023),
+                (20.87, 0.5, 0.0103, 0.026),
+                (36.68, 0.5, 0.0344, 0.027),
+            ],
+            target_spin=0.0,
+        )
+        tof_lo = _TOF_FACTOR * L_NOM / np.sqrt(45.0)
+        tof_hi = _TOF_FACTOR * L_NOM / np.sqrt(4.0)
+        tof_grid = np.linspace(tof_lo, tof_hi, 800)
+        e_true = np.sort((_TOF_FACTOR * L_NOM / tof_grid) ** 2)
+        # Clean transmission at the TRUE energies AND the true temperature.
+        t_clean = np.asarray(
+            nereids.forward_model(
+                e_true, [(u238, TRUE_DENSITY)], temperature_k=TRUE_TEMP
+            )
+        )
+        e_meas = _measured_energies_for_known_tzero(
+            e_true,
+            t0_true_us=T0_TRUE,
+            l_scale_true=L_SCALE_TRUE,
+            l_nom_m=L_NOM,
+        )
+        rng = np.random.default_rng(20260704)
+        sigma_noise = 0.004
+        t_obs = t_clean + rng.normal(0.0, sigma_noise, size=t_clean.shape)
+        sigma = np.full_like(t_obs, sigma_noise)
+
+        r = nereids.fit_spectrum_typed(
+            transmission=t_obs,
+            uncertainty=sigma,
+            energies=e_meas,
+            isotopes=[(u238, TRUE_DENSITY)],
+            solver="lm",
+            temperature_k=TRUE_TEMP - 60.0,  # seeded 60 K off
+            fit_temperature=True,
+            fit_energy_scale=True,
+            t0_init_us=0.0,
+            l_scale_init=1.0,
+            energy_scale_flight_path_m=L_NOM,
+            max_iter=300,
+        )
+        assert bool(r.converged) is True
+        assert r.t0_us is not None and np.isfinite(r.t0_us)
+        assert r.l_scale is not None and np.isfinite(r.l_scale)
+        assert r.temperature_k is not None
+        # L_scale + temperature are the well-constrained observables (t0/L
+        # share a shallow valley; see the class docstring).
+        assert abs(float(r.l_scale) - L_SCALE_TRUE) / L_SCALE_TRUE < 1e-2
+        assert abs(float(r.temperature_k) - TRUE_TEMP) < 15.0, (
+            f"temperature not recovered jointly: got {r.temperature_k}, "
+            f"want {TRUE_TEMP}"
+        )
+
+    def test_corrected_energies_accessor(self):
+        """Issue #634: FitResult.corrected_energies maps a nominal grid through
+        the fitted energy scale (finite ndarray), and returns None when the
+        energy scale was not fitted."""
+        L_NOM = 25.0
+        u238 = nereids.create_resonance_data(
+            z=92,
+            a=238,
+            awr=236.006,
+            scattering_radius=9.48,
+            resonances=[(6.67, 0.5, 0.0015, 0.023), (20.87, 0.5, 0.0103, 0.026)],
+            target_spin=0.0,
+        )
+        energies = np.linspace(4.0, 30.0, 400)
+        t_clean = np.asarray(nereids.forward_model(energies, [(u238, 3.0e-4)]))
+        sigma = np.full_like(t_clean, 0.005)
+
+        # Energy-scale fit → corrected_energies is a finite ndarray, ascending.
+        r_es = nereids.fit_spectrum_typed(
+            transmission=t_clean,
+            uncertainty=sigma,
+            energies=energies,
+            isotopes=[(u238, 3.0e-4)],
+            solver="lm",
+            fit_energy_scale=True,
+            t0_init_us=0.0,
+            l_scale_init=1.0,
+            energy_scale_flight_path_m=L_NOM,
+            max_iter=100,
+        )
+        corr = r_es.corrected_energies(energies, L_NOM)
+        assert corr is not None
+        corr = np.asarray(corr)
+        assert corr.shape == energies.shape
+        assert np.all(np.isfinite(corr)) and np.all(np.diff(corr) > 0)
+
+        # No energy-scale fit → None (distinguishes "unfit" from "identity").
+        r_plain = nereids.fit_spectrum_typed(
+            transmission=t_clean,
+            uncertainty=sigma,
+            energies=energies,
+            isotopes=[(u238, 3.0e-4)],
+            solver="lm",
+            max_iter=50,
+        )
+        assert r_plain.corrected_energies(energies, L_NOM) is None
+
 
 # ===========================================================================
 # Issue #558 — energy-grid validation at the PyO3 boundary

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -2759,6 +2759,18 @@ class TestFitEnergyScaleRecovery:
             f"temperature not recovered jointly: got {r.temperature_k}, "
             f"want {TRUE_TEMP}"
         )
+        # Non-identity accessor oracle (#634 review): at a genuinely shifted
+        # calibration, corrected_energies(e_meas) must land on the TRUE
+        # energy axis the data was synthesized on (to within the recovered
+        # parameters' accuracy) — a no-op accessor returns e_meas instead,
+        # which differs from e_true by ~0.5-1 % here.
+        corr = np.asarray(r.corrected_energies(e_meas))
+        med_rel = np.median(np.abs(corr - e_true) / e_true)
+        noop_rel = np.median(np.abs(e_meas - e_true) / e_true)
+        assert med_rel < 0.2 * noop_rel, (
+            f"corrected axis (med rel err {med_rel:.2e}) should be far closer "
+            f"to truth than the uncorrected axis ({noop_rel:.2e})"
+        )
 
     def test_corrected_energies_accessor(self):
         """Issue #634: FitResult.corrected_energies maps a nominal grid through
@@ -2795,6 +2807,15 @@ class TestFitEnergyScaleRecovery:
         corr = np.asarray(corr)
         assert corr.shape == energies.shape
         assert np.all(np.isfinite(corr)) and np.all(np.diff(corr) > 0)
+        # Non-circular numeric oracle (#634 review): hand-compute the SAMMY
+        # −t0 transform in numpy from the FITTED (t0, l_scale) and the fit's
+        # flight path — a no-op accessor, a sign flip, a t0/l_scale swap, or
+        # a wrong flight-path source all break this equality, none of which
+        # the shape/finite asserts above can see.
+        kl = _TOF_FACTOR * L_NOM
+        tof = kl / np.sqrt(energies)
+        expected = (kl * float(r_es.l_scale) / (tof - float(r_es.t0_us))) ** 2
+        np.testing.assert_allclose(corr, expected, rtol=1e-12)
 
         # No energy-scale fit → None (distinguishes "unfit" from "identity").
         r_plain = nereids.fit_spectrum_typed(

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -2790,7 +2790,7 @@ class TestFitEnergyScaleRecovery:
             energy_scale_flight_path_m=L_NOM,
             max_iter=100,
         )
-        corr = r_es.corrected_energies(energies, L_NOM)
+        corr = r_es.corrected_energies(energies)
         assert corr is not None
         corr = np.asarray(corr)
         assert corr.shape == energies.shape
@@ -2805,14 +2805,17 @@ class TestFitEnergyScaleRecovery:
             solver="lm",
             max_iter=50,
         )
-        assert r_plain.corrected_energies(energies, L_NOM) is None
+        assert r_plain.corrected_energies(energies) is None
 
-        # Invalid flight path is rejected, not squared into a plausible
-        # (all-zero / garbage) grid (#634 review).
+        # Invalid nominal grids are rejected with the binding's standard
+        # energy-grid validation (#634 review) — NaN, non-positive, and
+        # non-ascending grids raise instead of passing through.
         with pytest.raises(ValueError):
-            r_es.corrected_energies(energies, 0.0)
+            r_es.corrected_energies(np.array([np.nan, 2.0, 3.0]))
         with pytest.raises(ValueError):
-            r_es.corrected_energies(energies, -25.0)
+            r_es.corrected_energies(np.array([0.0, 1.0, 2.0]))
+        with pytest.raises(ValueError):
+            r_es.corrected_energies(np.array([3.0, 1.0, 2.0]))
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Closes #634 — the full issue in one PR (per maintainer decision): (1) support
`fit_energy_scale=True` **together with** `fit_temperature=True` in every
fitter, (2) expose a public `corrected_energies()` accessor, and (3) replace
`calibrate_energy`'s brute-force grid search with the LM energy-scale path
internally.

Resonance thermometry needs the flag combination: the energy scale must be
calibrated (t0, L_scale) while temperature is the target parameter. The old
rejection forced a manual two-stage workflow whose hand-derived corrected-axis
transform (a `+t0` instead of `−t0` slip) caused a silent **+400 K**
temperature bias in the IPTS-37432 campaign.

## Part 1 — joint fit (fitted temperature column in `EnergyScaleTransmissionModel`)

- New `temperature_index: Option<usize>` (builder `with_temperature_index`);
  `working_xs` reads T from the parameter vector; the σ cache key is widened
  to `(t0, L_scale, T)` bits so a T-only perturbation can't hit stale σ.
- **T Jacobian column = central finite difference**, reusing the model's
  per-coordinate FD arm (relative step `1e-4·T` ≈ 0.03 K at 300 K; matches
  this model's shipped t0-FD / L_scale-rank-1 design). The forward σ stays
  exact — an analytic ∂σ/∂T port is documented in-code as a deliberate
  future optimization (it would need a new physics helper + a third
  `(t0,L_scale,T)`-keyed derivative cache).
- All **4 rejection guards lifted**: `fit_transmission_lm`,
  `fit_transmission_poisson` (KL), `fit_counts_joint_poisson`,
  `spatial_map_typed`. (The separate #458 B3 guard — LM+energy-scale on
  counts — is untouched.)

## Part 2 — `corrected_energies()` accessor

- `resolution_calib::corrected_energy_grid` widened to `pub` (canonical
  implementation; SAMMY `dat/mdat0.f90:189` −t0 sign cited in rustdoc — no
  4th copy of the formula).
- `SpectrumFitResult::corrected_energies(nominal, flight_path_m)` (Rust) and
  `FitResult.corrected_energies(...)` (Python + `.pyi` stub): `None` when the
  energy scale was not fitted; `ValueError` on a degenerate t0.

## Part 3 — `calibrate_energy`: 3-phase grid → multi-start LM descent

The coarse/fine/ultra (L, t0) grid + per-candidate golden-section density
(~35k forward evaluations, >10 min on production windows per the issue)
becomes:

1. **density seed** — golden section in log10(n) at the identity scale
   (the original objective, `compute_chi2` over valid bins);
2. **coarse global alignment anchor** — 7 L_scale × 7 t0 candidates at the
   common seed density (49 evals; keeps old Phase-1 global-basin robustness);
3. **coordinate descent** — exact 1-D golden density ↔ alignment-only LM
   with the density **frozen via #633's `with_fix_densities`** (at fixed
   density, dip position mismatch is the only signal — alignment can't trade
   off against density); affine TOF maps compose across re-anchoring cycles
   (`t0 += ls·t0_k; ls *= ls_k`), covering the documented ±1.5 % L band
   beyond the per-fit ±1 % box;
4. **joint 3-parameter LM polish** from inside the basin (monotone χ² —
   cannot degrade the alternation's solution);
   with **multi-start over log-spaced density seeds + argmin-χ² selection**
   to defeat the sparse-grid aliasing degeneracy (dip width < bin spacing
   lets a wrong density trade against a sub-bin (t0, L_scale) shift — a
   single descent was observed converging 14× low at χ²=0.17 while the true
   basin sits at χ²≈0).

**Contract preserved:** public signature; `CalibrationResult` fields; all
up-front validation verbatim; density band `[1e-5, 1e-2]` + one-sided
boundary-saturation guard (LM density is unbounded above); no-finite-χ²
guard keyed on the final `compute_chi2` (the grid had no convergence concept
— best-found is the contract); invalid bins neutralised (`t=1, σ=1e30`) so
the grid stays intact for broadening while χ²_r stays defined over valid
bins with `dof = n_valid − 3`. One fitted density parameter via an
`IsotopeGroup` with normalised abundance ratios (`n_total = D/S`);
zero-abundance isotopes dropped (they contribute nothing, exactly as in
`compute_chi2`).

## Tests

- `energy_scale_temperature_jacobian_matches_analytic` — the FD T column vs
  the analytic ∂σ/∂T column of the fixed-grid model on the SAME corrected
  grid: **<1e-4 relative**, plus non-zero assertions (a mis-wired index gives
  a silent zero column).
- `test_energy_scale_with_temperature_recovers_all_three` — closed loop:
  inject (t0=0.6 µs, L_scale=1.004, T=340 K), seed away from truth, recover
  all three in one LM fit (new 3-resonance U-238 fixture
  `u238_three_resonances` breaks the single-dip t0/L_scale degeneracy).
- `test_energy_scale_temperature_sigma_covariance_plumbing` — (c1) strict
  physical invariant: joint σ_T > no-energy-scale σ_T on identical data;
  (c2) an **independent (JᵀWJ)⁻¹ reconstruction** (test-side FD Jacobian,
  same steps; Gauss–Jordan inverse; ×reduced-χ²) reproduces the solver σ_T
  to **<0.1 %** — the assertion class that catches wrong-covariance-slot
  bugs (cf. #641).
- Accessor tests (Rust + Python): equals the canonical transform; `None`
  when unfitted. Spatial acceptance test (temperature + energy-scale maps
  allocated). Python joint recovery via `TestFitEnergyScaleRecovery`.
- **All 17 pre-existing calibration tests pass unchanged** — every density
  band 1e-5…1e-2 (incl. both documented edges), boundary saturation
  (n=1.0 → "search boundary" error), all pinned error-message contracts,
  the round-trip, and the 1e308 no-finite-χ² case.

## Verification

- `cargo fmt --all`; `cargo clippy --workspace --exclude nereids-python
  --all-targets -- -D warnings` clean; `cargo test --workspace --exclude
  nereids-python` — 0 failures.
- `pixi run build` + `pixi run test-python` — **147 passed, 1 skipped**
  (incl. all calibrate_energy Python validation/smoke/non-mutation tests).
- `RUSTDOCFLAGS="-D warnings" cargo doc` clean on nereids-fitting +
  nereids-pipeline. All commits GPG-signed.

🤖 Assisted with [Claude Code](https://claude.com/claude-code) (Fable 5)
