### PR TITLE
feat(physics): physics-complete bounded Ikeda-Carpenter calibration (#642)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   kernel; `0` disables; optional `fit_psr` adds the FWHM as a 5th
   parameter). The missing shape freedom previously re-expressed as a ~90 K
   temperature degeneracy on real data. The IC τ-grid is now anchored to the
-  prompt core so low-β storage tails cannot undersample the pulse rise
-  (bit-identical for all previous callers). **Action required: earlier
+  prompt core and refined to resolve any requested burst/channel fold, so
+  low-β storage tails can neither undersample the pulse rise nor silently
+  degenerate the fold to a delta; a parameter combination whose τ-grid
+  cannot be resolved within the 8192-sample cap is now rejected with a
+  descriptive error (`IkedaCarpenter::new` / `kernel_at`) instead of
+  silently under-sampled — the calibrator treats such points as infeasible
+  during its search. Synthesized kernels are bit-identical to earlier
+  releases only when the storage tail does not extend past the prompt reach
+  (`slow_reach ≤ fast_reach`, the R ≈ 0 eV-regime case), no fold is finer
+  than the prompt design step, and `n_tau` ≤ 8192; direct-API kernels with
+  constant R > 0 and long storage tails (or folds finer than the design
+  step) change — finer, more accurate sampling. **Action required: earlier
   `family="ic"` calibrations (2-parameter, no PSR fold) are superseded —
   re-calibrate.** The raw `theta` for `"ic"` is now 4–5 ln/box-encoded
   values; read decoded physical parameters from `params()` (Python) or the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Physics-complete bounded Ikeda–Carpenter calibration family** (#642):
+  `family="ic"` now fits the full moderator shape — the prompt law
+  `α(E) = e^{c0}·√E + e^{c1}` is positive at every energy by construction
+  (exp-encoded; a real calibration once returned `a1 = −0.396`, driving
+  α(E) < 0 at low energy), the storage rate `β` and mixing fraction
+  `R ∈ [0, 1]` are free within physics bounds (previously β was pinned at
+  0.1 and R ≡ exp(−E_meV/25) ≈ 0, i.e. no storage freedom at all), and the
+  kernel is folded with the SNS PSR channel triangle (`psr_fwhm_ns`,
+  default 350 ns — the fold the VENUS FTS header records for the tabulated
+  kernel; `0` disables; optional `fit_psr` adds the FWHM as a 5th
+  parameter). The missing shape freedom previously re-expressed as a ~90 K
+  temperature degeneracy on real data. The IC τ-grid is now anchored to the
+  prompt core so low-β storage tails cannot undersample the pulse rise
+  (bit-identical for all previous callers). **Action required: earlier
+  `family="ic"` calibrations (2-parameter, no PSR fold) are superseded —
+  re-calibrate.** The raw `theta` for `"ic"` is now 4–5 ln/box-encoded
+  values; read decoded physical parameters from `params()` (Python) or the
+  returned `resolution` (Rust) instead of interpreting `theta` directly.
+
+### Added
+
+- **Calibration degeneracy reporting** (#642): `calibrate_resolution`
+  results now carry `n_free_params` and `bounds_hit` (parameters pinned at
+  a box bound, e.g. `"r:lower"` on the β↔R ridge when the calibrant shows
+  no storage tail), in Rust and Python.
+- **Calibration simplex re-inflation** (#642): each `calibrate_resolution`
+  restart now re-launches a fresh, larger Nelder–Mead simplex at the
+  incumbent until it stops improving, escaping premature simplex collapse
+  in the curved α↔β↔R valley of the 4-parameter IC family (a collapsed
+  simplex once stalled a 300 K calibration Δχ² ≈ +130 above the noise
+  floor, biasing the downstream pinned temperature fit by ~23 K). Applies
+  to all families; results can only improve or stay put.
+- **Closed-loop IC acceptance tests** (#642): synthetic Ta-181
+  calibrate→pin→refit-temperature loops at 300 K and 1073 K
+  (`crates/nereids-fitting/tests/ic_closed_loop.rs`) assert χ²/dof ≈ 1,
+  interior recovery of the truth kernel, and temperature recovery within
+  3σ with σ_T far below the old ~90 K degeneracy scale.
+
 ## [0.2.2] - 2026-07-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2850,6 +2850,7 @@ dependencies = [
  "nereids-endf",
  "nereids-physics",
  "rand 0.9.4",
+ "rand_chacha",
  "rand_distr",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2849,6 +2849,8 @@ dependencies = [
  "nereids-core",
  "nereids-endf",
  "nereids-physics",
+ "rand 0.9.4",
+ "rand_distr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,10 @@ rfd = { version = "=0.17.2", default-features = false }
 egui-file-dialog = "0.12"
 hdf5 = { package = "hdf5-metno", version = "0.12", features = ["static", "zlib"] }
 rand = "0.9"
+# Stable-stream RNG for seeded test noise: StdRng's stream is documented
+# UNSTABLE across rand versions, so acceptance tests that pin a noise
+# realization must name a concrete algorithm (ChaCha12) instead.
+rand_chacha = "0.9"
 rand_distr = "0.5"
 microlp = "0.4"
 tracing = "0.1"

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -662,7 +662,10 @@ def calibrate_resolution(
     ``beta`` and storage fraction ``r``, folded with the SNS PSR channel
     triangle of FWHM ``psr_fwhm_ns`` (default 350 ns, the VENUS FTS header
     value; 0 disables; applies to "ic" only — tabulated/UDR kernels already
-    carry the fold). ``fit_psr=True`` ("ic" only) also fits the PSR FWHM as a
+    carry the fold). ``psr_fwhm_ns`` is NANOSECONDS: nonzero values above
+    10_000 ns (10 us) raise ``ValueError`` as a us-as-ns unit slip (kernel
+    synthesis cost is quadratic in the fold width, so e.g. 350 meaning us
+    would hang for hours). ``fit_psr=True`` ("ic" only) also fits the PSR FWHM as a
     5th parameter (box-bounded 0.05-1 us), started at ``psr_fwhm_ns`` — which
     must then be > 0 (a zero start contradicts "0 disables" and raises
     ``ValueError``). ``psr_fwhm_ns`` / ``fit_psr`` sit at the END of the

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -346,8 +346,28 @@ class ResolutionCalibration:
         to fit."""
         ...
 
+    @property
+    def n_free_params(self) -> int:
+        """Number of outer-loop free parameters: resolution theta plus any
+        fitted position coordinates (4-5 for family="ic", 2 for the other
+        families)."""
+        ...
+
+    @property
+    def bounds_hit(self) -> list[str]:
+        """Coordinates pinned at a box bound at the solution, as
+        "name:lower" / "name:upper" strings (empty list = interior solution).
+        E.g. "r:lower" flags the beta-R ridge: the calibrant shows no storage
+        tail, so the reported beta carries no information."""
+        ...
+
     def params(self) -> dict[str, float]:
-        """Decoded, human-readable fitted parameters."""
+        """Decoded, human-readable fitted parameters.
+
+        For family="ic" the keys are a0/a1 (alpha(E) = a0*sqrt(E) + a1,
+        positive by construction), beta, r and psr_fwhm_us — decoded from the
+        calibrated resolution itself (the raw theta is ln/box-encoded
+        optimizer space)."""
         ...
 
     def as_tabulated(self) -> TabulatedResolution | None:
@@ -616,6 +636,8 @@ def calibrate_resolution(
     restarts: int = 1,
     ic_n_energies: int = 64,
     ic_n_tau: int = 500,
+    psr_fwhm_ns: float = 350.0,
+    fit_psr: bool = False,
     fit_t0: bool = False,
     fit_l_scale: bool = False,
     t0_center_us: float = 0.0,
@@ -630,6 +652,15 @@ def calibrate_resolution(
     and ``temperature_k`` fixed. ``base_udr`` is required for ``"udr_corr"``.
     Pin the returned resolution into a sample fit via ``.as_tabulated()`` (or
     ``.gaussian_params()`` for the Gaussian family).
+
+    The ``"ic"`` family fits the full bounded moderator shape:
+    ``alpha(E) = a0*sqrt(E) + a1`` (positive by construction), free bounded
+    ``beta`` and storage fraction ``r``, folded with the SNS PSR channel
+    triangle of FWHM ``psr_fwhm_ns`` (default 350 ns, the VENUS FTS header
+    value; 0 disables; applies to "ic" only — tabulated/UDR kernels already
+    carry the fold). ``fit_psr=True`` ("ic" only) also fits the PSR FWHM as a
+    5th parameter (box-bounded 0.05-1 us). Degenerate directions are reported
+    via ``bounds_hit``.
 
     By default position is PINNED (``fit_t0=fit_l_scale=False``): a pure
     shape/width fit on the already energy-calibrated grid. Set ``fit_t0`` /

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -666,9 +666,12 @@ def calibrate_resolution(
     10_000 ns (10 us) raise ``ValueError`` as a us-as-ns unit slip (kernel
     synthesis cost is quadratic in the fold width, so e.g. 350 meaning us
     would hang for hours). ``fit_psr=True`` ("ic" only) also fits the PSR FWHM as a
-    5th parameter (box-bounded 0.05-1 us), started at ``psr_fwhm_ns`` — which
-    must then be > 0 (a zero start contradicts "0 disables" and raises
-    ``ValueError``). ``psr_fwhm_ns`` / ``fit_psr`` sit at the END of the
+    5th parameter (box-bounded 0.05-1 us), started at ``psr_fwhm_ns`` clamped
+    into that box: an out-of-box start (legal as a pin up to 10 us) starts at
+    the nearer box edge with a stderr warning, and a fit that stays there
+    reports ``psr_fwhm_us:lower`` / ``:upper`` in ``bounds_hit``.
+    ``psr_fwhm_ns`` must then be > 0 (a zero start contradicts "0 disables"
+    and raises ``ValueError``). ``psr_fwhm_ns`` / ``fit_psr`` sit at the END of the
     signature so pre-existing positional calls keep their meaning. Degenerate
     directions are reported via ``bounds_hit``.
 

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -282,7 +282,11 @@ class IkedaCarpenter:
         ...
 
     def kernel_at(self, energy_ev: float) -> tuple[list[float], list[float]]:
-        """``(tof_offsets_us, weights)`` at one energy; mode at offset 0."""
+        """``(tof_offsets_us, weights)`` at one energy; mode at offset 0.
+
+        Raises ``ValueError`` when the tau-grid cannot resolve the prompt
+        core and requested folds within the sample cap at this energy.
+        """
         ...
 
     @property
@@ -636,14 +640,14 @@ def calibrate_resolution(
     restarts: int = 1,
     ic_n_energies: int = 64,
     ic_n_tau: int = 500,
-    psr_fwhm_ns: float = 350.0,
-    fit_psr: bool = False,
     fit_t0: bool = False,
     fit_l_scale: bool = False,
     t0_center_us: float = 0.0,
     l_scale_center: float = 1.0,
     t0_prior_us: float | None = None,
     l_scale_prior: float | None = None,
+    psr_fwhm_ns: float = 350.0,
+    fit_psr: bool = False,
 ) -> ResolutionCalibration:
     """Calibrate instrument-resolution parameters against a known-(rho,T) calibrant.
 
@@ -659,8 +663,11 @@ def calibrate_resolution(
     triangle of FWHM ``psr_fwhm_ns`` (default 350 ns, the VENUS FTS header
     value; 0 disables; applies to "ic" only — tabulated/UDR kernels already
     carry the fold). ``fit_psr=True`` ("ic" only) also fits the PSR FWHM as a
-    5th parameter (box-bounded 0.05-1 us). Degenerate directions are reported
-    via ``bounds_hit``.
+    5th parameter (box-bounded 0.05-1 us), started at ``psr_fwhm_ns`` — which
+    must then be > 0 (a zero start contradicts "0 disables" and raises
+    ``ValueError``). ``psr_fwhm_ns`` / ``fit_psr`` sit at the END of the
+    signature so pre-existing positional calls keep their meaning. Degenerate
+    directions are reported via ``bounds_hit``.
 
     By default position is PINNED (``fit_t0=fit_l_scale=False``): a pure
     shape/width fit on the already energy-calibrated grid. Set ``fit_t0`` /

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -50,8 +50,8 @@ use nereids_endf::resonance::{
 };
 use nereids_endf::retrieval::{EndfLibrary, EndfRetriever, mat_number};
 use nereids_fitting::resolution_calib::{
-    CalibrationConfig, DEFAULT_PSR_FWHM_NS, ResolutionFamily, UDR_S0_MAX, UDR_S0_MIN,
-    calibrate_resolution as rust_calibrate_resolution,
+    CalibrationConfig, DEFAULT_PSR_FWHM_NS, NS_TO_US, PSR_FWHM_PIN_CEILING_US, ResolutionFamily,
+    UDR_S0_MAX, UDR_S0_MIN, calibrate_resolution as rust_calibrate_resolution,
 };
 use nereids_io::normalization::{self as norm, NormalizationParams};
 use nereids_io::tof::BeamlineParams;
@@ -1320,7 +1320,9 @@ impl PyResolutionCalibration {
 ///     psr_fwhm_ns: SNS PSR channel-triangle FWHM in ns, folded into the
 ///         ``"ic"`` family's kernel only (default 350 — the VENUS FTS header
 ///         value; ``0`` disables). Tabulated/UDR kernels already carry the
-///         fold in the file and are never re-folded.
+///         fold in the file and are never re-folded. NANOSECONDS: values
+///         above 10_000 ns (10 µs) are rejected as a µs-as-ns unit slip
+///         (synthesis cost is quadratic in the fold width).
 ///     fit_psr: also FIT the PSR FWHM (``"ic"`` only; appends a 5th
 ///         parameter, box-bounded 0.05–1 µs, started at ``psr_fwhm_ns`` —
 ///         which must then be > 0: a zero start contradicts "0 disables").
@@ -1472,6 +1474,21 @@ fn calibrate_resolution(
         if !psr_fwhm_ns.is_finite() || psr_fwhm_ns < 0.0 {
             return Err(pyo3::exceptions::PyValueError::new_err(format!(
                 "psr_fwhm_ns must be finite and >= 0 (0 disables the PSR fold), got {psr_fwhm_ns}"
+            )));
+        }
+        // Sanity ceiling (mirrors the Rust calibrator; see
+        // PSR_FWHM_PIN_CEILING_US): psr_fwhm_ns is NANOSECONDS and kernel-
+        // synthesis cost is quadratic in the fold width, so a µs-as-ns unit
+        // slip (350 meaning µs) would hang the calibration for hours behind
+        // a fictitious fold. Reject with the precise Python-facing message.
+        if psr_fwhm_ns * NS_TO_US > PSR_FWHM_PIN_CEILING_US {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "psr_fwhm_ns={psr_fwhm_ns} ns (= {} us) exceeds the {PSR_FWHM_PIN_CEILING_US} \
+                 us sanity ceiling: psr_fwhm_ns is in NANOSECONDS (the SNS/VENUS FTS \
+                 convention is 350 ns) and kernel-synthesis cost grows quadratically with \
+                 the fold width, so a us-as-ns unit slip would hang the calibration. Pass \
+                 the width in ns, or 0 to disable the PSR fold",
+                psr_fwhm_ns * NS_TO_US
             )));
         }
         // fit_psr fits the PSR FWHM from the psr_fwhm_ns starting value, but 0

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -50,7 +50,7 @@ use nereids_endf::resonance::{
 };
 use nereids_endf::retrieval::{EndfLibrary, EndfRetriever, mat_number};
 use nereids_fitting::resolution_calib::{
-    CalibrationConfig, ResolutionFamily, UDR_S0_MAX, UDR_S0_MIN,
+    CalibrationConfig, DEFAULT_PSR_FWHM_NS, ResolutionFamily, UDR_S0_MAX, UDR_S0_MIN,
     calibrate_resolution as rust_calibrate_resolution,
 };
 use nereids_io::normalization::{self as norm, NormalizationParams};
@@ -1194,6 +1194,11 @@ impl PyResolutionCalibration {
     }
 
     /// Decoded, human-readable fitted parameters.
+    ///
+    /// For ``family="ic"`` (#642) the keys are ``a0``/``a1`` (α(E) = a0·√E +
+    /// a1, positive by construction), ``beta``, ``r`` and ``psr_fwhm_us`` —
+    /// decoded from the calibrated resolution itself (the raw ``theta`` is
+    /// ln/box-encoded optimizer space).
     fn params<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, pyo3::types::PyDict>> {
         let d = pyo3::types::PyDict::new(py);
         match self.inner.family.as_str() {
@@ -1209,12 +1214,40 @@ impl PyResolutionCalibration {
                 d.set_item("delta_l_m", self.inner.theta[1].abs())?;
             }
             _ => {
-                // IC fits (a0, a1); β is held fixed (unidentifiable in the eV regime).
-                d.set_item("a0", self.inner.theta[0].abs())?;
-                d.set_item("a1", self.inner.theta[1])?;
+                // IC: decode off the calibrated resolution — the single source
+                // of truth (never re-derive from the encoded theta by hand).
+                // The a0/a1 keys keep their pre-#642 meaning for back-compat.
+                if let ResolutionFunction::IkedaCarpenter(ic) = &self.inner.resolution {
+                    let p = ic.params();
+                    if let EnergyLaw::SqrtE { a0, a1 } = &p.alpha {
+                        d.set_item("a0", *a0)?;
+                        d.set_item("a1", *a1)?;
+                    }
+                    d.set_item("beta", p.beta)?;
+                    if let EnergyLaw::Const(r) = &p.r {
+                        d.set_item("r", *r)?;
+                    }
+                    d.set_item("psr_fwhm_us", p.channel_fwhm_us.unwrap_or(0.0))?;
+                }
             }
         }
         Ok(d)
+    }
+
+    /// Number of outer-loop free parameters: resolution θ plus any fitted
+    /// position coordinates (4–5 for ``"ic"``, 2 for the other families).
+    #[getter]
+    fn n_free_params(&self) -> usize {
+        self.inner.n_free_params
+    }
+
+    /// Coordinates pinned at a box bound at the solution, as
+    /// ``"name:lower"`` / ``"name:upper"`` strings (empty = interior
+    /// solution). E.g. ``"r:lower"`` flags the β↔R ridge: the calibrant shows
+    /// no storage tail, so the reported β carries no information.
+    #[getter]
+    fn bounds_hit(&self) -> Vec<String> {
+        self.inner.bounds_hit.clone()
     }
 
     /// The calibrated resolution as a [`TabulatedResolution`] — pass to
@@ -1240,8 +1273,12 @@ impl PyResolutionCalibration {
 
     fn __repr__(&self) -> String {
         format!(
-            "ResolutionCalibration(family={}, chi2/dof={:.4}, converged={})",
-            self.inner.family, self.inner.chi2_dof, self.inner.converged
+            "ResolutionCalibration(family={}, chi2/dof={:.4}, converged={}, n_free_params={}, bounds_hit={:?})",
+            self.inner.family,
+            self.inner.chi2_dof,
+            self.inner.converged,
+            self.inner.n_free_params,
+            self.inner.bounds_hit
         )
     }
 }
@@ -1254,12 +1291,21 @@ impl PyResolutionCalibration {
 ///
 /// Args:
 ///     energies, data, uncertainty: calibrant transmission spectrum.
-///     family: ``"gaussian"`` | ``"udr_corr"`` | ``"ic"``.
+///     family: ``"gaussian"`` | ``"udr_corr"`` | ``"ic"``. The ``"ic"`` family
+///         (#642) fits the full bounded moderator shape — ``α(E) = a0·√E + a1``
+///         positive by construction, free bounded ``beta`` and storage
+///         fraction ``r`` — folded with the SNS PSR channel triangle.
 ///     isotopes / groups: known calibrant composition + density (exactly one).
 ///     temperature_k: known calibrant temperature.
 ///     base_udr: base UDR kernel (required for ``family="udr_corr"``).
 ///     fit_background: also fit anorm + linear baseline (default anorm only).
 ///     restarts: optimizer restarts (keep the best).
+///     psr_fwhm_ns: SNS PSR channel-triangle FWHM in ns, folded into the
+///         ``"ic"`` family's kernel only (default 350 — the VENUS FTS header
+///         value; ``0`` disables). Tabulated/UDR kernels already carry the
+///         fold in the file and are never re-folded.
+///     fit_psr: also FIT the PSR FWHM (``"ic"`` only; appends a 5th
+///         parameter, box-bounded 0.05–1 µs, started at ``psr_fwhm_ns``).
 ///     fit_t0, fit_l_scale: also fit the SHARED SAMMY energy-scale ``(t0,
 ///         L_scale)``. Default ``False`` — position is PINNED at its center (a pure
 ///         shape/width calibration on the already energy-calibrated grid). Opt in
@@ -1280,6 +1326,7 @@ impl PyResolutionCalibration {
     energies, data, uncertainty, family, isotopes=None, groups=None,
     temperature_k=293.6, base_udr=None, flight_path_m=25.0, fit_background=false,
     restarts=1, ic_n_energies=64, ic_n_tau=500,
+    psr_fwhm_ns=DEFAULT_PSR_FWHM_NS, fit_psr=false,
     fit_t0=false, fit_l_scale=false, t0_center_us=0.0, l_scale_center=1.0,
     t0_prior_us=None, l_scale_prior=None
 ))]
@@ -1299,6 +1346,8 @@ fn calibrate_resolution(
     restarts: usize,
     ic_n_energies: usize,
     ic_n_tau: usize,
+    psr_fwhm_ns: f64,
+    fit_psr: bool,
     fit_t0: bool,
     fit_l_scale: bool,
     t0_center_us: f64,
@@ -1367,7 +1416,7 @@ fn calibrate_resolution(
 
     let fam = match family {
         "gaussian" => ResolutionFamily::Gaussian,
-        "ic" => ResolutionFamily::IkedaCarpenter,
+        "ic" => ResolutionFamily::IkedaCarpenter { fit_psr },
         "udr_corr" => {
             let base = base_udr.ok_or_else(|| {
                 pyo3::exceptions::PyValueError::new_err(
@@ -1383,11 +1432,18 @@ fn calibrate_resolution(
         }
     };
 
+    // fit_psr appends the PSR-FWHM fit coordinate, which only the IC family
+    // carries — reject the flag on other families instead of silently ignoring it.
+    if fit_psr && !matches!(fam, ResolutionFamily::IkedaCarpenter { .. }) {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "fit_psr=True requires family='ic', got family='{family}'"
+        )));
+    }
     // For family='ic' these size the kernel-synthesis grid; validate up front so an
     // out-of-range value gives a precise error instead of the generic "no finite-χ²
     // resolution" (every IkedaCarpenter::new eval would otherwise fail). They are
     // inert for the gaussian/udr_corr families.
-    if matches!(fam, ResolutionFamily::IkedaCarpenter) {
+    if matches!(fam, ResolutionFamily::IkedaCarpenter { .. }) {
         if ic_n_energies < 2 {
             return Err(pyo3::exceptions::PyValueError::new_err(format!(
                 "ic_n_energies must be >= 2 for family='ic', got {ic_n_energies}"
@@ -1398,6 +1454,14 @@ fn calibrate_resolution(
                 "ic_n_tau must be >= 8 for family='ic', got {ic_n_tau}"
             )));
         }
+        // PSR triangle FWHM: finite and >= 0 ns (0 disables the fold). Also
+        // enforced by the Rust calibrator; rejected here with the precise
+        // Python-facing message.
+        if !psr_fwhm_ns.is_finite() || psr_fwhm_ns < 0.0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "psr_fwhm_ns must be finite and >= 0 (0 disables the PSR fold), got {psr_fwhm_ns}"
+            )));
+        }
     }
 
     let cfg = CalibrationConfig {
@@ -1406,6 +1470,7 @@ fn calibrate_resolution(
         restarts,
         ic_n_energies,
         ic_n_tau,
+        psr_fwhm_ns,
         fit_t0,
         fit_l_scale,
         position_t0_center_us: t0_center_us,

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -758,8 +758,15 @@ impl PyIkedaCarpenter {
 
     /// `(tof_offsets_us, weights)` kernel at a single energy (eV); offsets
     /// ascending with the mode at 0, weights peak-normalized.
-    fn kernel_at(&self, energy_ev: f64) -> (Vec<f64>, Vec<f64>) {
-        self.inner.kernel_at(energy_ev)
+    ///
+    /// Raises ``ValueError`` when the τ-grid cannot resolve the prompt core
+    /// and requested folds within the sample cap at this energy (construction
+    /// validates the reference energies; a probe energy outside their range
+    /// can still be unresolvable).
+    fn kernel_at(&self, energy_ev: f64) -> PyResult<(Vec<f64>, Vec<f64>)> {
+        self.inner
+            .kernel_at(energy_ev)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
     /// Flight path length in meters.
@@ -1300,12 +1307,6 @@ impl PyResolutionCalibration {
 ///     base_udr: base UDR kernel (required for ``family="udr_corr"``).
 ///     fit_background: also fit anorm + linear baseline (default anorm only).
 ///     restarts: optimizer restarts (keep the best).
-///     psr_fwhm_ns: SNS PSR channel-triangle FWHM in ns, folded into the
-///         ``"ic"`` family's kernel only (default 350 — the VENUS FTS header
-///         value; ``0`` disables). Tabulated/UDR kernels already carry the
-///         fold in the file and are never re-folded.
-///     fit_psr: also FIT the PSR FWHM (``"ic"`` only; appends a 5th
-///         parameter, box-bounded 0.05–1 µs, started at ``psr_fwhm_ns``).
 ///     fit_t0, fit_l_scale: also fit the SHARED SAMMY energy-scale ``(t0,
 ///         L_scale)``. Default ``False`` — position is PINNED at its center (a pure
 ///         shape/width calibration on the already energy-calibrated grid). Opt in
@@ -1316,19 +1317,30 @@ impl PyResolutionCalibration {
 ///         set from the instrument's flight-path / timing metrology.
 ///     t0_center_us, l_scale_center: prior means / pinned values (default 0.0, 1.0).
 ///     t0_prior_us, l_scale_prior: Gaussian prior σ (``None`` = flat/bounded only).
+///     psr_fwhm_ns: SNS PSR channel-triangle FWHM in ns, folded into the
+///         ``"ic"`` family's kernel only (default 350 — the VENUS FTS header
+///         value; ``0`` disables). Tabulated/UDR kernels already carry the
+///         fold in the file and are never re-folded.
+///     fit_psr: also FIT the PSR FWHM (``"ic"`` only; appends a 5th
+///         parameter, box-bounded 0.05–1 µs, started at ``psr_fwhm_ns`` —
+///         which must then be > 0: a zero start contradicts "0 disables").
 ///
 /// Returns:
 ///     ResolutionCalibration with the fitted params, data χ²/dof, the fitted (or
 ///     pinned) ``position_t0_us`` / ``position_l_scale`` / ``prior_penalty``, and
 ///     the calibrated resolution (``.as_tabulated()`` / ``.gaussian_params()``).
+// `psr_fwhm_ns` / `fit_psr` sit at the END of the signature (after every
+// parameter that predates them): inserting them mid-signature would silently
+// shift the meaning of existing ≥ 14-positional-argument calls (review #645
+// F7). Keep any future additions at the end for the same reason.
 #[pyfunction]
 #[pyo3(signature = (
     energies, data, uncertainty, family, isotopes=None, groups=None,
     temperature_k=293.6, base_udr=None, flight_path_m=25.0, fit_background=false,
     restarts=1, ic_n_energies=64, ic_n_tau=500,
-    psr_fwhm_ns=DEFAULT_PSR_FWHM_NS, fit_psr=false,
     fit_t0=false, fit_l_scale=false, t0_center_us=0.0, l_scale_center=1.0,
-    t0_prior_us=None, l_scale_prior=None
+    t0_prior_us=None, l_scale_prior=None,
+    psr_fwhm_ns=DEFAULT_PSR_FWHM_NS, fit_psr=false
 ))]
 #[allow(clippy::too_many_arguments)]
 fn calibrate_resolution(
@@ -1346,14 +1358,14 @@ fn calibrate_resolution(
     restarts: usize,
     ic_n_energies: usize,
     ic_n_tau: usize,
-    psr_fwhm_ns: f64,
-    fit_psr: bool,
     fit_t0: bool,
     fit_l_scale: bool,
     t0_center_us: f64,
     l_scale_center: f64,
     t0_prior_us: Option<f64>,
     l_scale_prior: Option<f64>,
+    psr_fwhm_ns: f64,
+    fit_psr: bool,
 ) -> PyResult<PyResolutionCalibration> {
     if isotopes.is_some() == groups.is_some() {
         return Err(pyo3::exceptions::PyValueError::new_err(
@@ -1461,6 +1473,16 @@ fn calibrate_resolution(
             return Err(pyo3::exceptions::PyValueError::new_err(format!(
                 "psr_fwhm_ns must be finite and >= 0 (0 disables the PSR fold), got {psr_fwhm_ns}"
             )));
+        }
+        // fit_psr fits the PSR FWHM from the psr_fwhm_ns starting value, but 0
+        // means "no fold" — a zero start would be silently clamped into the
+        // [0.05, 1] us fit box, contradicting the documented "0 disables".
+        // Also enforced by the Rust calibrator.
+        if fit_psr && psr_fwhm_ns == 0.0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "fit_psr=True requires a positive psr_fwhm_ns starting value (psr_fwhm_ns=0 \
+                 disables the PSR fold; use fit_psr=False to calibrate without one)",
+            ));
         }
     }
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1324,8 +1324,12 @@ impl PyResolutionCalibration {
 ///         above 10_000 ns (10 µs) are rejected as a µs-as-ns unit slip
 ///         (synthesis cost is quadratic in the fold width).
 ///     fit_psr: also FIT the PSR FWHM (``"ic"`` only; appends a 5th
-///         parameter, box-bounded 0.05–1 µs, started at ``psr_fwhm_ns`` —
-///         which must then be > 0: a zero start contradicts "0 disables").
+///         parameter, box-bounded 0.05–1 µs, started at ``psr_fwhm_ns``
+///         clamped into that box — an out-of-box start, legal as a pin up
+///         to 10 µs, starts at the nearer box edge with a stderr warning,
+///         and a fit that stays there reports ``psr_fwhm_us:lower`` /
+///         ``:upper`` in ``bounds_hit``; ``psr_fwhm_ns`` must then be > 0:
+///         a zero start contradicts "0 disables").
 ///
 /// Returns:
 ///     ResolutionCalibration with the fitted params, data χ²/dof, the fitted (or

--- a/crates/nereids-endf/src/resonance.rs
+++ b/crates/nereids-endf/src/resonance.rs
@@ -1202,6 +1202,41 @@ pub mod test_support {
         )
     }
 
+    /// Multi-resonance sibling of [`synthetic_isotope`]: N s-wave resonances
+    /// `(energy_eV, Γn_eV, Γγ_eV)` in **one** L-group of a **single** range —
+    /// i.e. ONE potential-scattering term.  Deliberately NOT built by stacking
+    /// N `synthetic_isotope` single-resonance isotopes in a sample: each such
+    /// isotope carries its own AP hard-sphere background, so a stack N-folds
+    /// the potential-scattering baseline.  Same structural defaults as
+    /// [`synthetic_isotope`] (RM, AP=6, I=0, L=0, J=0.5, `awr ≈ a − 0.009`).
+    pub fn synthetic_isotope_multi(
+        z: u32,
+        a: u32,
+        resonances: &[(f64, f64, f64)],
+    ) -> ResonanceData {
+        let awr = a as f64 - 0.009;
+        wrap(
+            z,
+            a,
+            awr,
+            make_range(
+                1e-5,
+                1e4,
+                ResonanceFormalism::ReichMoore,
+                0.0,
+                6.0,
+                1,
+                0,
+                awr,
+                0.0,
+                resonances
+                    .iter()
+                    .map(|&(e, gn, gg)| res(e, 0.5, gn, gg))
+                    .collect(),
+            ),
+        )
+    }
+
     /// Hf-178 MLBW: two s-waves at 7.8 and 16.9 eV in the same J=1/2 group.
     /// Range `0 .. 100` eV, AP=9.48, NAPS=0.  MLBW positivity and
     /// total-vs-components regression tests in `slbw.rs`.
@@ -1349,5 +1384,33 @@ mod test_support_tests {
         let d = synthetic_isotope(74, 184, 10.0, 1e-3, 1e-2);
         assert_eq!(d.za, 74184);
         assert_eq!(d.ranges[0].l_groups[0].resonances[0].energy, 10.0);
+    }
+
+    #[test]
+    fn synthetic_isotope_multi_puts_all_resonances_in_one_group() {
+        // One range, one L-group, one potential-scattering term — NOT N
+        // stacked single-resonance isotopes (which would N-fold the AP
+        // background).
+        let d = synthetic_isotope_multi(
+            73,
+            181,
+            &[
+                (10.36, 0.003, 0.058),
+                (24.0, 0.009, 0.060),
+                (39.1, 0.040, 0.060),
+            ],
+        );
+        assert_eq!(d.za, 73181);
+        assert_eq!(d.ranges.len(), 1);
+        assert_eq!(d.ranges[0].l_groups.len(), 1);
+        let rs = &d.ranges[0].l_groups[0].resonances;
+        assert_eq!(rs.len(), 3);
+        assert_eq!(rs[0].energy, 10.36);
+        assert_eq!(rs[2].gn, 0.040);
+        // Structural defaults match synthetic_isotope (same awr law, RM, J=0.5).
+        let single = synthetic_isotope(73, 181, 10.36, 0.003, 0.058);
+        assert_eq!(d.awr, single.awr);
+        assert_eq!(d.ranges[0].formalism, single.ranges[0].formalism);
+        assert_eq!(rs[0].j, single.ranges[0].l_groups[0].resonances[0].j);
     }
 }

--- a/crates/nereids-fitting/Cargo.toml
+++ b/crates/nereids-fitting/Cargo.toml
@@ -18,3 +18,6 @@ nereids-physics = { workspace = true, features = ["test-support"] }
 # Exposes `nereids_endf::resonance::test_support` — synthetic
 # `ResonanceData` builders shared with sibling crates' tests.
 nereids-endf = { workspace = true, features = ["test-support"] }
+# Seeded synthetic noise for the IC closed-loop acceptance test (#642).
+rand = { workspace = true }
+rand_distr = { workspace = true }

--- a/crates/nereids-fitting/Cargo.toml
+++ b/crates/nereids-fitting/Cargo.toml
@@ -19,5 +19,9 @@ nereids-physics = { workspace = true, features = ["test-support"] }
 # `ResonanceData` builders shared with sibling crates' tests.
 nereids-endf = { workspace = true, features = ["test-support"] }
 # Seeded synthetic noise for the IC closed-loop acceptance test (#642).
+# rand_chacha pins the stream algorithm (ChaCha12): StdRng's stream is
+# documented unstable across rand versions and would silently change the
+# pinned noise realization on an upgrade.
 rand = { workspace = true }
+rand_chacha = { workspace = true }
 rand_distr = { workspace = true }

--- a/crates/nereids-fitting/src/resolution_calib.rs
+++ b/crates/nereids-fitting/src/resolution_calib.rs
@@ -128,7 +128,7 @@ const PSR_FWHM_US_MIN: f64 = 0.05;
 /// pulse base — anything larger is the moderator's job (α, β), not the burst.
 const PSR_FWHM_US_MAX: f64 = 1.0;
 /// Sanity ceiling (µs) on the configured PSR triangle FWHM: one decade above
-/// the [`PSR_FWHM_US_MAX`] fit bound. [`CalibrationConfig::psr_fwhm_ns`] is in
+/// the `PSR_FWHM_US_MAX` fit bound. [`CalibrationConfig::psr_fwhm_ns`] is in
 /// NANOSECONDS (the VENUS FTS header convention: "folded triang FWHM 350 ns
 /// PSR"), and kernel-synthesis cost grows QUADRATICALLY with a wide fold's
 /// width. The mechanism is NOT τ-step refinement — that applies only to
@@ -248,9 +248,13 @@ pub enum ResolutionFamily {
     /// ([`CalibrationConfig::psr_fwhm_ns`], default [`DEFAULT_PSR_FWHM_NS`]).
     IkedaCarpenter {
         /// Also fit the PSR triangle FWHM: appends `θ4` (µs, box-bounded
-        /// 0.05–1.0 µs, started at the config value). Off by default — the
-        /// 350 ns SNS PSR width is machine metrology, not a per-experiment
-        /// unknown.
+        /// 0.05–1.0 µs, started at [`CalibrationConfig::psr_fwhm_ns`]
+        /// clamped into that box). A positive starting width outside the box
+        /// — legal as a pin up to [`PSR_FWHM_PIN_CEILING_US`] — starts at
+        /// the nearer box edge with a stderr warning; a fit that stays there
+        /// reports `psr_fwhm_us:lower` / `:upper` in
+        /// [`CalibrationResult::bounds_hit`]. Off by default — the 350 ns
+        /// SNS PSR width is machine metrology, not a per-experiment unknown.
         fit_psr: bool,
     },
 }
@@ -316,9 +320,26 @@ impl ResolutionFamily {
                 if *fit_psr {
                     // cfg.psr_fwhm_ns > 0 is guaranteed here (fit_psr with a
                     // zero width is rejected up front — "0 disables" cannot
-                    // silently become a fitted 0.05 µs); the clamp only pulls
-                    // positive out-of-box starting widths onto the box.
-                    x0.push((cfg.psr_fwhm_ns * NS_TO_US).clamp(PSR_FWHM_US_MIN, PSR_FWHM_US_MAX));
+                    // silently become a fitted 0.05 µs). A positive start
+                    // outside the fit box — legal as a PIN up to
+                    // PSR_FWHM_PIN_CEILING_US — is CLAMPED to the nearer box
+                    // edge, not rejected (#645 round 4, F3), and the clamp is
+                    // announced on stderr: a clamped start that never leaves
+                    // its edge additionally surfaces as "psr_fwhm_us:lower" /
+                    // ":upper" in `CalibrationResult::bounds_hit`.
+                    let start_us = cfg.psr_fwhm_ns * NS_TO_US;
+                    let clamped_us = start_us.clamp(PSR_FWHM_US_MIN, PSR_FWHM_US_MAX);
+                    if clamped_us != start_us {
+                        eprintln!(
+                            "warning: fit_psr starting width psr_fwhm_ns = {} ns lies \
+                             outside the PSR fit box [{PSR_FWHM_US_MIN}, {PSR_FWHM_US_MAX}] µs; \
+                             starting the fit at the nearer box edge ({clamped_us} µs). A fit \
+                             that stays there reports \"psr_fwhm_us:lower\" / \":upper\" in \
+                             bounds_hit.",
+                            cfg.psr_fwhm_ns
+                        );
+                    }
+                    x0.push(clamped_us);
                     bounds.push((PSR_FWHM_US_MIN, PSR_FWHM_US_MAX));
                 }
                 (x0, bounds)
@@ -352,7 +373,11 @@ pub struct CalibrationConfig {
     /// structurally never re-folded here — applying it twice would
     /// double-count the burst. When the family is
     /// `IkedaCarpenter { fit_psr: true }` this value is the fit's starting
-    /// point instead of a pin. Nonzero widths above
+    /// point instead of a pin, clamped into the 0.05–1 µs fit box: a width
+    /// in (1, 10] µs is a legal pin but an out-of-box start — the fit then
+    /// starts at the box top (announced by a stderr warning), and if it
+    /// stays there it reports `psr_fwhm_us:upper` in
+    /// [`CalibrationResult::bounds_hit`]. Nonzero widths above
     /// [`PSR_FWHM_PIN_CEILING_US`] (10 µs = 10 000 ns) are rejected as a
     /// ns↔µs unit slip — see that constant for the quadratic-cost rationale.
     pub psr_fwhm_ns: f64,
@@ -1065,18 +1090,21 @@ pub fn calibrate_resolution(
     }
     let best = best.expect("at least one restart runs");
     if !best.fun.is_finite() {
-        // Every ∞ source of the objective, not only the forward model (#645
-        // round 3, F1): a hard forward-model failure aborts with its own
-        // error above, so reaching here means every vector tried hit an
-        // infeasible-point class — kernel synthesis rejected (τ-grid cap vs
-        // fold/prompt geometry), an invalid energy scale (corrected TOF ≤ 0),
-        // or a singular anorm/baseline system. The start itself synthesized
-        // (pre-flighted above), so the infeasibility arose during the search.
+        // Every ∞ source of the objective (#645 round 3 F1, round 4 F1):
+        // `nelder_mead_minimize` maps every objective `Err` — forward-model
+        // failures included — to an infeasible +∞ point rather than aborting
+        // (see the `eval` closure in `nelder_mead.rs`), so no failure class
+        // raises its own error during the search. Reaching here means every
+        // vector tried hit one of them — kernel synthesis rejected (τ-grid
+        // cap vs fold/prompt geometry), an invalid energy scale (corrected
+        // TOF ≤ 0), a singular anorm/baseline system, or a forward-model
+        // (transmission) failure. The start itself synthesized (pre-flighted
+        // above), so the infeasibility arose during the search.
         return Err(FittingError::EvaluationFailed(
             "calibration found no finite-objective resolution: every parameter vector \
              tried was infeasible — kernel synthesis rejected it (τ-grid cap vs \
              fold/prompt geometry), the energy scale was invalid (corrected TOF ≤ 0), \
-             or the anorm/baseline system was singular"
+             the anorm/baseline system was singular, or the forward model failed"
                 .into(),
         ));
     }
@@ -1185,6 +1213,34 @@ mod tests {
         let data: Vec<f64> = model.iter().map(|m| 1.0 * m).collect();
         let unc = vec![0.01; 4];
         assert!(inner_chi2(&data, &unc, &model, false, 0) < 1e-18);
+    }
+
+    /// #645 round 4, F3: a `fit_psr` starting width outside the 0.05–1 µs fit
+    /// box (legal as a PIN up to [`PSR_FWHM_PIN_CEILING_US`]) is clamped to
+    /// the nearer box edge — documented behavior, not an error.
+    #[test]
+    fn fit_psr_out_of_box_start_clamps_to_box_edge() {
+        let family = ResolutionFamily::IkedaCarpenter { fit_psr: true };
+        // 5 000 ns = 5 µs: a valid pin width, above the 1 µs fit-box top.
+        let above = CalibrationConfig {
+            psr_fwhm_ns: 5_000.0,
+            ..CalibrationConfig::default()
+        };
+        let (x0, bounds) = family.x0_bounds(&above);
+        assert_eq!(x0.len(), 5);
+        assert_eq!(x0[4], PSR_FWHM_US_MAX);
+        assert_eq!(bounds[4], (PSR_FWHM_US_MIN, PSR_FWHM_US_MAX));
+        // 10 ns: below the 50 ns identifiability floor — clamped UP.
+        let below = CalibrationConfig {
+            psr_fwhm_ns: 10.0,
+            ..CalibrationConfig::default()
+        };
+        let (x0, _) = family.x0_bounds(&below);
+        assert_eq!(x0[4], PSR_FWHM_US_MIN);
+        // The in-box default (350 ns) passes through unclamped.
+        let inside = CalibrationConfig::default();
+        let (x0, _) = family.x0_bounds(&inside);
+        assert_eq!(x0[4], DEFAULT_PSR_FWHM_NS * NS_TO_US);
     }
 
     #[test]

--- a/crates/nereids-fitting/src/resolution_calib.rs
+++ b/crates/nereids-fitting/src/resolution_calib.rs
@@ -125,6 +125,20 @@ const NS_TO_US: f64 = 1e-3;
 /// A coordinate within this fraction of its box range of a bound is reported
 /// in [`CalibrationResult::bounds_hit`] as pinned.
 const BOUND_HIT_REL_TOL: f64 = 1e-3;
+/// Cap on per-restart Nelder–Mead simplex re-inflations (fresh simplex
+/// restarted at the incumbent while it keeps improving by more than `fatol`).
+/// Guards against premature simplex collapse — see the re-inflation comment
+/// in [`calibrate_resolution`] — while guaranteeing termination.
+const MAX_SIMPLEX_REINFLATIONS: usize = 5;
+/// Initial-step fraction for the RE-INFLATED simplex (vs the default 0.05 of
+/// the first descent). A collapsed simplex rebuilt at the same 5 % scale
+/// deterministically re-collapses to the same trap (observed on the IC
+/// family's curved α↔β↔R valley); a 25 % edge straddles the valley and lets
+/// the restarted simplex see the descent direction.
+const REINFLATE_STEP_FRAC: f64 = 0.25;
+/// Absolute re-inflation step for near-zero coordinates (`|x| < 1e-8`),
+/// matching the box scale of the bounded coordinates (R ∈ [0, 1]).
+const REINFLATE_STEP_ABS: f64 = 0.1;
 /// Guard-rail bound (µs) on the optional fitted TOF zero `t0`. `t0` and `L_scale`
 /// are the SAMMY *energy-scale* parameters; resolution calibration pins them by
 /// default and fits them only as an explicit, prior-constrained opt-in (see
@@ -862,7 +876,7 @@ pub fn calibrate_resolution(
             .zip(&bounds)
             .map(|(&v, &(lo, hi))| (v + 0.1 * r as f64 * (hi - lo)).clamp(lo, hi))
             .collect();
-        let obj = |theta: &[f64]| -> Result<f64, FittingError> {
+        let mut obj = |theta: &[f64]| -> Result<f64, FittingError> {
             // theta = [resolution params (n_res)..., t0?, L_scale?]. The resolution
             // kernel uses only the first n_res; (t0, L_scale) set the energy scale.
             let res = build_resolution(&family, theta, e_min, e_max, config)?;
@@ -885,7 +899,37 @@ pub fn calibrate_resolution(
             };
             Ok(ssr + position_prior_penalty(t0, l_scale, config))
         };
-        let res = nelder_mead_minimize(obj, &start, Some(&bounds), &nm)?;
+        let mut res = nelder_mead_minimize(&mut obj, &start, Some(&bounds), &nm)?;
+        // Simplex RE-INFLATION: Nelder–Mead's known failure mode is premature
+        // simplex collapse — the spread criteria are met (`self_converged`)
+        // at a point that is NOT the basin minimum. Observed on the
+        // 4-parameter IC family: a 300 K synthetic calibrant stalled at
+        // Δχ² ≈ +130 above the noise floor in the curved α↔β↔R valley, and
+        // the ~1.5 % kernel-width error re-expressed as a ~23 K temperature
+        // bias in the downstream pinned fit. Standard cure: restart a FRESH,
+        // *larger* simplex at the incumbent (same 5 % edge re-collapses to
+        // the same trap deterministically) and keep the improvement, until
+        // it stops helping (bounded by MAX_SIMPLEX_REINFLATIONS). A
+        // re-inflation from a true minimum re-contracts quickly, so the
+        // extra cost there is small.
+        let reinflate_nm = NelderMeadConfig {
+            initial_step_frac: REINFLATE_STEP_FRAC,
+            initial_step_abs: REINFLATE_STEP_ABS,
+            ..nm.clone()
+        };
+        for _ in 0..MAX_SIMPLEX_REINFLATIONS {
+            let again = nelder_mead_minimize(&mut obj, &res.x, Some(&bounds), &reinflate_nm)?;
+            let improved = again.fun + nm.fatol < res.fun;
+            res.iterations += again.iterations;
+            res.n_evals += again.n_evals;
+            if improved {
+                res.x = again.x;
+                res.fun = again.fun;
+                res.self_converged = again.self_converged;
+            } else {
+                break;
+            }
+        }
         if best.as_ref().is_none_or(|b| res.fun < b.fun) {
             best = Some(res);
         }

--- a/crates/nereids-fitting/src/resolution_calib.rs
+++ b/crates/nereids-fitting/src/resolution_calib.rs
@@ -94,7 +94,8 @@ const IC_A1_X0: f64 = 0.05;
 /// unresolvable within the cap; such θ are treated as infeasible points
 /// (∞ objective) during the search, never as a calibration abort — see
 /// `ic_box_worst_corner_synthesizes_within_tau_cap` /
-/// `ic_unresolvable_theta_is_infeasible_point_not_abort`.
+/// `ic_unresolvable_theta_errs_in_build_resolution` /
+/// `ic_infeasible_pocket_inside_box_completes_calibration`.
 const IC_BETA_MIN: f64 = 0.02;
 /// Upper box bound on `β`: at 5 µs⁻¹ the storage tail is as fast as the
 /// prompt core itself (α range), beyond which β↔α are indistinguishable.
@@ -129,10 +130,15 @@ const PSR_FWHM_US_MAX: f64 = 1.0;
 /// Sanity ceiling (µs) on the configured PSR triangle FWHM: one decade above
 /// the [`PSR_FWHM_US_MAX`] fit bound. [`CalibrationConfig::psr_fwhm_ns`] is in
 /// NANOSECONDS (the VENUS FTS header convention: "folded triang FWHM 350 ns
-/// PSR"), and kernel-synthesis cost grows QUADRATICALLY with the fold width
-/// (the fold both refines the τ-step and widens the ± fold-reach margin):
-/// measured ~12 ms at 0.35 µs but ~1.3 s at 50 µs and ~28 s at 350 µs per
-/// single kernel-table synthesis at the default grid. A µs-as-ns unit slip
+/// PSR"), and kernel-synthesis cost grows QUADRATICALLY with a wide fold's
+/// width. The mechanism is NOT τ-step refinement — that applies only to
+/// folds FINER than the prompt design step, and a 50–350 µs fold's FWHM/3
+/// resolution floor is far coarser, leaving the step unchanged — it is the
+/// convolution itself: the ±FWHM fold-reach margin adds O(FWHM/step)
+/// τ-samples, each folded in `convolve_same` against a sampled triangle
+/// itself O(FWHM/step) long. Measured ~12 ms at 0.35 µs but ~1.3 s at 50 µs
+/// and ~28 s at 350 µs per single kernel-table synthesis at the default
+/// grid. A µs-as-ns unit slip
 /// (passing `350` meaning µs → interpreted as a 350 µs pin) would therefore
 /// turn a calibration into a multi-hour silent hang behind a physically
 /// fictitious fold. Any genuine width sits inside the fitted box; one decade
@@ -922,6 +928,39 @@ pub fn calibrate_resolution(
         );
         bounds.push((POSITION_L_SCALE_MIN, POSITION_L_SCALE_MAX));
     }
+    // PRE-FLIGHT the start (#645 round 3, F1): synthesize the resolution once
+    // at x0 before any optimization. A start whose kernel cannot be
+    // synthesized — e.g. any PSR triangle under ~58.6 ns: the default β/R
+    // start (β = 0.1, R = 0.1) spans a 16/β = 160 µs storage tail, capping
+    // the τ-step at 160/8191 ≈ 19.53 ns, above such a triangle's FWHM/3
+    // resolution floor (note the PSR fit-box floor 0.05 µs = 50 ns is ITSELF
+    // in this class, so a `>= PSR_FWHM_US_MIN` value check could not cover
+    // it) — passes every value-level config check above yet makes EVERY
+    // initial-simplex vertex infeasible (∞ objective): the Nelder–Mead
+    // objective range is then ∞ − ∞ = NaN, so it can never self-converge,
+    // burns max_iter, and used to die late with the generic "no
+    // finite-objective" error blaming the forward model. Reject the START
+    // precisely instead, surfacing the τ-geometry/synthesis diagnosis. A θ
+    // that becomes infeasible only DURING the search remains an ∞ point the
+    // simplex steps away from (see the objective below) — this pre-flight
+    // rejects only an infeasible start.
+    if let Err(synth_err) = build_resolution(&family, &x0, e_min, e_max, config) {
+        let psr_note = if matches!(family, ResolutionFamily::IkedaCarpenter { .. }) {
+            format!(
+                " The starting PSR width comes from psr_fwhm_ns = {} ns — widen the \
+                 triangle (the SNS/VENUS FTS convention is 350 ns), or pass 0 to \
+                 disable the fold when not fitting it.",
+                config.psr_fwhm_ns
+            )
+        } else {
+            String::new()
+        };
+        return Err(FittingError::InvalidConfig(format!(
+            "resolution kernel synthesis is infeasible at the starting parameter \
+             vector, so every optimizer restart would begin from an all-infeasible \
+             simplex: {synth_err}.{psr_note}"
+        )));
+    }
     let nm = NelderMeadConfig {
         xatol: config.xatol,
         fatol: config.fatol,
@@ -1026,9 +1065,18 @@ pub fn calibrate_resolution(
     }
     let best = best.expect("at least one restart runs");
     if !best.fun.is_finite() {
+        // Every ∞ source of the objective, not only the forward model (#645
+        // round 3, F1): a hard forward-model failure aborts with its own
+        // error above, so reaching here means every vector tried hit an
+        // infeasible-point class — kernel synthesis rejected (τ-grid cap vs
+        // fold/prompt geometry), an invalid energy scale (corrected TOF ≤ 0),
+        // or a singular anorm/baseline system. The start itself synthesized
+        // (pre-flighted above), so the infeasibility arose during the search.
         return Err(FittingError::EvaluationFailed(
-            "calibration found no finite-objective resolution (the forward model failed for \
-             every parameter vector tried)"
+            "calibration found no finite-objective resolution: every parameter vector \
+             tried was infeasible — kernel synthesis rejected it (τ-grid cap vs \
+             fold/prompt geometry), the energy scale was invalid (corrected TOF ≤ 0), \
+             or the anorm/baseline system was singular"
                 .into(),
         ));
     }
@@ -2293,6 +2341,56 @@ mod tests {
     }
 
     #[test]
+    fn rejects_infeasible_psr_start_width() {
+        // Review #645 round 3, F1: a nonzero PSR width in (0, ~58.6 ns)
+        // passes every value-level check (finite / sign / ceiling) yet cannot
+        // be SYNTHESIZED at the optimizer start: the default β/R start
+        // (β = 0.1, R = 0.1 > R_NEGLIGIBLE) spans a 16/β = 160 µs storage
+        // tail, capping the τ-step at 160/8191 ≈ 19.53 ns, and tau_geometry
+        // rejects any triangle whose FWHM/3 floor is below that (fwhm <
+        // ~58.6 ns). Every initial-simplex vertex was then ∞ (objective range
+        // ∞ − ∞ = NaN — no self-convergence), so the calibration burned
+        // max_iter and died with the generic "no finite-objective" error
+        // blaming the forward model. The pre-flight must reject the START
+        // precisely, surfacing the τ-geometry diagnosis and naming
+        // psr_fwhm_ns. The fit_psr arm starts AT the fit-box floor
+        // PSR_FWHM_US_MIN = 0.05 µs (50 ns), which is itself infeasible at
+        // the default start — proof that a `>= PSR_FWHM_US_MIN` value check
+        // would not be sufficient.
+        let iso = synthetic_isotope(72, 178, 20.0, 0.05, 0.06);
+        let sample = SampleParams::new(300.0, vec![(iso, 2.0e-3)]).unwrap();
+        let e: Vec<f64> = (0..60).map(|i| 15.0 + i as f64 * 0.2).collect();
+        let d = vec![0.9; 60];
+        let u = vec![0.01; 60];
+        for (fit_psr, psr_ns) in [(false, 55.0), (true, 50.0)] {
+            let cfg = CalibrationConfig {
+                psr_fwhm_ns: psr_ns,
+                ..Default::default()
+            };
+            let err = calibrate_resolution(
+                ResolutionFamily::IkedaCarpenter { fit_psr },
+                &e,
+                &d,
+                &u,
+                &sample,
+                &cfg,
+            )
+            .expect_err("a sub-59-ns PSR start must be rejected up front");
+            assert!(
+                matches!(
+                    &err,
+                    FittingError::InvalidConfig(msg)
+                        if msg.contains("starting parameter vector")
+                            && msg.contains("psr_fwhm_ns")
+                            && msg.contains("cannot resolve")
+                ),
+                "pre-flight error must name the start, psr_fwhm_ns and the τ-cap cause \
+                 (fit_psr = {fit_psr}, psr_ns = {psr_ns}), got {err:?}"
+            );
+        }
+    }
+
+    #[test]
     fn rejects_fit_psr_with_zero_psr_width() {
         // psr_fwhm_ns = 0 means "no PSR fold"; fit_psr = true would silently
         // clamp that 0 start into the [0.05, 1] µs fit box, contradicting the
@@ -2432,14 +2530,15 @@ mod tests {
     }
 
     #[test]
-    fn ic_unresolvable_theta_is_infeasible_point_not_abort() {
+    fn ic_unresolvable_theta_errs_in_build_resolution() {
         // A θ inside the box can still be unresolvable: a fitted PSR at its
         // 0.05 µs floor against β at its own floor needs a τ-step ≤ FWHM/3 ≈
         // 0.017 µs across an 800 µs storage tail — past the 8192-sample cap.
-        // build_resolution must Err for such θ; the calibration objective
-        // maps that to an ∞ objective (an infeasible point the simplex steps
-        // away from — same handling as an infeasible energy scale), so a
-        // wandering optimizer can never abort the whole calibration on it.
+        // This test asserts the build_resolution half only: such θ must Err.
+        // The calibration-level half — the objective maps that Err to an ∞
+        // point the simplex steps away from, never aborting the calibration —
+        // is asserted by ic_infeasible_pocket_inside_box_completes_calibration
+        // below (#645 round 3, F4).
         let cfg = CalibrationConfig::default();
         let theta = [
             IC_A0_X0.ln(),
@@ -2452,6 +2551,55 @@ mod tests {
         assert!(
             build_resolution(&fam, &theta, 6.0, 112.0, &cfg).is_err(),
             "β at its floor + PSR at its floor must be unresolvable"
+        );
+    }
+
+    #[test]
+    fn ic_infeasible_pocket_inside_box_completes_calibration() {
+        // Review #645 round 3, F4 — the calibration-level half of the claim
+        // above: with fit_psr the box CONTAINS the unresolvable pocket (PSR
+        // near its 0.05 µs floor against β near its own floor), and the
+        // simplex demonstrably brushes it — the 60 ns start sits just above
+        // the ~58.6 ns feasibility edge at the default β/R start (the
+        // pre-flight passes: 60/3 = 20 ns floor > 19.53 ns capped step), so
+        // the FIRST simplex already carries an ∞ vertex: the β-decreased
+        // vertex (ln β step is negative, β 0.1 → ~0.089) widens the storage
+        // reach to ~180 µs and the capped step to ~21.9 ns, past the 20 ns
+        // floor. The optimizer must treat such vertices as infeasible points
+        // and finish: Ok, finite χ², decoded resolution inside the box. Tiny
+        // grid/iteration budget — this asserts non-abortion, not fit quality.
+        let iso = synthetic_isotope(72, 178, 20.0, 0.05, 0.06);
+        let sample = SampleParams::new(300.0, vec![(iso, 2.0e-3)]).unwrap();
+        let e: Vec<f64> = (0..60).map(|i| 15.0 + i as f64 * 0.2).collect();
+        let d = vec![0.9; 60];
+        let u = vec![0.01; 60];
+        let cfg = CalibrationConfig {
+            psr_fwhm_ns: 60.0,
+            ic_n_energies: 8,
+            ic_n_tau: 32,
+            max_iter: 60,
+            ..Default::default()
+        };
+        let r = calibrate_resolution(
+            ResolutionFamily::IkedaCarpenter { fit_psr: true },
+            &e,
+            &d,
+            &u,
+            &sample,
+            &cfg,
+        )
+        .expect("an infeasible pocket inside the box must not abort the calibration");
+        assert!(
+            r.chi2_dof.is_finite(),
+            "calibration through the infeasible pocket must return a finite χ²/dof, got {}",
+            r.chi2_dof
+        );
+        let (_a0, _a1, beta, _r, psr_us) = decoded_ic(&r);
+        assert!(
+            (PSR_FWHM_US_MIN..=PSR_FWHM_US_MAX).contains(&psr_us)
+                && (IC_BETA_MIN..=IC_BETA_MAX).contains(&beta),
+            "decoded solution must be feasible and inside the box: β = {beta}, \
+             psr = {psr_us} µs"
         );
     }
 }

--- a/crates/nereids-fitting/src/resolution_calib.rs
+++ b/crates/nereids-fitting/src/resolution_calib.rs
@@ -86,8 +86,15 @@ const IC_A1_X0: f64 = 0.05;
 /// Lower box bound on the storage (slow) rate `β` (µs⁻¹). Covers the
 /// canonical Ikeda–Carpenter ambient-moderator value β ≈ 0.031 µs⁻¹
 /// (NIM A239 (1985) 536; also Mantid `IkedaCarpenterPV`'s β default) with
-/// margin below it. The τ-grid is prompt-anchored (nereids-physics
-/// `MAX_TAU_SAMPLES`), so the 16/β ≈ 800 µs tail at this bound stays sampled.
+/// margin below it. The τ-grid is prompt-anchored and capped (nereids-physics
+/// `MAX_TAU_SAMPLES`), so the 16/β ≈ 800 µs tail at this bound stays sampled
+/// at a ≈ 0.098 µs capped step — fine enough for the default 0.35 µs (and
+/// any ≥ ~0.3 µs) PSR triangle and for prompt rates up to α ≈ 26 µs⁻¹. A
+/// fitted PSR near its 0.05 µs floor combined with β near this bound is
+/// unresolvable within the cap; such θ are treated as infeasible points
+/// (∞ objective) during the search, never as a calibration abort — see
+/// `ic_box_worst_corner_synthesizes_within_tau_cap` /
+/// `ic_unresolvable_theta_is_infeasible_point_not_abort`.
 const IC_BETA_MIN: f64 = 0.02;
 /// Upper box bound on `β`: at 5 µs⁻¹ the storage tail is as fast as the
 /// prompt core itself (α range), beyond which β↔α are indistinguishable.
@@ -285,6 +292,10 @@ impl ResolutionFamily {
                     (IC_R_MIN, IC_R_MAX),
                 ];
                 if *fit_psr {
+                    // cfg.psr_fwhm_ns > 0 is guaranteed here (fit_psr with a
+                    // zero width is rejected up front — "0 disables" cannot
+                    // silently become a fitted 0.05 µs); the clamp only pulls
+                    // positive out-of-box starting widths onto the box.
                     x0.push((cfg.psr_fwhm_ns * NS_TO_US).clamp(PSR_FWHM_US_MIN, PSR_FWHM_US_MAX));
                     bounds.push((PSR_FWHM_US_MIN, PSR_FWHM_US_MAX));
                 }
@@ -663,7 +674,8 @@ fn solve_small(a: &[f64], b: &[f64], k: usize) -> Option<Vec<f64>> {
 /// bounded `β = e^{θ2}` and scalar storage fraction `R = θ3 ∈ [0, 1]`, folded
 /// with the SNS PSR channel triangle
 /// ([`CalibrationConfig::psr_fwhm_ns`], default 350 ns; `0` disables;
-/// optionally fitted via `IkedaCarpenter { fit_psr: true }`).
+/// optionally fitted via `IkedaCarpenter { fit_psr: true }` — a zero width
+/// combined with `fit_psr` contradicts "0 disables" and is rejected).
 ///
 /// Returns the fitted shape parameters, the reduced **data** χ²/dof, the fitted (or
 /// pinned) `(t0, L_scale)`, the prior penalty, the calibrated
@@ -769,6 +781,40 @@ pub fn calibrate_resolution(
             "psr_fwhm_ns must be finite and >= 0 (0 disables the PSR fold), got {}",
             config.psr_fwhm_ns
         )));
+    }
+    // fit_psr fits the PSR FWHM from the psr_fwhm_ns starting value, but 0 is
+    // documented as "no fold": a zero start would be silently clamped into the
+    // [PSR_FWHM_US_MIN, PSR_FWHM_US_MAX] fit box, contradicting the "0
+    // disables" contract. Reject the contradiction loudly.
+    if matches!(family, ResolutionFamily::IkedaCarpenter { fit_psr: true })
+        && config.psr_fwhm_ns == 0.0
+    {
+        return Err(FittingError::InvalidConfig(
+            "fit_psr requires a positive psr_fwhm_ns starting value (psr_fwhm_ns = 0 disables \
+             the PSR fold; use fit_psr = false to calibrate without one)"
+                .into(),
+        ));
+    }
+    // IC synthesis-grid resolution: validate up front for the IC family (inert
+    // for the others) so an out-of-range value gives this precise error instead
+    // of every IkedaCarpenter::new evaluation failing into the generic late
+    // "no finite-objective resolution" error. Thresholds mirror both
+    // IkedaCarpenter::new (n_energies >= 2, n_tau >= 8) and the Python
+    // binding's sibling validation, so the two public entry points reject the
+    // same inputs.
+    if matches!(family, ResolutionFamily::IkedaCarpenter { .. }) {
+        if config.ic_n_energies < 2 {
+            return Err(FittingError::InvalidConfig(format!(
+                "ic_n_energies must be >= 2 for the IC family, got {}",
+                config.ic_n_energies
+            )));
+        }
+        if config.ic_n_tau < 8 {
+            return Err(FittingError::InvalidConfig(format!(
+                "ic_n_tau must be >= 8 for the IC family, got {}",
+                config.ic_n_tau
+            )));
+        }
     }
     // Validate the energy-scale (t0, L_scale) prior/center configuration up front.
     if !config.position_t0_center_us.is_finite()
@@ -879,7 +925,16 @@ pub fn calibrate_resolution(
         let mut obj = |theta: &[f64]| -> Result<f64, FittingError> {
             // theta = [resolution params (n_res)..., t0?, L_scale?]. The resolution
             // kernel uses only the first n_res; (t0, L_scale) set the energy scale.
-            let res = build_resolution(&family, theta, e_min, e_max, config)?;
+            // An UNRESOLVABLE θ — nereids-physics rejects a kernel whose τ-grid
+            // cannot resolve the requested fold / prompt core within the
+            // MAX_TAU_SAMPLES cap (e.g. a fitted PSR at its 0.05 µs floor
+            // against β at its own floor) — is an infeasible POINT of the
+            // search, not a broken calibration: step away (mirrors the
+            // corrected-TOF ≤ 0 guard below). Config-level failures cannot
+            // reach here: they are rejected up front by calibrate_resolution.
+            let Ok(res) = build_resolution(&family, theta, e_min, e_max, config) else {
+                return Ok(f64::INFINITY);
+            };
             let inst = InstrumentParams { resolution: res };
             let (t0, l_scale) = unpack_position(theta);
             // Infeasible energy scale (corrected TOF ≤ 0) → step away.
@@ -1920,6 +1975,75 @@ mod tests {
     }
 
     #[test]
+    fn ic_recovers_known_psr_when_fit() {
+        // Loop-closure / optimizer test for fit_psr (#645 F2, same caveat as
+        // ic_recovers_known_alpha: truth and fit share the IC synthesis, so
+        // this checks the 5-parameter optimizer, not the pulse physics).
+        // Truth PSR FWHM = 0.6 µs — interior to the [0.05, 1] µs box and far
+        // from the 0.35 µs default start — with the rest of the truth kernel
+        // identical to ic_recovers_known_alpha. Two resonances (15 + 45 eV)
+        // give the E-leverage that separates the E-independent triangle
+        // width from the α(E) = a0·√E + a1 prompt law (a single resonance
+        // probes the kernel at essentially one energy).
+        // Full-density run (420 pts, 64×500 grid, restarts 2) recovers
+        // psr = 0.5984 µs at χ²/dof ≈ 1e-6; this slimmed grid keeps the same
+        // loop-closure semantics at a debug-friendly runtime.
+        let iso_lo = synthetic_isotope(72, 178, 15.0, 0.05, 0.06);
+        let iso_hi = synthetic_isotope(72, 179, 45.0, 0.05, 0.06);
+        let sample = SampleParams::new(300.0, vec![(iso_lo, 2.0e-3), (iso_hi, 2.0e-3)]).unwrap();
+        let energies: Vec<f64> = (0..280).map(|i| 8.0 + i as f64 * 0.15).collect();
+        let cfg = CalibrationConfig {
+            restarts: 1,
+            ic_n_energies: 32,
+            ic_n_tau: 320,
+            ..Default::default()
+        };
+        let psr_true = 0.6;
+        let ic_truth = IkedaCarpenter::new(
+            IkedaCarpenterParams {
+                alpha: EnergyLaw::SqrtE { a0: 0.35, a1: 0.05 },
+                beta: 0.1,
+                r: EnergyLaw::Const(0.1),
+                burst_sigma_us: None,
+                channel_fwhm_us: Some(psr_true),
+            },
+            cfg.flight_path_m,
+            &SynthesisGrid {
+                e_min_ev: (energies[0] * 0.5).max(1e-3),
+                e_max_ev: energies.last().unwrap() * 2.0,
+                n_energies: cfg.ic_n_energies,
+                n_tau: cfg.ic_n_tau,
+            },
+        )
+        .unwrap();
+        let truth = ResolutionFunction::IkedaCarpenter(Arc::new(ic_truth));
+        let data = forward_model(
+            &energies,
+            &sample,
+            Some(&InstrumentParams { resolution: truth }),
+        )
+        .unwrap();
+        let unc = vec![0.004; energies.len()];
+        let r = calibrate_resolution(
+            ResolutionFamily::IkedaCarpenter { fit_psr: true },
+            &energies,
+            &data,
+            &unc,
+            &sample,
+            &cfg,
+        )
+        .unwrap();
+        let (a0, _a1, _beta, _rr, psr) = decoded_ic(&r);
+        assert_eq!(r.n_free_params, 5);
+        assert!(
+            (psr - psr_true).abs() < 0.1,
+            "recovered PSR FWHM {psr} µs, expected {psr_true} µs"
+        );
+        assert!((a0 - 0.35).abs() < 0.05, "recovered a0={a0}, expected 0.35");
+        assert!(r.chi2_dof < 1.0, "matched χ²/dof={} too high", r.chi2_dof);
+    }
+
+    #[test]
     fn psr_disabled_at_zero_width() {
         // psr_fwhm_ns = 0.0 disables the triangle fold entirely: an UNFOLDED
         // truth is reproduced and the calibrated kernel carries no channel.
@@ -2067,5 +2191,168 @@ mod tests {
                 "psr_fwhm_ns={bad} should be rejected"
             );
         }
+    }
+
+    #[test]
+    fn rejects_fit_psr_with_zero_psr_width() {
+        // psr_fwhm_ns = 0 means "no PSR fold"; fit_psr = true would silently
+        // clamp that 0 start into the [0.05, 1] µs fit box, contradicting the
+        // documented "0 disables". The contradiction is a config error.
+        let iso = synthetic_isotope(72, 178, 20.0, 0.05, 0.06);
+        let sample = SampleParams::new(300.0, vec![(iso, 2.0e-3)]).unwrap();
+        let e: Vec<f64> = (0..60).map(|i| 15.0 + i as f64 * 0.2).collect();
+        let d = vec![0.9; 60];
+        let u = vec![0.01; 60];
+        let cfg = CalibrationConfig {
+            psr_fwhm_ns: 0.0,
+            ..Default::default()
+        };
+        let err = calibrate_resolution(
+            ResolutionFamily::IkedaCarpenter { fit_psr: true },
+            &e,
+            &d,
+            &u,
+            &sample,
+            &cfg,
+        )
+        .expect_err("fit_psr with psr_fwhm_ns = 0 must be rejected");
+        assert!(
+            matches!(&err, FittingError::InvalidConfig(msg) if msg.contains("fit_psr")),
+            "expected an InvalidConfig naming fit_psr, got {err:?}"
+        );
+        // The same zero width WITHOUT fit_psr stays valid ("0 disables").
+        // Tiny grid/iteration budget: this arm only asserts the config
+        // passes validation, not fit quality.
+        let cheap = CalibrationConfig {
+            psr_fwhm_ns: 0.0,
+            ic_n_energies: 8,
+            ic_n_tau: 32,
+            max_iter: 10,
+            ..Default::default()
+        };
+        assert!(
+            calibrate_resolution(
+                ResolutionFamily::IkedaCarpenter { fit_psr: false },
+                &e,
+                &d,
+                &u,
+                &sample,
+                &cheap,
+            )
+            .is_ok(),
+            "psr_fwhm_ns = 0 with fit_psr = false must remain a valid config"
+        );
+    }
+
+    #[test]
+    fn rejects_undersized_ic_synthesis_grid() {
+        // ic_n_energies < 2 / ic_n_tau < 8 previously surfaced only as the
+        // late, generic "no finite-objective resolution" error (every
+        // IkedaCarpenter::new evaluation failed). They must be precise
+        // up-front InvalidConfig errors for the IC family — sibling parity
+        // with the Python binding's validation.
+        let iso = synthetic_isotope(72, 178, 20.0, 0.05, 0.06);
+        let sample = SampleParams::new(300.0, vec![(iso, 2.0e-3)]).unwrap();
+        let e: Vec<f64> = (0..60).map(|i| 15.0 + i as f64 * 0.2).collect();
+        let d = vec![0.9; 60];
+        let u = vec![0.01; 60];
+        for (ne, nt, what) in [(1, 500, "ic_n_energies"), (64, 7, "ic_n_tau")] {
+            // The loose iteration/tolerance budget only cheapens the Gaussian
+            // is_ok arm below (validation-only assertion, not fit quality);
+            // the InvalidConfig arm rejects before any optimization runs.
+            let cfg = CalibrationConfig {
+                ic_n_energies: ne,
+                ic_n_tau: nt,
+                max_iter: 5,
+                xatol: 1.0,
+                fatol: 1.0,
+                ..Default::default()
+            };
+            let err = calibrate_resolution(
+                ResolutionFamily::IkedaCarpenter { fit_psr: false },
+                &e,
+                &d,
+                &u,
+                &sample,
+                &cfg,
+            )
+            .expect_err("undersized IC synthesis grid must be rejected");
+            assert!(
+                matches!(&err, FittingError::InvalidConfig(msg) if msg.contains(what)),
+                "expected an InvalidConfig naming {what}, got {err:?}"
+            );
+            // The same values are inert for a non-IC family (mirrors the
+            // Python binding: the knobs only size the IC synthesis grid).
+            assert!(
+                calibrate_resolution(ResolutionFamily::Gaussian, &e, &d, &u, &sample, &cfg).is_ok(),
+                "ic grid knobs must stay inert for the Gaussian family"
+            );
+        }
+    }
+
+    #[test]
+    fn ic_box_worst_corner_synthesizes_within_tau_cap() {
+        // #645 F1: the calibrator's box must not abort a calibration on an
+        // unresolvable τ-grid. Worst corner of the box in the τ-cap sense:
+        // β at its floor (slow reach 16/β = 800 µs — the longest admitted
+        // storage tail, so the capped step is at its widest ≈ 0.098 µs),
+        // R = 1 (storage fully active), a1 at its ceiling and a0 at the
+        // documented physical ceiling (α ≈ 1–3 µs⁻¹ in the eV regime ⇒
+        // a0 ≈ 0.2–0.5, see IC_A0_MIN), at the calibrator's default
+        // n_tau = 500 on a representative eV-regime synthesis window. The
+        // capped step resolves both the PSR triangle box (0.35 µs default
+        // pin up to the 1 µs fitted ceiling: ≥ 3 samples per side) and any
+        // prompt core with α ≤ 18/(7 · 0.098) ≈ 26 µs⁻¹ — far above eV-regime
+        // moderator physics. (The remaining unresolvable pockets — a fitted
+        // PSR near its 0.05 µs floor together with β near its floor, or
+        // a0 driven ~50× past the physical ceiling — are handled as
+        // infeasible points, see the companion test below.)
+        let cfg = CalibrationConfig::default();
+        for fwhm_us in [DEFAULT_PSR_FWHM_NS * NS_TO_US, PSR_FWHM_US_MAX] {
+            let corner = IkedaCarpenterParams {
+                alpha: EnergyLaw::SqrtE {
+                    a0: 0.5,
+                    a1: IC_A1_MAX,
+                },
+                beta: IC_BETA_MIN,
+                r: EnergyLaw::Const(IC_R_MAX),
+                burst_sigma_us: None,
+                channel_fwhm_us: Some(fwhm_us),
+            };
+            let grid = SynthesisGrid {
+                e_min_ev: 6.0,
+                e_max_ev: 112.0,
+                n_energies: cfg.ic_n_energies,
+                n_tau: cfg.ic_n_tau,
+            };
+            assert!(
+                IkedaCarpenter::new(corner, cfg.flight_path_m, &grid).is_ok(),
+                "calibration-box worst corner must synthesize (fwhm = {fwhm_us} µs)"
+            );
+        }
+    }
+
+    #[test]
+    fn ic_unresolvable_theta_is_infeasible_point_not_abort() {
+        // A θ inside the box can still be unresolvable: a fitted PSR at its
+        // 0.05 µs floor against β at its own floor needs a τ-step ≤ FWHM/3 ≈
+        // 0.017 µs across an 800 µs storage tail — past the 8192-sample cap.
+        // build_resolution must Err for such θ; the calibration objective
+        // maps that to an ∞ objective (an infeasible point the simplex steps
+        // away from — same handling as an infeasible energy scale), so a
+        // wandering optimizer can never abort the whole calibration on it.
+        let cfg = CalibrationConfig::default();
+        let theta = [
+            IC_A0_X0.ln(),
+            IC_A1_X0.ln(),
+            IC_BETA_MIN.ln(),
+            0.5,
+            PSR_FWHM_US_MIN,
+        ];
+        let fam = ResolutionFamily::IkedaCarpenter { fit_psr: true };
+        assert!(
+            build_resolution(&fam, &theta, 6.0, 112.0, &cfg).is_err(),
+            "β at its floor + PSR at its floor must be unresolvable"
+        );
     }
 }

--- a/crates/nereids-fitting/src/resolution_calib.rs
+++ b/crates/nereids-fitting/src/resolution_calib.rs
@@ -23,9 +23,14 @@
 //!   the Monte-Carlo shape, calibrates its width/energy-dependence. **UDR** =
 //!   *User-Defined Resolution*, SAMMY's term for a numerical (table-supplied)
 //!   resolution function.
-//! - **IkedaCarpenter** — fit `α(E)=a0√E+a1` (free analytic prompt-width shape);
-//!   `β` is held fixed because `R≈0` in the eV regime makes the storage term, and
-//!   hence `β`, unidentifiable.
+//! - **IkedaCarpenter** — physics-complete bounded moderator fit (#642):
+//!   `α(E) = e^{θ0}·√E + e^{θ1}` (positive at every energy by construction),
+//!   `β = e^{θ2}` (bounded), scalar storage fraction `R = θ3 ∈ [0, 1]`, all
+//!   folded with the SNS PSR channel triangle
+//!   ([`CalibrationConfig::psr_fwhm_ns`], default 350 ns; optionally fitted
+//!   via `fit_psr`). Beware the β↔R ridge: as `R → 0` the storage term
+//!   vanishes and β is unconstrained — such a fit reports `"r:lower"` in
+//!   [`CalibrationResult::bounds_hit`] and its β carries no information.
 
 use std::sync::Arc;
 
@@ -48,10 +53,78 @@ const UDR_E_REF: f64 = 10.0;
 pub const UDR_S0_MIN: f64 = 0.2;
 /// Upper width-scale clamp; see [`UDR_S0_MIN`].
 pub const UDR_S0_MAX: f64 = 5.0;
-/// Fixed storage rate for the IC calibration family. `R(E)≈0` across the eV
-/// resonance regime makes the slow/storage term — and hence `β` — unidentifiable,
-/// so it is held fixed rather than reported as a meaningless fit result.
-const IC_FIXED_BETA: f64 = 0.1;
+// --- Ikeda–Carpenter calibration family: θ encoding and physics bounds (#642) ---
+//
+// θ = [ln a0, ln a1, ln β, R, (PSR FWHM µs iff fit_psr)]. The rates are
+// exp-encoded so that `α(E) = e^{θ0}·√E + e^{θ1} > 0` at EVERY energy — on the
+// calibration grid and on any production grid the pinned kernel is later
+// applied to — by construction (a real calibration under the old plain-(a0,a1)
+// box once returned a1 = −0.396, which drives α(E) < 0 at low energy and makes
+// the pulse unphysical). β and R are FREE: the 2-parameter predecessor (β
+// pinned, R ≡ exp(−E_meV/25) ≈ 0 in the eV regime) lacked the storage-shape
+// freedom, which re-expressed as a ~90 K temperature degeneracy on real data.
+
+/// Lower box bound on the prompt-rate coefficient `a0` (µs⁻¹ per √eV) of
+/// `α(E) = a0·√E + a1`; same span as the previous plain box `(0.01, 5.0)`.
+/// α ≈ 1–3 µs⁻¹ in the eV regime (Ikeda & Carpenter, NIM A239 (1985) 536)
+/// gives a0 ≈ 0.2–0.5; the decade of head-room on each side is deliberate.
+const IC_A0_MIN: f64 = 0.01;
+/// Upper box bound on `a0`; see [`IC_A0_MIN`].
+const IC_A0_MAX: f64 = 5.0;
+/// Optimizer start for `a0` — the VENUS-scale prompt slope used since the
+/// family was introduced (matches the previous start).
+const IC_A0_X0: f64 = 0.30;
+/// Lower box bound on the energy-independent prompt offset `a1` (µs⁻¹).
+/// Strictly positive (exp-encoded) so `α(E) → a1 > 0` as `E → 0`: the offset
+/// can no longer flip α negative below the calibration window.
+const IC_A1_MIN: f64 = 1e-3;
+/// Upper box bound on `a1`: 2 µs⁻¹ already exceeds the whole prompt rate at
+/// 1 eV for any plausible a0, so the bound is not physically restrictive.
+const IC_A1_MAX: f64 = 2.0;
+/// Optimizer start for `a1` — small positive (a mostly-√E law).
+const IC_A1_X0: f64 = 0.05;
+/// Lower box bound on the storage (slow) rate `β` (µs⁻¹). Covers the
+/// canonical Ikeda–Carpenter ambient-moderator value β ≈ 0.031 µs⁻¹
+/// (NIM A239 (1985) 536; also Mantid `IkedaCarpenterPV`'s β default) with
+/// margin below it. The τ-grid is prompt-anchored (nereids-physics
+/// `MAX_TAU_SAMPLES`), so the 16/β ≈ 800 µs tail at this bound stays sampled.
+const IC_BETA_MIN: f64 = 0.02;
+/// Upper box bound on `β`: at 5 µs⁻¹ the storage tail is as fast as the
+/// prompt core itself (α range), beyond which β↔α are indistinguishable.
+const IC_BETA_MAX: f64 = 5.0;
+/// Optimizer start for `β` — the value the retired fixed-β family pinned.
+const IC_BETA_X0: f64 = 0.10;
+/// Lower box bound on the storage mixing fraction `R` (physical: a fraction).
+const IC_R_MIN: f64 = 0.0;
+/// Upper box bound on `R`; see [`IC_R_MIN`].
+const IC_R_MAX: f64 = 1.0;
+/// Optimizer start for `R`. A scalar `R` replaces the retired
+/// `ExpMilliEv{κ=25}` law: a free κ is unidentifiable in the eV regime
+/// (R ≡ 0 across 1–200 eV for ANY plausible κ), whereas a scalar R lets the
+/// data decide whether a storage tail is present at all.
+const IC_R_X0: f64 = 0.1;
+/// Default SNS PSR (proton-storage-ring / accumulator) channel-triangle FWHM
+/// in **ns**, folded into the IC family's kernel. The SNS proton pulse is
+/// shaped by the accumulator ring into an ~triangular ~700 ns base (FWHM ≈
+/// 350 ns) — the VENUS tabulated FTS kernel header records exactly this
+/// ("folded triang FWHM 350 ns PSR"). SAMMY's analog is the Gaussian-burst
+/// FWHM `DELTAG` (Manual Sec. III.C.1.a, eq. III C1 a.12) or square `BURST`
+/// width (Sec. III.C.2.a). `pub` so the Python binding's default and the Rust
+/// default cannot drift apart.
+pub const DEFAULT_PSR_FWHM_NS: f64 = 350.0;
+/// Lower box bound (µs) on a FITTED PSR triangle FWHM (`fit_psr = true`):
+/// below 50 ns the triangle is far under the IC prompt width in the eV
+/// regime and unidentifiable.
+const PSR_FWHM_US_MIN: f64 = 0.05;
+/// Upper box bound (µs) on a fitted PSR FWHM: 1 µs is ~3× the physical SNS
+/// pulse base — anything larger is the moderator's job (α, β), not the burst.
+const PSR_FWHM_US_MAX: f64 = 1.0;
+/// Nanoseconds → microseconds ([`CalibrationConfig::psr_fwhm_ns`] is in ns to
+/// match the FTS header convention; the kernel synthesis takes µs).
+const NS_TO_US: f64 = 1e-3;
+/// A coordinate within this fraction of its box range of a bound is reported
+/// in [`CalibrationResult::bounds_hit`] as pinned.
+const BOUND_HIT_REL_TOL: f64 = 1e-3;
 /// Guard-rail bound (µs) on the optional fitted TOF zero `t0`. `t0` and `L_scale`
 /// are the SAMMY *energy-scale* parameters; resolution calibration pins them by
 /// default and fits them only as an explicit, prior-constrained opt-in (see
@@ -125,9 +198,18 @@ pub enum ResolutionFamily {
         /// Base Monte-Carlo kernel to correct.
         base: Arc<TabulatedResolution>,
     },
-    /// Ikeda–Carpenter: fit `(a0, a1)` with `α(E)=a0√E+a1`; `β` held fixed
-    /// (`IC_FIXED_BETA`) because it is unidentifiable in the eV regime.
-    IkedaCarpenter,
+    /// Ikeda–Carpenter, physics-complete and bounded (#642):
+    /// `θ = [ln a0, ln a1, ln β, R]` with `α(E) = e^{θ0}√E + e^{θ1}` (positive
+    /// by construction), `β = e^{θ2}` bounded, scalar `R = θ3 ∈ [0, 1]`, all
+    /// folded with the SNS PSR channel triangle
+    /// ([`CalibrationConfig::psr_fwhm_ns`], default [`DEFAULT_PSR_FWHM_NS`]).
+    IkedaCarpenter {
+        /// Also fit the PSR triangle FWHM: appends `θ4` (µs, box-bounded
+        /// 0.05–1.0 µs, started at the config value). Off by default — the
+        /// 350 ns SNS PSR width is machine metrology, not a per-experiment
+        /// unknown.
+        fit_psr: bool,
+    },
 }
 
 impl ResolutionFamily {
@@ -135,9 +217,27 @@ impl ResolutionFamily {
     #[must_use]
     pub fn n_params(&self) -> usize {
         match self {
-            ResolutionFamily::Gaussian
-            | ResolutionFamily::UdrCorr { .. }
-            | ResolutionFamily::IkedaCarpenter => 2,
+            ResolutionFamily::Gaussian | ResolutionFamily::UdrCorr { .. } => 2,
+            ResolutionFamily::IkedaCarpenter { fit_psr } => 4 + usize::from(*fit_psr),
+        }
+    }
+
+    /// Names of the raw optimizer coordinates, in [`CalibrationResult::theta`]
+    /// order. Used to label [`CalibrationResult::bounds_hit`]; the `ln_*`
+    /// prefixes flag exp-encoded coordinates (decode via
+    /// [`CalibrationResult::resolution`] rather than by hand).
+    #[must_use]
+    pub fn param_names(&self) -> Vec<&'static str> {
+        match self {
+            ResolutionFamily::Gaussian => vec!["delta_t_us", "delta_l_m"],
+            ResolutionFamily::UdrCorr { .. } => vec!["log_s0", "p"],
+            ResolutionFamily::IkedaCarpenter { fit_psr } => {
+                let mut names = vec!["ln_a0", "ln_a1", "ln_beta", "r"];
+                if *fit_psr {
+                    names.push("psr_fwhm_us");
+                }
+                names
+            }
         }
     }
 
@@ -145,13 +245,14 @@ impl ResolutionFamily {
         match self {
             ResolutionFamily::Gaussian => "gaussian",
             ResolutionFamily::UdrCorr { .. } => "udr_corr",
-            ResolutionFamily::IkedaCarpenter => "ic",
+            ResolutionFamily::IkedaCarpenter { .. } => "ic",
         }
     }
 
     /// `(start vector, box bounds)` for the optimizer (mirrors the validated
     /// Python reference: `udr_corr` uses log-`s0`; bounds keep widths positive).
-    fn x0_bounds(&self) -> (Vec<f64>, Vec<(f64, f64)>) {
+    /// `cfg` supplies the starting PSR FWHM when the IC family fits it.
+    fn x0_bounds(&self, cfg: &CalibrationConfig) -> (Vec<f64>, Vec<(f64, f64)>) {
         match self {
             ResolutionFamily::Gaussian => (vec![2.0, 1e-3], vec![(1e-3, 50.0), (0.0, 0.5)]),
             ResolutionFamily::UdrCorr { .. } => {
@@ -161,7 +262,20 @@ impl ResolutionFamily {
                     vec![(UDR_S0_MIN.ln(), UDR_S0_MAX.ln()), (-4.0, 4.0)],
                 )
             }
-            ResolutionFamily::IkedaCarpenter => (vec![0.30, 0.0], vec![(0.01, 5.0), (-2.0, 2.0)]),
+            ResolutionFamily::IkedaCarpenter { fit_psr } => {
+                let mut x0 = vec![IC_A0_X0.ln(), IC_A1_X0.ln(), IC_BETA_X0.ln(), IC_R_X0];
+                let mut bounds = vec![
+                    (IC_A0_MIN.ln(), IC_A0_MAX.ln()),
+                    (IC_A1_MIN.ln(), IC_A1_MAX.ln()),
+                    (IC_BETA_MIN.ln(), IC_BETA_MAX.ln()),
+                    (IC_R_MIN, IC_R_MAX),
+                ];
+                if *fit_psr {
+                    x0.push((cfg.psr_fwhm_ns * NS_TO_US).clamp(PSR_FWHM_US_MIN, PSR_FWHM_US_MAX));
+                    bounds.push((PSR_FWHM_US_MIN, PSR_FWHM_US_MAX));
+                }
+                (x0, bounds)
+            }
         }
     }
 }
@@ -184,6 +298,15 @@ pub struct CalibrationConfig {
     /// IC synthesis grid resolution (energies × τ-samples per kernel).
     pub ic_n_energies: usize,
     pub ic_n_tau: usize,
+    /// SNS PSR (accumulator-ring) channel-triangle FWHM in **ns**, folded into
+    /// the **IC family only** (default [`DEFAULT_PSR_FWHM_NS`]; `0.0`
+    /// disables the fold). Tabulated/UDR (FTS) kernels already carry the fold
+    /// in the file itself (header: "folded triang FWHM 350 ns PSR") and are
+    /// structurally never re-folded here — applying it twice would
+    /// double-count the burst. When the family is
+    /// `IkedaCarpenter { fit_psr: true }` this value is the fit's starting
+    /// point instead of a pin.
+    pub psr_fwhm_ns: f64,
     /// Fit the SAMMY TOF-zero `t0` (µs) as a SHARED energy-scale parameter.
     /// **Default `false`** — position is pinned at
     /// [`position_t0_center_us`](Self::position_t0_center_us) so calibration is a
@@ -226,6 +349,7 @@ impl Default for CalibrationConfig {
             max_iter: 800,
             ic_n_energies: 64,
             ic_n_tau: 500,
+            psr_fwhm_ns: DEFAULT_PSR_FWHM_NS,
             // Position is PINNED by default: pure shape/width calibration on the
             // (already energy-calibrated) grid. Energy-scale fitting is an explicit
             // opt-in via `with_position_prior`.
@@ -270,7 +394,10 @@ impl CalibrationConfig {
 pub struct CalibrationResult {
     /// Family label (`"gaussian"` | `"udr_corr"` | `"ic"`).
     pub family: String,
-    /// Fitted parameter vector (raw optimizer space; see [`ResolutionFamily`]).
+    /// Fitted parameter vector (raw optimizer space; see [`ResolutionFamily`]
+    /// and [`ResolutionFamily::param_names`]). For the IC family these are
+    /// ln/box-encoded — read decoded physical values off
+    /// [`resolution`](Self::resolution) instead of exponentiating by hand.
     pub theta: Vec<f64>,
     /// Reduced **data** χ²/dof of the best fit (after anorm/baseline). The
     /// energy-scale prior penalty is *excluded* — it is reported separately as
@@ -297,6 +424,20 @@ pub struct CalibrationResult {
     /// prior_penalty`; report it alongside `chi2_dof` so a large position move
     /// (e.g. a wrong family needing ΔL/L ≫ the metrology σ) is visible, not hidden.
     pub prior_penalty: f64,
+    /// Total outer-loop free parameters: resolution θ plus any FITTED position
+    /// coordinates (`t0`, `L_scale`). Makes cross-family χ² comparisons and
+    /// dof bookkeeping explicit now that families differ in size (IC is 4–5
+    /// parameters, Gaussian/UdrCorr are 2).
+    pub n_free_params: usize,
+    /// Coordinates that finished within `BOUND_HIT_REL_TOL·(hi−lo)` of a box
+    /// bound, as `"name:lower"` / `"name:upper"` (names from
+    /// [`ResolutionFamily::param_names`], plus `"t0_us"` / `"l_scale"` when
+    /// position is fitted). Empty = interior solution. A pinned bound makes a
+    /// degenerate calibration visible instead of silent: e.g. an eV-regime
+    /// calibrant with no storage tail drives `R → 0` (`"r:lower"`) — on that
+    /// β↔R ridge the storage term vanishes and β is unconstrained, so the
+    /// reported β must not be physically interpreted.
+    pub bounds_hit: Vec<String>,
 }
 
 fn build_resolution(
@@ -320,19 +461,31 @@ fn build_resolution(
                 .map_err(|e| FittingError::EvaluationFailed(format!("udr_corr width: {e}")))?;
             Ok(ResolutionFunction::Tabulated(Arc::new(corrected)))
         }
-        ResolutionFamily::IkedaCarpenter => {
-            // R(E)=exp(-E_meV/25) -> ~0 across the eV resonance regime, so the
-            // slow/storage term vanishes and β is unidentifiable; hold β fixed
-            // and fit only the prompt-width law α(E)=a0·√E + a1.
+        ResolutionFamily::IkedaCarpenter { fit_psr } => {
+            // θ = [ln a0, ln a1, ln β, R, (PSR FWHM µs iff fit_psr)] — see the
+            // IC_* constants for the bounds and their physics. Decoding the
+            // exp-encoded coordinates here (not in a new EnergyLaw variant)
+            // keeps the kernel physics in nereids-physics untouched: the
+            // optimizer space guarantees α(E) > 0 and β > 0 by construction.
+            let psr_us = if *fit_psr {
+                theta[4]
+            } else {
+                cfg.psr_fwhm_ns * NS_TO_US
+            };
             let params = IkedaCarpenterParams {
                 alpha: EnergyLaw::SqrtE {
-                    a0: theta[0].abs(),
-                    a1: theta[1],
+                    a0: theta[0].exp(),
+                    a1: theta[1].exp(),
                 },
-                beta: IC_FIXED_BETA,
-                r: EnergyLaw::ExpMilliEv { kappa: 25.0 },
+                beta: theta[2].exp(),
+                // Scalar R: a free κ in ExpMilliEv is unidentifiable in the eV
+                // regime (R ≡ 0 across 1–200 eV for ANY plausible κ); a scalar
+                // lets the calibrant decide whether a storage tail is present.
+                r: EnergyLaw::Const(theta[3]),
                 burst_sigma_us: None,
-                channel_fwhm_us: None,
+                // SNS PSR channel-triangle fold (0 disables). IC family only —
+                // tabulated/UDR kernels already carry the fold in the file.
+                channel_fwhm_us: (psr_us > 0.0).then_some(psr_us),
             };
             let grid = SynthesisGrid {
                 e_min_ev: (e_min * 0.5).max(1e-3),
@@ -491,9 +644,18 @@ fn solve_small(a: &[f64], b: &[f64], k: usize) -> Option<Vec<f64>> {
 /// lag is the same `1/√E` basis as `L_scale`, so a free `L_scale` absorbs the lag
 /// and corrupts the calibrated width.
 ///
+/// The IC family fits the full bounded moderator shape (#642): `α(E) =
+/// e^{θ0}√E + e^{θ1}` — positive at every energy by construction — plus free
+/// bounded `β = e^{θ2}` and scalar storage fraction `R = θ3 ∈ [0, 1]`, folded
+/// with the SNS PSR channel triangle
+/// ([`CalibrationConfig::psr_fwhm_ns`], default 350 ns; `0` disables;
+/// optionally fitted via `IkedaCarpenter { fit_psr: true }`).
+///
 /// Returns the fitted shape parameters, the reduced **data** χ²/dof, the fitted (or
-/// pinned) `(t0, L_scale)`, the prior penalty, and the calibrated
-/// [`ResolutionFunction`] (ready to pin).
+/// pinned) `(t0, L_scale)`, the prior penalty, the calibrated
+/// [`ResolutionFunction`] (ready to pin), the free-parameter count
+/// ([`CalibrationResult::n_free_params`]), and the pinned-bound report
+/// ([`CalibrationResult::bounds_hit`]).
 ///
 /// # Errors
 /// [`FittingError::EmptyData`] / [`FittingError::LengthMismatch`] for bad
@@ -583,6 +745,17 @@ pub fn calibrate_resolution(
             "flight_path_m must be finite and > 0".into(),
         ));
     }
+    // PSR triangle width: finite and >= 0 (0.0 disables the fold). A NaN or
+    // negative width would otherwise flow into IkedaCarpenter::new on every
+    // evaluation and only surface as the generic "no finite-objective
+    // resolution" error. Validated for every family (it is inert outside IC)
+    // so a mis-set config is caught regardless of the family under test.
+    if !config.psr_fwhm_ns.is_finite() || config.psr_fwhm_ns < 0.0 {
+        return Err(FittingError::InvalidConfig(format!(
+            "psr_fwhm_ns must be finite and >= 0 (0 disables the PSR fold), got {}",
+            config.psr_fwhm_ns
+        )));
+    }
     // Validate the energy-scale (t0, L_scale) prior/center configuration up front.
     if !config.position_t0_center_us.is_finite()
         || !config.position_l_scale_center.is_finite()
@@ -641,7 +814,7 @@ pub fn calibrate_resolution(
     // position coordinate is appended only when fit; otherwise it is pinned at its
     // center. (Position is a SHARED energy-scale parameter, not a per-family
     // nuisance — fitting it is an explicit, prior-constrained opt-in.)
-    let (mut x0, mut bounds) = family.x0_bounds();
+    let (mut x0, mut bounds) = family.x0_bounds(config);
     if config.fit_t0 {
         x0.push(config.position_t0_center_us.clamp(t0_lo, t0_hi));
         bounds.push((t0_lo, t0_hi));
@@ -747,6 +920,34 @@ pub fn calibrate_resolution(
     let dof = data.len().saturating_sub(k + n_res + n_pos).max(1) as f64;
     let chi2_dof = ssr / dof;
     let theta = best.x[..n_res].to_vec();
+    // Bound-pinning report: label every optimizer coordinate that finished
+    // within BOUND_HIT_REL_TOL·(hi−lo) of its box bound. This is the
+    // degeneracy flag for the wider IC family (e.g. "r:lower" ⇒ the β↔R ridge:
+    // no storage tail in the data, β unconstrained).
+    let mut coord_names = family.param_names();
+    if config.fit_t0 {
+        coord_names.push("t0_us");
+    }
+    if config.fit_l_scale {
+        coord_names.push("l_scale");
+    }
+    let bounds_hit: Vec<String> = best
+        .x
+        .iter()
+        .zip(&bounds)
+        .zip(&coord_names)
+        .flat_map(|((&v, &(lo, hi)), name)| {
+            let tol = BOUND_HIT_REL_TOL * (hi - lo);
+            let mut hits = Vec::new();
+            if v - lo <= tol {
+                hits.push(format!("{name}:lower"));
+            }
+            if hi - v <= tol {
+                hits.push(format!("{name}:upper"));
+            }
+            hits
+        })
+        .collect();
     Ok(CalibrationResult {
         family: family.label().to_string(),
         theta,
@@ -757,6 +958,8 @@ pub fn calibrate_resolution(
         position_t0_us,
         position_l_scale,
         prior_penalty,
+        n_free_params: n_res + n_pos,
+        bounds_hit,
     })
 }
 
@@ -764,6 +967,23 @@ pub fn calibrate_resolution(
 mod tests {
     use super::*;
     use nereids_endf::resonance::test_support::synthetic_isotope;
+
+    /// Decode the calibrated IC parameters `(a0, a1, β, R, psr_fwhm_us)` off
+    /// the result's resolution — the single source of truth (raw `theta` is
+    /// ln/box-encoded).
+    fn decoded_ic(r: &CalibrationResult) -> (f64, f64, f64, f64, f64) {
+        let ResolutionFunction::IkedaCarpenter(ic) = &r.resolution else {
+            panic!("expected an IC resolution for family {}", r.family);
+        };
+        let p = ic.params();
+        let EnergyLaw::SqrtE { a0, a1 } = p.alpha else {
+            panic!("expected a SqrtE alpha law");
+        };
+        let EnergyLaw::Const(rr) = p.r else {
+            panic!("expected a Const R law");
+        };
+        (a0, a1, p.beta, rr, p.channel_fwhm_us.unwrap_or(0.0))
+    }
 
     fn synthetic_base_udr() -> TabulatedResolution {
         // Asymmetric kernel (sharp rise, +TOF tail), at two reference energies.
@@ -1088,7 +1308,7 @@ mod tests {
         let ic = IkedaCarpenter::new(
             IkedaCarpenterParams {
                 alpha: EnergyLaw::SqrtE { a0: 0.30, a1: 0.0 },
-                beta: IC_FIXED_BETA,
+                beta: 0.1,
                 r: EnergyLaw::ExpMilliEv { kappa: 25.0 },
                 burst_sigma_us: None,
                 channel_fwhm_us: None,
@@ -1292,7 +1512,7 @@ mod tests {
         let ic = IkedaCarpenter::new(
             IkedaCarpenterParams {
                 alpha: EnergyLaw::SqrtE { a0: 0.30, a1: 0.0 },
-                beta: IC_FIXED_BETA,
+                beta: 0.1,
                 r: EnergyLaw::ExpMilliEv { kappa: 25.0 },
                 burst_sigma_us: None,
                 channel_fwhm_us: None,
@@ -1314,8 +1534,11 @@ mod tests {
         )
         .unwrap();
         let unc = vec![0.004; energies.len()];
+        // The truth kernel carries NO PSR fold, so disable the calibrator's
+        // default 350 ns fold — otherwise the IC family could not close.
         let cfg = CalibrationConfig {
             restarts: 3,
+            psr_fwhm_ns: 0.0,
             ..Default::default()
         };
         let chi2 = |fam| {
@@ -1323,7 +1546,7 @@ mod tests {
                 .unwrap()
                 .chi2_dof
         };
-        let ic_chi2 = chi2(ResolutionFamily::IkedaCarpenter);
+        let ic_chi2 = chi2(ResolutionFamily::IkedaCarpenter { fit_psr: false });
         let gau_chi2 = chi2(ResolutionFamily::Gaussian);
         assert!(
             ic_chi2 < gau_chi2,
@@ -1352,11 +1575,19 @@ mod tests {
         .unwrap();
         let unc = vec![0.004; energies.len()];
         let cfg = CalibrationConfig::default();
-        for fam in [ResolutionFamily::Gaussian, ResolutionFamily::IkedaCarpenter] {
+        for (fam, n_expected) in [
+            (ResolutionFamily::Gaussian, 2),
+            (ResolutionFamily::IkedaCarpenter { fit_psr: false }, 4),
+        ] {
             let label = fam.label().to_string();
             let r = calibrate_resolution(fam, &energies, &data, &unc, &sample, &cfg).unwrap();
             assert!(r.chi2_dof.is_finite(), "{label} χ² not finite");
-            assert_eq!(r.theta.len(), 2, "{label} should fit 2 params");
+            assert_eq!(
+                r.theta.len(),
+                n_expected,
+                "{label} should fit {n_expected} params"
+            );
+            assert_eq!(r.n_free_params, n_expected, "{label} n_free_params");
             // The objective is smooth and noise-free, so Nelder–Mead reaches its
             // tolerance well within max_iter — guard the "_and_converge" promise.
             assert!(r.converged, "{label} did not self-converge");
@@ -1373,8 +1604,30 @@ mod tests {
             .n_params(),
             2
         );
-        // IC fits only (a0, a1); β is held fixed (unidentifiable in the eV regime).
-        assert_eq!(ResolutionFamily::IkedaCarpenter.n_params(), 2);
+        // IC fits θ = [ln a0, ln a1, ln β, R] (+ PSR FWHM iff fit_psr).
+        assert_eq!(
+            ResolutionFamily::IkedaCarpenter { fit_psr: false }.n_params(),
+            4
+        );
+        assert_eq!(
+            ResolutionFamily::IkedaCarpenter { fit_psr: true }.n_params(),
+            5
+        );
+        // param_names track n_params, coordinate for coordinate.
+        for fam in [
+            ResolutionFamily::Gaussian,
+            ResolutionFamily::IkedaCarpenter { fit_psr: false },
+            ResolutionFamily::IkedaCarpenter { fit_psr: true },
+        ] {
+            assert_eq!(fam.param_names().len(), fam.n_params());
+        }
+        assert_eq!(
+            ResolutionFamily::IkedaCarpenter { fit_psr: true }
+                .param_names()
+                .last()
+                .copied(),
+            Some("psr_fwhm_us")
+        );
     }
 
     #[test]
@@ -1551,26 +1804,34 @@ mod tests {
     #[test]
     fn ic_recovers_known_alpha() {
         // Loop-closure / optimizer test (same caveat as udr_corr): truth and fit
-        // both use the IC synthesis, so this checks the optimizer recovers a0 —
-        // the IC pulse physics is independently covered by the ic_pulse tests in
-        // nereids-physics. Truth a0 = 0.35; the calibration must recover it.
+        // both use the IC synthesis, so this checks the optimizer recovers the
+        // full bounded 4-parameter family (#642) — the IC pulse physics is
+        // independently covered by the ic_pulse tests in nereids-physics.
+        // Truth, all interior to the new boxes: a0=0.35, a1=0.05, β=0.1, R=0.1,
+        // PSR triangle 0.35 µs (= the calibrator's default 350 ns pin).
         let iso = synthetic_isotope(72, 178, 20.0, 0.05, 0.06);
         let sample = SampleParams::new(300.0, vec![(iso, 2.0e-3)]).unwrap();
         let energies: Vec<f64> = (0..400).map(|i| 12.0 + i as f64 * 0.04).collect();
+        let cfg = CalibrationConfig {
+            restarts: 2,
+            ..Default::default()
+        };
+        // Truth kernel on the SAME derived grid the calibrator synthesizes on,
+        // so the loop closes exactly (a grid mismatch would leak into recovery).
         let ic_truth = IkedaCarpenter::new(
             IkedaCarpenterParams {
-                alpha: EnergyLaw::SqrtE { a0: 0.35, a1: 0.0 },
-                beta: IC_FIXED_BETA,
-                r: EnergyLaw::ExpMilliEv { kappa: 25.0 },
+                alpha: EnergyLaw::SqrtE { a0: 0.35, a1: 0.05 },
+                beta: 0.1,
+                r: EnergyLaw::Const(0.1),
                 burst_sigma_us: None,
-                channel_fwhm_us: None,
+                channel_fwhm_us: Some(0.35),
             },
-            25.0,
+            cfg.flight_path_m,
             &SynthesisGrid {
-                e_min_ev: 6.0,
-                e_max_ev: 60.0,
-                n_energies: 64,
-                n_tau: 500,
+                e_min_ev: (energies[0] * 0.5).max(1e-3),
+                e_max_ev: energies.last().unwrap() * 2.0,
+                n_energies: cfg.ic_n_energies,
+                n_tau: cfg.ic_n_tau,
             },
         )
         .unwrap();
@@ -1582,12 +1843,8 @@ mod tests {
         )
         .unwrap();
         let unc = vec![0.004; energies.len()];
-        let cfg = CalibrationConfig {
-            restarts: 2,
-            ..Default::default()
-        };
         let r = calibrate_resolution(
-            ResolutionFamily::IkedaCarpenter,
+            ResolutionFamily::IkedaCarpenter { fit_psr: false },
             &energies,
             &data,
             &unc,
@@ -1595,8 +1852,176 @@ mod tests {
             &cfg,
         )
         .unwrap();
-        let a0 = r.theta[0].abs();
-        assert!((a0 - 0.35).abs() < 0.04, "recovered a0={a0}, expected 0.35");
+        let (a0, a1, beta, rr, psr) = decoded_ic(&r);
+        assert!((a0 - 0.35).abs() < 0.05, "recovered a0={a0}, expected 0.35");
+        assert!(a1 > 0.0, "a1 positive by construction, got {a1}");
+        // β and R shape the kernel only jointly through the storage tail
+        // (weight R, decay 1/β), so their windows are deliberately loose.
+        assert!(
+            (beta - 0.1).abs() < 0.08,
+            "recovered β={beta}, expected 0.1"
+        );
+        assert!((rr - 0.1).abs() < 0.08, "recovered R={rr}, expected 0.1");
+        assert!(
+            (psr - 0.35).abs() < 1e-12,
+            "PSR pin {psr} µs != 0.35 µs (config default)"
+        );
+        assert_eq!(r.n_free_params, 4);
+        assert!(
+            r.bounds_hit.is_empty(),
+            "interior truth must not pin bounds, got {:?}",
+            r.bounds_hit
+        );
         assert!(r.chi2_dof < 1.0, "matched χ²/dof={} too high", r.chi2_dof);
+    }
+
+    #[test]
+    fn psr_disabled_at_zero_width() {
+        // psr_fwhm_ns = 0.0 disables the triangle fold entirely: an UNFOLDED
+        // truth is reproduced and the calibrated kernel carries no channel.
+        let iso = synthetic_isotope(72, 178, 20.0, 0.05, 0.06);
+        let sample = SampleParams::new(300.0, vec![(iso, 2.0e-3)]).unwrap();
+        let energies: Vec<f64> = (0..250).map(|i| 14.0 + i as f64 * 0.05).collect();
+        let cfg = CalibrationConfig {
+            psr_fwhm_ns: 0.0,
+            ic_n_energies: 32,
+            ic_n_tau: 300,
+            ..Default::default()
+        };
+        let ic_truth = IkedaCarpenter::new(
+            IkedaCarpenterParams {
+                alpha: EnergyLaw::SqrtE { a0: 0.35, a1: 0.05 },
+                beta: 0.1,
+                r: EnergyLaw::Const(0.1),
+                burst_sigma_us: None,
+                channel_fwhm_us: None, // unfolded truth
+            },
+            cfg.flight_path_m,
+            &SynthesisGrid {
+                e_min_ev: (energies[0] * 0.5).max(1e-3),
+                e_max_ev: energies.last().unwrap() * 2.0,
+                n_energies: cfg.ic_n_energies,
+                n_tau: cfg.ic_n_tau,
+            },
+        )
+        .unwrap();
+        let truth = ResolutionFunction::IkedaCarpenter(Arc::new(ic_truth));
+        let data = forward_model(
+            &energies,
+            &sample,
+            Some(&InstrumentParams { resolution: truth }),
+        )
+        .unwrap();
+        let unc = vec![0.004; energies.len()];
+        let r = calibrate_resolution(
+            ResolutionFamily::IkedaCarpenter { fit_psr: false },
+            &energies,
+            &data,
+            &unc,
+            &sample,
+            &cfg,
+        )
+        .unwrap();
+        let ResolutionFunction::IkedaCarpenter(ic) = &r.resolution else {
+            panic!("expected an IC resolution");
+        };
+        assert!(
+            ic.params().channel_fwhm_us.is_none(),
+            "psr_fwhm_ns = 0 must leave channel_fwhm_us = None, got {:?}",
+            ic.params().channel_fwhm_us
+        );
+        assert!(
+            r.chi2_dof < 1.0,
+            "unfolded self-fit χ²/dof={} too high",
+            r.chi2_dof
+        );
+    }
+
+    #[test]
+    fn bounds_hit_reports_pinned_parameter() {
+        // A truth WITHOUT a storage tail (R = 0) drives the fitted R onto its
+        // lower box bound; the result must say so ("r:lower") — the β↔R-ridge
+        // degeneracy flag (with no tail, β is unconstrained).
+        let iso = synthetic_isotope(72, 178, 20.0, 0.05, 0.06);
+        let sample = SampleParams::new(300.0, vec![(iso, 2.0e-3)]).unwrap();
+        let energies: Vec<f64> = (0..250).map(|i| 14.0 + i as f64 * 0.05).collect();
+        let cfg = CalibrationConfig {
+            ic_n_energies: 32,
+            ic_n_tau: 300,
+            restarts: 2,
+            ..Default::default()
+        };
+        let ic_truth = IkedaCarpenter::new(
+            IkedaCarpenterParams {
+                alpha: EnergyLaw::SqrtE { a0: 0.35, a1: 0.05 },
+                beta: 0.1, // irrelevant at R = 0 (no storage term)
+                r: EnergyLaw::Const(0.0),
+                burst_sigma_us: None,
+                channel_fwhm_us: Some(0.35),
+            },
+            cfg.flight_path_m,
+            &SynthesisGrid {
+                e_min_ev: (energies[0] * 0.5).max(1e-3),
+                e_max_ev: energies.last().unwrap() * 2.0,
+                n_energies: cfg.ic_n_energies,
+                n_tau: cfg.ic_n_tau,
+            },
+        )
+        .unwrap();
+        let truth = ResolutionFunction::IkedaCarpenter(Arc::new(ic_truth));
+        let data = forward_model(
+            &energies,
+            &sample,
+            Some(&InstrumentParams { resolution: truth }),
+        )
+        .unwrap();
+        let unc = vec![0.004; energies.len()];
+        let r = calibrate_resolution(
+            ResolutionFamily::IkedaCarpenter { fit_psr: false },
+            &energies,
+            &data,
+            &unc,
+            &sample,
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            r.bounds_hit.iter().any(|s| s == "r:lower"),
+            "R = 0 truth must pin the storage fraction: bounds_hit = {:?}, decoded = {:?}",
+            r.bounds_hit,
+            decoded_ic(&r)
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_psr_fwhm_ns() {
+        // NaN / negative / infinite PSR widths are config errors caught up
+        // front (NaN would silently disable the `> 0.0` fold gate; a negative
+        // width would fail deep in IkedaCarpenter::new on every evaluation).
+        let iso = synthetic_isotope(72, 178, 20.0, 0.05, 0.06);
+        let sample = SampleParams::new(300.0, vec![(iso, 2.0e-3)]).unwrap();
+        let e: Vec<f64> = (0..60).map(|i| 15.0 + i as f64 * 0.2).collect();
+        let d = vec![0.9; 60];
+        let u = vec![0.01; 60];
+        for bad in [f64::NAN, -1.0, f64::INFINITY] {
+            let cfg = CalibrationConfig {
+                psr_fwhm_ns: bad,
+                ..Default::default()
+            };
+            assert!(
+                matches!(
+                    calibrate_resolution(
+                        ResolutionFamily::IkedaCarpenter { fit_psr: false },
+                        &e,
+                        &d,
+                        &u,
+                        &sample,
+                        &cfg
+                    ),
+                    Err(FittingError::InvalidConfig(_))
+                ),
+                "psr_fwhm_ns={bad} should be rejected"
+            );
+        }
     }
 }

--- a/crates/nereids-fitting/src/resolution_calib.rs
+++ b/crates/nereids-fitting/src/resolution_calib.rs
@@ -126,9 +126,25 @@ const PSR_FWHM_US_MIN: f64 = 0.05;
 /// Upper box bound (µs) on a fitted PSR FWHM: 1 µs is ~3× the physical SNS
 /// pulse base — anything larger is the moderator's job (α, β), not the burst.
 const PSR_FWHM_US_MAX: f64 = 1.0;
+/// Sanity ceiling (µs) on the configured PSR triangle FWHM: one decade above
+/// the [`PSR_FWHM_US_MAX`] fit bound. [`CalibrationConfig::psr_fwhm_ns`] is in
+/// NANOSECONDS (the VENUS FTS header convention: "folded triang FWHM 350 ns
+/// PSR"), and kernel-synthesis cost grows QUADRATICALLY with the fold width
+/// (the fold both refines the τ-step and widens the ± fold-reach margin):
+/// measured ~12 ms at 0.35 µs but ~1.3 s at 50 µs and ~28 s at 350 µs per
+/// single kernel-table synthesis at the default grid. A µs-as-ns unit slip
+/// (passing `350` meaning µs → interpreted as a 350 µs pin) would therefore
+/// turn a calibration into a multi-hour silent hang behind a physically
+/// fictitious fold. Any genuine width sits inside the fitted box; one decade
+/// of headroom keeps deliberate sensitivity studies possible while still
+/// catching the 1000× ns↔µs slip. `0.0` (fold disabled) is always accepted.
+/// `pub` for parity with the Python binding's mirrored validation.
+pub const PSR_FWHM_PIN_CEILING_US: f64 = 10.0 * PSR_FWHM_US_MAX;
 /// Nanoseconds → microseconds ([`CalibrationConfig::psr_fwhm_ns`] is in ns to
-/// match the FTS header convention; the kernel synthesis takes µs).
-const NS_TO_US: f64 = 1e-3;
+/// match the FTS header convention; the kernel synthesis takes µs). `pub` so
+/// the Python binding's mirrored [`PSR_FWHM_PIN_CEILING_US`] check converts
+/// with the identical factor.
+pub const NS_TO_US: f64 = 1e-3;
 /// A coordinate within this fraction of its box range of a bound is reported
 /// in [`CalibrationResult::bounds_hit`] as pinned.
 const BOUND_HIT_REL_TOL: f64 = 1e-3;
@@ -330,7 +346,9 @@ pub struct CalibrationConfig {
     /// structurally never re-folded here — applying it twice would
     /// double-count the burst. When the family is
     /// `IkedaCarpenter { fit_psr: true }` this value is the fit's starting
-    /// point instead of a pin.
+    /// point instead of a pin. Nonzero widths above
+    /// [`PSR_FWHM_PIN_CEILING_US`] (10 µs = 10 000 ns) are rejected as a
+    /// ns↔µs unit slip — see that constant for the quadratic-cost rationale.
     pub psr_fwhm_ns: f64,
     /// Fit the SAMMY TOF-zero `t0` (µs) as a SHARED energy-scale parameter.
     /// **Default `false`** — position is pinned at
@@ -780,6 +798,23 @@ pub fn calibrate_resolution(
         return Err(FittingError::InvalidConfig(format!(
             "psr_fwhm_ns must be finite and >= 0 (0 disables the PSR fold), got {}",
             config.psr_fwhm_ns
+        )));
+    }
+    // Sanity ceiling on the width itself (see PSR_FWHM_PIN_CEILING_US):
+    // psr_fwhm_ns is NANOSECONDS and synthesis cost is quadratic in the fold
+    // width, so a µs-as-ns unit slip pins a fictitious multi-hundred-µs fold
+    // that hangs the calibration for hours. Reject loudly, up front, for
+    // every family (inert outside IC, same rationale as the checks above).
+    if config.psr_fwhm_ns * NS_TO_US > PSR_FWHM_PIN_CEILING_US {
+        return Err(FittingError::InvalidConfig(format!(
+            "psr_fwhm_ns = {} ns (= {} µs) exceeds the {PSR_FWHM_PIN_CEILING_US} µs sanity \
+             ceiling (10x the {PSR_FWHM_US_MAX} µs fit bound). psr_fwhm_ns is in NANOSECONDS \
+             — the SNS/VENUS FTS convention is 350 ns — and kernel-synthesis cost grows \
+             quadratically with the fold width, so a µs-as-ns unit slip would hang the \
+             calibration behind a fictitious fold. Pass the width in ns, or 0 to disable \
+             the PSR fold",
+            config.psr_fwhm_ns,
+            config.psr_fwhm_ns * NS_TO_US
         )));
     }
     // fit_psr fits the PSR FWHM from the psr_fwhm_ns starting value, but 0 is
@@ -2189,6 +2224,70 @@ mod tests {
                     Err(FittingError::InvalidConfig(_))
                 ),
                 "psr_fwhm_ns={bad} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_absurd_pinned_psr_width() {
+        // Review #645 round 2, F1: psr_fwhm_ns is NANOSECONDS (FTS convention
+        // 350 ns) and synthesis cost is quadratic in the fold width — a
+        // µs-as-ns unit slip (350 meaning µs → 350_000 ns) previously passed
+        // the finite/sign check and pinned a fictitious 350 µs fold: a
+        // multi-hour silent hang. Widths above PSR_FWHM_PIN_CEILING_US
+        // (10 µs = 10_000 ns) must be a loud up-front config error.
+        let iso = synthetic_isotope(72, 178, 20.0, 0.05, 0.06);
+        let sample = SampleParams::new(300.0, vec![(iso, 2.0e-3)]).unwrap();
+        let e: Vec<f64> = (0..60).map(|i| 15.0 + i as f64 * 0.2).collect();
+        let d = vec![0.9; 60];
+        let u = vec![0.01; 60];
+        let cfg = CalibrationConfig {
+            psr_fwhm_ns: 350_000.0, // "350 µs" unit slip
+            ..Default::default()
+        };
+        let err = calibrate_resolution(
+            ResolutionFamily::IkedaCarpenter { fit_psr: false },
+            &e,
+            &d,
+            &u,
+            &sample,
+            &cfg,
+        )
+        .expect_err("a 350_000 ns (350 µs) pinned PSR width must be rejected");
+        assert!(
+            matches!(
+                &err,
+                FittingError::InvalidConfig(msg)
+                    if msg.contains("NANOSECONDS") && msg.contains("350 ns")
+            ),
+            "ceiling error must name the ns unit and the 350-ns convention, got {err:?}"
+        );
+
+        // Boundary + normal pins stay valid: exactly 10_000 ns sits ON the
+        // ceiling (rejection is strict `>`; 10_000·1e-3 rounds to exactly
+        // 10.0) and 350 ns is the FTS default. psr_fwhm_ns = 0 (disable) is
+        // pinned valid by rejects_fit_psr_with_zero_psr_width. Tiny
+        // grid/iteration budget: these arms assert config validity, not fit
+        // quality.
+        for ok_ns in [350.0, 10_000.0] {
+            let cheap = CalibrationConfig {
+                psr_fwhm_ns: ok_ns,
+                ic_n_energies: 8,
+                ic_n_tau: 32,
+                max_iter: 10,
+                ..Default::default()
+            };
+            assert!(
+                calibrate_resolution(
+                    ResolutionFamily::IkedaCarpenter { fit_psr: false },
+                    &e,
+                    &d,
+                    &u,
+                    &sample,
+                    &cheap,
+                )
+                .is_ok(),
+                "psr_fwhm_ns = {ok_ns} ns must remain a valid pinned width"
             );
         }
     }

--- a/crates/nereids-fitting/tests/ic_closed_loop.rs
+++ b/crates/nereids-fitting/tests/ic_closed_loop.rs
@@ -32,7 +32,7 @@ use nereids_physics::ikeda_carpenter::{
 use nereids_physics::resolution::ResolutionFunction;
 use nereids_physics::transmission::{InstrumentParams, SampleParams, forward_model};
 use rand::SeedableRng;
-use rand::rngs::StdRng;
+use rand_chacha::ChaCha12Rng;
 use rand_distr::{Distribution, Normal};
 
 /// IC truth: all coordinates interior to the calibration boxes (a0 ∈
@@ -122,8 +122,12 @@ fn closed_loop(t_true_k: f64) {
         "calibrant dip minimum T = {t_min} outside the non-black target band"
     );
 
-    // Seeded absolute Gaussian noise.
-    let mut rng = StdRng::seed_from_u64(642);
+    // Seeded absolute Gaussian noise. ChaCha12Rng by NAME (review #645 round
+    // 2, F5): StdRng's stream is documented unstable across rand versions —
+    // a rand upgrade would silently swap the noise realization under this
+    // test's fixed tolerances. (rand 0.9's StdRng is currently ChaCha12, so
+    // this pin preserves the exact realization the tolerances were set on.)
+    let mut rng = ChaCha12Rng::seed_from_u64(642);
     let normal = Normal::new(0.0, NOISE_SIGMA).unwrap();
     let data: Vec<f64> = clean.iter().map(|&t| t + normal.sample(&mut rng)).collect();
     let unc = vec![NOISE_SIGMA; data.len()];

--- a/crates/nereids-fitting/tests/ic_closed_loop.rs
+++ b/crates/nereids-fitting/tests/ic_closed_loop.rs
@@ -1,0 +1,261 @@
+//! Closed-loop acceptance test for the physics-complete bounded IC
+//! calibration family (#642).
+//!
+//! The issue's failure mode: the old 2-parameter IC family (β pinned, R ≡ 0,
+//! no PSR fold, α(E) allowed to go negative) lacked the storage-shape freedom,
+//! which re-expressed as a ~90 K temperature degeneracy on real data. This
+//! test closes the loop end-to-end on synthetic Ta-181:
+//!
+//! 1. generate noisy transmission from an IC truth kernel whose parameters are
+//!    all INTERIOR to the new calibration boxes (storage tail present, PSR
+//!    triangle folded);
+//! 2. calibrate the IC family at the known (ρ, T) — the calibration must
+//!    reach χ²/dof ≈ 1 with no pinned bounds and recover the truth;
+//! 3. pin the calibrated resolution and re-fit the TEMPERATURE alone — the
+//!    recovered T must agree with truth within its own uncertainty, and that
+//!    uncertainty must be far below the 90 K degeneracy scale.
+//!
+//! Run at 300 K (ambient calibrant) and 1073 K (furnace condition).
+
+use std::sync::Arc;
+
+use nereids_endf::resonance::test_support::synthetic_isotope_multi;
+use nereids_fitting::lm::{self, LmConfig};
+use nereids_fitting::parameters::{FitParameter, ParameterSet};
+use nereids_fitting::resolution_calib::{
+    CalibrationConfig, ResolutionFamily, calibrate_resolution,
+};
+use nereids_fitting::transmission_model::TransmissionFitModel;
+use nereids_physics::ikeda_carpenter::{
+    EnergyLaw, IkedaCarpenter, IkedaCarpenterParams, SynthesisGrid,
+};
+use nereids_physics::resolution::ResolutionFunction;
+use nereids_physics::transmission::{InstrumentParams, SampleParams, forward_model};
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use rand_distr::{Distribution, Normal};
+
+/// IC truth: all coordinates interior to the calibration boxes (a0 ∈
+/// [0.01, 5], a1 ∈ [1e-3, 2], β ∈ [0.02, 5], R ∈ [0, 1], PSR = config pin).
+const A0_TRUE: f64 = 0.35;
+const A1_TRUE: f64 = 0.05;
+const BETA_TRUE: f64 = 0.25;
+const R_TRUE: f64 = 0.15;
+/// PSR triangle FWHM (µs) — equals the calibrator's default 350 ns pin.
+const PSR_TRUE_US: f64 = 0.35;
+/// Ta-181 areal density (at/b). Sized so the broadened dip minima land at
+/// T ≈ 0.2–0.6 (non-black: at ~2e-3 the resonances saturate to T ≈ 1e-4 and
+/// the calibrant carries no width information at the dip cores).
+const DENSITY_TRUE: f64 = 2.0e-4;
+/// Absolute transmission noise σ (0.3 % of the unit open-beam level).
+const NOISE_SIGMA: f64 = 0.003;
+
+/// Full calibrate → pin → refit-T loop at one truth temperature.
+fn closed_loop(t_true_k: f64) {
+    // Real Ta-181 resonance energies (10.36 / 24.0 / 39.1 eV; Γn, Γγ in eV) in
+    // ONE L-group, so the potential-scattering background is not N-folded.
+    let ta181 = synthetic_isotope_multi(
+        73,
+        181,
+        &[
+            (10.36, 0.003, 0.058),
+            (24.0, 0.009, 0.060),
+            (39.1, 0.040, 0.060),
+        ],
+    );
+    let sample = SampleParams::new(t_true_k, vec![(ta181.clone(), DENSITY_TRUE)]).unwrap();
+    // Grid density and synthesis resolution are sized for debug-build runtime
+    // (tests run unoptimized): 500 points / 40×320 synthesis keeps one loop
+    // under ~5 min; max_iter = 1200 plus the calibrator's built-in simplex
+    // re-inflation lets the 4-parameter Nelder–Mead actually reach the χ²
+    // minimum (a collapsed simplex once stalled the 300 K loop at
+    // Δχ² ≈ +130, whose ~1.5 % kernel-width error re-expressed as a ~23 K
+    // temperature bias in the pinned refit). The ASSERTIONS are the
+    // acceptance spec and are not relaxed.
+    let n_points = 500;
+    let (e_lo, e_hi) = (6.0, 44.0);
+    let energies: Vec<f64> = (0..n_points)
+        .map(|i| e_lo + (e_hi - e_lo) * i as f64 / (n_points - 1) as f64)
+        .collect();
+
+    let cfg = CalibrationConfig {
+        restarts: 2,
+        ic_n_energies: 40,
+        ic_n_tau: 320,
+        max_iter: 1200,
+        ..Default::default()
+    };
+
+    // Truth kernel on the SAME derived grid the calibrator synthesizes on
+    // (e_min = E₀/2, e_max = 2·E_last, cfg.ic_n_energies × cfg.ic_n_tau), so
+    // the loop closes exactly and any residual is noise, not grid mismatch.
+    let ic_truth = IkedaCarpenter::new(
+        IkedaCarpenterParams {
+            alpha: EnergyLaw::SqrtE {
+                a0: A0_TRUE,
+                a1: A1_TRUE,
+            },
+            beta: BETA_TRUE,
+            r: EnergyLaw::Const(R_TRUE),
+            burst_sigma_us: None,
+            channel_fwhm_us: Some(PSR_TRUE_US),
+        },
+        cfg.flight_path_m,
+        &SynthesisGrid {
+            e_min_ev: (energies[0] * 0.5).max(1e-3),
+            e_max_ev: energies.last().unwrap() * 2.0,
+            n_energies: cfg.ic_n_energies,
+            n_tau: cfg.ic_n_tau,
+        },
+    )
+    .unwrap();
+    let inst_truth = InstrumentParams {
+        resolution: ResolutionFunction::IkedaCarpenter(Arc::new(ic_truth)),
+    };
+    // FGM Doppler broadening at t_true_k is applied inside forward_model.
+    let clean = forward_model(&energies, &sample, Some(&inst_truth)).unwrap();
+
+    // Non-black calibrant check: dip minima in the informative 0.2–0.6 band.
+    let t_min = clean.iter().cloned().fold(f64::MAX, f64::min);
+    assert!(
+        (0.15..=0.65).contains(&t_min),
+        "calibrant dip minimum T = {t_min} outside the non-black target band"
+    );
+
+    // Seeded absolute Gaussian noise.
+    let mut rng = StdRng::seed_from_u64(642);
+    let normal = Normal::new(0.0, NOISE_SIGMA).unwrap();
+    let data: Vec<f64> = clean.iter().map(|&t| t + normal.sample(&mut rng)).collect();
+    let unc = vec![NOISE_SIGMA; data.len()];
+
+    // --- Step 1: calibrate the bounded IC family at the KNOWN (ρ, T). ---
+    let cal = calibrate_resolution(
+        ResolutionFamily::IkedaCarpenter { fit_psr: false },
+        &energies,
+        &data,
+        &unc,
+        &sample,
+        &cfg,
+    )
+    .unwrap();
+
+    eprintln!(
+        "closed_loop(T={t_true_k} K): calibration χ²/dof={:.4}, converged={}, \
+         theta={:?}, bounds_hit={:?}",
+        cal.chi2_dof, cal.converged, cal.theta, cal.bounds_hit
+    );
+    assert!(
+        (0.7..=1.4).contains(&cal.chi2_dof),
+        "calibration χ²/dof = {} not ≈ 1 at T = {t_true_k} K",
+        cal.chi2_dof
+    );
+    assert_eq!(cal.n_free_params, 4, "IC family fits 4 parameters");
+    assert!(
+        cal.bounds_hit.is_empty(),
+        "interior truth must not pin bounds at T = {t_true_k} K: {:?}",
+        cal.bounds_hit
+    );
+    // Decoded recovery (loose windows: β and R act jointly via the storage
+    // tail, so their marginals are broad under noise).
+    let ResolutionFunction::IkedaCarpenter(ic_cal) = &cal.resolution else {
+        panic!("expected an IC resolution");
+    };
+    let p = ic_cal.params();
+    let EnergyLaw::SqrtE { a0, a1 } = p.alpha else {
+        panic!("expected a SqrtE alpha law");
+    };
+    let EnergyLaw::Const(r_cal) = p.r else {
+        panic!("expected a Const R law");
+    };
+    assert!(a1 > 0.0, "α(E) positive by construction (a1 = {a1})");
+    assert!(
+        (a0 - A0_TRUE).abs() < 0.10,
+        "a0 = {a0}, truth {A0_TRUE} (T = {t_true_k} K)"
+    );
+    assert!(
+        (p.beta - BETA_TRUE).abs() < 0.20,
+        "β = {}, truth {BETA_TRUE} (T = {t_true_k} K)",
+        p.beta
+    );
+    assert!(
+        (r_cal - R_TRUE).abs() < 0.12,
+        "R = {r_cal}, truth {R_TRUE} (T = {t_true_k} K)"
+    );
+    let psr_us = p
+        .channel_fwhm_us
+        .expect("PSR fold must be active at the default config");
+    // Approximate compare: the pin travels through ns → µs conversion
+    // (350.0 · 1e-3 = 0.35000000000000003).
+    assert!(
+        (psr_us - PSR_TRUE_US).abs() < 1e-12,
+        "PSR pin {psr_us} µs != config default {PSR_TRUE_US} µs"
+    );
+
+    // --- Step 2 (the point of #642): pin the calibrated resolution, free T. ---
+    // Density fixed at truth; temperature free from a 20 % low start. If the
+    // calibrated shape were wrong (the old 2-parameter family), the missing
+    // width would re-express here as a ~90 K temperature bias.
+    let model = TransmissionFitModel::new(
+        energies.clone(),
+        vec![ta181],
+        0.0, // ignored — temperature_index is set
+        Some(Arc::new(InstrumentParams {
+            resolution: cal.resolution.clone(),
+        })),
+        (vec![0], vec![1.0]),
+        Some(1), // params[1] = temperature
+        None,
+    )
+    .unwrap();
+    let mut params = ParameterSet::new(vec![
+        FitParameter::fixed("density", DENSITY_TRUE),
+        FitParameter {
+            name: "temperature_k".into(),
+            value: 0.8 * t_true_k,
+            lower: 1.0,
+            upper: 3000.0,
+            fixed: false,
+        },
+    ]);
+    let lm_cfg = LmConfig {
+        max_iter: 200,
+        ..LmConfig::default()
+    };
+    let result = lm::levenberg_marquardt(&model, &data, &unc, &mut params, &lm_cfg).unwrap();
+
+    assert!(
+        result.converged,
+        "T-refit did not converge at T = {t_true_k} K ({} iterations)",
+        result.iterations
+    );
+    let t_fit = result.params[1];
+    // uncertainties covers FREE parameters only; temperature is the only one.
+    let sigma_t = result
+        .uncertainties
+        .expect("temperature uncertainty available")[0];
+    assert!(
+        sigma_t.is_finite() && sigma_t > 0.0 && sigma_t < 30.0,
+        "σ_T = {sigma_t} K not in (0, 30) at T = {t_true_k} K — the degeneracy \
+         scale of the old family was ~90 K"
+    );
+    assert!(
+        (t_fit - t_true_k).abs() <= 3.0 * sigma_t,
+        "T recovered {t_fit} K vs truth {t_true_k} K exceeds 3σ = {} K",
+        3.0 * sigma_t
+    );
+    eprintln!(
+        "closed_loop(T={t_true_k} K): χ²/dof={:.3}, a0={a0:.3}, a1={a1:.4}, β={:.3}, R={:.3}, \
+         T_fit={t_fit:.1} ± {sigma_t:.1} K",
+        cal.chi2_dof, p.beta, r_cal
+    );
+}
+
+#[test]
+fn closed_loop_recovers_temperature_at_300k() {
+    closed_loop(300.0);
+}
+
+#[test]
+fn closed_loop_recovers_temperature_at_1073k() {
+    closed_loop(1073.0);
+}

--- a/crates/nereids-fitting/tests/ic_closed_loop.rs
+++ b/crates/nereids-fitting/tests/ic_closed_loop.rs
@@ -49,6 +49,13 @@ const PSR_TRUE_US: f64 = 0.35;
 const DENSITY_TRUE: f64 = 2.0e-4;
 /// Absolute transmission noise σ (0.3 % of the unit open-beam level).
 const NOISE_SIGMA: f64 = 0.003;
+/// Absolute ceiling (K) on the recovered-temperature bias |T_fit − T_true|
+/// (#645 round 3, F3). The σ_T < 30 K gate plus the 3σ statistical window
+/// jointly admit a worst-case bias of ~90 K — numerically the very
+/// degeneracy scale of the old 2-parameter family this test exists to guard.
+/// Observed biases are 0.5 K (300 K) / 1.2 K (1073 K); 30 K is far above
+/// noise wander yet a third of the degeneracy scale.
+const T_BIAS_MAX_K: f64 = 30.0;
 
 /// Full calibrate → pin → refit-T loop at one truth temperature.
 fn closed_loop(t_true_k: f64) {
@@ -246,6 +253,13 @@ fn closed_loop(t_true_k: f64) {
         (t_fit - t_true_k).abs() <= 3.0 * sigma_t,
         "T recovered {t_fit} K vs truth {t_true_k} K exceeds 3σ = {} K",
         3.0 * sigma_t
+    );
+    // Absolute bias bound alongside the statistical one: the two assertions
+    // above alone admit |bias| up to 3·30 = 90 K — see T_BIAS_MAX_K.
+    assert!(
+        (t_fit - t_true_k).abs() <= T_BIAS_MAX_K,
+        "T recovered {t_fit} K vs truth {t_true_k} K exceeds the absolute \
+         {T_BIAS_MAX_K} K bias ceiling (old-family degeneracy scale ~90 K)"
     );
     eprintln!(
         "closed_loop(T={t_true_k} K): χ²/dof={:.3}, a0={a0:.3}, a1={a1:.4}, β={:.3}, R={:.3}, \

--- a/crates/nereids-physics/src/ikeda_carpenter.rs
+++ b/crates/nereids-physics/src/ikeda_carpenter.rs
@@ -150,14 +150,55 @@ pub const DEFAULT_N_ENERGIES: usize = 64;
 /// Default number of τ-samples spanning the prompt core of each kernel.
 pub const DEFAULT_N_TAU: usize = 600;
 
-/// Hard cap on the τ-sample count of one synthesized kernel. The τ-step is
-/// anchored to the PROMPT core (`fast_reach / (n_tau − 1)`), so a long storage
-/// tail (β ≪ α with R > 0) is covered by growing the sample COUNT rather than
-/// by widening the step — otherwise a β as low as the calibration bound
-/// 0.02 µs⁻¹ (slow reach 16/β = 800 µs) would set a ~1.6 µs step that
-/// undersamples the prompt core and degenerates a 0.35 µs channel triangle to
-/// a delta. This cap bounds that growth (CPU/memory); only past it does the
-/// step widen to `tau_max / (MAX_TAU_SAMPLES − 1)`.
+/// Minimum accepted `n_tau` (τ-samples across the prompt core). Doubles as
+/// the module's prompt-core **resolution floor**: when [`MAX_TAU_SAMPLES`]
+/// widens the τ-step (see [`tau_geometry`]), the step may never exceed
+/// `fast_reach / (MIN_N_TAU − 1)` — the coarsest prompt sampling
+/// [`IkedaCarpenter::new`] has ever accepted as valid via its `n_tau ≥ 8`
+/// check.
+const MIN_N_TAU: usize = 8;
+
+/// Minimum nonzero samples per side of a sampled channel triangle
+/// (`dtau ≤ FWHM / 3`, half-base = FWHM). Below this the discrete triangle
+/// degenerates toward an exact delta `[0, 1, 0]` and a requested fold would
+/// silently vanish from the kernel — [`tau_geometry`] rejects that instead.
+const TRI_MIN_SAMPLES_PER_SIDE: f64 = 3.0;
+
+/// Reach of the sampled/folded Gaussian burst in standard deviations (±4σ:
+/// e^{−8} ≈ 3.4e-4 of peak at the edge, well below any consuming tolerance
+/// once convolved). Also fixes the burst resolution floor `dtau ≤ σ`
+/// (≥ `GAUSS_REACH_SIGMAS` samples per side).
+const GAUSS_REACH_SIGMAS: f64 = 4.0;
+
+/// Prompt-tail reach in e-folds: the τ-grid spans `FAST_REACH_E_FOLDS / α`
+/// so the prompt Gamma(3) tail `τ²e^{−ατ}` is < ~1e-8 of peak at the edge.
+const FAST_REACH_E_FOLDS: f64 = 18.0;
+
+/// Slow/storage-tail reach in e-folds (`SLOW_REACH_E_FOLDS / β` when storage
+/// is active). Sits AT the trim horizon: `e^{−16} ≈ 1.1e-7 ≈` [`TRIM_REL`]
+/// (`ln(1/TRIM_REL) ≈ 16.1`), so the reach cannot be truncated shorter
+/// without discarding tail weight the [`TRIM_REL`] trim would keep — no
+/// hidden approximation lives in this constant.
+const SLOW_REACH_E_FOLDS: f64 = 16.0;
+
+/// Storage fractions below this are treated as "no storage tail" when sizing
+/// the τ-grid (the slow term's weight is far below [`TRIM_REL`]).
+const R_NEGLIGIBLE: f64 = 1e-9;
+
+/// Cap on the τ-sample count spanning the PULSE BODY (`[0, τ_max]`) of one
+/// synthesized kernel. The τ-step is anchored to the prompt core and refined
+/// to resolve active folds (see [`tau_geometry`]), so a long storage tail
+/// (β ≪ α with R > 0) grows the sample COUNT rather than the step; this cap
+/// bounds that growth (CPU/memory) by widening the step to
+/// `tau_max / (MAX_TAU_SAMPLES − 1)` — but never past the resolution floor
+/// (prompt core: `fast_reach / (MIN_N_TAU − 1)`; triangle: FWHM /
+/// [`TRI_MIN_SAMPLES_PER_SIDE`]; burst: σ). A parameter/grid combination
+/// whose floor cannot be met within the cap is REJECTED loudly by
+/// [`IkedaCarpenter::new`] instead of silently under-sampled. The actual
+/// guarantee is on the pulse body only: the symmetric burst/channel fold
+/// margin (± `4σ + FWHM` at the resolved step) adds its samples ON TOP of
+/// the cap, so the final grid can exceed `MAX_TAU_SAMPLES` by the margin
+/// sample count.
 const MAX_TAU_SAMPLES: usize = 8192;
 
 /// Taylor expansion of `h(u)/u³` where `h(u) = 1 − e^{−u}(1 + u + ½u²)`, for
@@ -300,7 +341,15 @@ pub struct SynthesisGrid {
     pub e_max_ev: f64,
     /// Number of log-spaced reference energies (≥ 2).
     pub n_energies: usize,
-    /// Number of τ-samples spanning the prompt core of each kernel (≥ 8).
+    /// Number of τ-samples spanning the prompt core of each kernel
+    /// (≥ [`MIN_N_TAU`](crate::ikeda_carpenter) = 8). A long storage tail
+    /// (β ≪ α with R > 0) grows the per-kernel sample count beyond `n_tau`;
+    /// that count is capped at 8192 (`MAX_TAU_SAMPLES`), past which the
+    /// τ-step widens — never below the resolution floor (prompt core at the
+    /// `n_tau = 8` density, folds at ≥ 3 triangle samples per side / ≥ 1
+    /// sample per burst σ): a combination that cannot be resolved within the
+    /// cap is rejected by [`IkedaCarpenter::new`]. Active burst/channel folds
+    /// add their ±(4σ + FWHM) margin samples on top of the cap.
     pub n_tau: usize,
 }
 
@@ -339,8 +388,12 @@ impl IkedaCarpenter {
     /// # Errors
     /// Returns [`ResolutionParseError::InvalidFormat`] for a non-positive
     /// flight path, a degenerate grid (`n_energies < 2`, `n_tau < 8`,
-    /// `e_min ≤ 0`, `e_max ≤ e_min`), a non-positive `β`, or if the synthesized
-    /// kernels fail [`TabulatedResolution::from_kernels`] validation.
+    /// `e_min ≤ 0`, `e_max ≤ e_min`), a non-positive `β`, a parameter/grid
+    /// combination whose τ-grid cannot resolve the prompt core and requested
+    /// folds within the `MAX_TAU_SAMPLES` cap at some reference energy (see
+    /// [`tau_geometry`] — remedy: larger `β`, `R = 0`, or a wider/disabled
+    /// fold), or if the synthesized kernels fail
+    /// [`TabulatedResolution::from_kernels`] validation.
     pub fn new(
         params: IkedaCarpenterParams,
         flight_path_m: f64,
@@ -357,9 +410,9 @@ impl IkedaCarpenter {
                 grid.n_energies
             )));
         }
-        if grid.n_tau < 8 {
+        if grid.n_tau < MIN_N_TAU {
             return Err(ResolutionParseError::InvalidFormat(format!(
-                "n_tau must be >= 8, got {}",
+                "n_tau must be >= {MIN_N_TAU}, got {}",
                 grid.n_tau
             )));
         }
@@ -425,10 +478,14 @@ impl IkedaCarpenter {
             }
         }
 
+        // Synthesis is fallible: a kernel whose τ-grid cannot resolve the
+        // requested physics within MAX_TAU_SAMPLES (long slow tail vs a fine
+        // fold / fast prompt core) errs loudly here instead of silently
+        // degrading — see `tau_geometry`.
         let kernels: Vec<(Vec<f64>, Vec<f64>)> = ref_energies
             .iter()
             .map(|&e| synth_kernel(&params, grid.n_tau, e))
-            .collect();
+            .collect::<Result<_, _>>()?;
 
         let tabulated =
             TabulatedResolution::from_kernels(ref_energies.clone(), kernels, flight_path_m)?;
@@ -471,42 +528,129 @@ impl IkedaCarpenter {
     /// Returns ascending TOF-offsets (µs, mode at 0) and peak-normalized
     /// weights (max = 1), matching the [`TabulatedResolution`] storage
     /// convention.
-    #[must_use]
-    pub fn kernel_at(&self, energy_ev: f64) -> (Vec<f64>, Vec<f64>) {
+    ///
+    /// # Errors
+    /// Returns [`ResolutionParseError::InvalidFormat`] when the τ-grid cannot
+    /// resolve the prompt core and requested folds within [`MAX_TAU_SAMPLES`]
+    /// at this energy. Construction validates every *reference* energy, but a
+    /// probe energy outside `[e_min, e_max]` (a smaller α(E), hence a finer
+    /// prompt floor against the same storage-tail span) can still leave the
+    /// resolvable region.
+    pub fn kernel_at(&self, energy_ev: f64) -> Result<(Vec<f64>, Vec<f64>), ResolutionParseError> {
         synth_kernel(&self.params, self.n_tau, energy_ev)
     }
+}
+
+/// τ-grid geometry for one kernel: `(dtau, tau_max, margin)`, or a
+/// descriptive error when no exact sampled representation fits the cap.
+///
+/// The step is anchored to the PROMPT core — `n_tau` samples across the fast
+/// Gamma(3) pulse (`fast_reach / (n_tau − 1)`) — and REFINED to resolve any
+/// requested instrument fold (triangle: ≥ [`TRI_MIN_SAMPLES_PER_SIDE`]
+/// samples per side, i.e. `dtau ≤ FWHM/3`; Gaussian burst: `dtau ≤ σ`, i.e.
+/// ≥ [`GAUSS_REACH_SIGMAS`] samples per ±4σ side). A longer storage tail
+/// (β ≪ α, R > 0) extends the SAMPLE COUNT (`j_hi ∝ tau_max/dtau`) instead
+/// of the step; [`MAX_TAU_SAMPLES`] bounds that count by widening the step —
+/// but never past the resolution FLOOR (`fast_reach / (MIN_N_TAU − 1)` for
+/// the prompt core, the fold minima above for folds). A combination whose
+/// floor cannot be met within the cap has no faithful sampled representation
+/// here, so it is rejected loudly: a capped step above the fold width would
+/// degenerate the sampled triangle to an exact delta `[0,1,0]` (the fold
+/// silently vanishes), and a capped step above the prompt scale steps OVER
+/// the prompt pulse entirely (probe: α = 250, β = 0.02, R = 0.1 loses the
+/// prompt's 0.9 weight share).
+///
+/// Bit-identical to the pre-#642-review `max(fast_reach/(n_tau−1),
+/// tau_max/(MAX_TAU_SAMPLES−1))` step whenever no fold is finer than the
+/// prompt design step and the capped step stays at or below the floor.
+fn tau_geometry(
+    params: &IkedaCarpenterParams,
+    n_tau: usize,
+    alpha: f64,
+    beta: f64,
+    r: f64,
+) -> Result<(f64, f64, f64), String> {
+    // τ_max: reach far enough that the prompt tail (e^{−ατ}) and, when
+    // storage is active, the slow tail (e^{−βτ}) are below the trim level.
+    let fast_reach = FAST_REACH_E_FOLDS / alpha;
+    let slow_reach = if r > R_NEGLIGIBLE {
+        SLOW_REACH_E_FOLDS / beta
+    } else {
+        0.0
+    };
+    let tau_max = fast_reach.max(slow_reach);
+
+    // Requested step and resolution floor. `floor ≥ dtau_req` always: the
+    // prompt terms satisfy MIN_N_TAU ≤ n_tau (validated by `new`) and the
+    // fold terms are common to both.
+    let mut dtau_req = fast_reach / (n_tau as f64 - 1.0);
+    let mut floor = fast_reach / (MIN_N_TAU as f64 - 1.0);
+    let mut fold_desc = String::new();
+    if let Some(fwhm) = params.channel_fwhm_us
+        && fwhm > 0.0
+    {
+        let tri_floor = fwhm / TRI_MIN_SAMPLES_PER_SIDE;
+        dtau_req = dtau_req.min(tri_floor);
+        floor = floor.min(tri_floor);
+        fold_desc.push_str(&format!(", channel triangle FWHM = {fwhm} µs"));
+    }
+    if let Some(sigma) = params.burst_sigma_us
+        && sigma > 0.0
+    {
+        dtau_req = dtau_req.min(sigma);
+        floor = floor.min(sigma);
+        fold_desc.push_str(&format!(", burst σ = {sigma} µs"));
+    }
+
+    let capped_step = tau_max / (MAX_TAU_SAMPLES as f64 - 1.0);
+    if capped_step > floor {
+        return Err(format!(
+            "the {MAX_TAU_SAMPLES}-sample τ-grid cap cannot resolve the requested physics: \
+             the pulse spans τ_max = {tau_max:.3} µs (α = {alpha:.4} µs⁻¹, β = {beta:.4} µs⁻¹, \
+             R = {r:.3}{fold_desc}), forcing a τ-step of {capped_step:.4} µs — above the \
+             finest-feature resolution floor of {floor:.4} µs. Increase β (shorter storage \
+             tail), set R = 0 (drop the storage term), or widen/disable the burst/channel fold"
+        ));
+    }
+    Ok((dtau_req.max(capped_step), tau_max, margin_of(params)))
+}
+
+/// Symmetric τ-grid margin for the burst/channel folds: ±(4σ + FWHM), the
+/// folds' full reach. These samples come ON TOP of [`MAX_TAU_SAMPLES`] (the
+/// cap governs the pulse body only).
+fn margin_of(params: &IkedaCarpenterParams) -> f64 {
+    params
+        .burst_sigma_us
+        .map_or(0.0, |s| GAUSS_REACH_SIGMAS * s)
+        + params.channel_fwhm_us.unwrap_or(0.0)
 }
 
 /// Synthesize one `(offsets, weights)` kernel for `energy_ev` from the IC
 /// parameters: sample `I(τ)`, fold in burst + channel, anchor the mode at
 /// offset 0, trim negligible tails, peak-normalize.
+///
+/// # Errors
+/// [`ResolutionParseError::InvalidFormat`] when [`tau_geometry`] cannot
+/// resolve the prompt core and requested folds within [`MAX_TAU_SAMPLES`].
 fn synth_kernel(
     params: &IkedaCarpenterParams,
     n_tau: usize,
     energy_ev: f64,
-) -> (Vec<f64>, Vec<f64>) {
+) -> Result<(Vec<f64>, Vec<f64>), ResolutionParseError> {
     let alpha = params.alpha.eval(energy_ev).max(MIN_RATE);
     let beta = params.beta.max(MIN_RATE);
     let r = params.r.eval(energy_ev).clamp(0.0, 1.0);
 
-    // τ_max: reach far enough that the prompt Gamma(3) tail (e^{−ατ}) and, when
-    // storage is present, the slow tail (e^{−βτ}) are < ~1e-8 of peak.
-    let fast_reach = 18.0 / alpha;
-    let slow_reach = if r > 1e-9 { 16.0 / beta } else { 0.0 };
-    let tau_max = fast_reach.max(slow_reach);
-    // τ-step anchored to the PROMPT core, not to τ_max: `n_tau` samples span the
-    // fast Gamma(3) rise, and a longer storage tail (β ≪ α, R > 0) extends the
-    // SAMPLE COUNT (`j_hi ∝ tau_max/dtau`) instead of the step, capped at
-    // MAX_TAU_SAMPLES. Bit-identical to the old `tau_max/(n_tau−1)` step
-    // whenever slow_reach ≤ fast_reach (the R≈0 eV-regime case).
-    let dtau = (fast_reach / (n_tau as f64 - 1.0)).max(tau_max / (MAX_TAU_SAMPLES as f64 - 1.0));
+    let (dtau, tau_max, margin) = tau_geometry(params, n_tau, alpha, beta, r).map_err(|msg| {
+        ResolutionParseError::InvalidFormat(format!(
+            "Ikeda–Carpenter kernel at E = {energy_ev} eV: {msg}"
+        ))
+    })?;
 
     // Extend the grid to slightly negative τ so a symmetric burst/channel can
     // spread the leading edge correctly (the moderator pulse itself is 0 there).
     // Widths are validated finite and >= 0 by `IkedaCarpenter::new`, so they are
     // used directly (no `.abs()` masking of a sign error).
-    let margin =
-        params.burst_sigma_us.map_or(0.0, |s| 4.0 * s) + params.channel_fwhm_us.unwrap_or(0.0);
     let j_lo: isize = -((margin / dtau).ceil() as isize);
     let j_hi: isize = ((tau_max + margin) / dtau).ceil() as isize;
 
@@ -543,7 +687,7 @@ fn synth_kernel(
 
     let offsets: Vec<f64> = (lo..=hi).map(|j| taus[j] - tau_peak).collect();
     let w: Vec<f64> = (lo..=hi).map(|j| weights[j] / peak_val).collect();
-    (offsets, w)
+    Ok((offsets, w))
 }
 
 /// Index of the maximum element (first on ties). Slice is non-empty by
@@ -561,9 +705,9 @@ fn argmax(xs: &[f64]) -> usize {
 }
 
 /// Symmetric, unit-sum Gaussian kernel sampled on a `dtau`-spaced grid out to
-/// ±4σ.
+/// ±[`GAUSS_REACH_SIGMAS`]·σ.
 fn gaussian_kernel(dtau: f64, sigma: f64) -> Vec<f64> {
-    let half = ((4.0 * sigma / dtau).ceil() as isize).max(1);
+    let half = ((GAUSS_REACH_SIGMAS * sigma / dtau).ceil() as isize).max(1);
     let mut k: Vec<f64> = (-half..=half)
         .map(|j| {
             let t = j as f64 * dtau / sigma;
@@ -724,7 +868,7 @@ mod tests {
             burst_sigma_us: None,
             channel_fwhm_us: None,
         };
-        let (offs, wts) = synth_kernel(&p, 600, 1.0);
+        let (offs, wts) = synth_kernel(&p, 600, 1.0).unwrap();
         assert!(offs.iter().chain(wts.iter()).all(|v| v.is_finite()));
     }
 
@@ -754,7 +898,7 @@ mod tests {
     #[test]
     fn kernel_mode_anchored_at_zero() {
         let p = IkedaCarpenterParams::constant(1.0, 0.1, 0.3);
-        let (offsets, weights) = synth_kernel(&p, 600, 10.0);
+        let (offsets, weights) = synth_kernel(&p, 600, 10.0).unwrap();
         let peak = argmax(&weights);
         // The peak offset is the closest to zero of all offsets.
         let peak_abs = offsets[peak].abs();
@@ -768,7 +912,7 @@ mod tests {
     fn kernel_tail_points_to_positive_offset() {
         // Asymmetry: longer/heavier tail toward +offset (later TOF, lower E).
         let p = IkedaCarpenterParams::constant(1.0, 0.1, 0.2);
-        let (offsets, weights) = synth_kernel(&p, 600, 10.0);
+        let (offsets, weights) = synth_kernel(&p, 600, 10.0).unwrap();
         let max_pos = offsets.iter().cloned().fold(f64::MIN, f64::max);
         let min_neg = offsets.iter().cloned().fold(f64::MAX, f64::min);
         assert!(
@@ -802,7 +946,7 @@ mod tests {
             channel_fwhm_us: None,
         };
         let support = |e: f64| {
-            let (o, _) = synth_kernel(&p, 600, e);
+            let (o, _) = synth_kernel(&p, 600, e).unwrap();
             o.iter().cloned().fold(f64::MIN, f64::max) - o.iter().cloned().fold(f64::MAX, f64::min)
         };
         assert!(support(100.0) < support(5.0));
@@ -975,7 +1119,7 @@ mod tests {
             channel_fwhm_us: Some(0.35),
             ..IkedaCarpenterParams::constant(alpha, 0.25, 0.5)
         };
-        let (offs, wts) = synth_kernel(&p, n_tau, 10.0);
+        let (offs, wts) = synth_kernel(&p, n_tau, 10.0).unwrap();
         let dtau = offs[1] - offs[0];
         assert!(
             (dtau - prompt_step).abs() < 1e-12,
@@ -992,13 +1136,21 @@ mod tests {
             nonzero_per_side >= 3,
             "triangle degenerated: {nonzero_per_side} nonzero samples per side"
         );
-        // The tail is still reached: the last positive-offset sample must sit
-        // near the mode-relative slow reach (tau_max − tau_peak ≈ 63 µs) or be
-        // trimmed as negligible — assert the pulse there is below trim level.
+        // The tail is still reached: for β = 0.25 the slow tail crosses the
+        // TRIM_REL = 1e-7 trim level near τ ≈ 63 µs (e^{−βτ}·slow-amplitude ÷
+        // peak = 1e-7 at τ ≈ 62.6 µs), so the trimmed kernel must still span
+        // well past 40 µs — a step anchored to τ_max instead of the prompt
+        // core would pass a narrow-span check, but a grid that stops short of
+        // the storage tail would not survive this one.
         let span = offs.last().unwrap() - offs.first().unwrap();
         let peak = wts.iter().cloned().fold(f64::MIN, f64::max);
         assert!((peak - 1.0).abs() < 1e-12, "weights not peak-normalized");
         assert!(span > 3.0 / alpha, "kernel span {span} lost the pulse body");
+        assert!(
+            span > 40.0,
+            "kernel span {span} µs stops short of the β = 0.25 storage tail \
+             (trim horizon ≈ 63 µs)"
+        );
 
         // (b) Extreme admitted tail (β = 0.02 ⇒ slow_reach = 800 µs): the
         // MAX_TAU_SAMPLES cap bites; the step widens to tau_max/(cap−1) but
@@ -1008,7 +1160,7 @@ mod tests {
             channel_fwhm_us: Some(0.35),
             ..IkedaCarpenterParams::constant(alpha, 0.02, 0.5)
         };
-        let (offs_ext, _) = synth_kernel(&p_ext, n_tau, 10.0);
+        let (offs_ext, _) = synth_kernel(&p_ext, n_tau, 10.0).unwrap();
         let dtau_ext = offs_ext[1] - offs_ext[0];
         let capped_step = 800.0 / (MAX_TAU_SAMPLES as f64 - 1.0);
         assert!(
@@ -1035,7 +1187,7 @@ mod tests {
     fn burst_and_channel_broaden_further() {
         // Folding in burst + channel widens the kernel TOF support.
         let base = IkedaCarpenterParams::constant(1.0, 0.1, 0.0);
-        let (o0, _) = synth_kernel(&base, 600, 10.0);
+        let (o0, _) = synth_kernel(&base, 600, 10.0).unwrap();
         let support0 = o0.iter().cloned().fold(f64::MIN, f64::max)
             - o0.iter().cloned().fold(f64::MAX, f64::min);
         let folded = IkedaCarpenterParams {
@@ -1043,9 +1195,124 @@ mod tests {
             channel_fwhm_us: Some(0.35),
             ..IkedaCarpenterParams::constant(1.0, 0.1, 0.0)
         };
-        let (o1, _) = synth_kernel(&folded, 600, 10.0);
+        let (o1, _) = synth_kernel(&folded, 600, 10.0).unwrap();
         let support1 = o1.iter().cloned().fold(f64::MIN, f64::max)
             - o1.iter().cloned().fold(f64::MAX, f64::min);
         assert!(support1 > support0, "folded {support1} !> bare {support0}");
+    }
+
+    /// Sum-weighted variance of a sampled `(offsets, weights)` kernel on a
+    /// uniform τ-grid. Normalization-independent (divides by Σw).
+    fn kernel_variance(offsets: &[f64], weights: &[f64]) -> f64 {
+        let w_sum: f64 = weights.iter().sum();
+        let mean: f64 = offsets.iter().zip(weights).map(|(o, w)| o * w).sum::<f64>() / w_sum;
+        offsets
+            .iter()
+            .zip(weights)
+            .map(|(o, w)| (o - mean).powi(2) * w)
+            .sum::<f64>()
+            / w_sum
+    }
+
+    #[test]
+    fn unresolvable_tau_grid_is_rejected_loudly() {
+        // Review #645 F1, probe 1: β = 0.005 ⇒ slow reach 16/β = 3200 µs ⇒
+        // capped step 3200/8191 ≈ 0.39 µs > the 0.35 µs triangle FWHM — the
+        // sampled triangle would be the exact delta [0, 1, 0] and the
+        // requested fold would silently vanish from the kernel. Must be a
+        // loud construction error, not silent physics degradation.
+        let p1 = IkedaCarpenterParams {
+            channel_fwhm_us: Some(0.35),
+            ..IkedaCarpenterParams::constant(2.0, 0.005, 0.5)
+        };
+        let err = IkedaCarpenter::new(p1.clone(), 25.0, &SynthesisGrid::new(1.0, 100.0))
+            .expect_err("a delta-degenerate fold must be rejected");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("cannot resolve") && msg.contains("Increase"),
+            "error must diagnose the cap and name remedies: {msg}"
+        );
+        // The per-energy synthesis (kernel_at path) refuses identically.
+        assert!(synth_kernel(&p1, 600, 10.0).is_err());
+
+        // Probe 2: α = 250 ⇒ the whole prompt pulse spans 18/α ≈ 0.07 µs,
+        // less than ONE capped step (800/8191 ≈ 0.098 µs): sampling would
+        // step over the prompt term entirely (0.9 of the pulse weight at
+        // R = 0.1). Must also be rejected.
+        let p2 = IkedaCarpenterParams::constant(250.0, 0.02, 0.1);
+        assert!(
+            IkedaCarpenter::new(p2, 25.0, &SynthesisGrid::new(1.0, 100.0)).is_err(),
+            "a capped step wider than the prompt core must be rejected"
+        );
+    }
+
+    #[test]
+    fn requested_fold_is_never_a_silent_no_op() {
+        // Adjacent to probe 1 but resolvable (β = 0.05 ⇒ capped step
+        // 320/8191 ≈ 0.039 µs ≤ FWHM/3): when synthesis is Ok and a fold is
+        // requested, the folded kernel must genuinely differ from the
+        // unfolded one — by approximately the analytic fold variance
+        // FWHM²/6 — never by ~0 (the silent delta no-op this guards against).
+        let base = IkedaCarpenterParams::constant(2.0, 0.05, 0.5);
+        let folded = IkedaCarpenterParams {
+            channel_fwhm_us: Some(0.35),
+            ..base.clone()
+        };
+        let (o0, w0) = synth_kernel(&base, 600, 10.0).unwrap();
+        let (o1, w1) = synth_kernel(&folded, 600, 10.0).unwrap();
+        let dv = kernel_variance(&o1, &w1) - kernel_variance(&o0, &w0);
+        let expected = 0.35f64.powi(2) / 6.0;
+        assert!(
+            dv > 0.5 * expected,
+            "fold variance increment {dv} µs² vs analytic {expected} µs²: \
+             the requested fold (nearly) vanished"
+        );
+    }
+
+    #[test]
+    fn fold_variance_matches_analytic_oracle() {
+        // Independent analytic oracle for the fold convention (#645 F8): a
+        // convolution adds second central moments, so the sampled kernel's
+        // variance must grow by EXACTLY the fold kernel's analytic variance —
+        // FWHM²/6 for the symmetric channel triangle (half-base = FWHM),
+        // σ² for the Gaussian burst. Unlike the closed-loop calibration
+        // tests, the expectation here comes from analysis, not from the
+        // shared synthesis code. Pure-prompt pulse (R = 0) keeps trim /
+        // edge-truncation error far below the increments.
+        let base = IkedaCarpenterParams::constant(2.0, 0.1, 0.0);
+        let (o0, w0) = synth_kernel(&base, 600, 10.0).unwrap();
+        let v0 = kernel_variance(&o0, &w0);
+        // Sanity: the bare Gamma(3, α) variance is 3/α².
+        let v_gamma = 3.0 / (2.0f64 * 2.0);
+        assert!(
+            (v0 - v_gamma).abs() < 0.01 * v_gamma,
+            "bare pulse variance {v0}, Gamma(3) analytic {v_gamma}"
+        );
+
+        let fwhm = 0.35;
+        let tri = IkedaCarpenterParams {
+            channel_fwhm_us: Some(fwhm),
+            ..base.clone()
+        };
+        let (o1, w1) = synth_kernel(&tri, 600, 10.0).unwrap();
+        let dv_tri = kernel_variance(&o1, &w1) - v0;
+        let want_tri = fwhm * fwhm / 6.0;
+        assert!(
+            ((dv_tri - want_tri) / want_tri).abs() < 0.02,
+            "triangle fold added {dv_tri} µs², analytic FWHM²/6 = {want_tri} µs²"
+        );
+
+        let sigma = 0.3;
+        let gau = IkedaCarpenterParams {
+            burst_sigma_us: Some(sigma),
+            ..base.clone()
+        };
+        let (o2, w2) = synth_kernel(&gau, 600, 10.0).unwrap();
+        let dv_gau = kernel_variance(&o2, &w2) - v0;
+        let want_gau = sigma * sigma;
+        assert!(
+            ((dv_gau - want_gau) / want_gau).abs() < 0.02,
+            "Gaussian burst added {dv_gau} µs², analytic σ² = {want_gau} µs²"
+        );
     }
 }

--- a/crates/nereids-physics/src/ikeda_carpenter.rs
+++ b/crates/nereids-physics/src/ikeda_carpenter.rs
@@ -113,9 +113,21 @@
 //!
 //! The full instrument function folds the moderator with a proton-burst
 //! (Gaussian σ) and a chopper/channel (triangle, FWHM) term. Both are optional
-//! here (`None` ⇒ omitted). Note: a tabulated file whose header says the
-//! channel triangle is already "folded" in must NOT be double-counted against
-//! an IC model that also applies the channel.
+//! here (`None` ⇒ omitted).
+//!
+//! **Provenance of the triangle (`channel_fwhm_us`).** SAMMY broadens for the
+//! accelerator burst either as a Gaussian of FWHM `DELTAG` (SAMMY Manual R8
+//! Sec. III.C.1.a, eq. III C1 a.12) or as a square pulse of width `BURST`
+//! (Sec. III.C.2.a). At SNS the proton pulse delivered to the target is shaped
+//! by the accumulator ring (Proton Storage Ring, PSR) into an approximately
+//! triangular ~700 ns base — FWHM ≈ 350 ns — which is what the VENUS tabulated
+//! FTS kernel header records as "folded triang FWHM 350 ns PSR". NEREIDS folds
+//! that PSR triangle via `channel_fwhm_us` (symmetric triangle, half-base =
+//! FWHM, [`triangle_kernel`]). Note: a tabulated file whose header says the
+//! triangle is already "folded" in must NOT be double-counted against an IC
+//! model that also applies it (the `nereids-fitting` calibrator therefore
+//! applies its `psr_fwhm_ns` fold to the IC family only, never to
+//! tabulated/UDR kernels).
 
 use crate::resolution::{ResolutionParseError, TabulatedResolution};
 
@@ -137,6 +149,16 @@ pub const DEFAULT_N_ENERGIES: usize = 64;
 
 /// Default number of τ-samples spanning the prompt core of each kernel.
 pub const DEFAULT_N_TAU: usize = 600;
+
+/// Hard cap on the τ-sample count of one synthesized kernel. The τ-step is
+/// anchored to the PROMPT core (`fast_reach / (n_tau − 1)`), so a long storage
+/// tail (β ≪ α with R > 0) is covered by growing the sample COUNT rather than
+/// by widening the step — otherwise a β as low as the calibration bound
+/// 0.02 µs⁻¹ (slow reach 16/β = 800 µs) would set a ~1.6 µs step that
+/// undersamples the prompt core and degenerates a 0.35 µs channel triangle to
+/// a delta. This cap bounds that growth (CPU/memory); only past it does the
+/// step widen to `tau_max / (MAX_TAU_SAMPLES − 1)`.
+const MAX_TAU_SAMPLES: usize = 8192;
 
 /// Taylor expansion of `h(u)/u³` where `h(u) = 1 − e^{−u}(1 + u + ½u²)`, for
 /// `|u|` small (the `α ≈ β` limit), where direct evaluation cancels
@@ -472,7 +494,12 @@ fn synth_kernel(
     let fast_reach = 18.0 / alpha;
     let slow_reach = if r > 1e-9 { 16.0 / beta } else { 0.0 };
     let tau_max = fast_reach.max(slow_reach);
-    let dtau = tau_max / (n_tau as f64 - 1.0);
+    // τ-step anchored to the PROMPT core, not to τ_max: `n_tau` samples span the
+    // fast Gamma(3) rise, and a longer storage tail (β ≪ α, R > 0) extends the
+    // SAMPLE COUNT (`j_hi ∝ tau_max/dtau`) instead of the step, capped at
+    // MAX_TAU_SAMPLES. Bit-identical to the old `tau_max/(n_tau−1)` step
+    // whenever slow_reach ≤ fast_reach (the R≈0 eV-regime case).
+    let dtau = (fast_reach / (n_tau as f64 - 1.0)).max(tau_max / (MAX_TAU_SAMPLES as f64 - 1.0));
 
     // Extend the grid to slightly negative τ so a symmetric burst/channel can
     // spread the leading edge correctly (the moderator pulse itself is 0 there).
@@ -929,6 +956,79 @@ mod tests {
         for (a, b) in direct.iter().zip(&planned) {
             assert!((a - b).abs() < 1e-12, "plan vs direct mismatch: {a} vs {b}");
         }
+    }
+
+    #[test]
+    fn tau_step_anchors_to_prompt_core_not_storage_tail() {
+        // Regression for the τ-grid fix: with a slow storage tail active
+        // (β ≪ α, R > 0) the τ-step must stay anchored to the prompt core —
+        // the old `tau_max/(n_tau−1)` step let the tail dilate dtau and
+        // degenerate the 0.35 µs channel triangle toward a delta.
+        let n_tau = 600;
+        let alpha = 2.0; // fast_reach = 18/α = 9 µs
+        let prompt_step = (18.0 / alpha) / (n_tau as f64 - 1.0);
+
+        // (a) Moderate tail (β = 0.25 ⇒ slow_reach = 64 µs): the cap does not
+        // bite, so the step equals the prompt-core step exactly and the grid
+        // still spans the full tail.
+        let p = IkedaCarpenterParams {
+            channel_fwhm_us: Some(0.35),
+            ..IkedaCarpenterParams::constant(alpha, 0.25, 0.5)
+        };
+        let (offs, wts) = synth_kernel(&p, n_tau, 10.0);
+        let dtau = offs[1] - offs[0];
+        assert!(
+            (dtau - prompt_step).abs() < 1e-12,
+            "uncapped step {dtau} != prompt-core step {prompt_step}"
+        );
+        assert!(
+            dtau <= prompt_step + 1e-12,
+            "prompt-core spacing {dtau} > fast_reach/(n_tau−1) = {prompt_step}"
+        );
+        // ≥ 3 nonzero triangle samples per side at this step.
+        let tri = triangle_kernel(dtau, 0.35);
+        let nonzero_per_side = tri.iter().take(tri.len() / 2).filter(|&&v| v > 0.0).count();
+        assert!(
+            nonzero_per_side >= 3,
+            "triangle degenerated: {nonzero_per_side} nonzero samples per side"
+        );
+        // The tail is still reached: the last positive-offset sample must sit
+        // near the mode-relative slow reach (tau_max − tau_peak ≈ 63 µs) or be
+        // trimmed as negligible — assert the pulse there is below trim level.
+        let span = offs.last().unwrap() - offs.first().unwrap();
+        let peak = wts.iter().cloned().fold(f64::MIN, f64::max);
+        assert!((peak - 1.0).abs() < 1e-12, "weights not peak-normalized");
+        assert!(span > 3.0 / alpha, "kernel span {span} lost the pulse body");
+
+        // (b) Extreme admitted tail (β = 0.02 ⇒ slow_reach = 800 µs): the
+        // MAX_TAU_SAMPLES cap bites; the step widens to tau_max/(cap−1) but
+        // must still resolve the 0.35 µs triangle with ≥ 3 samples per side
+        // (the old tail-anchored step was 800/599 ≈ 1.34 µs — a delta).
+        let p_ext = IkedaCarpenterParams {
+            channel_fwhm_us: Some(0.35),
+            ..IkedaCarpenterParams::constant(alpha, 0.02, 0.5)
+        };
+        let (offs_ext, _) = synth_kernel(&p_ext, n_tau, 10.0);
+        let dtau_ext = offs_ext[1] - offs_ext[0];
+        let capped_step = 800.0 / (MAX_TAU_SAMPLES as f64 - 1.0);
+        assert!(
+            (dtau_ext - capped_step).abs() < 1e-9,
+            "capped step {dtau_ext} != tau_max/(MAX_TAU_SAMPLES−1) = {capped_step}"
+        );
+        assert!(
+            dtau_ext <= 0.35 / 3.0,
+            "capped step {dtau_ext} cannot resolve the 0.35 µs triangle"
+        );
+        let tri_ext = triangle_kernel(dtau_ext, 0.35);
+        let nonzero_ext = tri_ext
+            .iter()
+            .take(tri_ext.len() / 2)
+            .filter(|&&v| v > 0.0)
+            .count();
+        assert!(
+            nonzero_ext >= 3,
+            "triangle degenerated under cap: {nonzero_ext} nonzero samples per side"
+        );
     }
 
     #[test]

--- a/crates/nereids-physics/src/ikeda_carpenter.rs
+++ b/crates/nereids-physics/src/ikeda_carpenter.rs
@@ -158,10 +158,16 @@ pub const DEFAULT_N_TAU: usize = 600;
 /// check.
 const MIN_N_TAU: usize = 8;
 
-/// Minimum nonzero samples per side of a sampled channel triangle
-/// (`dtau ≤ FWHM / 3`, half-base = FWHM). Below this the discrete triangle
-/// degenerates toward an exact delta `[0, 1, 0]` and a requested fold would
-/// silently vanish from the kernel — [`tau_geometry`] rejects that instead.
+/// Minimum samples per side SPANNING a sampled channel triangle
+/// (`dtau ≤ FWHM / 3`, half-base = FWHM). At the exactly-admitted boundary
+/// `dtau = FWHM/3` the per-side samples sit at `{FWHM/3, 2FWHM/3, FWHM}` —
+/// triangle weights `{2/3, 1/3, 0}` — so each side carries ≥ 2 strictly
+/// interior (nonzero) samples while the endpoint lands ON the triangle
+/// zero; the sampled fold is distinctly non-delta (discrete variance
+/// 4·FWHM²/27 ≈ 89 % of the analytic FWHM²/6). Coarser steps degenerate
+/// the discrete triangle toward the exact delta `[0, 1, 0]`, silently
+/// erasing a requested fold — [`tau_geometry`] rejects that instead
+/// (strictly: `capped_step > FWHM/3`).
 const TRI_MIN_SAMPLES_PER_SIDE: f64 = 3.0;
 
 /// Reach of the sampled/folded Gaussian burst in standard deviations (±4σ:
@@ -182,7 +188,17 @@ const FAST_REACH_E_FOLDS: f64 = 18.0;
 const SLOW_REACH_E_FOLDS: f64 = 16.0;
 
 /// Storage fractions below this are treated as "no storage tail" when sizing
-/// the τ-grid (the slow term's weight is far below [`TRIM_REL`]).
+/// the τ-grid. DELIBERATELY two decades below [`TRIM_REL`], not derived from
+/// it: whether a slow tail actually survives the [`TRIM_REL`] trim depends on
+/// the α/β contrast (the trim threshold is relative to the prompt-dominated
+/// peak, and the slow term's peak weight scales with both R and β/α), so no
+/// single constant derived from [`TRIM_REL`] is exact for every admitted
+/// (α, β) — treating a larger R as absent would be a hidden approximation.
+/// The margin's only consequence is conservatism: for R ∈ (1e-9, ~1e-7) the
+/// τ-grid is sized — and the [`MAX_TAU_SAMPLES`] cap gate applied — for a
+/// slow tail whose weight the trim then discards anyway, spending samples
+/// (or rejecting a configuration) for physics that cannot appear in the
+/// kernel. It can never drop tail weight the trim would have kept.
 const R_NEGLIGIBLE: f64 = 1e-9;
 
 /// Cap on the τ-sample count spanning the PULSE BODY (`[0, τ_max]`) of one
@@ -533,9 +549,9 @@ impl IkedaCarpenter {
     /// Returns [`ResolutionParseError::InvalidFormat`] when the τ-grid cannot
     /// resolve the prompt core and requested folds within [`MAX_TAU_SAMPLES`]
     /// at this energy. Construction validates every *reference* energy, but a
-    /// probe energy outside `[e_min, e_max]` (a smaller α(E), hence a finer
-    /// prompt floor against the same storage-tail span) can still leave the
-    /// resolvable region.
+    /// probe energy outside `[e_min, e_max]` — for the √E law, above `e_max`,
+    /// where the larger α(E) imposes a finer prompt resolution floor against
+    /// the same storage-tail span — can still leave the resolvable region.
     pub fn kernel_at(&self, energy_ev: f64) -> Result<(Vec<f64>, Vec<f64>), ResolutionParseError> {
         synth_kernel(&self.params, self.n_tau, energy_ev)
     }
@@ -1266,6 +1282,74 @@ mod tests {
             dv > 0.5 * expected,
             "fold variance increment {dv} µs² vs analytic {expected} µs²: \
              the requested fold (nearly) vanished"
+        );
+    }
+
+    #[test]
+    fn boundary_step_fwhm_over_3_is_admitted_and_fold_survives() {
+        // Review #645 round 2, F3: pin the exactly-admitted boundary
+        // `dtau = FWHM/3` (rejection is STRICT: `capped_step > floor`). Per
+        // the TRI_MIN_SAMPLES_PER_SIDE doc, each triangle side then samples
+        // at {FWHM/3, 2FWHM/3, FWHM} — weights {2/3, 1/3, 0}: exactly 2
+        // strictly interior nonzero samples, endpoint ON the triangle zero —
+        // and the fold stays effective (non-delta, second moment ≈ 4FWHM²/27).
+        //
+        // Route to the boundary: n_tau = MIN_N_TAU = 8 with α = 1 gives a
+        // prompt design step 18/7 ≈ 2.57 µs, far coarser than FWHM/3 for a
+        // 1 µs triangle, so the fold refinement pins dtau to exactly
+        // `fwhm / TRI_MIN_SAMPLES_PER_SIDE`. R = 0 keeps the cap inert
+        // (capped step 18/8191 ≪ floor).
+        let fwhm = 1.0;
+        let p = IkedaCarpenterParams {
+            channel_fwhm_us: Some(fwhm),
+            ..IkedaCarpenterParams::constant(1.0, 0.1, 0.0)
+        };
+        let (offs, _) = synth_kernel(&p, MIN_N_TAU, 10.0)
+            .expect("the dtau = FWHM/3 boundary must be admitted, not rejected");
+        let dtau = offs[1] - offs[0];
+        let boundary = fwhm / TRI_MIN_SAMPLES_PER_SIDE;
+        assert!(
+            (dtau - boundary).abs() < 1e-12,
+            "step {dtau} µs is not the FWHM/3 boundary {boundary} µs"
+        );
+
+        // The sampled triangle at the boundary: ≥ 7 samples, exactly 2
+        // strictly interior nonzero per side, center far below the delta's 1.
+        let tri = triangle_kernel(dtau, fwhm);
+        assert!(tri.len() >= 7, "boundary triangle too short: {}", tri.len());
+        let per_side = tri
+            .iter()
+            .take(tri.len() / 2)
+            .filter(|&&v| v > 1e-9)
+            .count();
+        assert_eq!(
+            per_side, 2,
+            "boundary triangle must keep 2 strictly interior nonzero samples \
+             per side: {tri:?}"
+        );
+        let center = tri[tri.len() / 2];
+        assert!(
+            center < 0.5,
+            "center weight {center} — boundary triangle degenerated toward a delta"
+        );
+
+        // Fold effectiveness: the discrete triangle's variance is 4·FWHM²/27
+        // (samples {0, ±FWHM/3, ±2FWHM/3} with weights ∝ {1, 2/3, 1/3}),
+        // ≈ 89 % of the analytic FWHM²/6 — the fold physics survives the
+        // 2-interior-sample discretization.
+        let tri_offs: Vec<f64> = (0..tri.len())
+            .map(|i| (i as f64 - (tri.len() / 2) as f64) * dtau)
+            .collect();
+        let v = kernel_variance(&tri_offs, &tri);
+        let want = 4.0 * fwhm * fwhm / 27.0;
+        assert!(
+            ((v - want) / want).abs() < 0.02,
+            "boundary triangle variance {v} µs² vs discrete analytic {want} µs²"
+        );
+        assert!(
+            v > 0.5 * (fwhm * fwhm / 6.0),
+            "boundary fold variance {v} µs² collapsed below half the \
+             continuous FWHM²/6 — fold (nearly) vanished"
         );
     }
 

--- a/crates/nereids-physics/src/ikeda_carpenter.rs
+++ b/crates/nereids-physics/src/ikeda_carpenter.rs
@@ -123,7 +123,7 @@
 //! triangular ~700 ns base — FWHM ≈ 350 ns — which is what the VENUS tabulated
 //! FTS kernel header records as "folded triang FWHM 350 ns PSR". NEREIDS folds
 //! that PSR triangle via `channel_fwhm_us` (symmetric triangle, half-base =
-//! FWHM, [`triangle_kernel`]). Note: a tabulated file whose header says the
+//! FWHM, `triangle_kernel`). Note: a tabulated file whose header says the
 //! triangle is already "folded" in must NOT be double-counted against an IC
 //! model that also applies it (the `nereids-fitting` calibrator therefore
 //! applies its `psr_fwhm_ns` fold to the IC family only, never to
@@ -407,7 +407,7 @@ impl IkedaCarpenter {
     /// `e_min ≤ 0`, `e_max ≤ e_min`), a non-positive `β`, a parameter/grid
     /// combination whose τ-grid cannot resolve the prompt core and requested
     /// folds within the `MAX_TAU_SAMPLES` cap at some reference energy (see
-    /// [`tau_geometry`] — remedy: larger `β`, `R = 0`, or a wider/disabled
+    /// `tau_geometry` — remedy: larger `β`, `R = 0`, or a wider/disabled
     /// fold), or if the synthesized kernels fail
     /// [`TabulatedResolution::from_kernels`] validation.
     pub fn new(
@@ -547,7 +547,7 @@ impl IkedaCarpenter {
     ///
     /// # Errors
     /// Returns [`ResolutionParseError::InvalidFormat`] when the τ-grid cannot
-    /// resolve the prompt core and requested folds within [`MAX_TAU_SAMPLES`]
+    /// resolve the prompt core and requested folds within `MAX_TAU_SAMPLES`
     /// at this energy. Construction validates every *reference* energy, but a
     /// probe energy outside `[e_min, e_max]` — for the √E law, above `e_max`,
     /// where the larger α(E) imposes a finer prompt resolution floor against

--- a/docs/guide/src/resolution-calibration.md
+++ b/docs/guide/src/resolution-calibration.md
@@ -104,15 +104,35 @@ calibrated = cal.as_tabulated()         # pin this into the sample fit
 
 The families calibrate different knobs:
 
-| family       | fits                                  | meaning                                   |
-|--------------|---------------------------------------|-------------------------------------------|
-| `gaussian`   | `Δt, ΔL`                              | analytical Gaussian width                 |
-| `udr_corr`   | `s(E)=s0·(E/E_ref)^p` on a base UDR   | trust the MC *shape*, calibrate its width |
-| `ic`         | `α(E)=a0√E+a1` (β fixed)               | free analytic shape                       |
+| family       | fits                                        | meaning                                   |
+|--------------|---------------------------------------------|-------------------------------------------|
+| `gaussian`   | `Δt, ΔL`                                    | analytical Gaussian width                 |
+| `udr_corr`   | `s(E)=s0·(E/E_ref)^p` on a base UDR         | trust the MC *shape*, calibrate its width |
+| `ic`         | `α(E)=e^c0·√E+e^c1`, `β`, `R` (⊗ PSR triangle) | full bounded analytic moderator shape     |
+
+The `ic` family fits the **complete bounded Ikeda–Carpenter shape**: the
+prompt law `α(E) = e^{c0}·√E + e^{c1}` is *positive at every energy by
+construction* (the coefficients are exp-encoded — a calibration can no longer
+return an `a1 < 0` that flips α negative below the fit window), and the
+storage rate `β` and mixing fraction `R ∈ [0, 1]` are free within physics
+bounds. The kernel is convolved with the SNS PSR (accumulator-ring) channel
+triangle — FWHM `psr_fwhm_ns` (default 350 ns, the value the VENUS FTS file
+header records as already folded into the *tabulated* kernel; `0` disables).
+Pass `fit_psr=True` to also fit the triangle FWHM as a 5th parameter.
+The PSR fold applies to `ic` only: tabulated/UDR kernels already carry it in
+the file and are never re-folded.
+
+Every result echoes `n_free_params` and `bounds_hit` — a list of
+`"name:lower"` / `"name:upper"` strings for parameters pinned at a box bound.
+A pinned bound flags a degenerate direction: e.g. an eV-regime calibrant with
+no storage tail drives `R → 0` (`"r:lower"`), and on that β↔R ridge the
+reported `β` carries no information.
 
 Use `.as_tabulated()` for `udr_corr` / `ic` (a `TabulatedResolution` to pass as
 `resolution=`); use `.gaussian_params()` → `(delta_t_us, delta_l_m)` for the
-Gaussian family.
+Gaussian family. For `ic`, `cal.params()` returns the decoded
+`{a0, a1, beta, r, psr_fwhm_us}` (the raw `theta` is ln/box-encoded optimizer
+space).
 
 ### Pin and fit the sample
 

--- a/docs/guide/src/resolution-calibration.md
+++ b/docs/guide/src/resolution-calibration.md
@@ -97,7 +97,7 @@ cal = nereids.calibrate_resolution(
     base_udr=udr,                       # required for family="udr_corr"
     restarts=2,
 )
-print(cal)                # ResolutionCalibration(family=udr_corr, chi2/dof=..., converged=...)
+print(cal)                # ResolutionCalibration(family=udr_corr, chi2/dof=..., converged=..., n_free_params=2, bounds_hit=[])
 print(cal.params())       # decoded fitted parameters
 calibrated = cal.as_tabulated()         # pin this into the sample fit
 ```

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -3008,3 +3008,33 @@ class TestCalibrateResolution:
                     temperature_k=300.0,
                     psr_fwhm_ns=bad,
                 )
+
+    def test_fit_psr_with_zero_width_rejected(self):
+        # psr_fwhm_ns=0 is documented as "no PSR fold"; fit_psr=True would
+        # silently clamp the 0 start into the [0.05, 1] us fit box. The
+        # contradiction must raise, not fit a phantom fold.
+        iso, e, t, unc = self._calibrant()
+        with pytest.raises(ValueError, match="fit_psr"):
+            nereids.calibrate_resolution(
+                e,
+                t,
+                unc,
+                "ic",
+                isotopes=[(iso, 5.0e-4)],
+                temperature_k=300.0,
+                psr_fwhm_ns=0.0,
+                fit_psr=True,
+            )
+
+    def test_psr_parameters_trail_the_signature(self):
+        # Review #645 F7: psr_fwhm_ns / fit_psr were added AFTER the original
+        # signature froze, so they must sit at the END — inserting them
+        # mid-signature would silently shift every pre-existing call passing
+        # >= 14 positional arguments.
+        sig = nereids.calibrate_resolution.__text_signature__
+        assert sig is not None
+        assert (
+            sig.index("l_scale_prior")
+            < sig.index("psr_fwhm_ns")
+            < sig.index("fit_psr")
+        ), f"psr_fwhm_ns/fit_psr must trail the signature: {sig}"

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -3009,6 +3009,27 @@ class TestCalibrateResolution:
                     psr_fwhm_ns=bad,
                 )
 
+    def test_absurd_pinned_psr_width_rejected(self):
+        # Review #645 round 2, F1: psr_fwhm_ns is NANOSECONDS (FTS convention
+        # 350 ns); kernel-synthesis cost is quadratic in the fold width, so a
+        # us-as-ns unit slip (350 meaning us -> 350_000 ns) previously passed
+        # the finite/sign check and became a multi-hour silent hang behind a
+        # fictitious 350 us fold. Nonzero widths above the 10_000 ns (10 us)
+        # ceiling must raise up front; the message names the ns unit and the
+        # 350-ns convention. (Boundary acceptance at exactly 10_000 ns is
+        # pinned Rust-side: rejects_absurd_pinned_psr_width.)
+        iso, e, t, unc = self._calibrant()
+        with pytest.raises(ValueError, match="NANOSECONDS.*350 ns"):
+            nereids.calibrate_resolution(
+                e,
+                t,
+                unc,
+                "ic",
+                isotopes=[(iso, 5.0e-4)],
+                temperature_k=300.0,
+                psr_fwhm_ns=350_000.0,
+            )
+
     def test_fit_psr_with_zero_width_rejected(self):
         # psr_fwhm_ns=0 is documented as "no PSR fold"; fit_psr=True would
         # silently clamp the 0 start into the [0.05, 1] us fit box. The

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -2943,3 +2943,68 @@ class TestCalibrateResolution:
                     flight_path_m=-1.0,
                     **kw,
                 )
+
+    def test_ic_params_decoded_and_bounds_reported(self):
+        # The bounded "ic" family (#642) exposes decoded physical parameters
+        # (single source of truth: the calibrated resolution, not the
+        # ln/box-encoded theta) plus the degeneracy report.
+        iso, e, t, unc = self._calibrant()
+        cal = nereids.calibrate_resolution(
+            e, t, unc, "ic", isotopes=[(iso, 5.0e-4)], temperature_k=300.0
+        )
+        p = cal.params()
+        for key in ("a0", "a1", "beta", "r", "psr_fwhm_us"):
+            assert key in p, f"missing decoded param {key}"
+        assert p["a0"] > 0.0
+        assert p["a1"] > 0.0  # alpha(E) positive by construction
+        assert p["beta"] > 0.0
+        assert 0.0 <= p["r"] <= 1.0
+        assert p["psr_fwhm_us"] >= 0.0
+        assert cal.n_free_params == 4
+        assert len(cal.theta) == 4
+        assert isinstance(cal.bounds_hit, list)
+        assert all(isinstance(s, str) for s in cal.bounds_hit)
+        assert "n_free_params=4" in repr(cal)
+
+    def test_fit_psr_appends_fifth_parameter(self):
+        iso, e, t, unc = self._calibrant()
+        cal = nereids.calibrate_resolution(
+            e,
+            t,
+            unc,
+            "ic",
+            isotopes=[(iso, 5.0e-4)],
+            temperature_k=300.0,
+            fit_psr=True,
+        )
+        assert cal.n_free_params == 5
+        assert len(cal.theta) == 5
+        # The fitted PSR FWHM respects its box (0.05-1 us).
+        assert 0.05 <= cal.params()["psr_fwhm_us"] <= 1.0
+
+    def test_fit_psr_requires_ic_family(self):
+        iso, e, t, unc = self._calibrant()
+        with pytest.raises(ValueError, match="fit_psr"):
+            nereids.calibrate_resolution(
+                e,
+                t,
+                unc,
+                "gaussian",
+                isotopes=[(iso, 5.0e-4)],
+                temperature_k=300.0,
+                fit_psr=True,
+            )
+
+    def test_invalid_psr_fwhm_rejected(self):
+        iso, e, t, unc = self._calibrant()
+        for bad in (-1.0, float("nan")):
+            with pytest.raises(ValueError, match="psr_fwhm_ns"):
+                nereids.calibrate_resolution(
+                    e,
+                    t,
+                    unc,
+                    "ic",
+                    isotopes=[(iso, 5.0e-4)],
+                    temperature_k=300.0,
+                    psr_fwhm_ns=bad,
+                )

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -3030,6 +3030,30 @@ class TestCalibrateResolution:
                 psr_fwhm_ns=350_000.0,
             )
 
+    def test_infeasible_start_psr_width_rejected(self):
+        # Review #645 round 3, F1: a pinned PSR width in (0, ~58.6 ns) passes
+        # the finite/sign/ceiling checks but cannot be SYNTHESIZED at the
+        # optimizer's default beta/R start (beta = 0.1 spans a 160 us storage
+        # tail, capping the tau-step at ~19.5 ns > fwhm/3). Previously every
+        # initial simplex vertex was infinite and the calibration burned
+        # max_iter before a generic "no finite-objective" error blaming the
+        # forward model. The Rust pre-flight must reject the start up front,
+        # and the informative message (naming psr_fwhm_ns and the tau-cap
+        # cause) must propagate through the binding as a ValueError.
+        iso, e, t, unc = self._calibrant()
+        with pytest.raises(
+            ValueError, match="starting parameter vector.*psr_fwhm_ns"
+        ):
+            nereids.calibrate_resolution(
+                e,
+                t,
+                unc,
+                "ic",
+                isotopes=[(iso, 5.0e-4)],
+                temperature_k=300.0,
+                psr_fwhm_ns=55.0,
+            )
+
     def test_fit_psr_with_zero_width_rejected(self):
         # psr_fwhm_ns=0 is documented as "no PSR fold"; fit_psr=True would
         # silently clamp the 0 start into the [0.05, 1] us fit box. The


### PR DESCRIPTION
Closes #642.

## What

Makes the analytical `ic` resolution family physics-complete and bounded, per the issue's four requests:

1. **Free β and R (bounded), restarts kept** — the family now fits 4 parameters (5 with `fit_psr`): `θ = [ln a0, ln a1, ln β, R]`. β spans 0.02–5 µs⁻¹ (covers the Mantid IC default β ≈ 0.031 µs⁻¹, Ikeda & Carpenter 1985 NIM A239 536); R is a bounded `Const ∈ [0, 1]` (a free κ in `exp_mev` is unidentifiable — R ≡ 0 across 1–200 eV for any plausible κ).
2. **PSR triangle fold** — synthesized IC kernels are convolved with the SNS accumulator-ring triangle via the existing `channel_fwhm_us` machinery; width from new `psr_fwhm_ns` config (default 350 ns, matching the FTS file header "folded triang FWHM 350 ns PSR"; `0` disables; `fit_psr` optionally fits it, box-bounded 0.05–1 µs). Applied to the `ic` family only — tabulated/UDR kernels already carry the fold and are structurally never re-folded.
3. **α(E) > 0 by construction** — a0 and a1 are exp-encoded (`α(E) = e^{c0}·√E + e^{c1}`), so α is positive on *any* synthesis grid, including the production `e_min_ev = 0.5e-3` grid the old negative-a1 fit poisoned.
4. **Degeneracy echo** — `CalibrationResult` now carries `n_free_params` and `bounds_hit` (`"r:lower"` etc.), in Rust and Python, so bound-pinned/degenerate calibrations are visible.

Supporting changes found necessary during the closed loop:

- **IC τ-grid anchored to the prompt core** (`nereids-physics`): with freed R and low β the storage tail previously set the τ-step and degenerated the 350 ns triangle to a delta; the tail now extends the sample count (capped 8192), bit-identical for all previous callers.
- **Simplex re-inflation** (`calibrate_resolution`): each restart relaunches a fresh, larger Nelder–Mead simplex at the incumbent until improvement stops. Without it, a collapsed simplex stalled the 300 K synthetic calibration Δχ² ≈ +130 high, and the ~1.5 % kernel-width error re-expressed as a ~23 K temperature bias — the exact degeneracy mode this issue targets.

## Acceptance

**(a) Synthetic closed loop** (`crates/nereids-fitting/tests/ic_closed_loop.rs`, runs without SNS access): Ta-181-like 3-resonance transmission (10.36/24.0/39.1 eV) from an IC(α,β,R)⊗triangle truth + FGM Doppler, 0.3 % seeded noise; calibrate at fixed T; pin the resolution; refit T free:

| T_true | calibration χ²/dof | bounds_hit | T_fit |
|---|---|---|---|
| 300 K | 0.995 | (none) | **300.5 ± 4.9 K** |
| 1073 K | 0.995 | (none) | **1071.8 ± 10.1 K** |

σ_T ≈ 5–10 K is far below the ~90 K degeneracy scale of the old 2-parameter family (which failed this exact test at T_fit = 276.8 K before the re-inflation + full-DOF changes).

**(b) Real-data gate (IPTS-37432)** is SNS-side and out of repo scope — to be run by the discovering analysis context as done for #631/#632.

## Breaking / action required

- Earlier `family="ic"` calibrations (2-parameter, no PSR fold) are **superseded — re-calibrate**. Raw `theta` is now ln/box-encoded optimizer space; read decoded physical parameters from `params()` (Python: `{a0, a1, beta, r, psr_fwhm_us}`) or the returned resolution (Rust).

## Out of scope (per @KedoKudo's design note on the issue)

The parameterization is kept clean and physical as input for the future **analytic IC⊗Doppler evaluation path** (erfc/EMG closed forms, analytic Jacobians); no performance work is coupled here. That path should be filed as a separate issue once this lands.

## Verification

- `cargo fmt` / `clippy --workspace --exclude nereids-python --all-targets -- -D warnings` / `cargo test --workspace --exclude nereids-python`: clean, **1080 tests passed, 0 failed** (25 binaries)
- Acceptance tests: 2/2 passed (541 s)
- Python wheel + `pytest tests/test_nereids.py`: **141 passed**

PR assisted with [Claude Code](https://claude.com/claude-code).