### PR TITLE
feat(io): detect_dead_pixels hardening — hot/chunked detectors, union semantics, integrity-only docs (#643)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,17 +59,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   separately, and every normalization recomputes the effective mask
   from scratch as declared ∪ freshly-detected — detections never
   accumulate across open-beam swaps or re-normalizations.
-- **Project files persist the declared mask component only** (#646):
-  `/intermediate/dead_pixels` (path, dtype, and shape unchanged) now
-  stores the declared mask rather than the effective
+- **Project files persist the pixel mask as two separate components**
+  (#646): `/intermediate/dead_pixels` (path, dtype, and shape
+  unchanged) now stores the declared mask rather than the effective
   (declared ∪ detected) mask, so save→load→save cycles no longer bake
-  each session's detections into the next session's declared component
-  — detections are session-scoped and recomputed on normalization.
-  Project files written by earlier versions stored the effective mask;
-  loading one promotes it to declared once (the only lossless reading
-  of a file that never recorded the split) — masks saved by old
-  versions keep any detections they had already absorbed, but stop
-  growing from now on.
+  each session's detections into the next session's declared component;
+  the detected component is persisted alongside it as a new
+  session-scoped, versioned dataset
+  (`/intermediate/detected_dead_pixels`, u8, `format_version` = 1).
+  On restore the effective mask is rebuilt as declared ∪
+  persisted-detected — a restored project carrying embedded normalized
+  data without the raw stacks (where detection cannot re-run) refits
+  with exactly the dead/hot exclusions active at save time instead of
+  silently losing them.  When the raw stacks ARE present on restore,
+  detection is recomputed purely as a drift check: a mismatch with the
+  persisted detected mask is surfaced in the status bar and the
+  provenance log (the saved mask stays active; re-running normalization
+  adopts the fresh detection explicitly).  Neither component can grow
+  across save/load cycles.
+  Backward/forward compatibility: files written by earlier versions
+  stored the effective mask at the declared path and lack the detected
+  dataset — loading one promotes the stored mask to declared once (the
+  only lossless reading of a file that never recorded the split; such
+  masks keep any detections they had already absorbed, but stop growing
+  from now on) and restores with no detected component (declared-only),
+  as does any file whose detected dataset carries an unrecognized
+  `format_version`.
 - Dead/hot detectors' validating entry points (`detect_bad_pixels`,
   `detect_hot_pixels`, `detect_dead_pixels_chunked`) now reject stacks
   and chunks with an empty TOF axis (`shape[0] == 0`), whose vacuous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   median + k·MAD cut (k = 6 default, with a Poisson floor on the robust
   scale so quantized low-count images never turn the screen into a
   low-count filter) confirmed by a 10× local-8-neighbor-median isolation
-  test, so bimodal scenes (dark-majority sample + bright open-beam
-  region) never get their bright region masked — a contiguous bright
-  region is scene, not a defect.  Requires raw (unscaled) counts.  In
-  Rust (`nereids_io::normalization`) and Python.
+  test iterated to a fixpoint (already-flagged neighbors stop vouching),
+  which erodes railed clusters up to 3 px wide from the boundary inward
+  — a single local pass would miss the interior of clusters ≥2 px wide.
+  Bimodal scenes (dark-majority sample + bright open-beam region) never
+  get their bright region masked — a contiguous bright region ≥2 px
+  wide is scene, not a defect, and the erosion never seeds in it; a
+  1-px-wide bright line at ≥10× local contrast is indistinguishable
+  from a railed line and is masked by design (documented trade-off;
+  real VENUS features are PSF-blurred over ≥2 px).  Requires raw
+  (unscaled) counts.  In Rust (`nereids_io::normalization`) and Python.
 - **Chunked dead-pixel detection** (#643):
   `detect_dead_pixels_chunked` — per-acquisition-chunk detection that
   flags pixels dead in *any* chunk, catching intermittent deadness
@@ -32,9 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - **GUI normalization now masks dead(sample) ∪ dead(OB) ∪ hot(sample)
   ∪ hot(OB)** instead of dead(sample) only (#643), on both the TIFF-pair
-  and the HDF5-with-open-beam paths (the HDF5 path unions the detected
-  mask with any mask carried by the file) — masked-pixel counts may
-  differ on re-normalization of existing data.
+  and the HDF5-with-open-beam paths — masked-pixel counts may differ on
+  re-normalization of existing data.  Mask provenance is explicit
+  (#646): the file-declared mask (HDF5 dead-pixel dataset or a saved
+  project's mask) is kept separately, and every normalization recomputes
+  the effective mask from scratch as declared ∪ freshly-detected —
+  detections never accumulate across open-beam swaps or
+  re-normalizations.
 - Dead/hot detectors' validating entry points (`detect_bad_pixels`,
   `detect_hot_pixels`, `detect_dead_pixels_chunked`) now reject stacks
   and chunks with an empty TOF axis (`shape[0] == 0`), whose vacuous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Hot/railed pixel detection** (#643): `detect_hot_pixels` — robust
+  one-sided log-space median + k·MAD screen on per-pixel total counts
+  (k = 6 default, with a Poisson floor on the robust scale so quantized
+  low-count images never turn the screen into a low-count filter), in
+  Rust (`nereids_io::normalization`) and Python.
+- **Chunked dead-pixel detection** (#643):
+  `detect_dead_pixels_chunked` — per-acquisition-chunk detection that
+  flags pixels dead in *any* chunk, catching intermittent deadness
+  invisible to the summed-stack test, in Rust and Python.
+- **Unified bad-pixel entry point** (#643): `detect_bad_pixels` —
+  validating detector computing dead ∪ hot over the sample and
+  (optionally) the open-beam stack, in Rust and Python.
+- `nereids-core` gains a `stats` module (`median`,
+  `median_abs_deviation`, `MAD_TO_SIGMA`).
+
+### Changed
+
+- **GUI normalization now masks dead(sample) ∪ dead(OB) ∪ hot(sample)
+  ∪ hot(OB)** instead of dead(sample) only (#643) — masked-pixel counts
+  may differ on re-normalization of existing data.
+- Pixel-mask documentation now states the semantics explicitly (#643):
+  masks are a pipeline-integrity screen only, never a
+  data-quality/coverage filter — low-count pixels are alive and are
+  kept.
+
 ## [0.2.2] - 2026-07-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- **Hot/railed pixel detection** (#643): `detect_hot_pixels` — robust
-  one-sided log-space median + k·MAD screen on per-pixel total counts
-  (k = 6 default, with a Poisson floor on the robust scale so quantized
-  low-count images never turn the screen into a low-count filter), in
+- **Hot/railed pixel detection** (#643): `detect_hot_pixels` — two-stage
+  screen on per-pixel total counts: a robust one-sided log-space
+  median + k·MAD cut (k = 6 default, with a Poisson floor on the robust
+  scale so quantized low-count images never turn the screen into a
+  low-count filter) confirmed by a 10× local-8-neighbor-median isolation
+  test, so bimodal scenes (dark-majority sample + bright open-beam
+  region) never get their bright region masked — a contiguous bright
+  region is scene, not a defect.  Requires raw (unscaled) counts.  In
   Rust (`nereids_io::normalization`) and Python.
 - **Chunked dead-pixel detection** (#643):
   `detect_dead_pixels_chunked` — per-acquisition-chunk detection that
@@ -27,8 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - **GUI normalization now masks dead(sample) ∪ dead(OB) ∪ hot(sample)
-  ∪ hot(OB)** instead of dead(sample) only (#643) — masked-pixel counts
-  may differ on re-normalization of existing data.
+  ∪ hot(OB)** instead of dead(sample) only (#643), on both the TIFF-pair
+  and the HDF5-with-open-beam paths (the HDF5 path unions the detected
+  mask with any mask carried by the file) — masked-pixel counts may
+  differ on re-normalization of existing data.
+- Dead/hot detectors' validating entry points (`detect_bad_pixels`,
+  `detect_hot_pixels`, `detect_dead_pixels_chunked`) now reject stacks
+  and chunks with an empty TOF axis (`shape[0] == 0`), whose vacuous
+  all-zero test would otherwise mask the whole detector (#643).
 - Pixel-mask documentation now states the semantics explicitly (#643):
   masks are a pipeline-integrity screen only, never a
   data-quality/coverage filter — low-count pixels are alive and are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   provenance log (the saved mask stays active; re-running normalization
   adopts the fresh detection explicitly).  Neither component can grow
   across save/load cycles.
+  Restore also validates both persisted components against the restored
+  transmission geometry (when the project carries normalized data) and
+  drops any component that cannot apply — a hand-corrupted mask can no
+  longer become the effective mask (or crash a refit with restored
+  ROIs).  Every mask drop on restore is surfaced in the status bar and
+  the provenance log, and survives the restore replacing the session
+  provenance with the project's own history.
   Backward/forward compatibility: files written by earlier versions
   stored the effective mask at the declared path and lack the detected
   dataset — loading one promotes the stored mask to declared once (the
@@ -84,7 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   masks keep any detections they had already absorbed, but stop growing
   from now on) and restores with no detected component (declared-only),
   as does any file whose detected dataset carries an unrecognized
-  `format_version`.
+  `format_version` or a rank other than 2.
 - Dead/hot detectors' validating entry points (`detect_bad_pixels`,
   `detect_hot_pixels`, `detect_dead_pixels_chunked`) now reject stacks
   and chunks with an empty TOF axis (`shape[0] == 0`), whose vacuous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   low-count filter) confirmed by a 10× local-8-neighbor-median isolation
   test iterated to a fixpoint (already-flagged neighbors stop vouching),
   which erodes railed clusters up to 3 px wide from the boundary inward
-  — a single local pass would miss the interior of clusters ≥2 px wide.
+  — a single local pass would miss the interior of clusters ≥2 px wide —
+  provided the cluster exposes at least one end cap or convex corner to
+  normal-scene neighbors (erosion must seed somewhere).  An edge-to-edge
+  railed band ≥2 px wide (both ends off-detector) has no seed and is not
+  caught — deliberate: a slit-aperture open beam produces a genuine
+  full-width bright scene band indistinguishable from it, and a
+  full-span row/column screen would mask that scene (the bimodal
+  failure); declare such full-span detector pathologies in a file mask.
+  A full-span width-1 railed line is caught.
   Bimodal scenes (dark-majority sample + bright open-beam region) never
   get their bright region masked — a contiguous bright region ≥2 px
   wide is scene, not a defect, and the erosion never seeds in it; a
@@ -36,15 +44,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- **GUI normalization now masks dead(sample) ∪ dead(OB) ∪ hot(sample)
-  ∪ hot(OB)** instead of dead(sample) only (#643), on both the TIFF-pair
-  and the HDF5-with-open-beam paths — masked-pixel counts may differ on
-  re-normalization of existing data.  Mask provenance is explicit
-  (#646): the file-declared mask (HDF5 dead-pixel dataset or a saved
-  project's mask) is kept separately, and every normalization recomputes
-  the effective mask from scratch as declared ∪ freshly-detected —
-  detections never accumulate across open-beam swaps or
-  re-normalizations.
+- **GUI normalization now masks dead ∪ hot on every raw-counts path**
+  (#643): the TIFF-pair and HDF5-with-open-beam paths mask
+  dead(sample) ∪ hot(sample) ∪ dead(OB) ∪ hot(OB) instead of
+  dead(sample) only, and the HDF5-without-open-beam path (histogram or
+  event data prepared with uniform weighting) now runs the same
+  detection on the sample stack alone — masked-pixel counts may differ
+  on re-normalization of existing data.  TransmissionTiff runs no
+  detection: its data is a pre-normalized transmission ratio, not raw
+  counts, so the hot screen's Poisson floor does not apply and an
+  all-zero "dead" test would conflate opaque scene with a dead
+  detector.  Mask provenance is explicit (#646): the file-declared mask
+  (HDF5 dead-pixel dataset or a saved project's mask) is kept
+  separately, and every normalization recomputes the effective mask
+  from scratch as declared ∪ freshly-detected — detections never
+  accumulate across open-beam swaps or re-normalizations.
+- **Project files persist the declared mask component only** (#646):
+  `/intermediate/dead_pixels` (path, dtype, and shape unchanged) now
+  stores the declared mask rather than the effective
+  (declared ∪ detected) mask, so save→load→save cycles no longer bake
+  each session's detections into the next session's declared component
+  — detections are session-scoped and recomputed on normalization.
+  Project files written by earlier versions stored the effective mask;
+  loading one promotes it to declared once (the only lossless reading
+  of a file that never recorded the split) — masks saved by old
+  versions keep any detections they had already absorbed, but stop
+  growing from now on.
 - Dead/hot detectors' validating entry points (`detect_bad_pixels`,
   `detect_hot_pixels`, `detect_dead_pixels_chunked`) now reject stacks
   and chunks with an empty TOF axis (`shape[0] == 0`), whose vacuous

--- a/apps/gui/src/guided/bin.rs
+++ b/apps/gui/src/guided/bin.rs
@@ -158,6 +158,7 @@ fn histogram_events(state: &mut AppState) {
             // AppState::set_detected_dead_pixels.
             state.file_dead_pixels = data.dead_pixels.clone();
             state.dead_pixels = data.dead_pixels;
+            state.detected_dead_pixels = None;
 
             state.log_provenance(
                 ProvenanceEventKind::DataLoaded,

--- a/apps/gui/src/guided/bin.rs
+++ b/apps/gui/src/guided/bin.rs
@@ -152,7 +152,7 @@ fn histogram_events(state: &mut AppState) {
             }
 
             // Declared-mask provenance (#646) — same contract as the
-            // histogram load site (guided::load::load_hdf5_data): the
+            // histogram load site (guided::load::load_hdf5_histogram): the
             // file-declared mask is assigned unconditionally to its own
             // field, and normalization recomputes the effective mask via
             // AppState::set_detected_dead_pixels.

--- a/apps/gui/src/guided/bin.rs
+++ b/apps/gui/src/guided/bin.rs
@@ -151,9 +151,13 @@ fn histogram_events(state: &mut AppState) {
                 }
             }
 
-            if let Some(dead) = data.dead_pixels {
-                state.dead_pixels = Some(dead);
-            }
+            // Declared-mask provenance (#646) — same contract as the
+            // histogram load site (guided::load::load_hdf5_data): the
+            // file-declared mask is assigned unconditionally to its own
+            // field, and normalization recomputes the effective mask via
+            // AppState::set_detected_dead_pixels.
+            state.file_dead_pixels = data.dead_pixels.clone();
+            state.dead_pixels = data.dead_pixels;
 
             state.log_provenance(
                 ProvenanceEventKind::DataLoaded,

--- a/apps/gui/src/guided/load.rs
+++ b/apps/gui/src/guided/load.rs
@@ -614,9 +614,14 @@ fn load_hdf5_histogram(state: &mut AppState) {
                 }
             }
 
-            if let Some(dead) = data.dead_pixels {
-                state.dead_pixels = Some(dead);
-            }
+            // Declared-mask provenance (#646): the file-declared mask gets
+            // its own field (assigned unconditionally — a file without a
+            // mask must not inherit a previous file's), and the effective
+            // mask starts as exactly that.  Every normalization recomputes
+            // dead_pixels = declared ∪ detected from scratch
+            // (AppState::set_detected_dead_pixels).
+            state.file_dead_pixels = data.dead_pixels.clone();
+            state.dead_pixels = data.dead_pixels;
 
             let shape = data.counts.shape();
             state.log_provenance(
@@ -762,6 +767,7 @@ pub(crate) fn on_tiff_sample_picked(state: &mut AppState, path: std::path::PathB
     state.sample_data = None;
     state.normalized = None;
     state.dead_pixels = None;
+    state.file_dead_pixels = None;
     state.energies = None;
     state.pixel_fit_result = None;
     state.spatial_result = None;
@@ -774,6 +780,7 @@ pub(crate) fn on_tiff_open_beam_picked(state: &mut AppState, path: std::path::Pa
     state.open_beam_data = None;
     state.normalized = None;
     state.dead_pixels = None;
+    state.file_dead_pixels = None;
     state.energies = None;
     state.pixel_fit_result = None;
     state.spatial_result = None;

--- a/apps/gui/src/guided/load.rs
+++ b/apps/gui/src/guided/load.rs
@@ -619,9 +619,11 @@ fn load_hdf5_histogram(state: &mut AppState) {
             // mask must not inherit a previous file's), and the effective
             // mask starts as exactly that.  Every normalization recomputes
             // dead_pixels = declared ∪ detected from scratch
-            // (AppState::set_detected_dead_pixels).
+            // (AppState::set_detected_dead_pixels).  No detection has run
+            // on the fresh data yet.
             state.file_dead_pixels = data.dead_pixels.clone();
             state.dead_pixels = data.dead_pixels;
+            state.detected_dead_pixels = None;
 
             let shape = data.counts.shape();
             state.log_provenance(
@@ -768,6 +770,7 @@ pub(crate) fn on_tiff_sample_picked(state: &mut AppState, path: std::path::PathB
     state.normalized = None;
     state.dead_pixels = None;
     state.file_dead_pixels = None;
+    state.detected_dead_pixels = None;
     state.energies = None;
     state.pixel_fit_result = None;
     state.spatial_result = None;
@@ -781,6 +784,7 @@ pub(crate) fn on_tiff_open_beam_picked(state: &mut AppState, path: std::path::Pa
     state.normalized = None;
     state.dead_pixels = None;
     state.file_dead_pixels = None;
+    state.detected_dead_pixels = None;
     state.energies = None;
     state.pixel_fit_result = None;
     state.spatial_result = None;

--- a/apps/gui/src/guided/normalize.rs
+++ b/apps/gui/src/guided/normalize.rs
@@ -468,24 +468,25 @@ pub(crate) fn normalize_data(state: &mut AppState) {
             // single AppState helper — see set_detected_dead_pixels (#646).
             // TIFF stacks carry no declared mask, so this is normally the
             // detected mask alone.
-            let mask_err = match nereids_io::normalization::detect_bad_pixels(
+            let (mask_notice, mask_err) = match nereids_io::normalization::detect_bad_pixels(
                 &sample,
                 Some(open_beam.as_ref()),
                 Some(nereids_io::normalization::HOT_PIXEL_K_MAD),
             ) {
-                Ok(mask) => {
-                    state.set_detected_dead_pixels(Some(mask));
-                    None
-                }
+                Ok(mask) => (state.set_detected_dead_pixels(Some(mask)), None),
                 // Unreachable in practice: normalize() above already validated
                 // both stacks finite/non-negative and shape-equal; fall back
                 // to the declared component rather than keep a stale
                 // detection if that invariant ever breaks.
-                Err(e) => {
-                    state.set_detected_dead_pixels(None);
-                    Some(e)
-                }
+                Err(e) => (state.set_detected_dead_pixels(None), Some(e)),
             };
+            // A declared-mask drop (geometry mismatch) is RETURNED by the
+            // setter, not logged inside it (#646 F1 — restore must defer
+            // it past its provenance replacement).  Here the provenance
+            // log is stable: surface it immediately.
+            if let Some(notice) = mask_notice {
+                state.log_provenance(ProvenanceEventKind::ConfigChanged, notice);
+            }
 
             let n_tof = sample.shape()[0];
             match compute_energies(state, n_tof) {
@@ -558,32 +559,32 @@ pub(crate) fn prepare_transmission(state: &mut AppState) {
     // Poisson floor assumes Var[N] = N and would be silently distorted,
     // and an all-zero "dead" test on ratios conflates opaque scene with a
     // dead detector — so no detection runs for that mode.
-    let mask_err = match state.input_mode {
+    let (mask_notice, mask_err) = match state.input_mode {
         InputMode::Hdf5Histogram | InputMode::Hdf5Event => {
             match nereids_io::normalization::detect_bad_pixels(
                 &sample,
                 None,
                 Some(nereids_io::normalization::HOT_PIXEL_K_MAD),
             ) {
-                Ok(detected) => {
-                    // Effective mask recomputed from scratch as
-                    // declared ∪ detected — see set_detected_dead_pixels.
-                    state.set_detected_dead_pixels(Some(detected));
-                    None
-                }
+                // Effective mask recomputed from scratch as
+                // declared ∪ detected — see set_detected_dead_pixels.
+                Ok(detected) => (state.set_detected_dead_pixels(Some(detected)), None),
                 // These stacks are not pre-validated by normalize():
                 // negative/non-finite HDF5 values are rejected by
                 // detect_bad_pixels.  Fall back to the file-declared mask
                 // alone (never a stale detection) and surface the failure
                 // in the final status.
-                Err(e) => {
-                    state.set_detected_dead_pixels(None);
-                    Some(e)
-                }
+                Err(e) => (state.set_detected_dead_pixels(None), Some(e)),
             }
         }
-        _ => None,
+        _ => (None, None),
     };
+    // Surface a declared-mask drop immediately (#646 F1) — see
+    // normalize_data above for why the setter returns it instead of
+    // logging.
+    if let Some(notice) = mask_notice {
+        state.log_provenance(ProvenanceEventKind::ConfigChanged, notice);
+    }
 
     let n_tof = sample.shape()[0];
     // Uniform uncertainty: σ = 1 for all bins.
@@ -705,25 +706,25 @@ pub(crate) fn normalize_hdf5_with_ob(state: &mut AppState) {
     // dead_pixels, which after an open-beam swap still holds the previous
     // run's detection and would accumulate stale flags monotonically
     // (#646).  See set_detected_dead_pixels for the full semantics.
-    let mask_err = match nereids_io::normalization::detect_bad_pixels(
+    let (mask_notice, mask_err) = match nereids_io::normalization::detect_bad_pixels(
         &sample_arc,
         Some(ob_arc.as_ref()),
         Some(nereids_io::normalization::HOT_PIXEL_K_MAD),
     ) {
-        Ok(detected) => {
-            state.set_detected_dead_pixels(Some(detected));
-            None
-        }
+        Ok(detected) => (state.set_detected_dead_pixels(Some(detected)), None),
         // Unlike the TIFF path, these stacks are not pre-validated by
         // normalize(): negative/non-finite HDF5 values are clamped by the
         // transmission loop above but rejected by detect_bad_pixels.  Fall
         // back to the file-declared mask alone (never a stale detection)
         // and surface the failure in the final status.
-        Err(e) => {
-            state.set_detected_dead_pixels(None);
-            Some(e)
-        }
+        Err(e) => (state.set_detected_dead_pixels(None), Some(e)),
     };
+    // Surface a declared-mask drop immediately (#646 F1) — see
+    // normalize_data above for why the setter returns it instead of
+    // logging.
+    if let Some(notice) = mask_notice {
+        state.log_provenance(ProvenanceEventKind::ConfigChanged, notice);
+    }
 
     match compute_energies(state, n_tof) {
         Ok(energies) => state.energies = Some(energies),

--- a/apps/gui/src/guided/normalize.rs
+++ b/apps/gui/src/guided/normalize.rs
@@ -137,7 +137,7 @@ fn normalization_controls_card(ui: &mut egui::Ui, state: &mut AppState) {
                     ui.label("Transmission computed.");
                     if let Some(ref dead) = state.dead_pixels {
                         let n_dead = dead.iter().filter(|&&d| d).count();
-                        ui.label(format!("Dead pixels: {}", n_dead));
+                        ui.label(format!("Masked pixels (dead/hot): {}", n_dead));
                     }
                 } else if state.sample_data.is_some() && state.open_beam_data.is_some() {
                     ui.label("Click Normalize to compute transmission.");
@@ -459,7 +459,23 @@ pub(crate) fn normalize_data(state: &mut AppState) {
 
     match nereids_io::normalization::normalize(sample, open_beam, &params, None) {
         Ok(norm) => {
-            state.dead_pixels = Some(nereids_io::normalization::detect_dead_pixels(sample));
+            // Pipeline-integrity mask: dead ∪ hot over BOTH stacks — a pixel
+            // dead or railed only in the open-beam run still corrupts every
+            // transmission ratio computed from it (#643).
+            state.dead_pixels = match nereids_io::normalization::detect_bad_pixels(
+                sample,
+                Some(open_beam.as_ref()),
+                Some(nereids_io::normalization::HOT_PIXEL_K_MAD),
+            ) {
+                Ok(mask) => Some(mask),
+                // Unreachable in practice: normalize() above already validated
+                // both stacks finite/non-negative and shape-equal; keep the
+                // mask absent rather than stale if that invariant ever breaks.
+                Err(e) => {
+                    state.status_message = format!("Pixel-mask detection: {}", e);
+                    None
+                }
+            };
 
             let n_tof = sample.shape()[0];
             match compute_energies(state, n_tof) {

--- a/apps/gui/src/guided/normalize.rs
+++ b/apps/gui/src/guided/normalize.rs
@@ -443,12 +443,14 @@ pub(crate) fn normalize_data(state: &mut AppState) {
     state.pixel_fit_result = None;
     state.spatial_result = None;
 
+    // Clone Arcs (O(1)) so no field borrow is held across the
+    // set_detected_dead_pixels(&mut self) call below.
     let sample = match state.sample_data {
-        Some(ref d) => d,
+        Some(ref d) => Arc::clone(d),
         None => return,
     };
     let open_beam = match state.open_beam_data {
-        Some(ref d) => d,
+        Some(ref d) => Arc::clone(d),
         None => return,
     };
 
@@ -457,25 +459,30 @@ pub(crate) fn normalize_data(state: &mut AppState) {
         proton_charge_ob: state.proton_charge_ob,
     };
 
-    match nereids_io::normalization::normalize(sample, open_beam, &params, None) {
+    match nereids_io::normalization::normalize(&sample, &open_beam, &params, None) {
         Ok(norm) => {
             // Pipeline-integrity mask: dead ∪ hot over BOTH stacks — a pixel
             // dead or railed only in the open-beam run still corrupts every
-            // transmission ratio computed from it (#643).
+            // transmission ratio computed from it (#643).  The effective
+            // mask is recomputed from scratch (declared ∪ detected) via the
+            // single AppState helper — see set_detected_dead_pixels (#646).
+            // TIFF stacks carry no declared mask, so this is normally the
+            // detected mask alone.
             let mask_err = match nereids_io::normalization::detect_bad_pixels(
-                sample,
+                &sample,
                 Some(open_beam.as_ref()),
                 Some(nereids_io::normalization::HOT_PIXEL_K_MAD),
             ) {
                 Ok(mask) => {
-                    state.dead_pixels = Some(mask);
+                    state.set_detected_dead_pixels(Some(mask));
                     None
                 }
                 // Unreachable in practice: normalize() above already validated
-                // both stacks finite/non-negative and shape-equal; keep the
-                // mask absent rather than stale if that invariant ever breaks.
+                // both stacks finite/non-negative and shape-equal; fall back
+                // to the declared component rather than keep a stale
+                // detection if that invariant ever breaks.
                 Err(e) => {
-                    state.dead_pixels = None;
+                    state.set_detected_dead_pixels(None);
                     Some(e)
                 }
             };
@@ -528,9 +535,11 @@ pub(crate) fn prepare_transmission(state: &mut AppState) {
         None => return,
     };
 
-    // Only clear dead pixels for TransmissionTiff — HDF5 modes load them from the file.
+    // Only clear dead pixels for TransmissionTiff (TIFFs carry no declared
+    // mask) — HDF5 modes keep the file-declared mask installed at load time.
     if state.input_mode == InputMode::TransmissionTiff {
         state.dead_pixels = None;
+        state.file_dead_pixels = None;
     }
 
     let n_tof = sample.shape()[0];
@@ -637,33 +646,31 @@ pub(crate) fn normalize_hdf5_with_ob(state: &mut AppState) {
         });
 
     // Pipeline-integrity mask: dead ∪ hot over BOTH stacks, same as the
-    // TIFF-pair path (#643).  HDF5 files may also carry their own mask
-    // (loaded into state.dead_pixels at load time) — union with it rather
-    // than overwrite: file-declared defects and detected defects both hold.
+    // TIFF-pair path (#643).  HDF5 files may also carry their own declared
+    // mask (kept in state.file_dead_pixels since load time); the effective
+    // mask is recomputed FROM SCRATCH as declared ∪ freshly-detected via
+    // the single AppState helper — never unioned into the previous
+    // dead_pixels, which after an open-beam swap still holds the previous
+    // run's detection and would accumulate stale flags monotonically
+    // (#646).  See set_detected_dead_pixels for the full semantics.
     let mask_err = match nereids_io::normalization::detect_bad_pixels(
         &sample_arc,
         Some(ob_arc.as_ref()),
         Some(nereids_io::normalization::HOT_PIXEL_K_MAD),
     ) {
         Ok(detected) => {
-            state.dead_pixels = Some(match state.dead_pixels.take() {
-                Some(mut loaded) if loaded.dim() == detected.dim() => {
-                    ndarray::Zip::from(&mut loaded)
-                        .and(&detected)
-                        .for_each(|m, &d| *m = *m || d);
-                    loaded
-                }
-                // No file mask, or one of a different detector size (it
-                // cannot apply to this data): use the detected mask alone.
-                _ => detected,
-            });
+            state.set_detected_dead_pixels(Some(detected));
             None
         }
         // Unlike the TIFF path, these stacks are not pre-validated by
         // normalize(): negative/non-finite HDF5 values are clamped by the
-        // transmission loop above but rejected by detect_bad_pixels.  Keep
-        // any file-loaded mask and surface the failure in the final status.
-        Err(e) => Some(e),
+        // transmission loop above but rejected by detect_bad_pixels.  Fall
+        // back to the file-declared mask alone (never a stale detection)
+        // and surface the failure in the final status.
+        Err(e) => {
+            state.set_detected_dead_pixels(None);
+            Some(e)
+        }
     };
 
     match compute_energies(state, n_tof) {

--- a/apps/gui/src/guided/normalize.rs
+++ b/apps/gui/src/guided/normalize.rs
@@ -543,6 +543,9 @@ pub(crate) fn prepare_transmission(state: &mut AppState) {
     if state.input_mode == InputMode::TransmissionTiff {
         state.dead_pixels = None;
         state.file_dead_pixels = None;
+        // No detection ever runs for TransmissionTiff (see below), so the
+        // component would otherwise stay stale from a previous mode.
+        state.detected_dead_pixels = None;
     }
 
     // Pipeline-integrity mask (#643, #646 review R3 F2): the HDF5 modes

--- a/apps/gui/src/guided/normalize.rs
+++ b/apps/gui/src/guided/normalize.rs
@@ -521,10 +521,13 @@ pub(crate) fn normalize_data(state: &mut AppState) {
     }
 }
 
-/// Prepare pre-normalized transmission data (TransmissionTiff mode).
+/// Wrap the sample stack as transmission with uniform σ = 1 (no open beam).
 ///
-/// Called automatically when TransmissionTiff data is ready but not yet
-/// wrapped as `NormalizedData`.  Idempotent — does nothing if already prepared.
+/// Serves TransmissionTiff (pre-normalized transmission read from file)
+/// and the HDF5 modes (`Hdf5Histogram` / `Hdf5Event` — raw counts) when no
+/// open beam is loaded.  Called automatically when data is ready but not
+/// yet wrapped as `NormalizedData`.  Idempotent — does nothing if already
+/// prepared.
 pub(crate) fn prepare_transmission(state: &mut AppState) {
     state.cancel_pending_tasks();
     state.pixel_fit_result = None;
@@ -541,6 +544,43 @@ pub(crate) fn prepare_transmission(state: &mut AppState) {
         state.dead_pixels = None;
         state.file_dead_pixels = None;
     }
+
+    // Pipeline-integrity mask (#643, #646 review R3 F2): the HDF5 modes
+    // reach this path with RAW counts — histogram datasets are read
+    // verbatim, events are histogrammed at +1 per event (unweighted), and
+    // the optional rebin SUMS adjacent TOF bins — exactly the raw-counts
+    // precondition of detect_bad_pixels, applied to the sample stack alone
+    // (no open beam exists on this path).  TransmissionTiff data is a
+    // pre-normalized transmission RATIO, not raw counts: the hot screen's
+    // Poisson floor assumes Var[N] = N and would be silently distorted,
+    // and an all-zero "dead" test on ratios conflates opaque scene with a
+    // dead detector — so no detection runs for that mode.
+    let mask_err = match state.input_mode {
+        InputMode::Hdf5Histogram | InputMode::Hdf5Event => {
+            match nereids_io::normalization::detect_bad_pixels(
+                &sample,
+                None,
+                Some(nereids_io::normalization::HOT_PIXEL_K_MAD),
+            ) {
+                Ok(detected) => {
+                    // Effective mask recomputed from scratch as
+                    // declared ∪ detected — see set_detected_dead_pixels.
+                    state.set_detected_dead_pixels(Some(detected));
+                    None
+                }
+                // These stacks are not pre-validated by normalize():
+                // negative/non-finite HDF5 values are rejected by
+                // detect_bad_pixels.  Fall back to the file-declared mask
+                // alone (never a stale detection) and surface the failure
+                // in the final status.
+                Err(e) => {
+                    state.set_detected_dead_pixels(None);
+                    Some(e)
+                }
+            }
+        }
+        _ => None,
+    };
 
     let n_tof = sample.shape()[0];
     // Uniform uncertainty: σ = 1 for all bins.
@@ -576,7 +616,16 @@ pub(crate) fn prepare_transmission(state: &mut AppState) {
         ProvenanceEventKind::Normalized,
         "Transmission data prepared (uniform σ=1 — no open-beam data)",
     );
-    state.status_message = "Transmission ready (uniform weighting — chi² is approximate)".into();
+    // Compose the mask failure into the final status — a plain "ready"
+    // would silently swallow it (same rationale as normalize_data above).
+    state.status_message = match mask_err {
+        None => "Transmission ready (uniform weighting — chi² is approximate)".into(),
+        Some(e) => format!(
+            "Transmission ready (uniform weighting — chi² is approximate) — \
+             pixel-mask detection failed ({}), detected mask not applied",
+            e
+        ),
+    };
 }
 
 /// Normalize HDF5 counts with open beam: T = sample / open_beam.

--- a/apps/gui/src/guided/normalize.rs
+++ b/apps/gui/src/guided/normalize.rs
@@ -462,18 +462,21 @@ pub(crate) fn normalize_data(state: &mut AppState) {
             // Pipeline-integrity mask: dead ∪ hot over BOTH stacks — a pixel
             // dead or railed only in the open-beam run still corrupts every
             // transmission ratio computed from it (#643).
-            state.dead_pixels = match nereids_io::normalization::detect_bad_pixels(
+            let mask_err = match nereids_io::normalization::detect_bad_pixels(
                 sample,
                 Some(open_beam.as_ref()),
                 Some(nereids_io::normalization::HOT_PIXEL_K_MAD),
             ) {
-                Ok(mask) => Some(mask),
+                Ok(mask) => {
+                    state.dead_pixels = Some(mask);
+                    None
+                }
                 // Unreachable in practice: normalize() above already validated
                 // both stacks finite/non-negative and shape-equal; keep the
                 // mask absent rather than stale if that invariant ever breaks.
                 Err(e) => {
-                    state.status_message = format!("Pixel-mask detection: {}", e);
-                    None
+                    state.dead_pixels = None;
+                    Some(e)
                 }
             };
 
@@ -494,7 +497,16 @@ pub(crate) fn normalize_data(state: &mut AppState) {
                 ProvenanceEventKind::Normalized,
                 "Normalization complete (Method 2)",
             );
-            state.status_message = "Normalization complete".into();
+            // Compose the mask failure into the final status — a plain
+            // "Normalization complete" would silently swallow it.
+            state.status_message = match mask_err {
+                None => "Normalization complete".into(),
+                Some(e) => format!(
+                    "Normalization complete — pixel-mask detection failed \
+                     ({}), no pixel mask applied",
+                    e
+                ),
+            };
         }
         Err(e) => {
             state.status_message = format!("Normalization error: {}", e);
@@ -624,6 +636,36 @@ pub(crate) fn normalize_hdf5_with_ob(state: &mut AppState) {
             }
         });
 
+    // Pipeline-integrity mask: dead ∪ hot over BOTH stacks, same as the
+    // TIFF-pair path (#643).  HDF5 files may also carry their own mask
+    // (loaded into state.dead_pixels at load time) — union with it rather
+    // than overwrite: file-declared defects and detected defects both hold.
+    let mask_err = match nereids_io::normalization::detect_bad_pixels(
+        &sample_arc,
+        Some(ob_arc.as_ref()),
+        Some(nereids_io::normalization::HOT_PIXEL_K_MAD),
+    ) {
+        Ok(detected) => {
+            state.dead_pixels = Some(match state.dead_pixels.take() {
+                Some(mut loaded) if loaded.dim() == detected.dim() => {
+                    ndarray::Zip::from(&mut loaded)
+                        .and(&detected)
+                        .for_each(|m, &d| *m = *m || d);
+                    loaded
+                }
+                // No file mask, or one of a different detector size (it
+                // cannot apply to this data): use the detected mask alone.
+                _ => detected,
+            });
+            None
+        }
+        // Unlike the TIFF path, these stacks are not pre-validated by
+        // normalize(): negative/non-finite HDF5 values are clamped by the
+        // transmission loop above but rejected by detect_bad_pixels.  Keep
+        // any file-loaded mask and surface the failure in the final status.
+        Err(e) => Some(e),
+    };
+
     match compute_energies(state, n_tof) {
         Ok(energies) => state.energies = Some(energies),
         Err(e) => {
@@ -641,7 +683,16 @@ pub(crate) fn normalize_hdf5_with_ob(state: &mut AppState) {
         ProvenanceEventKind::Normalized,
         "HDF5 normalized with open beam (T = sample/OB)",
     );
-    state.status_message = "Normalized with open beam — counts-domain fitting available".into();
+    // Compose the mask failure into the final status so it is not
+    // silently overwritten (same rationale as normalize_data above).
+    state.status_message = match mask_err {
+        None => "Normalized with open beam — counts-domain fitting available".into(),
+        Some(e) => format!(
+            "Normalized with open beam — pixel-mask detection failed ({}), \
+             detected mask not applied",
+            e
+        ),
+    };
 }
 
 /// Compute energy bin centers from the spectrum file loaded in state.

--- a/apps/gui/src/project.rs
+++ b/apps/gui/src/project.rs
@@ -738,6 +738,7 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
     state.open_beam_data = None;
     state.spectrum_values = None;
     state.dead_pixels = None;
+    state.file_dead_pixels = None;
     state.fm_spectrum = None;
     state.fm_per_isotope_spectra.clear();
     state.detect_results.clear();
@@ -1039,8 +1040,16 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
     }
     state.energies = snap.energies;
 
-    // 15b. Restore dead-pixel mask (D-20).
+    // 15b. Restore dead-pixel mask (D-20).  The persisted mask is treated
+    // as DECLARED (#646): loading a project declares its saved mask, which
+    // then persists across re-normalizations exactly like an HDF5
+    // file-declared mask, while re-detections are recomputed from scratch
+    // (AppState::set_detected_dead_pixels) instead of unioning into it —
+    // detections never accumulate across the save/load boundary.  If the
+    // linked HDF5 is reloaded, the load site overwrites the declared mask
+    // with the file's own.
     state.dead_pixels = snap.dead_pixels;
+    state.file_dead_pixels = state.dead_pixels.clone();
 
     // 16. Restore results
     if let Some(density_maps) = snap.density_maps {

--- a/apps/gui/src/project.rs
+++ b/apps/gui/src/project.rs
@@ -343,17 +343,25 @@ pub fn snapshot_from_state(state: &AppState) -> ProjectSnapshot {
         normalized,
         normalized_uncertainty,
         energies: state.energies.clone(),
-        // Persist the DECLARED mask component only (#646 review R3, F3):
-        // detections are session-scoped and recomputed on every
-        // normalization.  Persisting the effective mask (declared ∪
-        // detected) would let the restore-side declared-promotion bake
-        // each session's detections into the next session's declared
-        // component — monotonic mask growth across save/load cycles.
-        // Old project files stored the effective mask at this same
-        // dataset path (`/intermediate/dead_pixels` — unchanged dtype and
-        // shape, no format marker needed) and get a documented one-time
-        // promotion on load; new saves end the accumulation.
+        // Persist the two mask components SEPARATELY (#646 review R3 F3 +
+        // R4 P1-1).  `/intermediate/dead_pixels` carries the DECLARED
+        // component only: persisting the effective mask (declared ∪
+        // detected) there would let the restore-side declared-promotion
+        // bake each session's detections into the next session's declared
+        // component — monotonic mask growth across save/load cycles.  Old
+        // project files stored the effective mask at this same dataset
+        // path (unchanged dtype and shape, no format marker needed) and
+        // get a documented one-time promotion on load; new saves end the
+        // accumulation.
         dead_pixels: state.file_dead_pixels.clone(),
+        // The DETECTED component gets its own versioned, session-scoped
+        // dataset (`/intermediate/detected_dead_pixels`): a restore
+        // without raw stacks cannot re-run detection, and dropping the
+        // component there would silently refit without the dead/hot
+        // exclusions active at save time.  Restore rebuilds the effective
+        // mask as declared ∪ detected — both components round-trip
+        // unchanged, so cycles still cannot grow either one.
+        detected_dead_pixels: state.detected_dead_pixels.clone(),
         density_maps,
         uncertainty_maps,
         chi_squared_map,
@@ -749,6 +757,7 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
     state.spectrum_values = None;
     state.dead_pixels = None;
     state.file_dead_pixels = None;
+    state.detected_dead_pixels = None;
     state.fm_spectrum = None;
     state.fm_per_isotope_spectra.clear();
     state.detect_results.clear();
@@ -1050,21 +1059,86 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
     }
     state.energies = snap.energies;
 
-    // 15b. Restore dead-pixel mask (D-20) as DECLARED (#646).  NEW project
-    // files persist exactly the declared component (snapshot_from_state
-    // writes state.file_dead_pixels), so this restore is the identity.
-    // OLD files stored the effective mask (declared ∪ detected at save
-    // time) at the same dataset path; promoting it to declared here is a
+    // 15b. Restore the dead-pixel mask components (D-20, #646).  NEW
+    // project files persist the DECLARED component at
+    // `/intermediate/dead_pixels` (snapshot_from_state writes
+    // state.file_dead_pixels) and the DETECTED component at
+    // `/intermediate/detected_dead_pixels` (#646 R4, P1-1); the effective
+    // mask is rebuilt here as declared ∪ persisted-detected via the same
+    // single-site helper every normalization uses — a restored project
+    // may carry embedded normalized data WITHOUT raw stacks, where
+    // detection never re-runs, and a declared-only restore would silently
+    // refit without the exclusions active at save time.  OLD files stored
+    // the effective mask at the declared dataset path and lack the
+    // detected dataset; promoting the effective mask to declared is a
     // documented one-time promotion — the only lossless reading of a file
-    // that never recorded the declared/detected split.  Either way,
-    // detections stay session-scoped: every normalization recomputes the
-    // effective mask from scratch as declared ∪ freshly-detected
-    // (AppState::set_detected_dead_pixels), so save→load→save cycles no
-    // longer grow the persisted mask (#646 review R3, F3).  If the linked
-    // HDF5 is reloaded, the load site overwrites the declared mask with
-    // the file's own.
-    state.dead_pixels = snap.dead_pixels;
-    state.file_dead_pixels = state.dead_pixels.clone();
+    // that never recorded the split.  Either way, the next normalization
+    // recomputes the effective mask from scratch as declared ∪
+    // freshly-detected (AppState::set_detected_dead_pixels), so
+    // save→load→save cycles cannot grow either component (#646 review R3
+    // F3, R4 P1-1).  If the linked HDF5 is reloaded, the load site
+    // overwrites the declared mask with the file's own.
+    state.file_dead_pixels = snap.dead_pixels;
+    state.set_detected_dead_pixels(snap.detected_dead_pixels);
+
+    // 15c. Detection-drift check (#646 R4, P1-1): when the raw stacks WERE
+    // restored (embedded save), re-run the same detection normalization
+    // would run and WARN if it no longer reproduces the persisted detected
+    // component — hidden state drift becomes observable instead of being
+    // silently replaced (or silently trusted).  The persisted component
+    // stays active either way; re-normalizing adopts the fresh detection
+    // explicitly.  Mode gating mirrors the three normalization call sites:
+    // TransmissionTiff never detects; the TIFF pair detects over
+    // sample ∪ OB (skip when the OB stack was not restored — recomputing
+    // on the sample alone would warn spuriously); the HDF5 modes detect
+    // over whatever is present.
+    let detected_drift: Option<String> = match (&state.detected_dead_pixels, &state.sample_data) {
+        (Some(persisted), Some(sample)) => {
+            let ob = state.open_beam_data.as_deref();
+            let stacks = match state.input_mode {
+                InputMode::TransmissionTiff => None,
+                InputMode::TiffPair => ob.map(|o| (sample.as_ref(), Some(o))),
+                InputMode::Hdf5Histogram | InputMode::Hdf5Event => Some((sample.as_ref(), ob)),
+            };
+            stacks.and_then(|(s, o)| {
+                match nereids_io::normalization::detect_bad_pixels(
+                    s,
+                    o,
+                    Some(nereids_io::normalization::HOT_PIXEL_K_MAD),
+                ) {
+                    Ok(fresh) if fresh.dim() == persisted.dim() => {
+                        let n_diff = fresh
+                            .iter()
+                            .zip(persisted.iter())
+                            .filter(|(f, p)| f != p)
+                            .count();
+                        (n_diff > 0).then(|| {
+                            format!(
+                                "recomputed dead/hot detection on the restored raw stacks \
+                                 differs from the saved detected mask at {n_diff} pixel(s); \
+                                 saved mask kept active — re-run normalization to adopt \
+                                 the fresh detection"
+                            )
+                        })
+                    }
+                    Ok(fresh) => Some(format!(
+                        "recomputed dead/hot detection is {:?} but the saved detected \
+                         mask is {:?}; saved mask kept active",
+                        fresh.dim(),
+                        persisted.dim()
+                    )),
+                    Err(e) => Some(format!(
+                        "dead/hot detection drift check failed ({e}); saved detected \
+                         mask kept active"
+                    )),
+                }
+            })
+        }
+        _ => None,
+    };
+    // (Logged to provenance at step 22 — step 17 below REPLACES the
+    // provenance log with the snapshot's, which would drop an entry
+    // appended here.)
 
     // 16. Restore results
     if let Some(density_maps) = snap.density_maps {
@@ -1215,10 +1289,14 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
         state.guided_step = state.pipeline[0].step;
     }
 
-    // 20. Status message
+    // 20. Status message — compose the drift warning (15c) in rather than
+    // leaving it provenance-only; a plain "Project loaded" would bury it.
     let mut status = format!("Project loaded from {}", path.display());
     if !missing.is_empty() {
         status.push_str(&format!(" (missing files: {})", missing.join(", ")));
+    }
+    if let Some(ref msg) = detected_drift {
+        status.push_str(&format!(" — WARNING: {msg}"));
     }
     state.status_message = status;
 
@@ -1226,11 +1304,18 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
     state.cached_session = None;
     state.clear_dirty();
 
-    // 22. Log provenance
+    // 22. Log provenance (drift entry after step 17's wholesale replacement
+    // of the provenance log — see 15c)
     state.log_provenance(
         ProvenanceEventKind::ProjectLoaded,
         format!("Loaded from {}", path.display()),
     );
+    if let Some(ref msg) = detected_drift {
+        state.log_provenance(
+            ProvenanceEventKind::ProjectLoaded,
+            format!("Detected-mask drift: {msg}"),
+        );
+    }
 }
 
 /// Parse a timestamp string ("YYYY-MM-DD HH:MM:SS UTC" or ISO 8601) into SystemTime.
@@ -1281,16 +1366,27 @@ fn ymd_to_days(y: u64, m: u64, d: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ndarray::Array2;
+    use ndarray::{Array2, Array3};
+    use nereids_io::project::{load_project, save_project, save_project_with_data};
 
-    /// #646 review R3, F3: project SAVE persists the DECLARED mask
-    /// component only, so a save→load→save cycle with an active session
-    /// detection must not grow the persisted mask.  Before the fix the
-    /// snapshot carried the EFFECTIVE mask (declared ∪ detected) and the
-    /// restore-side declared-promotion baked each session's detections
-    /// into the next session's declared component — monotonic growth.
+    /// The mask the refit consumes: `guided::analyze` merges
+    /// `state.dead_pixels` with the ROI mask, and with no ROIs (the case
+    /// in these tests) uses `state.dead_pixels` as-is.
+    fn refit_active_mask(state: &AppState) -> Option<Array2<bool>> {
+        assert!(state.rois.is_empty());
+        state.dead_pixels.clone()
+    }
+
+    /// #646 review R3 F3 + R4 P1-1: project SAVE persists the mask as two
+    /// SEPARATE components (declared at `/intermediate/dead_pixels`,
+    /// detected at `/intermediate/detected_dead_pixels`), so a
+    /// save→load→save cycle must not grow EITHER component.  Before the
+    /// R3 fix the snapshot carried the EFFECTIVE mask (declared ∪
+    /// detected) at the declared path and the restore-side
+    /// declared-promotion baked each session's detections into the next
+    /// session's declared component — monotonic growth.
     #[test]
-    fn test_snapshot_persists_declared_mask_only_no_growth_across_cycles() {
+    fn test_snapshot_persists_split_mask_components_no_growth_across_cycles() {
         let mut declared = Array2::from_elem((3, 3), false);
         declared[[0, 0]] = true;
         let mut detected = Array2::from_elem((3, 3), false);
@@ -1313,21 +1409,190 @@ mod tests {
             2
         );
 
-        // ...but the snapshot persists the declared component only.
+        // ...and the snapshot persists the two components separately —
+        // the declared dataset never absorbs the detection.
         let snap = snapshot_from_state(&state);
         assert_eq!(snap.dead_pixels.as_ref().unwrap(), &declared);
+        assert_eq!(snap.detected_dead_pixels.as_ref().unwrap(), &detected);
 
-        // Load into a fresh session: the persisted mask restores as the
-        // declared component (and the effective mask starts as exactly it).
+        // Load into a fresh session: each component restores to its own
+        // field and the effective mask is rebuilt as declared ∪ detected.
         let mut restored = AppState::default();
         state_from_snapshot(snap, &mut restored, Path::new("/nonexistent/p.nrd.h5"));
         assert_eq!(restored.file_dead_pixels.as_ref().unwrap(), &declared);
-        assert_eq!(restored.dead_pixels.as_ref().unwrap(), &declared);
+        assert_eq!(restored.detected_dead_pixels.as_ref().unwrap(), &detected);
+        assert_eq!(
+            restored
+                .dead_pixels
+                .as_ref()
+                .unwrap()
+                .iter()
+                .filter(|&&m| m)
+                .count(),
+            2
+        );
 
         // The next normalization re-detects; the next save STILL persists
-        // only the declared component — no growth across cycles.
-        restored.set_detected_dead_pixels(Some(detected));
+        // the same two components — no growth of either across cycles.
+        restored.set_detected_dead_pixels(Some(detected.clone()));
         let snap2 = snapshot_from_state(&restored);
         assert_eq!(snap2.dead_pixels.as_ref().unwrap(), &declared);
+        assert_eq!(snap2.detected_dead_pixels.as_ref().unwrap(), &detected);
+    }
+
+    /// #646 R4 P1-1 acceptance (b): save→restore→refit WITHOUT raw stacks
+    /// — the exact scenario the detected-component persistence exists
+    /// for.  Normalization (and thus detection) cannot re-run, so the
+    /// refit's active mask must still equal the at-save mask, through the
+    /// real HDF5 writer/reader.
+    #[test]
+    fn test_save_restore_refit_active_mask_without_raw_stacks() {
+        let mut declared = Array2::from_elem((3, 3), false);
+        declared[[0, 0]] = true;
+        let mut detected = Array2::from_elem((3, 3), false);
+        detected[[1, 1]] = true;
+
+        let mut state = AppState {
+            input_mode: InputMode::Hdf5Histogram,
+            file_dead_pixels: Some(declared.clone()),
+            ..AppState::default()
+        };
+        state.set_detected_dead_pixels(Some(detected.clone()));
+        let at_save_mask = refit_active_mask(&state).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("no_raw.nrd.h5");
+        save_project(&path, &snapshot_from_state(&state)).unwrap();
+
+        let mut restored = AppState::default();
+        state_from_snapshot(load_project(&path).unwrap(), &mut restored, &path);
+
+        // Scenario precondition: no raw stacks after restore.
+        assert!(restored.sample_data.is_none());
+        // The refit's active mask equals the at-save mask (before P1-1 the
+        // detected component was lost and this was declared-only).
+        assert_eq!(refit_active_mask(&restored).unwrap(), at_save_mask);
+        // No drift check without raw stacks: nothing to recompute from.
+        assert!(!restored.status_message.contains("WARNING"));
+        assert!(
+            !restored
+                .provenance_log
+                .iter()
+                .any(|e| e.message.contains("drift"))
+        );
+    }
+
+    /// #646 R4 P1-1 acceptance (a): save→restore→refit WITH raw stacks
+    /// embedded.  The persisted detected component still restores the
+    /// at-save active mask, and — since the recomputed detection agrees
+    /// with the persisted one — no drift warning is raised.
+    #[test]
+    fn test_save_restore_refit_active_mask_with_raw_stacks() {
+        // Raw stack with a genuinely detectable hot pixel: uniform 100
+        // counts, one railed pixel (see
+        // test_detect_hot_pixels_uniform_image_poisson_floor_path).
+        let mut sample = Array3::from_elem((1, 3, 3), 100.0);
+        sample[[0, 1, 1]] = 65535.0;
+        let detected = nereids_io::normalization::detect_bad_pixels(
+            &sample,
+            None,
+            Some(nereids_io::normalization::HOT_PIXEL_K_MAD),
+        )
+        .unwrap();
+        assert!(detected[[1, 1]], "fixture must detect the railed pixel");
+
+        let mut declared = Array2::from_elem((3, 3), false);
+        declared[[0, 0]] = true;
+
+        let mut state = AppState {
+            input_mode: InputMode::Hdf5Histogram,
+            sample_data: Some(Arc::new(sample.clone())),
+            file_dead_pixels: Some(declared),
+            ..AppState::default()
+        };
+        state.set_detected_dead_pixels(Some(detected));
+        let at_save_mask = refit_active_mask(&state).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("with_raw.nrd.h5");
+        let embedded = EmbeddedData {
+            sample: Some(&sample),
+            open_beam: None,
+            spectrum: None,
+        };
+        save_project_with_data(&path, &snapshot_from_state(&state), Some(&embedded)).unwrap();
+
+        let mut restored = AppState::default();
+        state_from_snapshot(load_project(&path).unwrap(), &mut restored, &path);
+
+        // Scenario precondition: raw stacks present after restore.
+        assert!(restored.sample_data.is_some());
+        assert_eq!(refit_active_mask(&restored).unwrap(), at_save_mask);
+        // Recomputed detection reproduces the persisted component → no
+        // drift warning.
+        assert!(!restored.status_message.contains("WARNING"));
+        assert!(
+            !restored
+                .provenance_log
+                .iter()
+                .any(|e| e.message.contains("drift"))
+        );
+    }
+
+    /// #646 R4 P1-1: when raw stacks are present on restore and the
+    /// recomputed detection DISAGREES with the persisted detected
+    /// component, the persisted mask stays active (never silently
+    /// replaced) and the drift is surfaced in both the status message and
+    /// the provenance log.
+    #[test]
+    fn test_restore_with_raw_stacks_warns_on_detection_drift_keeps_saved_mask() {
+        let mut sample = Array3::from_elem((1, 3, 3), 100.0);
+        sample[[0, 1, 1]] = 65535.0; // recompute will flag (1, 1)
+
+        // Persisted detected component from a "different" detection run:
+        // flags (0, 2) instead — drift at 2 pixels ((1,1) and (0,2)).
+        let mut stale_detected = Array2::from_elem((3, 3), false);
+        stale_detected[[0, 2]] = true;
+
+        let mut state = AppState {
+            input_mode: InputMode::Hdf5Histogram,
+            sample_data: Some(Arc::new(sample.clone())),
+            ..AppState::default()
+        };
+        state.set_detected_dead_pixels(Some(stale_detected.clone()));
+        let at_save_mask = refit_active_mask(&state).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("drift.nrd.h5");
+        let embedded = EmbeddedData {
+            sample: Some(&sample),
+            open_beam: None,
+            spectrum: None,
+        };
+        save_project_with_data(&path, &snapshot_from_state(&state), Some(&embedded)).unwrap();
+
+        let mut restored = AppState::default();
+        state_from_snapshot(load_project(&path).unwrap(), &mut restored, &path);
+
+        // The saved mask is kept active — drift never silently replaces it.
+        assert_eq!(refit_active_mask(&restored).unwrap(), at_save_mask);
+        assert_eq!(
+            restored.detected_dead_pixels.as_ref().unwrap(),
+            &stale_detected
+        );
+        // ...and the drift is observable in status + provenance.
+        assert!(
+            restored.status_message.contains("WARNING"),
+            "status must surface the drift: {}",
+            restored.status_message
+        );
+        assert!(restored.status_message.contains("2 pixel(s)"));
+        assert!(
+            restored
+                .provenance_log
+                .iter()
+                .any(|e| e.message.contains("Detected-mask drift")),
+            "provenance must record the drift"
+        );
     }
 }

--- a/apps/gui/src/project.rs
+++ b/apps/gui/src/project.rs
@@ -1078,8 +1078,66 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
     // save→load→save cycles cannot grow either component (#646 review R3
     // F3, R4 P1-1).  If the linked HDF5 is reloaded, the load site
     // overwrites the declared mask with the file's own.
-    state.file_dead_pixels = snap.dead_pixels;
-    state.set_detected_dead_pixels(snap.detected_dead_pixels);
+    //
+    // Geometry validation (#646 F3): both components now come from a
+    // FILE, so a hand-corrupted project can carry a mask whose geometry
+    // does not match the data it will be applied to.  The refit consumes
+    // the effective mask against the restored normalized transmission
+    // (guided::analyze returns early without state.normalized) — without
+    // ROIs the pipeline rejects a wrong-geometry mask cleanly, but with
+    // restored ROIs the analyze-side ROI∪mask merge (ndarray::Zip)
+    // panics on the shape mismatch.  So when the snapshot carries
+    // normalized data (restored at step 15 above), validate each
+    // component against its spatial dims and DROP any that cannot apply,
+    // surfaced via the same deferred-notice mechanism as the drift
+    // warning below — never silently.  When the snapshot carries no
+    // normalized data, geometry is unknown here, but no refit can run
+    // either: the only route to a mask consumer is a fresh normalization,
+    // which recomputes the detected component at the data's own geometry
+    // and drops an inapplicable declared mask via the setter's returned
+    // notice.
+    let mut mask_notices: Vec<String> = Vec::new();
+    let expected_dims = state.normalized.as_ref().map(|n| {
+        let s = n.transmission.shape();
+        (s[1], s[2])
+    });
+    let mut declared = snap.dead_pixels;
+    let mut detected = snap.detected_dead_pixels;
+    if let Some(dims) = expected_dims {
+        if let Some(ref m) = declared
+            && m.dim() != dims
+        {
+            mask_notices.push(format!(
+                "restored declared pixel mask {:?} does not match the \
+                 restored transmission geometry {:?}; declared mask \
+                 dropped",
+                m.dim(),
+                dims
+            ));
+            declared = None;
+        }
+        if let Some(ref m) = detected
+            && m.dim() != dims
+        {
+            mask_notices.push(format!(
+                "restored detected pixel mask {:?} does not match the \
+                 restored transmission geometry {:?}; detected mask \
+                 dropped",
+                m.dim(),
+                dims
+            ));
+            detected = None;
+        }
+    }
+    state.file_dead_pixels = declared;
+    // The setter RETURNS a declared-mask-drop notice instead of logging
+    // it (#646 F1): step 17 below replaces the provenance log wholesale
+    // with the snapshot's, which would erase an entry appended here.
+    // Deferred — with the geometry notices above — to steps 20/22,
+    // exactly like the drift warning (15c).
+    if let Some(notice) = state.set_detected_dead_pixels(detected) {
+        mask_notices.push(notice);
+    }
 
     // 15c. Detection-drift check (#646 R4, P1-1): when the raw stacks WERE
     // restored (embedded save), re-run the same detection normalization
@@ -1289,11 +1347,15 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
         state.guided_step = state.pipeline[0].step;
     }
 
-    // 20. Status message — compose the drift warning (15c) in rather than
-    // leaving it provenance-only; a plain "Project loaded" would bury it.
+    // 20. Status message — compose the mask-drop notices (15b) and the
+    // drift warning (15c) in rather than leaving them provenance-only; a
+    // plain "Project loaded" would bury them.
     let mut status = format!("Project loaded from {}", path.display());
     if !missing.is_empty() {
         status.push_str(&format!(" (missing files: {})", missing.join(", ")));
+    }
+    for msg in &mask_notices {
+        status.push_str(&format!(" — WARNING: {msg}"));
     }
     if let Some(ref msg) = detected_drift {
         status.push_str(&format!(" — WARNING: {msg}"));
@@ -1304,12 +1366,18 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
     state.cached_session = None;
     state.clear_dirty();
 
-    // 22. Log provenance (drift entry after step 17's wholesale replacement
-    // of the provenance log — see 15c)
+    // 22. Log provenance (mask-drop and drift entries after step 17's
+    // wholesale replacement of the provenance log — see 15b/15c)
     state.log_provenance(
         ProvenanceEventKind::ProjectLoaded,
         format!("Loaded from {}", path.display()),
     );
+    for msg in &mask_notices {
+        state.log_provenance(
+            ProvenanceEventKind::ConfigChanged,
+            format!("Pixel-mask restore: {msg}"),
+        );
+    }
     if let Some(ref msg) = detected_drift {
         state.log_provenance(
             ProvenanceEventKind::ProjectLoaded,
@@ -1396,7 +1464,11 @@ mod tests {
             file_dead_pixels: Some(declared.clone()),
             ..AppState::default()
         };
-        state.set_detected_dead_pixels(Some(detected.clone()));
+        assert!(
+            state
+                .set_detected_dead_pixels(Some(detected.clone()))
+                .is_none()
+        );
         // Effective mask in the session is declared ∪ detected...
         assert_eq!(
             state
@@ -1434,7 +1506,11 @@ mod tests {
 
         // The next normalization re-detects; the next save STILL persists
         // the same two components — no growth of either across cycles.
-        restored.set_detected_dead_pixels(Some(detected.clone()));
+        assert!(
+            restored
+                .set_detected_dead_pixels(Some(detected.clone()))
+                .is_none()
+        );
         let snap2 = snapshot_from_state(&restored);
         assert_eq!(snap2.dead_pixels.as_ref().unwrap(), &declared);
         assert_eq!(snap2.detected_dead_pixels.as_ref().unwrap(), &detected);
@@ -1457,7 +1533,11 @@ mod tests {
             file_dead_pixels: Some(declared.clone()),
             ..AppState::default()
         };
-        state.set_detected_dead_pixels(Some(detected.clone()));
+        assert!(
+            state
+                .set_detected_dead_pixels(Some(detected.clone()))
+                .is_none()
+        );
         let at_save_mask = refit_active_mask(&state).unwrap();
 
         let dir = tempfile::tempdir().unwrap();
@@ -1510,7 +1590,7 @@ mod tests {
             file_dead_pixels: Some(declared),
             ..AppState::default()
         };
-        state.set_detected_dead_pixels(Some(detected));
+        assert!(state.set_detected_dead_pixels(Some(detected)).is_none());
         let at_save_mask = refit_active_mask(&state).unwrap();
 
         let dir = tempfile::tempdir().unwrap();
@@ -1559,7 +1639,11 @@ mod tests {
             sample_data: Some(Arc::new(sample.clone())),
             ..AppState::default()
         };
-        state.set_detected_dead_pixels(Some(stale_detected.clone()));
+        assert!(
+            state
+                .set_detected_dead_pixels(Some(stale_detected.clone()))
+                .is_none()
+        );
         let at_save_mask = refit_active_mask(&state).unwrap();
 
         let dir = tempfile::tempdir().unwrap();
@@ -1593,6 +1677,170 @@ mod tests {
                 .iter()
                 .any(|e| e.message.contains("Detected-mask drift")),
             "provenance must record the drift"
+        );
+    }
+
+    /// #646 F1 acceptance: a mismatched declared/detected pair on restore
+    /// must stay observable THROUGH step 17's wholesale replacement of
+    /// the session provenance log with the snapshot's — the erasure the
+    /// direct-call setter test (state.rs) cannot see.  End-to-end through
+    /// the real HDF5 writer/reader: no normalized data in the snapshot,
+    /// so restore-side geometry validation cannot apply and the corrupt
+    /// pair reaches `set_detected_dead_pixels`, whose drop notice is
+    /// deferred past step 17 into the final provenance log AND the
+    /// status message.
+    #[test]
+    fn test_restore_mismatched_mask_pair_drop_notice_survives_provenance_replacement() {
+        let mut snap = snapshot_from_state(&AppState::default());
+        // Hand-corrupted pair: declared (4, 4) vs detected (2, 2).
+        snap.dead_pixels = Some(Array2::from_elem((4, 4), true));
+        let mut detected = Array2::from_elem((2, 2), false);
+        detected[[0, 0]] = true;
+        snap.detected_dead_pixels = Some(detected.clone());
+        // The snapshot carries its own provenance history — step 17
+        // replaces the session log with exactly this, which used to
+        // erase the drop entry the setter appended at step 15b.
+        snap.provenance = vec![(
+            "2026-07-04 00:00:00 UTC".into(),
+            "ProjectSaved".into(),
+            "saved in an earlier session".into(),
+        )];
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mismatched_pair.nrd.h5");
+        save_project(&path, &snap).unwrap();
+
+        let mut restored = AppState::default();
+        state_from_snapshot(load_project(&path).unwrap(), &mut restored, &path);
+
+        // Effective mask: the inapplicable declared mask is dropped —
+        // the refit runs with the detected component only.
+        assert_eq!(refit_active_mask(&restored).unwrap(), detected);
+        // The drop survives step 17: the FINAL provenance log carries it
+        // (naming both geometries)...
+        assert!(
+            restored
+                .provenance_log
+                .iter()
+                .any(|e| e.message.contains("(4, 4)") && e.message.contains("(2, 2)")),
+            "final provenance log must carry the declared-mask drop"
+        );
+        // ...alongside the snapshot's own restored history (i.e. the
+        // replacement DID happen and the notice still made it through)...
+        assert!(
+            restored
+                .provenance_log
+                .iter()
+                .any(|e| e.message.contains("saved in an earlier session")),
+            "snapshot provenance must have replaced the session log"
+        );
+        // ...and the status message surfaces it too.
+        assert!(
+            restored.status_message.contains("WARNING")
+                && restored.status_message.contains("(4, 4)")
+                && restored.status_message.contains("(2, 2)"),
+            "status must surface the drop: {}",
+            restored.status_message
+        );
+    }
+
+    /// #646 F3: a hand-corrupted persisted DETECTED component of the
+    /// wrong geometry must not become the effective mask — with restored
+    /// ROIs the analyze-side ROI∪mask merge (`ndarray::Zip`,
+    /// guided/analyze.rs) panics on the shape mismatch.  With normalized
+    /// data restored the geometry is known at step 15b, so the component
+    /// is dropped and the drop surfaced in status + provenance.
+    #[test]
+    fn test_restore_drops_wrong_geometry_detected_component_with_notice() {
+        let mut declared = Array2::from_elem((3, 3), false);
+        declared[[0, 0]] = true;
+
+        let mut snap = snapshot_from_state(&AppState::default());
+        snap.normalized = Some(Array3::from_elem((1, 3, 3), 0.5));
+        snap.dead_pixels = Some(declared.clone());
+        // Corrupt: detected component from a different geometry.
+        snap.detected_dead_pixels = Some(Array2::from_elem((2, 2), true));
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("wrong_geom_detected.nrd.h5");
+        save_project(&path, &snap).unwrap();
+
+        let mut restored = AppState::default();
+        state_from_snapshot(load_project(&path).unwrap(), &mut restored, &path);
+
+        // The wrong-geometry detected component is dropped; the declared
+        // component (which matches the data) is kept and becomes the
+        // effective mask.
+        assert!(restored.detected_dead_pixels.is_none());
+        assert_eq!(restored.file_dead_pixels.as_ref().unwrap(), &declared);
+        assert_eq!(refit_active_mask(&restored).unwrap(), declared);
+        // Mask-geometry invariant that makes the analyze ROI-merge panic
+        // unreachable: the effective mask matches the restored
+        // transmission's spatial dims.
+        let t = &restored.normalized.as_ref().unwrap().transmission;
+        let dims = (t.shape()[1], t.shape()[2]);
+        assert_eq!(restored.dead_pixels.as_ref().unwrap().dim(), dims);
+        // Drive the same ROI∪mask merge analyze performs (Zip panics on
+        // shape mismatch) — must not panic now that geometry is enforced.
+        let mut roi_mask = Array2::from_elem(dims, true);
+        if let Some(ref dp) = restored.dead_pixels {
+            ndarray::Zip::from(&mut roi_mask)
+                .and(dp)
+                .for_each(|m, &d| *m = *m || d);
+        }
+        // Drop surfaced in status + final provenance, never silent.
+        assert!(
+            restored.status_message.contains("WARNING")
+                && restored.status_message.contains("detected mask"),
+            "status must surface the drop: {}",
+            restored.status_message
+        );
+        assert!(
+            restored
+                .provenance_log
+                .iter()
+                .any(|e| e.message.contains("detected mask") && e.message.contains("dropped")),
+            "provenance must record the drop"
+        );
+    }
+
+    /// #646 F3: BOTH persisted components wrong against the restored
+    /// data geometry — both are dropped (effective mask absent, not
+    /// wrong), each drop gets its own notice, and the setter's own
+    /// mismatch arm never double-fires (it receives an already-validated
+    /// pair).
+    #[test]
+    fn test_restore_drops_both_wrong_geometry_mask_components() {
+        let mut snap = snapshot_from_state(&AppState::default());
+        snap.normalized = Some(Array3::from_elem((1, 3, 3), 0.5));
+        snap.dead_pixels = Some(Array2::from_elem((4, 4), true));
+        snap.detected_dead_pixels = Some(Array2::from_elem((2, 2), true));
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("both_wrong_geom.nrd.h5");
+        save_project(&path, &snap).unwrap();
+
+        let mut restored = AppState::default();
+        state_from_snapshot(load_project(&path).unwrap(), &mut restored, &path);
+
+        assert!(restored.file_dead_pixels.is_none());
+        assert!(restored.detected_dead_pixels.is_none());
+        assert!(restored.dead_pixels.is_none());
+        // One notice per dropped component, both in status and provenance.
+        assert!(
+            restored.status_message.contains("declared mask")
+                && restored.status_message.contains("detected mask"),
+            "status must surface both drops: {}",
+            restored.status_message
+        );
+        assert_eq!(
+            restored
+                .provenance_log
+                .iter()
+                .filter(|e| e.message.contains("Pixel-mask restore:"))
+                .count(),
+            2,
+            "one provenance entry per dropped component"
         );
     }
 }

--- a/apps/gui/src/project.rs
+++ b/apps/gui/src/project.rs
@@ -343,7 +343,17 @@ pub fn snapshot_from_state(state: &AppState) -> ProjectSnapshot {
         normalized,
         normalized_uncertainty,
         energies: state.energies.clone(),
-        dead_pixels: state.dead_pixels.clone(),
+        // Persist the DECLARED mask component only (#646 review R3, F3):
+        // detections are session-scoped and recomputed on every
+        // normalization.  Persisting the effective mask (declared ∪
+        // detected) would let the restore-side declared-promotion bake
+        // each session's detections into the next session's declared
+        // component — monotonic mask growth across save/load cycles.
+        // Old project files stored the effective mask at this same
+        // dataset path (`/intermediate/dead_pixels` — unchanged dtype and
+        // shape, no format marker needed) and get a documented one-time
+        // promotion on load; new saves end the accumulation.
+        dead_pixels: state.file_dead_pixels.clone(),
         density_maps,
         uncertainty_maps,
         chi_squared_map,
@@ -1040,14 +1050,19 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
     }
     state.energies = snap.energies;
 
-    // 15b. Restore dead-pixel mask (D-20).  The persisted mask is treated
-    // as DECLARED (#646): loading a project declares its saved mask, which
-    // then persists across re-normalizations exactly like an HDF5
-    // file-declared mask, while re-detections are recomputed from scratch
-    // (AppState::set_detected_dead_pixels) instead of unioning into it —
-    // detections never accumulate across the save/load boundary.  If the
-    // linked HDF5 is reloaded, the load site overwrites the declared mask
-    // with the file's own.
+    // 15b. Restore dead-pixel mask (D-20) as DECLARED (#646).  NEW project
+    // files persist exactly the declared component (snapshot_from_state
+    // writes state.file_dead_pixels), so this restore is the identity.
+    // OLD files stored the effective mask (declared ∪ detected at save
+    // time) at the same dataset path; promoting it to declared here is a
+    // documented one-time promotion — the only lossless reading of a file
+    // that never recorded the declared/detected split.  Either way,
+    // detections stay session-scoped: every normalization recomputes the
+    // effective mask from scratch as declared ∪ freshly-detected
+    // (AppState::set_detected_dead_pixels), so save→load→save cycles no
+    // longer grow the persisted mask (#646 review R3, F3).  If the linked
+    // HDF5 is reloaded, the load site overwrites the declared mask with
+    // the file's own.
     state.dead_pixels = snap.dead_pixels;
     state.file_dead_pixels = state.dead_pixels.clone();
 
@@ -1261,4 +1276,58 @@ fn ymd_to_days(y: u64, m: u64, d: u64) -> u64 {
     let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
     let base = era * 146097 + doe;
     base.saturating_sub(719468)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::Array2;
+
+    /// #646 review R3, F3: project SAVE persists the DECLARED mask
+    /// component only, so a save→load→save cycle with an active session
+    /// detection must not grow the persisted mask.  Before the fix the
+    /// snapshot carried the EFFECTIVE mask (declared ∪ detected) and the
+    /// restore-side declared-promotion baked each session's detections
+    /// into the next session's declared component — monotonic growth.
+    #[test]
+    fn test_snapshot_persists_declared_mask_only_no_growth_across_cycles() {
+        let mut declared = Array2::from_elem((3, 3), false);
+        declared[[0, 0]] = true;
+        let mut detected = Array2::from_elem((3, 3), false);
+        detected[[1, 1]] = true;
+
+        let mut state = AppState {
+            file_dead_pixels: Some(declared.clone()),
+            ..AppState::default()
+        };
+        state.set_detected_dead_pixels(Some(detected.clone()));
+        // Effective mask in the session is declared ∪ detected...
+        assert_eq!(
+            state
+                .dead_pixels
+                .as_ref()
+                .unwrap()
+                .iter()
+                .filter(|&&m| m)
+                .count(),
+            2
+        );
+
+        // ...but the snapshot persists the declared component only.
+        let snap = snapshot_from_state(&state);
+        assert_eq!(snap.dead_pixels.as_ref().unwrap(), &declared);
+
+        // Load into a fresh session: the persisted mask restores as the
+        // declared component (and the effective mask starts as exactly it).
+        let mut restored = AppState::default();
+        state_from_snapshot(snap, &mut restored, Path::new("/nonexistent/p.nrd.h5"));
+        assert_eq!(restored.file_dead_pixels.as_ref().unwrap(), &declared);
+        assert_eq!(restored.dead_pixels.as_ref().unwrap(), &declared);
+
+        // The next normalization re-detects; the next save STILL persists
+        // only the declared component — no growth across cycles.
+        restored.set_detected_dead_pixels(Some(detected));
+        let snap2 = snapshot_from_state(&restored);
+        assert_eq!(snap2.dead_pixels.as_ref().unwrap(), &declared);
+    }
 }

--- a/apps/gui/src/state.rs
+++ b/apps/gui/src/state.rs
@@ -703,7 +703,23 @@ pub struct AppState {
     pub sample_data: Option<Arc<Array3<f64>>>,
     pub open_beam_data: Option<Arc<Array3<f64>>>,
     pub normalized: Option<Arc<NormalizedData>>,
+    /// Effective pixel mask applied by the analysis:
+    /// `file_dead_pixels ∪ latest detection`.  Recomputed FROM SCRATCH on
+    /// every normalization via [`AppState::set_detected_dead_pixels`] —
+    /// never unioned with its own previous value, so detections can not
+    /// accumulate across open-beam swaps / re-normalizations (#646).
     pub dead_pixels: Option<Array2<bool>>,
+    /// Declared-mask provenance (#646): the pixel mask carried by an input
+    /// artifact — the HDF5 file's dead-pixel dataset (set where the sample
+    /// is loaded: `guided::load::load_hdf5_data`, `guided::bin`) or a saved
+    /// project's `/intermediate/dead_pixels` (set on project restore).
+    /// Lives exactly as long as the loaded sample: cleared by
+    /// [`AppState::invalidate_results`] and the file-pick handlers.  This
+    /// is the only mask component that persists across re-normalizations;
+    /// detected masks are always recomputed
+    /// ([`AppState::set_detected_dead_pixels`] is the single site that
+    /// combines the two).
+    pub file_dead_pixels: Option<Array2<bool>>,
 
     // -- Spectrum file --
     pub spectrum_path: Option<PathBuf>,
@@ -1317,6 +1333,37 @@ impl AppState {
         self.export_status = None;
     }
 
+    /// Recompute the effective pixel mask FROM SCRATCH (#646):
+    /// `dead_pixels = file/persisted-declared ∪ freshly detected`.
+    ///
+    /// The single site where normalization installs a detected mask — the
+    /// uniform semantics across all paths: detected masks are always
+    /// recomputed, only the declared component (`file_dead_pixels`)
+    /// persists.  Never unions with the previous `dead_pixels`, which may
+    /// hold a detection from an earlier run (e.g. before an open-beam
+    /// swap) — unioning would accumulate stale flags monotonically.
+    ///
+    /// `detected == None` means detection failed or was skipped: the
+    /// effective mask falls back to the declared component alone; a
+    /// previous detection is never kept (it may be stale for the current
+    /// open beam).  A declared mask whose dimensions differ from the
+    /// detected mask cannot apply to the data being normalized (e.g. a
+    /// mask persisted before a rebin) and is ignored.
+    pub fn set_detected_dead_pixels(&mut self, detected: Option<Array2<bool>>) {
+        self.dead_pixels = match (self.file_dead_pixels.clone(), detected) {
+            (Some(mut declared), Some(det)) if declared.dim() == det.dim() => {
+                ndarray::Zip::from(&mut declared)
+                    .and(&det)
+                    .for_each(|m, &d| *m = *m || d);
+                Some(declared)
+            }
+            // Declared mask of a different detector size: detected only.
+            (Some(_), Some(det)) => Some(det),
+            (Some(declared), None) => Some(declared),
+            (None, det) => det,
+        };
+    }
+
     /// Clear pixel selection, ROI, results, normalization, and cancel pending tasks.
     /// Called when the underlying data changes.
     pub fn invalidate_results(&mut self) {
@@ -1333,6 +1380,10 @@ impl AppState {
         self.energies = None;
         self.normalized = None;
         self.dead_pixels = None;
+        // The declared mask belongs to the invalidated data; every caller
+        // of invalidate_results either replaces the sample or triggers a
+        // reload, and the load sites reinstall the file-declared mask.
+        self.file_dead_pixels = None;
         self.spectrum_values = None;
         self.tile_display.clear();
         self.studio_selected_tile = 0;
@@ -1469,6 +1520,7 @@ impl Default for AppState {
             open_beam_data: None,
             normalized: None,
             dead_pixels: None,
+            file_dead_pixels: None,
             load_error: false,
             rebin_factor: 1,
             rebin_applied: false,
@@ -1628,5 +1680,92 @@ impl Default for AppState {
 
             cached_session: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The #646 accumulation pin: re-detection REPLACES the previous
+    /// detection instead of unioning with it — only the file-declared
+    /// component persists across runs (e.g. open-beam swaps).
+    #[test]
+    fn test_set_detected_dead_pixels_no_accumulation_across_runs() {
+        let mut declared = Array2::from_elem((3, 3), false);
+        declared[[0, 0]] = true;
+        let mut state = AppState {
+            file_dead_pixels: Some(declared),
+            ..AppState::default()
+        };
+
+        // First normalization detects (1, 1).
+        let mut det1 = Array2::from_elem((3, 3), false);
+        det1[[1, 1]] = true;
+        state.set_detected_dead_pixels(Some(det1));
+        let mask = state.dead_pixels.as_ref().unwrap();
+        assert!(mask[[0, 0]] && mask[[1, 1]]);
+        assert_eq!(mask.iter().filter(|&&m| m).count(), 2);
+
+        // OB swap: the fresh detection flags (2, 2) instead.  (1, 1) is
+        // stale and must be GONE; (0, 0) is file-declared and persists.
+        let mut det2 = Array2::from_elem((3, 3), false);
+        det2[[2, 2]] = true;
+        state.set_detected_dead_pixels(Some(det2));
+        let mask = state.dead_pixels.as_ref().unwrap();
+        assert!(mask[[0, 0]], "file-declared flag must persist");
+        assert!(!mask[[1, 1]], "stale detection must not accumulate");
+        assert!(mask[[2, 2]], "fresh detection must be present");
+        assert_eq!(mask.iter().filter(|&&m| m).count(), 2);
+    }
+
+    /// Detection failure falls back to the declared component alone —
+    /// a previous detection is never kept.
+    #[test]
+    fn test_set_detected_dead_pixels_failure_keeps_declared_only() {
+        let mut declared = Array2::from_elem((2, 2), false);
+        declared[[0, 1]] = true;
+        let mut state = AppState {
+            file_dead_pixels: Some(declared.clone()),
+            ..AppState::default()
+        };
+
+        let mut det = Array2::from_elem((2, 2), false);
+        det[[1, 0]] = true;
+        state.set_detected_dead_pixels(Some(det));
+        assert_eq!(
+            state
+                .dead_pixels
+                .as_ref()
+                .unwrap()
+                .iter()
+                .filter(|&&m| m)
+                .count(),
+            2
+        );
+
+        state.set_detected_dead_pixels(None);
+        assert_eq!(state.dead_pixels.as_ref().unwrap(), &declared);
+
+        // No declared mask either: the effective mask is absent, not stale.
+        state.file_dead_pixels = None;
+        state.set_detected_dead_pixels(None);
+        assert!(state.dead_pixels.is_none());
+    }
+
+    /// A declared mask of a different detector size cannot apply to the
+    /// data being normalized (e.g. persisted before a rebin) — detected
+    /// mask only.
+    #[test]
+    fn test_set_detected_dead_pixels_dim_mismatch_uses_detected() {
+        let mut state = AppState {
+            file_dead_pixels: Some(Array2::from_elem((4, 4), true)),
+            ..AppState::default()
+        };
+
+        let mut det = Array2::from_elem((2, 2), false);
+        det[[0, 0]] = true;
+        state.set_detected_dead_pixels(Some(det.clone()));
+        assert_eq!(state.dead_pixels.as_ref().unwrap(), &det);
     }
 }

--- a/apps/gui/src/state.rs
+++ b/apps/gui/src/state.rs
@@ -711,7 +711,7 @@ pub struct AppState {
     pub dead_pixels: Option<Array2<bool>>,
     /// Declared-mask provenance (#646): the pixel mask carried by an input
     /// artifact — the HDF5 file's dead-pixel dataset (set where the sample
-    /// is loaded: `guided::load::load_hdf5_data`, `guided::bin`) or a saved
+    /// is loaded: `guided::load::load_hdf5_histogram`, `guided::bin`) or a saved
     /// project's `/intermediate/dead_pixels` (set on project restore).
     /// Lives exactly as long as the loaded sample: cleared by
     /// [`AppState::invalidate_results`] and the file-pick handlers.  This
@@ -1359,10 +1359,17 @@ impl AppState {
     /// `detected == None` means detection failed or was skipped: the
     /// effective mask falls back to the declared component alone; a
     /// previous detection is never kept (it may be stale for the current
-    /// open beam).  A declared mask whose dimensions differ from the
-    /// detected mask cannot apply to the data being normalized (e.g. a
-    /// project's saved mask from a different detector or ROI-cropped
-    /// geometry than the data now loaded) and is ignored.
+    /// open beam).  The dimension-mismatch arm is **defensive**: every
+    /// load site installs the declared mask from the same artifact the
+    /// data comes from, so in the current wiring the two components
+    /// always agree in shape.  It is reachable in principle through
+    /// state drift this method cannot rule out — e.g. a hand-edited or
+    /// corrupt project file whose declared mask was saved from a
+    /// different detector or ROI-cropped geometry than its own detected
+    /// mask / embedded data.  A declared mask that cannot apply to the
+    /// data is dropped for this recomputation (detected-only mask), and
+    /// the drop is logged to the provenance trail (#646 R4, F5) —
+    /// masking decisions stay observable, never silent.
     pub fn set_detected_dead_pixels(&mut self, detected: Option<Array2<bool>>) {
         // Keep the raw detected component (#646 R4, P1-1): project SAVE
         // persists it as /intermediate/detected_dead_pixels so a restore
@@ -1375,8 +1382,21 @@ impl AppState {
                     .for_each(|m, &d| *m = *m || d);
                 Some(declared)
             }
-            // Declared mask of a different detector size: detected only.
-            (Some(_), Some(det)) => Some(det),
+            // Defensive arm (see rustdoc): a declared mask of a different
+            // geometry cannot apply — detected only, drop surfaced.
+            (Some(declared), Some(det)) => {
+                self.log_provenance(
+                    ProvenanceEventKind::ConfigChanged,
+                    format!(
+                        "Declared pixel mask {:?} does not match the data \
+                         geometry {:?}; declared mask ignored for this \
+                         recomputation — detected-only mask applied",
+                        declared.dim(),
+                        det.dim()
+                    ),
+                );
+                Some(det)
+            }
             (Some(declared), None) => Some(declared),
             (None, det) => det,
         };
@@ -1774,19 +1794,35 @@ mod tests {
         assert!(state.dead_pixels.is_none());
     }
 
-    /// A declared mask of a different detector size cannot apply to the
-    /// data being normalized (e.g. a project's saved mask from a
-    /// different detector or ROI-cropped geometry) — detected mask only.
+    /// The DEFENSIVE dimension-mismatch arm (unreachable in the current
+    /// wiring — load sites install the declared mask from the same
+    /// artifact the data comes from; reachable in principle via a
+    /// hand-edited/corrupt project whose declared mask was saved from a
+    /// different detector or ROI-cropped geometry): the inapplicable
+    /// declared mask is dropped for the recomputation (detected-only
+    /// mask) and the drop is SURFACED in the provenance log, never
+    /// silent (#646 R4, F5).
     #[test]
-    fn test_set_detected_dead_pixels_dim_mismatch_uses_detected() {
+    fn test_set_detected_dead_pixels_dim_mismatch_uses_detected_and_logs() {
         let mut state = AppState {
             file_dead_pixels: Some(Array2::from_elem((4, 4), true)),
             ..AppState::default()
         };
+        let provenance_len_before = state.provenance_log.len();
 
         let mut det = Array2::from_elem((2, 2), false);
         det[[0, 0]] = true;
         state.set_detected_dead_pixels(Some(det.clone()));
         assert_eq!(state.dead_pixels.as_ref().unwrap(), &det);
+        // The drop is observable: one provenance entry naming both
+        // geometries.
+        assert_eq!(state.provenance_log.len(), provenance_len_before + 1);
+        let msg = &state.provenance_log.last().unwrap().message;
+        assert!(msg.contains("(4, 4)") && msg.contains("(2, 2)"), "{msg}");
+
+        // The matching-geometry path stays silent — no drop, no entry.
+        state.file_dead_pixels = Some(Array2::from_elem((2, 2), false));
+        state.set_detected_dead_pixels(Some(det));
+        assert_eq!(state.provenance_log.len(), provenance_len_before + 1);
     }
 }

--- a/apps/gui/src/state.rs
+++ b/apps/gui/src/state.rs
@@ -1348,7 +1348,8 @@ impl AppState {
     /// previous detection is never kept (it may be stale for the current
     /// open beam).  A declared mask whose dimensions differ from the
     /// detected mask cannot apply to the data being normalized (e.g. a
-    /// mask persisted before a rebin) and is ignored.
+    /// project's saved mask from a different detector or ROI-cropped
+    /// geometry than the data now loaded) and is ignored.
     pub fn set_detected_dead_pixels(&mut self, detected: Option<Array2<bool>>) {
         self.dead_pixels = match (self.file_dead_pixels.clone(), detected) {
             (Some(mut declared), Some(det)) if declared.dim() == det.dim() => {
@@ -1754,8 +1755,8 @@ mod tests {
     }
 
     /// A declared mask of a different detector size cannot apply to the
-    /// data being normalized (e.g. persisted before a rebin) — detected
-    /// mask only.
+    /// data being normalized (e.g. a project's saved mask from a
+    /// different detector or ROI-cropped geometry) — detected mask only.
     #[test]
     fn test_set_detected_dead_pixels_dim_mismatch_uses_detected() {
         let mut state = AppState {

--- a/apps/gui/src/state.rs
+++ b/apps/gui/src/state.rs
@@ -720,6 +720,19 @@ pub struct AppState {
     /// ([`AppState::set_detected_dead_pixels`] is the single site that
     /// combines the two).
     pub file_dead_pixels: Option<Array2<bool>>,
+    /// Detected-mask component (#646 R4, P1-1): the dead ∪ hot mask from
+    /// the most recent detection run, exactly as
+    /// [`AppState::set_detected_dead_pixels`] received it.  Kept separate
+    /// from the effective mask so project SAVE can persist it as its own
+    /// session-scoped, versioned dataset
+    /// (`/intermediate/detected_dead_pixels`): a restored project may
+    /// carry embedded normalized data WITHOUT raw stacks — detection
+    /// never re-runs there, and without this component a refit would
+    /// silently lose the dead/hot exclusions active at save time.
+    /// Restore rebuilds the effective mask as declared ∪ this component.
+    /// Cleared wherever the mask pair is cleared/replaced (load sites,
+    /// [`AppState::invalidate_results`]).
+    pub detected_dead_pixels: Option<Array2<bool>>,
 
     // -- Spectrum file --
     pub spectrum_path: Option<PathBuf>,
@@ -1351,6 +1364,10 @@ impl AppState {
     /// project's saved mask from a different detector or ROI-cropped
     /// geometry than the data now loaded) and is ignored.
     pub fn set_detected_dead_pixels(&mut self, detected: Option<Array2<bool>>) {
+        // Keep the raw detected component (#646 R4, P1-1): project SAVE
+        // persists it as /intermediate/detected_dead_pixels so a restore
+        // without raw stacks can still rebuild the effective mask.
+        self.detected_dead_pixels = detected.clone();
         self.dead_pixels = match (self.file_dead_pixels.clone(), detected) {
             (Some(mut declared), Some(det)) if declared.dim() == det.dim() => {
                 ndarray::Zip::from(&mut declared)
@@ -1385,6 +1402,8 @@ impl AppState {
         // of invalidate_results either replaces the sample or triggers a
         // reload, and the load sites reinstall the file-declared mask.
         self.file_dead_pixels = None;
+        // The detected component belongs to the invalidated data too.
+        self.detected_dead_pixels = None;
         self.spectrum_values = None;
         self.tile_display.clear();
         self.studio_selected_tile = 0;
@@ -1522,6 +1541,7 @@ impl Default for AppState {
             normalized: None,
             dead_pixels: None,
             file_dead_pixels: None,
+            detected_dead_pixels: None,
             load_error: false,
             rebin_factor: 1,
             rebin_applied: false,

--- a/apps/gui/src/state.rs
+++ b/apps/gui/src/state.rs
@@ -1368,13 +1368,26 @@ impl AppState {
     /// different detector or ROI-cropped geometry than its own detected
     /// mask / embedded data.  A declared mask that cannot apply to the
     /// data is dropped for this recomputation (detected-only mask), and
-    /// the drop is logged to the provenance trail (#646 R4, F5) —
-    /// masking decisions stay observable, never silent.
-    pub fn set_detected_dead_pixels(&mut self, detected: Option<Array2<bool>>) {
+    /// the drop is RETURNED as a notice the caller must surface (#646
+    /// R4 F5; return-value design per review F1) — masking decisions
+    /// stay observable, never silent.
+    ///
+    /// The notice is returned rather than logged here because one
+    /// caller — project restore (`project::state_from_snapshot`, step
+    /// 15b) — runs BEFORE the snapshot's provenance history replaces
+    /// the session log wholesale (step 17), which would erase an entry
+    /// appended by this method; a `#[must_use]` return value cannot be
+    /// silently erased, and forces every caller to route the drop into
+    /// its own provenance/status surface (immediately at the
+    /// normalization sites, deferred past the log replacement on
+    /// restore).
+    #[must_use = "declared-mask-drop notice: surface it (provenance/status), never drop it (#646 F1)"]
+    pub fn set_detected_dead_pixels(&mut self, detected: Option<Array2<bool>>) -> Option<String> {
         // Keep the raw detected component (#646 R4, P1-1): project SAVE
         // persists it as /intermediate/detected_dead_pixels so a restore
         // without raw stacks can still rebuild the effective mask.
         self.detected_dead_pixels = detected.clone();
+        let mut notice = None;
         self.dead_pixels = match (self.file_dead_pixels.clone(), detected) {
             (Some(mut declared), Some(det)) if declared.dim() == det.dim() => {
                 ndarray::Zip::from(&mut declared)
@@ -1383,23 +1396,22 @@ impl AppState {
                 Some(declared)
             }
             // Defensive arm (see rustdoc): a declared mask of a different
-            // geometry cannot apply — detected only, drop surfaced.
+            // geometry cannot apply — detected only, drop surfaced via
+            // the returned notice.
             (Some(declared), Some(det)) => {
-                self.log_provenance(
-                    ProvenanceEventKind::ConfigChanged,
-                    format!(
-                        "Declared pixel mask {:?} does not match the data \
-                         geometry {:?}; declared mask ignored for this \
-                         recomputation — detected-only mask applied",
-                        declared.dim(),
-                        det.dim()
-                    ),
-                );
+                notice = Some(format!(
+                    "Declared pixel mask {:?} does not match the data \
+                     geometry {:?}; declared mask ignored for this \
+                     recomputation — detected-only mask applied",
+                    declared.dim(),
+                    det.dim()
+                ));
                 Some(det)
             }
             (Some(declared), None) => Some(declared),
             (None, det) => det,
         };
+        notice
     }
 
     /// Clear pixel selection, ROI, results, normalization, and cancel pending tasks.
@@ -1743,7 +1755,7 @@ mod tests {
         // First normalization detects (1, 1).
         let mut det1 = Array2::from_elem((3, 3), false);
         det1[[1, 1]] = true;
-        state.set_detected_dead_pixels(Some(det1));
+        assert!(state.set_detected_dead_pixels(Some(det1)).is_none());
         let mask = state.dead_pixels.as_ref().unwrap();
         assert!(mask[[0, 0]] && mask[[1, 1]]);
         assert_eq!(mask.iter().filter(|&&m| m).count(), 2);
@@ -1752,7 +1764,7 @@ mod tests {
         // stale and must be GONE; (0, 0) is file-declared and persists.
         let mut det2 = Array2::from_elem((3, 3), false);
         det2[[2, 2]] = true;
-        state.set_detected_dead_pixels(Some(det2));
+        assert!(state.set_detected_dead_pixels(Some(det2)).is_none());
         let mask = state.dead_pixels.as_ref().unwrap();
         assert!(mask[[0, 0]], "file-declared flag must persist");
         assert!(!mask[[1, 1]], "stale detection must not accumulate");
@@ -1773,7 +1785,7 @@ mod tests {
 
         let mut det = Array2::from_elem((2, 2), false);
         det[[1, 0]] = true;
-        state.set_detected_dead_pixels(Some(det));
+        assert!(state.set_detected_dead_pixels(Some(det)).is_none());
         assert_eq!(
             state
                 .dead_pixels
@@ -1785,25 +1797,29 @@ mod tests {
             2
         );
 
-        state.set_detected_dead_pixels(None);
+        assert!(state.set_detected_dead_pixels(None).is_none());
         assert_eq!(state.dead_pixels.as_ref().unwrap(), &declared);
 
         // No declared mask either: the effective mask is absent, not stale.
         state.file_dead_pixels = None;
-        state.set_detected_dead_pixels(None);
+        assert!(state.set_detected_dead_pixels(None).is_none());
         assert!(state.dead_pixels.is_none());
     }
 
-    /// The DEFENSIVE dimension-mismatch arm (unreachable in the current
-    /// wiring — load sites install the declared mask from the same
-    /// artifact the data comes from; reachable in principle via a
+    /// The DEFENSIVE dimension-mismatch arm (reachable via a
     /// hand-edited/corrupt project whose declared mask was saved from a
     /// different detector or ROI-cropped geometry): the inapplicable
     /// declared mask is dropped for the recomputation (detected-only
-    /// mask) and the drop is SURFACED in the provenance log, never
-    /// silent (#646 R4, F5).
+    /// mask) and the drop is RETURNED as a must-surface notice, never
+    /// silent (#646 R4 F5; return-value design F1).  The setter itself
+    /// no longer logs to provenance — project restore replaces the
+    /// provenance log wholesale AFTER calling it (step 17), which would
+    /// erase such an entry; see
+    /// `test_restore_mismatched_mask_pair_drop_notice_survives_provenance_replacement`
+    /// (project.rs) for the end-to-end restore-path property this
+    /// direct-call test cannot see.
     #[test]
-    fn test_set_detected_dead_pixels_dim_mismatch_uses_detected_and_logs() {
+    fn test_set_detected_dead_pixels_dim_mismatch_uses_detected_and_returns_notice() {
         let mut state = AppState {
             file_dead_pixels: Some(Array2::from_elem((4, 4), true)),
             ..AppState::default()
@@ -1812,17 +1828,19 @@ mod tests {
 
         let mut det = Array2::from_elem((2, 2), false);
         det[[0, 0]] = true;
-        state.set_detected_dead_pixels(Some(det.clone()));
+        let notice = state.set_detected_dead_pixels(Some(det.clone()));
         assert_eq!(state.dead_pixels.as_ref().unwrap(), &det);
-        // The drop is observable: one provenance entry naming both
-        // geometries.
-        assert_eq!(state.provenance_log.len(), provenance_len_before + 1);
-        let msg = &state.provenance_log.last().unwrap().message;
+        // The drop is observable: the returned notice names both
+        // geometries...
+        let msg = notice.expect("dim mismatch must return a drop notice");
         assert!(msg.contains("(4, 4)") && msg.contains("(2, 2)"), "{msg}");
+        // ...and surfacing is the CALLER's job — the setter appends
+        // nothing itself (a caller-side log would be erased by restore's
+        // provenance replacement; the return value cannot be).
+        assert_eq!(state.provenance_log.len(), provenance_len_before);
 
-        // The matching-geometry path stays silent — no drop, no entry.
+        // The matching-geometry path returns no notice — no drop.
         state.file_dead_pixels = Some(Array2::from_elem((2, 2), false));
-        state.set_detected_dead_pixels(Some(det));
-        assert_eq!(state.provenance_log.len(), provenance_len_before + 1);
+        assert!(state.set_detected_dead_pixels(Some(det)).is_none());
     }
 }

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -930,7 +930,16 @@ def detect_hot_pixels(
     ``height * width`` passes; in practice ~the defect-cluster radius),
     eroding railed CLUSTERS from the boundary inward — a single pass would
     miss the interior of clusters >= 2 px wide, whose neighbors are railed
-    too.  Clusters up to 3 px wide are fully consumed.  The local
+    too.  Clusters up to 3 px wide are fully consumed PROVIDED they expose
+    at least one end cap or convex corner to normal-scene neighbors
+    (erosion must seed somewhere): an EDGE-TO-EDGE railed band >= 2 px
+    wide, spanning the full detector width or height with both ends
+    off-detector, has no seed and is NOT caught — deliberately, because a
+    slit-aperture open beam produces a genuine full-width bright scene
+    band pixel-for-pixel indistinguishable from it, and a full-span screen
+    would mask that scene (the bimodal failure).  Declare such full-span
+    detector pathologies in a file mask.  A full-span width-1 railed line
+    IS caught (each pixel keeps >= 4 normal neighbors).  The local
     confirmation keeps bimodal scenes honest: with a dark majority (a
     sample covering >50% of the field of view, or an aperture-limited open
     beam), the global statistics describe only the dark population and the

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -920,16 +920,35 @@ def detect_hot_pixels(
     pixel is a candidate when ``ln(total) > median + k_mad * sigma``, with
     median and MAD taken over the live (``total > 0``) pixels only and
     ``sigma`` floored by the Poisson counting noise of the median total.
-    Stage 2 (local): a candidate is flagged only if its total also exceeds
-    10x the median total of its live 8-neighbors (edge pixels use whatever
-    neighbors exist; a candidate with no live neighbor keeps the global
-    verdict).  The local confirmation keeps bimodal scenes honest: with a
-    dark majority (a sample covering >50% of the field of view, or an
-    aperture-limited open beam), the global statistics describe only the
-    dark population and the entire bright region would otherwise be masked
-    — a contiguous bright region is scene, not a defect.  Upper tail only —
-    stuck-low pixels are indistinguishable from low-count-alive pixels and
-    are kept (masks are pipeline-integrity only, never a low-count screen).
+    Stage 2 (local), iterated to a fixpoint: a candidate is flagged only if
+    its total also exceeds 10x the median of its 8-neighborhood reference
+    sample — live unflagged neighbors contribute their totals,
+    already-flagged neighbors contribute 0 (a known defect cannot vouch for
+    its neighbors), dead neighbors are omitted; edge pixels use whatever
+    neighbors exist, and a candidate with no live neighbor keeps the global
+    verdict.  Passes repeat until no new flag is added (bounded by
+    ``height * width`` passes; in practice ~the defect-cluster radius),
+    eroding railed CLUSTERS from the boundary inward — a single pass would
+    miss the interior of clusters >= 2 px wide, whose neighbors are railed
+    too.  Clusters up to 3 px wide are fully consumed.  The local
+    confirmation keeps bimodal scenes honest: with a dark majority (a
+    sample covering >50% of the field of view, or an aperture-limited open
+    beam), the global statistics describe only the dark population and the
+    entire bright region would otherwise be masked — a contiguous bright
+    region is scene, not a defect.  Upper tail only — stuck-low pixels are
+    indistinguishable from low-count-alive pixels and are kept (masks are
+    pipeline-integrity only, never a low-count screen).
+
+    Bright SCENE regions never erode: a boundary pixel of a contiguous
+    bright region >= 2 px wide keeps >= 4 same-side neighbors for any
+    straight or diagonal edge, so its reference median stays bright and
+    scene gradients (<= 2-3x across real edges) never reach the 10x factor
+    — the erosion has no seed.  Documented width-1 limitation (accepted
+    trade-off): a 1-px-wide bright scene line at >= 10x local contrast is
+    spatially indistinguishable from a railed line and IS masked; real
+    scene features on VENUS are PSF-blurred over >= 2 px, so >= 10x
+    single-pixel scene contrast is physically rare, and contiguous bright
+    regions of width >= 2 are safe from the local stage.
 
     ``data`` must be RAW detected counts (unscaled): the Poisson floor
     assumes ``Var[N] = N``.  Scaled inputs silently distort the floor —

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -889,6 +889,13 @@ def detect_dead_pixels(
 ) -> NDArray[np.bool_]:
     """Detect dead pixels (all-zero across the spectral axis).
 
+    Pixel masks are a pipeline-integrity screen only — they exclude pixels
+    whose data stream is broken (dead, hot/railed), never low-count or
+    poorly covered pixels.  Low-count pixels are alive and must be kept.
+    Prefer ``detect_bad_pixels()`` (validating, unions sample and open-beam,
+    optional hot screen); see also ``detect_hot_pixels()`` and
+    ``detect_dead_pixels_chunked()``.
+
     Parameters
     ----------
     data :
@@ -900,6 +907,114 @@ def detect_dead_pixels(
     NDArray[np.bool_]
         2D boolean mask with shape ``(height, width)``, where ``True`` marks
         a dead pixel (all-zero across the spectral axis).
+    """
+    ...
+
+def detect_hot_pixels(
+    data: NDArray[np.float64],
+    k_mad: float = 6.0,
+) -> NDArray[np.bool_]:
+    """Detect hot (railed / runaway) pixels.
+
+    Robust one-sided screen on per-pixel total counts: a pixel is flagged
+    when ``ln(total) > median + k_mad * sigma``, with median and MAD taken
+    over the live (``total > 0``) pixels only and ``sigma`` floored by the
+    Poisson counting noise of the median total.  Upper tail only —
+    stuck-low pixels are indistinguishable from low-count-alive pixels and
+    are kept (masks are pipeline-integrity only, never a low-count screen).
+
+    Parameters
+    ----------
+    data :
+        3D NumPy array with shape ``(n_frames, height, width)``.
+    k_mad :
+        Robust-sigma multiplier for the upper-tail cut. The default 6.0
+        corresponds to a one-sided Gaussian tail of ~1e-9 — it essentially
+        never flags a statistically plausible pixel.
+
+    Returns
+    -------
+    NDArray[np.bool_]
+        2D boolean mask with shape ``(height, width)``, where ``True`` marks
+        a hot pixel.
+
+    Raises
+    ------
+    ValueError
+        If ``data`` contains non-finite or negative values, or ``k_mad`` is
+        not finite and positive.
+    """
+    ...
+
+def detect_dead_pixels_chunked(
+    chunks: list[NDArray[np.float64]],
+) -> NDArray[np.bool_]:
+    """Detect dead pixels across acquisition chunks (dead in ANY chunk).
+
+    Catches intermittent deadness invisible to ``detect_dead_pixels()`` on
+    the summed stack: a pixel dead for one acquisition chunk but alive in
+    another has nonzero summed counts, yet its dead-chunk data corrupts the
+    combined spectrum.  Chunk the acquisition so each live pixel has an
+    expected >= 20 total counts per chunk (misflag probability per live
+    pixel is ``m * exp(-lambda)`` over ``m`` chunks).
+
+    Parameters
+    ----------
+    chunks :
+        List of 3D NumPy arrays, one per acquisition chunk, each with shape
+        ``(n_frames_i, height, width)``.  Frame counts may differ between
+        chunks (ragged event re-histogramming is fine); spatial dimensions
+        must agree.
+
+    Returns
+    -------
+    NDArray[np.bool_]
+        2D boolean mask with shape ``(height, width)``, where ``True`` marks
+        a pixel that is all-zero in at least one chunk.
+
+    Raises
+    ------
+    ValueError
+        If ``chunks`` is empty, any chunk contains non-finite or negative
+        values, or the spatial dimensions differ between chunks.
+    """
+    ...
+
+def detect_bad_pixels(
+    sample: NDArray[np.float64],
+    open_beam: NDArray[np.float64] | None = None,
+    hot_k_mad: float | None = 6.0,
+) -> NDArray[np.bool_]:
+    """Detect all pipeline-corrupting pixels: dead + hot, sample and OB.
+
+    The validating entry point.  Deadness/hotness is per-acquisition — a
+    pixel dead only in the open-beam run still corrupts every transmission
+    ratio computed from it — so the masks of both stacks are unioned:
+    ``dead(sample) | hot(sample) [| dead(open_beam) | hot(open_beam)]``.
+    Frame counts may differ between the stacks; spatial dimensions must
+    agree.  The result can be passed to ``spatial_map_typed(dead_pixels=...)``.
+
+    Parameters
+    ----------
+    sample :
+        3D NumPy array with shape ``(n_frames, height, width)``.
+    open_beam :
+        Optional 3D NumPy array with shape ``(n_frames2, height, width)``.
+    hot_k_mad :
+        Robust-sigma multiplier for the hot-pixel screen (default 6.0), or
+        ``None`` to disable it (dead-only detection).
+
+    Returns
+    -------
+    NDArray[np.bool_]
+        2D boolean mask with shape ``(height, width)``, where ``True`` marks
+        a pixel to exclude from fitting.
+
+    Raises
+    ------
+    ValueError
+        If either stack contains non-finite or negative values, the spatial
+        dimensions differ, or ``hot_k_mad`` is not finite and positive.
     """
     ...
 

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -914,23 +914,39 @@ def detect_hot_pixels(
     data: NDArray[np.float64],
     k_mad: float = 6.0,
 ) -> NDArray[np.bool_]:
-    """Detect hot (railed / runaway) pixels.
+    """Detect hot (railed / runaway) pixels — two-stage screen.
 
-    Robust one-sided screen on per-pixel total counts: a pixel is flagged
-    when ``ln(total) > median + k_mad * sigma``, with median and MAD taken
-    over the live (``total > 0``) pixels only and ``sigma`` floored by the
-    Poisson counting noise of the median total.  Upper tail only —
+    Stage 1 (global): robust one-sided cut on per-pixel total counts — a
+    pixel is a candidate when ``ln(total) > median + k_mad * sigma``, with
+    median and MAD taken over the live (``total > 0``) pixels only and
+    ``sigma`` floored by the Poisson counting noise of the median total.
+    Stage 2 (local): a candidate is flagged only if its total also exceeds
+    10x the median total of its live 8-neighbors (edge pixels use whatever
+    neighbors exist; a candidate with no live neighbor keeps the global
+    verdict).  The local confirmation keeps bimodal scenes honest: with a
+    dark majority (a sample covering >50% of the field of view, or an
+    aperture-limited open beam), the global statistics describe only the
+    dark population and the entire bright region would otherwise be masked
+    — a contiguous bright region is scene, not a defect.  Upper tail only —
     stuck-low pixels are indistinguishable from low-count-alive pixels and
     are kept (masks are pipeline-integrity only, never a low-count screen).
+
+    ``data`` must be RAW detected counts (unscaled): the Poisson floor
+    assumes ``Var[N] = N``.  Scaled inputs silently distort the floor —
+    down-scaling (proton-charge-normalized rates << 1, gain division)
+    inflates it and can suppress real flags; up-scaling (event weights > 1)
+    deflates it below true counting noise.  Detect on raw counts and
+    normalize afterwards.
 
     Parameters
     ----------
     data :
-        3D NumPy array with shape ``(n_frames, height, width)``.
+        3D NumPy array of raw counts with shape ``(n_frames, height, width)``.
     k_mad :
-        Robust-sigma multiplier for the upper-tail cut. The default 6.0
-        corresponds to a one-sided Gaussian tail of ~1e-9 — it essentially
-        never flags a statistically plausible pixel.
+        Robust-sigma multiplier for the stage-1 upper-tail cut. The default
+        6.0 corresponds to a one-sided Gaussian tail of ~1e-9 — on a
+        unimodal image it essentially never flags a statistically plausible
+        pixel.
 
     Returns
     -------
@@ -941,8 +957,8 @@ def detect_hot_pixels(
     Raises
     ------
     ValueError
-        If ``data`` contains non-finite or negative values, or ``k_mad`` is
-        not finite and positive.
+        If ``data`` contains non-finite or negative values or has zero
+        frames (``shape[0] == 0``), or ``k_mad`` is not finite and positive.
     """
     ...
 
@@ -975,8 +991,10 @@ def detect_dead_pixels_chunked(
     Raises
     ------
     ValueError
-        If ``chunks`` is empty, any chunk contains non-finite or negative
-        values, or the spatial dimensions differ between chunks.
+        If ``chunks`` is empty, any chunk has zero frames
+        (``shape[0] == 0`` — its all-zero test would vacuously mark every
+        pixel dead), any chunk contains non-finite or negative values, or
+        the spatial dimensions differ between chunks.
     """
     ...
 
@@ -994,12 +1012,17 @@ def detect_bad_pixels(
     Frame counts may differ between the stacks; spatial dimensions must
     agree.  The result can be passed to ``spatial_map_typed(dead_pixels=...)``.
 
+    Both stacks must be RAW detected counts (unscaled) — see
+    ``detect_hot_pixels()``: scaling distorts the Poisson floor of the hot
+    screen.  Detect on raw counts, before any normalization.
+
     Parameters
     ----------
     sample :
-        3D NumPy array with shape ``(n_frames, height, width)``.
+        3D NumPy array of raw counts with shape ``(n_frames, height, width)``.
     open_beam :
-        Optional 3D NumPy array with shape ``(n_frames2, height, width)``.
+        Optional 3D NumPy array of raw counts with shape
+        ``(n_frames2, height, width)``.
     hot_k_mad :
         Robust-sigma multiplier for the hot-pixel screen (default 6.0), or
         ``None`` to disable it (dead-only detection).
@@ -1013,8 +1036,9 @@ def detect_bad_pixels(
     Raises
     ------
     ValueError
-        If either stack contains non-finite or negative values, the spatial
-        dimensions differ, or ``hot_k_mad`` is not finite and positive.
+        If either stack contains non-finite or negative values or has zero
+        frames (``shape[0] == 0``), the spatial dimensions differ, or
+        ``hot_k_mad`` is not finite and positive.
     """
     ...
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -2645,7 +2645,17 @@ fn detect_dead_pixels<'py>(
 /// defect-cluster radius), eroding railed CLUSTERS from the boundary
 /// inward — a single pass would miss the interior of clusters >= 2 px
 /// wide, whose neighbors are railed too.  Clusters up to 3 px wide are
-/// fully consumed.  The local confirmation keeps bimodal scenes honest:
+/// fully consumed PROVIDED they expose at least one end cap or convex
+/// corner to normal-scene neighbors (erosion must seed somewhere): an
+/// EDGE-TO-EDGE railed band >= 2 px wide, spanning the full detector
+/// width or height with both ends off-detector, has no seed and is NOT
+/// caught — deliberately, because a slit-aperture open beam produces a
+/// genuine full-width bright scene band pixel-for-pixel
+/// indistinguishable from it, and a full-span screen would mask that
+/// scene (the bimodal failure).  Declare such full-span detector
+/// pathologies in a file mask.  A full-span width-1 railed line IS
+/// caught (each pixel keeps >= 4 normal neighbors).  The local
+/// confirmation keeps bimodal scenes honest:
 /// with a dark majority holding the median, the global statistics describe
 /// only the dark population and the entire bright region would otherwise
 /// be masked — a contiguous bright region is scene, not a defect.  Upper

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -2628,29 +2628,44 @@ fn detect_dead_pixels<'py>(
     Ok(PyArray2::from_owned_array(py, mask))
 }
 
-/// Detect hot (railed / runaway) pixels.
+/// Detect hot (railed / runaway) pixels — two-stage screen.
 ///
-/// Robust one-sided screen on per-pixel total counts: a pixel is flagged
-/// when ``ln(total) > median + k_mad * sigma``, where median and MAD are
-/// computed over the live (``total > 0``) pixels only and ``sigma`` is the
-/// MAD-based robust scale floored by the Poisson counting noise of the
-/// median total.  Upper tail only — stuck-low pixels are indistinguishable
-/// from low-count-alive pixels and are kept (masks are pipeline-integrity
-/// only, never a low-count screen).
+/// Stage 1 (global): robust one-sided cut on per-pixel total counts — a
+/// pixel is a candidate when ``ln(total) > median + k_mad * sigma``, where
+/// median and MAD are computed over the live (``total > 0``) pixels only
+/// and ``sigma`` is the MAD-based robust scale floored by the Poisson
+/// counting noise of the median total.  Stage 2 (local): a candidate is
+/// flagged only if its total also exceeds 10x the median total of its live
+/// 8-neighbors (edge pixels use whatever neighbors exist; a candidate with
+/// no live neighbor keeps the global verdict).  The local confirmation
+/// keeps bimodal scenes honest: with a dark majority holding the median,
+/// the global statistics describe only the dark population and the entire
+/// bright region would otherwise be masked — a contiguous bright region is
+/// scene, not a defect.  Upper tail only — stuck-low pixels are
+/// indistinguishable from low-count-alive pixels and are kept (masks are
+/// pipeline-integrity only, never a low-count screen).
+///
+/// ``data`` must be RAW detected counts (unscaled): the Poisson floor
+/// assumes ``Var[N] = N``, so scaled inputs silently distort it —
+/// down-scaling (proton-charge-normalized rates << 1, gain division)
+/// inflates the floor and can suppress real flags; up-scaling (event
+/// weights > 1) deflates it.  Detect on raw counts, normalize afterwards.
 ///
 /// Args:
-///     data: 3D numpy array with shape ``(n_frames, height, width)``.
-///     k_mad: Robust-sigma multiplier for the upper-tail cut (default 6.0:
-///         one-sided Gaussian tail ~1e-9, essentially never flags a
-///         statistically plausible pixel).
+///     data: 3D numpy array of raw counts with shape
+///         ``(n_frames, height, width)``.
+///     k_mad: Robust-sigma multiplier for the stage-1 upper-tail cut
+///         (default 6.0: one-sided Gaussian tail ~1e-9, on a unimodal
+///         image essentially never flags a statistically plausible pixel).
 ///
 /// Returns:
 ///     2D boolean numpy array with shape ``(height, width)``.
 ///     ``True`` marks a hot pixel.
 ///
 /// Raises:
-///     ValueError: If ``data`` contains non-finite or negative values, or
-///         ``k_mad`` is not finite and positive.
+///     ValueError: If ``data`` contains non-finite or negative values or
+///         has zero frames (``shape[0] == 0``), or ``k_mad`` is not finite
+///         and positive.
 #[pyfunction]
 #[pyo3(signature = (data, k_mad = norm::HOT_PIXEL_K_MAD))]
 fn detect_hot_pixels<'py>(
@@ -2685,8 +2700,10 @@ fn detect_hot_pixels<'py>(
 ///     ``True`` marks a pixel that is all-zero in at least one chunk.
 ///
 /// Raises:
-///     ValueError: If ``chunks`` is empty, any chunk contains non-finite
-///         or negative values, or the spatial dimensions differ.
+///     ValueError: If ``chunks`` is empty, any chunk has zero frames
+///         (``shape[0] == 0`` — its all-zero test would vacuously mark
+///         every pixel dead), any chunk contains non-finite or negative
+///         values, or the spatial dimensions differ.
 #[pyfunction]
 fn detect_dead_pixels_chunked<'py>(
     py: Python<'py>,
@@ -2708,9 +2725,14 @@ fn detect_dead_pixels_chunked<'py>(
 /// are unioned: ``dead(sample) | hot(sample) [| dead(ob) | hot(ob)]``.
 /// The stacks' frame counts may differ; spatial dimensions must agree.
 ///
+/// Both stacks must be RAW detected counts (unscaled) — see
+/// ``detect_hot_pixels()``: scaling distorts the Poisson floor of the hot
+/// screen.  Detect on raw counts, before any normalization.
+///
 /// Args:
-///     sample: 3D numpy array with shape ``(n_frames, height, width)``.
-///     open_beam: Optional 3D numpy array with shape
+///     sample: 3D numpy array of raw counts with shape
+///         ``(n_frames, height, width)``.
+///     open_beam: Optional 3D numpy array of raw counts with shape
 ///         ``(n_frames2, height, width)``.
 ///     hot_k_mad: Robust-sigma multiplier for the hot-pixel screen
 ///         (default 6.0), or ``None`` to disable it (dead-only detection).
@@ -2720,9 +2742,9 @@ fn detect_dead_pixels_chunked<'py>(
 ///     ``True`` marks a pixel to exclude.
 ///
 /// Raises:
-///     ValueError: If either stack contains non-finite or negative values,
-///         the spatial dimensions differ, or ``hot_k_mad`` is not finite
-///         and positive.
+///     ValueError: If either stack contains non-finite or negative values
+///         or has zero frames (``shape[0] == 0``), the spatial dimensions
+///         differ, or ``hot_k_mad`` is not finite and positive.
 #[pyfunction]
 #[pyo3(signature = (sample, open_beam = None, hot_k_mad = Some(norm::HOT_PIXEL_K_MAD)))]
 fn detect_bad_pixels<'py>(

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -2634,16 +2634,35 @@ fn detect_dead_pixels<'py>(
 /// pixel is a candidate when ``ln(total) > median + k_mad * sigma``, where
 /// median and MAD are computed over the live (``total > 0``) pixels only
 /// and ``sigma`` is the MAD-based robust scale floored by the Poisson
-/// counting noise of the median total.  Stage 2 (local): a candidate is
-/// flagged only if its total also exceeds 10x the median total of its live
-/// 8-neighbors (edge pixels use whatever neighbors exist; a candidate with
-/// no live neighbor keeps the global verdict).  The local confirmation
-/// keeps bimodal scenes honest: with a dark majority holding the median,
-/// the global statistics describe only the dark population and the entire
-/// bright region would otherwise be masked — a contiguous bright region is
-/// scene, not a defect.  Upper tail only — stuck-low pixels are
-/// indistinguishable from low-count-alive pixels and are kept (masks are
-/// pipeline-integrity only, never a low-count screen).
+/// counting noise of the median total.  Stage 2 (local), iterated to a
+/// fixpoint: a candidate is flagged only if its total also exceeds 10x the
+/// median of its 8-neighborhood reference sample — live unflagged
+/// neighbors contribute their totals, already-flagged neighbors contribute
+/// 0 (a known defect cannot vouch for its neighbors), dead neighbors are
+/// omitted; edge pixels use whatever neighbors exist, and a candidate with
+/// no live neighbor keeps the global verdict.  Passes repeat until no new
+/// flag is added (bounded by ``height * width`` passes; in practice ~the
+/// defect-cluster radius), eroding railed CLUSTERS from the boundary
+/// inward — a single pass would miss the interior of clusters >= 2 px
+/// wide, whose neighbors are railed too.  Clusters up to 3 px wide are
+/// fully consumed.  The local confirmation keeps bimodal scenes honest:
+/// with a dark majority holding the median, the global statistics describe
+/// only the dark population and the entire bright region would otherwise
+/// be masked — a contiguous bright region is scene, not a defect.  Upper
+/// tail only — stuck-low pixels are indistinguishable from low-count-alive
+/// pixels and are kept (masks are pipeline-integrity only, never a
+/// low-count screen).
+///
+/// Bright SCENE regions never erode: a boundary pixel of a contiguous
+/// bright region >= 2 px wide keeps >= 4 same-side neighbors for any
+/// straight or diagonal edge, so its reference median stays bright and
+/// scene gradients (<= 2-3x across real edges) never reach the 10x factor
+/// — the erosion has no seed.  Documented width-1 limitation (accepted
+/// trade-off): a 1-px-wide bright scene line at >= 10x local contrast is
+/// spatially indistinguishable from a railed line and IS masked; real
+/// scene features on VENUS are PSF-blurred over >= 2 px, so >= 10x
+/// single-pixel scene contrast is physically rare, and contiguous bright
+/// regions of width >= 2 are safe from the local stage.
 ///
 /// ``data`` must be RAW detected counts (unscaled): the Poisson floor
 /// assumes ``Var[N] = N``, so scaled inputs silently distort it —

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -2601,7 +2601,15 @@ fn precompute_cross_sections<'py>(
 ///
 /// A pixel is marked as "dead" when all its counts across the spectral/TOF
 /// axis are exactly zero.  The returned mask can be passed directly to
-/// ``spatial_map(dead_pixels=...)``.
+/// ``spatial_map_typed(dead_pixels=...)``.
+///
+/// Pixel masks are a **pipeline-integrity screen only** — they exclude
+/// pixels whose data stream is broken (dead, hot/railed), never low-count
+/// or poorly covered pixels.  Low-count pixels are alive and must be kept.
+/// Prefer ``detect_bad_pixels()`` (validating, unions sample and open-beam,
+/// optional hot screen); see also ``detect_hot_pixels()`` and
+/// ``detect_dead_pixels_chunked()`` for intermittent deadness across
+/// acquisition chunks.
 ///
 /// Args:
 ///     data: 3D numpy array with shape ``(n_frames, height, width)``.
@@ -2617,6 +2625,116 @@ fn detect_dead_pixels<'py>(
 ) -> PyResult<Bound<'py, PyArray2<bool>>> {
     let arr = data.as_array().to_owned();
     let mask = py.detach(move || norm::detect_dead_pixels(&arr));
+    Ok(PyArray2::from_owned_array(py, mask))
+}
+
+/// Detect hot (railed / runaway) pixels.
+///
+/// Robust one-sided screen on per-pixel total counts: a pixel is flagged
+/// when ``ln(total) > median + k_mad * sigma``, where median and MAD are
+/// computed over the live (``total > 0``) pixels only and ``sigma`` is the
+/// MAD-based robust scale floored by the Poisson counting noise of the
+/// median total.  Upper tail only — stuck-low pixels are indistinguishable
+/// from low-count-alive pixels and are kept (masks are pipeline-integrity
+/// only, never a low-count screen).
+///
+/// Args:
+///     data: 3D numpy array with shape ``(n_frames, height, width)``.
+///     k_mad: Robust-sigma multiplier for the upper-tail cut (default 6.0:
+///         one-sided Gaussian tail ~1e-9, essentially never flags a
+///         statistically plausible pixel).
+///
+/// Returns:
+///     2D boolean numpy array with shape ``(height, width)``.
+///     ``True`` marks a hot pixel.
+///
+/// Raises:
+///     ValueError: If ``data`` contains non-finite or negative values, or
+///         ``k_mad`` is not finite and positive.
+#[pyfunction]
+#[pyo3(signature = (data, k_mad = norm::HOT_PIXEL_K_MAD))]
+fn detect_hot_pixels<'py>(
+    py: Python<'py>,
+    data: PyReadonlyArray3<f64>,
+    k_mad: f64,
+) -> PyResult<Bound<'py, PyArray2<bool>>> {
+    let arr = data.as_array().to_owned();
+    let mask = py.detach(move || norm::detect_hot_pixels(&arr, k_mad));
+    let mask = mask.map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("{}", e)))?;
+    Ok(PyArray2::from_owned_array(py, mask))
+}
+
+/// Detect dead pixels across acquisition chunks (dead in ANY chunk).
+///
+/// Catches intermittent deadness that ``detect_dead_pixels()`` on the
+/// summed stack cannot see: a pixel dead for one acquisition chunk but
+/// alive in another has nonzero summed counts, yet its dead-chunk data
+/// corrupts the combined spectrum.  Chunk the acquisition so each live
+/// pixel has an expected >= 20 total counts per chunk (misflag probability
+/// per live pixel is ``m * exp(-lambda)`` over ``m`` chunks).
+///
+/// Chunks may have different numbers of frames (ragged event
+/// re-histogramming is fine); spatial dimensions must agree.
+///
+/// Args:
+///     chunks: List of 3D numpy arrays, one per acquisition chunk, each
+///         with shape ``(n_frames_i, height, width)``.
+///
+/// Returns:
+///     2D boolean numpy array with shape ``(height, width)``.
+///     ``True`` marks a pixel that is all-zero in at least one chunk.
+///
+/// Raises:
+///     ValueError: If ``chunks`` is empty, any chunk contains non-finite
+///         or negative values, or the spatial dimensions differ.
+#[pyfunction]
+fn detect_dead_pixels_chunked<'py>(
+    py: Python<'py>,
+    chunks: Vec<PyReadonlyArray3<f64>>,
+) -> PyResult<Bound<'py, PyArray2<bool>>> {
+    // Copy to owned arrays before releasing the GIL.
+    let owned: Vec<_> = chunks.iter().map(|c| c.as_array().to_owned()).collect();
+    let mask = py.detach(move || norm::detect_dead_pixels_chunked(&owned));
+    let mask = mask.map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("{}", e)))?;
+    Ok(PyArray2::from_owned_array(py, mask))
+}
+
+/// Detect all pipeline-corrupting pixels: dead + hot over sample and
+/// (optionally) open beam.
+///
+/// This is the validating entry point.  Deadness/hotness is
+/// per-acquisition — a pixel dead only in the open-beam run still corrupts
+/// every transmission ratio computed from it — so the masks of both stacks
+/// are unioned: ``dead(sample) | hot(sample) [| dead(ob) | hot(ob)]``.
+/// The stacks' frame counts may differ; spatial dimensions must agree.
+///
+/// Args:
+///     sample: 3D numpy array with shape ``(n_frames, height, width)``.
+///     open_beam: Optional 3D numpy array with shape
+///         ``(n_frames2, height, width)``.
+///     hot_k_mad: Robust-sigma multiplier for the hot-pixel screen
+///         (default 6.0), or ``None`` to disable it (dead-only detection).
+///
+/// Returns:
+///     2D boolean numpy array with shape ``(height, width)``.
+///     ``True`` marks a pixel to exclude.
+///
+/// Raises:
+///     ValueError: If either stack contains non-finite or negative values,
+///         the spatial dimensions differ, or ``hot_k_mad`` is not finite
+///         and positive.
+#[pyfunction]
+#[pyo3(signature = (sample, open_beam = None, hot_k_mad = Some(norm::HOT_PIXEL_K_MAD)))]
+fn detect_bad_pixels<'py>(
+    py: Python<'py>,
+    sample: PyReadonlyArray3<f64>,
+    open_beam: Option<PyReadonlyArray3<f64>>,
+    hot_k_mad: Option<f64>,
+) -> PyResult<Bound<'py, PyArray2<bool>>> {
+    let s = sample.as_array().to_owned();
+    let ob = open_beam.map(|o| o.as_array().to_owned());
+    let mask = py.detach(move || norm::detect_bad_pixels(&s, ob.as_ref(), hot_k_mad));
+    let mask = mask.map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("{}", e)))?;
     Ok(PyArray2::from_owned_array(py, mask))
 }
 
@@ -3058,6 +3176,9 @@ fn nereids(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_trace_detectability_survey, m)?)?;
     m.add_function(wrap_pyfunction!(precompute_cross_sections, m)?)?;
     m.add_function(wrap_pyfunction!(detect_dead_pixels, m)?)?;
+    m.add_function(wrap_pyfunction!(detect_hot_pixels, m)?)?;
+    m.add_function(wrap_pyfunction!(detect_dead_pixels_chunked, m)?)?;
+    m.add_function(wrap_pyfunction!(detect_bad_pixels, m)?)?;
     m.add_function(wrap_pyfunction!(py_calibrate_energy, m)?)?;
     m.add_class::<PyCalibrationResult>()?;
     // Phase 5: Typed API

--- a/crates/nereids-core/src/lib.rs
+++ b/crates/nereids-core/src/lib.rs
@@ -7,5 +7,6 @@
 pub mod constants;
 pub mod elements;
 pub mod error;
+pub mod stats;
 pub mod types;
 pub mod validation;

--- a/crates/nereids-core/src/stats.rs
+++ b/crates/nereids-core/src/stats.rs
@@ -1,0 +1,145 @@
+//! Small robust-statistics helpers shared across NEREIDS crates.
+//!
+//! These live in `nereids-core` (the dependency-free foundation crate) so that
+//! the same estimator is computed identically everywhere instead of being
+//! re-implemented per crate.  Each helper returns a plain `Option`/value
+//! rather than a formatted error, so the calling crate can map degenerate
+//! inputs onto its own error type / message wording without `nereids-core`
+//! having to know about `IoError`, `FittingError`, etc.
+//!
+//! Precondition: callers pass **finite** inputs (they enforce this via
+//! [`crate::validation`] before calling in).  The helpers nevertheless sort
+//! with [`f64::total_cmp`], which is a total order even over NaN (NaN sorts
+//! last), so a violated precondition degrades to a deterministic — if
+//! meaningless — result instead of a `partial_cmp` panic path.
+
+/// Consistency factor converting a median absolute deviation into a Gaussian
+/// standard-deviation estimate: `sigma ≈ MAD_TO_SIGMA * MAD`.
+///
+/// Derivation: for X ~ N(μ, σ²), the MAD about the median satisfies
+/// P(|X − μ| ≤ MAD) = 1/2, i.e. MAD = σ·Φ⁻¹(3/4) where Φ is the standard
+/// normal CDF.  The consistency factor is therefore
+///
+///   1 / Φ⁻¹(3/4) = 1 / 0.674489750196081… = 1.482602218505601…
+///
+/// so that `MAD_TO_SIGMA * MAD` is an unbiased estimate of σ for Gaussian
+/// data while staying robust (50% breakdown point) against outliers.
+pub const MAD_TO_SIGMA: f64 = 1.482_602_218_505_601_8;
+
+/// Median of a slice of values.
+///
+/// Copies the input and sorts with [`f64::total_cmp`] (total, deterministic —
+/// see the module-level precondition note on NaN).  For even `n` the median
+/// is the midpoint mean of the two central order statistics.
+///
+/// # Arguments
+/// * `values` — Sample values.  Precondition: finite (callers enforce via
+///   [`crate::validation`]).
+///
+/// # Returns
+/// `Some(median)`, or `None` if `values` is empty.
+pub fn median(values: &[f64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable_by(f64::total_cmp);
+    let n = sorted.len();
+    if n % 2 == 1 {
+        Some(sorted[n / 2])
+    } else {
+        // Even n: midpoint mean of the two central order statistics.
+        Some((sorted[n / 2 - 1] + sorted[n / 2]) / 2.0)
+    }
+}
+
+/// Median absolute deviation of a slice about a given center.
+///
+/// Computes `median(|v − center|)` with the same conventions as [`median`]
+/// (total-order sort, even-`n` midpoint mean).  Note this returns the *raw*
+/// MAD — multiply by [`MAD_TO_SIGMA`] to obtain a Gaussian-consistent σ
+/// estimate.
+///
+/// # Arguments
+/// * `values` — Sample values.  Precondition: finite (callers enforce via
+///   [`crate::validation`]).
+/// * `center` — Center to take deviations about (typically the sample
+///   median).
+///
+/// # Returns
+/// `Some(mad)`, or `None` if `values` is empty.
+pub fn median_abs_deviation(values: &[f64], center: f64) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    let deviations: Vec<f64> = values.iter().map(|v| (v - center).abs()).collect();
+    median(&deviations)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn median_empty_is_none() {
+        assert_eq!(median(&[]), None);
+    }
+
+    #[test]
+    fn median_single_element() {
+        assert_eq!(median(&[3.5]), Some(3.5));
+    }
+
+    #[test]
+    fn median_odd_n() {
+        // Unsorted input; median of {1, 2, 9} is 2.
+        assert_eq!(median(&[9.0, 1.0, 2.0]), Some(2.0));
+    }
+
+    #[test]
+    fn median_even_n_midpoint_mean() {
+        // Sorted {1, 2, 3, 10} → midpoint mean of 2 and 3 = 2.5.
+        assert_eq!(median(&[10.0, 3.0, 1.0, 2.0]), Some(2.5));
+    }
+
+    #[test]
+    fn mad_empty_is_none() {
+        assert_eq!(median_abs_deviation(&[], 0.0), None);
+    }
+
+    #[test]
+    fn mad_basic() {
+        // Values {1, 2, 4, 8}, center 3 → |dev| = {2, 1, 1, 5} → sorted
+        // {1, 1, 2, 5} → midpoint mean of 1 and 2 = 1.5.
+        assert_eq!(median_abs_deviation(&[1.0, 2.0, 4.0, 8.0], 3.0), Some(1.5));
+    }
+
+    #[test]
+    fn mad_about_own_median() {
+        // Values {1, 2, 3, 4, 100}, median 3 → |dev| = {2, 1, 0, 1, 97}
+        // → median 1: the outlier does not blow up the scale estimate.
+        let vals = [1.0, 2.0, 3.0, 4.0, 100.0];
+        let med = median(&vals).unwrap();
+        assert_eq!(med, 3.0);
+        assert_eq!(median_abs_deviation(&vals, med), Some(1.0));
+    }
+
+    #[test]
+    fn mad_of_constant_slice_is_zero() {
+        let vals = [7.0; 5];
+        let med = median(&vals).unwrap();
+        assert_eq!(median_abs_deviation(&vals, med), Some(0.0));
+    }
+
+    #[test]
+    fn mad_to_sigma_matches_inverse_normal_quantile() {
+        // Φ(1/MAD_TO_SIGMA) must equal 3/4: check via the error function
+        // relation Φ(x) = (1 + erf(x/√2))/2 evaluated numerically with a
+        // rational-approximation-free identity — instead verify the inverse
+        // direction: for the standard normal, P(|X| <= q) = 1/2 at
+        // q = 1/MAD_TO_SIGMA ≈ 0.67449.  We hard-check the published value
+        // of Φ⁻¹(3/4) to 15 significant digits.
+        let q = 1.0 / MAD_TO_SIGMA;
+        assert!((q - 0.674_489_750_196_081_7).abs() < 1e-15);
+    }
+}

--- a/crates/nereids-io/src/lib.rs
+++ b/crates/nereids-io/src/lib.rs
@@ -7,7 +7,7 @@
 //! - [`export`] — Export spatial mapping results to TIFF, HDF5, and Markdown
 //! - `nexus` — NeXus/HDF5 reading for rustpix-processed data (`hdf5` feature;
 //!   not an intra-doc link so default-feature doc builds stay warning-free)
-//! - [`normalization`] — Raw + open beam → transmission (Method 2), dead pixel detection, ROI
+//! - [`normalization`] — Raw + open beam → transmission (Method 2), dead/hot pixel masks (pipeline-integrity), ROI
 //! - `project` — Project file save/load for `.nrd.h5` archives (`hdf5` feature)
 //! - [`rebin`] — Energy rebinning (coarsen the TOF/energy axis by an integer factor)
 //! - [`spectrum`] — Spectrum file parser for TOF/energy bin edges or centers

--- a/crates/nereids-io/src/normalization.rs
+++ b/crates/nereids-io/src/normalization.rs
@@ -1306,6 +1306,148 @@ mod tests {
         );
     }
 
+    /// Build the 8×8 single-TOF-bin two-moat fixture for the stage-1
+    /// robust-scale tests (#646 review R4, P1-2): two 3×3 all-dead moats
+    /// (rows 1–3 × cols 1–3 and rows 4–6 × cols 4–6) with a `probe` at
+    /// (2,2) and a `control` at (5,5) in their centers, and the remaining
+    /// 46 pixels filled row-major with `n_a` × `a` then (46 − n_a) × `b`.
+    ///
+    /// A dead moat makes a probe's stage-2 reference sample EMPTY (every
+    /// neighbor dead → omitted), which keeps the global verdict — so a
+    /// probe's flag outcome is decided purely by the stage-1 threshold
+    /// under test, never vetoed by the local confirmation.  Dead pixels
+    /// are excluded from the stage-1 statistics, so with `n_a = 24` the
+    /// live sample is 24×`a`, 22×`b`, probe, control (n = 48, both
+    /// probes above `b`): the two central order statistics are the 24th
+    /// (= ln a) and 25th (= ln b), pinning `med = (ln a + ln b)/2`
+    /// exactly; the deviation sample has 46 × |ln(b/a)|/2 below the two
+    /// probe deviations, pinning `mad = |ln(b/a)|/2` exactly.
+    fn stage1_two_moat_grid(a: f64, n_a: usize, b: f64, probe: f64, control: f64) -> Array3<f64> {
+        let mut data = Array3::<f64>::zeros((1, 8, 8));
+        data[[0, 2, 2]] = probe;
+        data[[0, 5, 5]] = control;
+        let mut filled = 0usize;
+        for y in 0..8 {
+            for x in 0..8 {
+                let in_moat1 = (1..=3).contains(&y) && (1..=3).contains(&x);
+                let in_moat2 = (4..=6).contains(&y) && (4..=6).contains(&x);
+                if in_moat1 || in_moat2 {
+                    // Moat cells stay 0.0 (dead); the probe/control
+                    // assignments above are inside the moats and survive.
+                    continue;
+                }
+                data[[0, y, x]] = if filled < n_a { a } else { b };
+                filled += 1;
+            }
+        }
+        assert_eq!(filled, 46, "8×8 minus two 3×3 moats is 46 background px");
+        data
+    }
+
+    /// #646 review R4, P1-2 (1/3): the robust-MAD branch of the stage-1
+    /// scale `sigma = max(MAD_TO_SIGMA·mad, exp(−med/2))` DECIDES an
+    /// outcome.  Every earlier test drove sigma through the Poisson
+    /// floor (uniform/quantized backgrounds → mad = 0), so a mutation of
+    /// the MAD branch survived the suite.
+    ///
+    /// Fixture (see [`stage1_two_moat_grid`]): 24 × A = 8000,
+    /// 22 × B = 12500, probe P = 40 000, control C = 200 000.
+    /// A·B = 10⁸ and B/A = 1.25², so ln A = 8.9871968 and
+    /// ln B = 9.4334839 sit symmetrically about ln 10⁴.  Worked stage-1
+    /// arithmetic over the 48 live pixels:
+    ///
+    ///   med = (ln A + ln B)/2 = ln 10⁴          = 9.2103404
+    ///   mad = ln 1.25                            = 0.2231436
+    ///   MAD term = 1.4826022 × 0.2231436         = 0.3308331
+    ///   floor    = exp(−med/2) = 10⁻²            = 0.01
+    ///   sigma = max(0.3308331, 0.01)             = 0.3308331   (MAD wins)
+    ///   threshold = med + 6·sigma                = 11.1953391
+    ///
+    /// Probe: ln P = 10.5966347 < 11.1953391 (margin 0.60) → NOT a
+    /// candidate → kept.  Under a floor-only mutation (sigma = 0.01) the
+    /// threshold collapses to 9.2703404 < ln P and the dead moat flags
+    /// the probe unconditionally — this assertion fails.
+    /// Control: ln C = 12.2060726 > 11.1953391 (margin 1.01) → flagged;
+    /// a mutation that INFLATES the MAD term (≥2× → threshold ≥ 13.18)
+    /// unflags it.  The MAD value itself separates the two probes.
+    #[test]
+    fn test_detect_hot_pixels_mad_scale_decides_stage1_threshold() {
+        let data = stage1_two_moat_grid(8000.0, 24, 12500.0, 40_000.0, 200_000.0);
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        assert!(
+            !mask[[2, 2]],
+            "probe below the MAD-driven threshold must be kept"
+        );
+        assert!(
+            mask[[5, 5]],
+            "control above the MAD-driven threshold must be flagged"
+        );
+        assert_eq!(mask.iter().filter(|&&m| m).count(), 1);
+    }
+
+    /// #646 review R4, P1-2 (2/3) — crossover pin, MAD term just ABOVE
+    /// the Poisson floor: `max()` must pick the MAD branch.
+    ///
+    /// Fixture: 24 × A = 100/1.08, 22 × B = 108 (A·B = 10⁴ →
+    /// med = (ln A + ln B)/2 = ln 100 = 4.6051702, floor =
+    /// exp(−med/2) = 10⁻¹ = 0.1), probe P = 190, control C = 10 000.
+    ///
+    ///   mad = ln 1.08                            = 0.0769610
+    ///   MAD term = 1.4826022 × 0.0769610         = 0.1141026
+    ///     → 14 % ABOVE the 0.1 floor: MAD branch wins, barely.
+    ///   correct threshold = 4.6051702 + 6×0.1141026 = 5.2897858
+    ///   floor-mutant thr  = 4.6051702 + 6×0.1       = 5.2051702
+    ///
+    /// ln P = ln 190 = 5.2470241 sits BETWEEN the two thresholds
+    /// (margins 0.042 above the mutant's, 0.043 below the correct one):
+    /// correct code keeps the probe; a mutant that resolves the
+    /// crossover the wrong way (max→min, dropped MAD branch, deflated
+    /// MAD_TO_SIGMA) flags it via the dead moat.  Control:
+    /// ln C = 9.2103404 ≫ 5.2897858 → flagged (liveness control).
+    #[test]
+    fn test_detect_hot_pixels_mad_term_just_above_poisson_floor_wins() {
+        let data = stage1_two_moat_grid(100.0 / 1.08, 24, 108.0, 190.0, 10_000.0);
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        assert!(
+            !mask[[2, 2]],
+            "probe between floor and MAD thresholds must be kept when the MAD branch wins"
+        );
+        assert!(mask[[5, 5]], "control must be flagged");
+        assert_eq!(mask.iter().filter(|&&m| m).count(), 1);
+    }
+
+    /// #646 review R4, P1-2 (3/3) — crossover pin, MAD term just BELOW
+    /// the Poisson floor: `max()` must pick the floor.
+    ///
+    /// Fixture: 24 × A = 100/1.06, 22 × B = 106 (med = ln 100 =
+    /// 4.6051702, floor = 0.1 as above), probe P = 175, control
+    /// C = 10 000.
+    ///
+    ///   mad = ln 1.06                            = 0.0582689
+    ///   MAD term = 1.4826022 × 0.0582689         = 0.0863896
+    ///     → 14 % BELOW the 0.1 floor: the floor wins, barely.
+    ///   correct threshold = 4.6051702 + 6×0.1        = 5.2051702
+    ///   MAD-mutant thr    = 4.6051702 + 6×0.0863896  = 5.1235079
+    ///
+    /// ln P = ln 175 = 5.1647860 sits BETWEEN the two thresholds
+    /// (margins 0.041 above the mutant's, 0.040 below the correct one):
+    /// correct code keeps the probe; a mutant that drops the floor
+    /// (sigma = MAD term unconditionally — here max→min picks the MAD
+    /// term) flags it via the dead moat.  Together with the ABOVE case
+    /// this pins both branches of the crossover and the `max()` itself
+    /// from both sides.
+    #[test]
+    fn test_detect_hot_pixels_poisson_floor_just_above_mad_term_wins() {
+        let data = stage1_two_moat_grid(100.0 / 1.06, 24, 106.0, 175.0, 10_000.0);
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        assert!(
+            !mask[[2, 2]],
+            "probe between MAD and floor thresholds must be kept when the floor wins"
+        );
+        assert!(mask[[5, 5]], "control must be flagged");
+        assert_eq!(mask.iter().filter(|&&m| m).count(), 1);
+    }
+
     #[test]
     fn test_detect_hot_pixels_majority_dead_live_not_flagged() {
         // A large dead population must not drag the median down and get the

--- a/crates/nereids-io/src/normalization.rs
+++ b/crates/nereids-io/src/normalization.rs
@@ -525,8 +525,26 @@ pub fn detect_dead_pixels_chunked(chunks: &[Array3<f64>]) -> Result<Array2<bool>
 /// stalls; with the zero contribution the median stays on the background
 /// side and erosion completes.  Erosion fully consumes clusters up to 3 px
 /// wide in their narrower dimension (point defects, 1-px lines, 2–3-px-wide
-/// blobs/segments — the physical shapes of railed detector defects).  A
-/// hard-edged railed rectangle ≥4 px wide keeps its interior (only its
+/// blobs/segments — the physical shapes of railed detector defects)
+/// PROVIDED the cluster exposes at least one end cap or convex corner to
+/// normal-scene neighbors — erosion must seed somewhere.  An EDGE-TO-EDGE
+/// railed band ≥2 px wide (both ends off-detector — spanning the full
+/// detector width or height) exposes neither: every interior band pixel
+/// keeps ≥5 railed of 8 neighbors, and even the on-detector-border band
+/// ends keep 3 railed of 5, so every neighbor median stays railed, no
+/// pixel ever seeds, and the band is NOT caught
+/// (`test_detect_hot_pixels_edge_to_edge_2px_band_not_flagged_by_design`).
+/// This is deliberate, not an oversight: a slit-aperture open beam
+/// produces a genuine full-width bright SCENE band that is
+/// pixel-for-pixel indistinguishable from such a defect, so a full-span
+/// row/column screen would mask it — re-introducing the exact bimodal
+/// failure stage 2 exists to prevent.  Full-span detector pathologies of
+/// width ≥2 belong in a declared/file mask.  (A full-span width-1 railed
+/// line IS caught — each of its pixels keeps ≥4 normal neighbors,
+/// `test_detect_hot_pixels_full_railed_column_caught`; and a ≥2-px band
+/// with even one end cap inside the detector is fully consumed from that
+/// cap, `test_detect_hot_pixels_2px_band_one_end_on_detector_fully_caught`.)
+/// A hard-edged railed rectangle ≥4 px wide keeps its interior (only its
 /// convex corners flag): it is pixel-for-pixel indistinguishable from a
 /// hard-edged bright scene region, which must survive (below).
 ///
@@ -1479,6 +1497,67 @@ mod tests {
             mask.iter().filter(|&&m| m).count(),
             10,
             "only the railed column may be flagged"
+        );
+    }
+
+    #[test]
+    fn test_detect_hot_pixels_edge_to_edge_2px_band_not_flagged_by_design() {
+        // Documented-limitation pin (#646 review R3, F1): an EDGE-TO-EDGE
+        // railed band ≥2 px wide (both ends off-detector) exposes no end
+        // cap or convex corner, so the erosion has no seed — interior
+        // band pixels keep 3 bg + 5 railed neighbors (median railed) and
+        // even the on-detector-border band ends keep 2 bg + 3 railed
+        // (median railed).  Nothing flags, deliberately: a slit-aperture
+        // open beam produces a genuine full-width bright SCENE band that
+        // is pixel-for-pixel indistinguishable from this defect, and a
+        // full-span row/column screen would mask it (the bimodal
+        // failure).  Such detector pathologies belong in a declared/file
+        // mask (see rustdoc, "Fixpoint erosion of railed clusters").
+        let mut data = Array3::from_elem((4, 9, 9), 100.0);
+        for t in 0..4 {
+            for y in 3..5 {
+                for x in 0..9 {
+                    data[[t, y, x]] = 65535.0;
+                }
+            }
+        }
+
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        assert!(
+            mask.iter().all(|&m| !m),
+            "an edge-to-edge ≥2-px railed band must NOT be flagged \
+             (documented limitation — geometrically ambiguous with a \
+             slit-aperture bright scene band)"
+        );
+    }
+
+    #[test]
+    fn test_detect_hot_pixels_2px_band_one_end_on_detector_fully_caught() {
+        // Companion to the edge-to-edge pin (#646 review R3, F1): the
+        // same 2-row railed band, but with ONE end cap inside the
+        // detector.  The two cap pixels keep 5 bg + 3 railed neighbors
+        // (median bg) and seed in pass 1; the fixpoint then erodes the
+        // band column-pair by column-pair all the way to the opposite
+        // (detector-border) end.
+        let mut data = Array3::from_elem((4, 9, 9), 100.0);
+        for t in 0..4 {
+            for y in 3..5 {
+                for x in 0..7 {
+                    data[[t, y, x]] = 65535.0;
+                }
+            }
+        }
+
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        for y in 3..5 {
+            for x in 0..7 {
+                assert!(mask[[y, x]], "band pixel ({y}, {x}) must be flagged");
+            }
+        }
+        assert_eq!(
+            mask.iter().filter(|&&m| m).count(),
+            14,
+            "only the railed band may be flagged"
         );
     }
 

--- a/crates/nereids-io/src/normalization.rs
+++ b/crates/nereids-io/src/normalization.rs
@@ -355,9 +355,22 @@ pub const HOT_PIXEL_K_MAD: f64 = 6.0;
 ///   ≤2–3×; even directly across a sharp sample edge only one ring of
 ///   neighbors is mixed, and the neighbor *median* stays on the pixel's
 ///   own side of the edge.
-/// - A fully-railed row/column segment still leaves each railed pixel with
+/// - A fully-railed 1-px row/column still leaves each railed pixel with
 ///   ≥5 normal neighbors of 8, so the neighbor median stays normal and the
-///   segment IS caught.
+///   line IS caught in a single pass.  Railed CLUSTERS ≥2 px wide are
+///   caught by the stage-2 fixpoint erosion — see the
+///   "Fixpoint erosion of railed clusters" section of
+///   [`detect_hot_pixels`].
+///
+/// **Width-1 limitation (accepted trade-off)**: a 1-px-wide bright *scene*
+/// line at ≥`HOT_LOCAL_FACTOR`× local contrast is spatially
+/// indistinguishable from a railed line and IS masked.  Contiguous bright
+/// regions ≥2 px wide are safe (their boundary pixels keep a same-side
+/// neighbor median, so the erosion never seeds — see [`detect_hot_pixels`],
+/// "Why bright scene regions never erode").  Real scene features on VENUS
+/// are PSF-blurred over ≥2 px, so ≥10× single-pixel scene contrast is
+/// physically rare; masking it is the accepted price for catching railed
+/// rows/columns.
 pub const HOT_LOCAL_FACTOR: f64 = 10.0;
 
 /// Reject a stack with an empty TOF axis (`shape[0] == 0`).
@@ -482,12 +495,73 @@ pub fn detect_dead_pixels_chunked(chunks: &[Array3<f64>]) -> Result<Array2<bool>
 ///    Railed/always-max pixels are subsumed by the upper tail: no fixed
 ///    saturation value exists after efficiency correction, so a
 ///    saturation-constant test would be wrong anyway.
-/// 6. Stage 2 (local confirmation): a candidate is flagged iff its total
-///    also exceeds [`HOT_LOCAL_FACTOR`] × the median total of its available
-///    live (`total > 0`) 8-neighbors.  Edge pixels use whatever neighbors
-///    exist.  If a candidate has *no* live neighbor at all (isolated live
-///    pixel in a dead field), the global verdict stands — there is nothing
-///    local to refute it.
+/// 6. Stage 2 (local confirmation), iterated to a **fixpoint**: a candidate
+///    is flagged iff its total also exceeds [`HOT_LOCAL_FACTOR`] × the
+///    median of its 8-neighborhood reference sample, where each neighbor
+///    contributes its total if live (`total > 0`) and not yet flagged,
+///    contributes `0.0` if already flagged (a known defect cannot vouch
+///    for its neighbors — see below), and is omitted if dead (a dead pixel
+///    carries no scene information).  Edge pixels use whatever neighbors
+///    exist.  A candidate whose reference sample is empty (every neighbor
+///    dead — isolated live pixel in a dead field) keeps the global verdict;
+///    a candidate whose neighbors are mostly flagged defects likewise stays
+///    flagged (its reference median is 0).  After each full pass over the
+///    fixed stage-1 candidate list, newly confirmed flags are applied and
+///    the pass repeats until a pass adds no new flag.
+///
+/// # Fixpoint erosion of railed clusters
+///
+/// A single stage-2 pass misses the INTERIOR of a railed cluster ≥2 px
+/// wide: an interior pixel's 8-neighbors are railed too, so its neighbor
+/// median is railed and the ratio test refutes the flag.  Iterating to a
+/// fixpoint erodes such clusters from the boundary inward — once the
+/// cluster's outermost pixels are flagged they stop vouching (each
+/// contributes `0.0` instead of its railed total), the reference median of
+/// the next ring drops back to the background level, and the next pass
+/// flags that ring.  Contributing `0.0` (rather than omitting the flagged
+/// neighbor) is load-bearing: with omission, a 3-background + 3-railed
+/// reference sample has an even-count [`nereids_core::stats::median`]
+/// midpoint mid-gap (≈ railed/2), the ratio test reads ~2× and the erosion
+/// stalls; with the zero contribution the median stays on the background
+/// side and erosion completes.  Erosion fully consumes clusters up to 3 px
+/// wide in their narrower dimension (point defects, 1-px lines, 2–3-px-wide
+/// blobs/segments — the physical shapes of railed detector defects).  A
+/// hard-edged railed rectangle ≥4 px wide keeps its interior (only its
+/// convex corners flag): it is pixel-for-pixel indistinguishable from a
+/// hard-edged bright scene region, which must survive (below).
+///
+/// **Termination bound**: flags are only ever added, and every pass except
+/// the last adds at least one, so at most `height·width` passes can do
+/// work; the loop is additionally capped at `height·width` passes to make
+/// the bound structural rather than reasoned.  In practice the pass count
+/// is on the order of the defect-cluster radius (one pass for point
+/// defects and 1-px lines).
+///
+/// # Why bright scene regions never erode
+///
+/// Erosion must *seed* at a bright-region boundary pixel.  A boundary
+/// pixel of a contiguous bright scene region ≥2 px wide keeps ≥4 of its
+/// 8 neighbors on its own (bright) side for any straight or diagonal
+/// edge, so its reference median stays bright and its ratio is the scene
+/// gradient (≤2–3× across real edges) — far below the ≥10×
+/// [`HOT_LOCAL_FACTOR`].  Stage 1's global cut additionally gates which
+/// pixels can seed at all.  With no seed, the fixpoint is reached with
+/// zero flags in the region and it survives intact
+/// (`test_detect_hot_pixels_large_psf_bright_region_not_eroded`).  Two
+/// documented, test-pinned exceptions — both physically rare on VENUS,
+/// where the detector PSF blurs real scene features over ≥2 px so ≥10×
+/// single-pixel contrast steps do not occur in scene:
+///
+/// - a **width-1 bright line** at ≥10× local contrast is spatially
+///   indistinguishable from a railed line and IS masked — the accepted
+///   trade-off for catching railed rows/columns
+///   (`test_detect_hot_pixels_1px_bright_line_flagged_by_design`);
+/// - the single pixel at a **sharp convex (90°) corner** of a hard-edged
+///   ≥10× region sees only 3 same-side neighbors, its reference median
+///   falls on the dark side, and it is flagged (this predates the
+///   fixpoint); erosion does NOT propagate past it — the adjacent edge
+///   pixels keep ≥4 bright unflagged neighbors
+///   (`test_detect_hot_pixels_hard_edged_bright_rectangle_corners_only`).
 ///
 /// The two stages encode complementary definitions of "hot": stage 1 says
 /// *statistically implausible for this image*, stage 2 says *spatially
@@ -500,8 +574,8 @@ pub fn detect_dead_pixels_chunked(chunks: &[Array3<f64>]) -> Result<Array2<bool>
 /// REGION is scene, not a defect — masking it would reject statistically
 /// plausible pixels, the exact failure the module rules ban.  A true point
 /// defect beats its neighbor median by ≥100× and is caught by both stages
-/// even *inside* a bright region and even as part of a short railed
-/// row/column segment (see [`HOT_LOCAL_FACTOR`]).
+/// even *inside* a bright region and even as part of a railed row/column
+/// or a small railed cluster (see [`HOT_LOCAL_FACTOR`]).
 ///
 /// # Raw counts required
 ///
@@ -561,34 +635,87 @@ pub fn detect_hot_pixels(data: &Array3<f64>, k_mad: f64) -> Result<Array2<bool>,
     let sigma = f64::max(nereids_core::stats::MAD_TO_SIGMA * mad, (-med / 2.0).exp());
     let threshold = med + k_mad * sigma;
 
-    // Stage 2 (local confirmation): only a spatially ISOLATED excess is a
-    // detector point defect — a contiguous bright region is scene.  This is
-    // what keeps the global cut honest on bimodal images (see rustdoc).
+    // Stage 1 (global robust cut), upper tail only: the candidate list is
+    // fixed for the whole stage-2 fixpoint iteration below.
     let (height, width) = totals.dim();
-    let mut neighbor_totals: Vec<f64> = Vec::with_capacity(8);
+    let mut candidates: Vec<(usize, usize)> = Vec::new();
     for y in 0..height {
         for x in 0..width {
             let total = totals[[y, x]];
-            // Stage 1 (global robust cut), upper tail only.
-            if !(total > 0.0 && total.ln() > threshold) {
+            if total > 0.0 && total.ln() > threshold {
+                candidates.push((y, x));
+            }
+        }
+    }
+
+    // Stage 2 (local confirmation): only a spatially ISOLATED excess is a
+    // detector point defect — a contiguous bright region is scene.  This is
+    // what keeps the global cut honest on bimodal images (see rustdoc).
+    //
+    // Iterated to a FIXPOINT to erode railed clusters from their boundary
+    // inward (see rustdoc, "Fixpoint erosion of railed clusters"): each
+    // pass evaluates the not-yet-flagged candidates against the PREVIOUS
+    // pass's mask (batch update — order-independent within a pass), and
+    // the loop ends when a pass adds no new flag.
+    //
+    // Termination bound: flags are only ever added and every pass except
+    // the last adds at least one, so ≤ height·width passes can do work;
+    // the explicit cap makes that bound structural.  Pass 1 sees an
+    // all-false mask and is exactly the pre-fixpoint single pass.
+    let max_passes = height * width;
+    let mut neighbor_totals: Vec<f64> = Vec::with_capacity(8);
+    for _pass in 0..max_passes {
+        let mut newly_flagged: Vec<(usize, usize)> = Vec::new();
+        for &(y, x) in &candidates {
+            if mask[[y, x]] {
                 continue;
             }
-            // Live (total > 0) 8-neighbors; edge pixels use what exists.
+            let total = totals[[y, x]];
+            // 8-neighborhood reference sample; edge pixels use what exists.
             neighbor_totals.clear();
             for ny in y.saturating_sub(1)..=(y + 1).min(height - 1) {
                 for nx in x.saturating_sub(1)..=(x + 1).min(width - 1) {
-                    let t = totals[[ny, nx]];
-                    if (ny, nx) != (y, x) && t > 0.0 {
-                        neighbor_totals.push(t);
+                    if (ny, nx) == (y, x) {
+                        continue;
+                    }
+                    if mask[[ny, nx]] {
+                        // Already-flagged neighbor: a known defect cannot
+                        // vouch for the candidate.  It contributes the
+                        // lowest possible scene value (zero total) so the
+                        // reference median is not dragged up by the defect
+                        // itself — load-bearing for cluster erosion (see
+                        // rustdoc: an omitted neighbor leaves an even-count
+                        // sample whose midpoint median stalls the erosion).
+                        neighbor_totals.push(0.0);
+                    } else {
+                        // Live (total > 0) unflagged neighbors contribute
+                        // their totals; dead neighbors carry no scene
+                        // information and are omitted.
+                        let t = totals[[ny, nx]];
+                        if t > 0.0 {
+                            neighbor_totals.push(t);
+                        }
                     }
                 }
             }
-            mask[[y, x]] = match nereids_core::stats::median(&neighbor_totals) {
+            let flagged = match nereids_core::stats::median(&neighbor_totals) {
                 Some(local_med) => total > HOT_LOCAL_FACTOR * local_med,
-                // No live neighbor at all (isolated live pixel in a dead
-                // field): nothing local can refute the global verdict.
+                // Empty sample: every neighbor is dead (isolated live pixel
+                // in a dead field) — nothing local can refute the global
+                // verdict.  (A mostly-flagged neighborhood is NOT empty:
+                // the zeros give a reference median of 0 and the candidate
+                // stays flagged, the consistent generalization.)
                 None => true,
             };
+            if flagged {
+                newly_flagged.push((y, x));
+            }
+        }
+        if newly_flagged.is_empty() {
+            break;
+        }
+        for &(y, x) in &newly_flagged {
+            mask[[y, x]] = true;
         }
     }
     Ok(mask)
@@ -1257,6 +1384,219 @@ mod tests {
             mask.iter().filter(|&&m| m).count(),
             3,
             "only the railed segment may be flagged"
+        );
+    }
+
+    #[test]
+    fn test_detect_hot_pixels_2x2_railed_cluster_fully_caught() {
+        // Fixpoint acceptance (#646 review R2, F1): a 2×2 railed cluster
+        // has no interior — every pixel keeps 5 background neighbors of 8,
+        // so the whole cluster is caught in the first pass.  Regression
+        // guard for the smallest ≥2-px-wide cluster.
+        let mut data = Array3::from_elem((4, 7, 7), 100.0);
+        for t in 0..4 {
+            for y in 2..4 {
+                for x in 2..4 {
+                    data[[t, y, x]] = 65535.0;
+                }
+            }
+        }
+
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        for y in 2..4 {
+            for x in 2..4 {
+                assert!(mask[[y, x]], "2x2 cluster pixel ({y}, {x}) must be flagged");
+            }
+        }
+        assert_eq!(
+            mask.iter().filter(|&&m| m).count(),
+            4,
+            "only the railed cluster may be flagged"
+        );
+    }
+
+    #[test]
+    fn test_detect_hot_pixels_3x3_railed_blob_fully_caught() {
+        // Fixpoint acceptance (#646 review R2, F1) — THE erosion proof.
+        // A 3×3 railed blob: pass 1 flags only the 4 corners (5 background
+        // neighbors each); the edge centers (3 bg + 5 railed) and the
+        // interior (8 railed) are refuted by a single pass — the
+        // pre-fixpoint code missed them.  With flagged neighbors
+        // contributing zero totals, pass 2 flags the edge centers
+        // (sample [0, 0, bg, bg, bg, R, R, R] → median bg) and pass 3 the
+        // interior (all-flagged neighborhood → median 0).
+        let mut data = Array3::from_elem((4, 9, 9), 100.0);
+        for t in 0..4 {
+            for y in 3..6 {
+                for x in 3..6 {
+                    data[[t, y, x]] = 65535.0;
+                }
+            }
+        }
+
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        for y in 3..6 {
+            for x in 3..6 {
+                assert!(
+                    mask[[y, x]],
+                    "3x3 blob pixel ({y}, {x}) must be flagged (interior included)"
+                );
+            }
+        }
+        assert_eq!(
+            mask.iter().filter(|&&m| m).count(),
+            9,
+            "only the railed blob may be flagged"
+        );
+    }
+
+    #[test]
+    fn test_detect_hot_pixels_2px_wide_railed_column_fully_caught() {
+        // Fixpoint acceptance (#646 review R2, F1): the interior of a
+        // 2-px-wide railed column (3 bg + 5 railed neighbors per interior
+        // pixel) was invisible to the single pass — only the 4 end pixels
+        // (5 bg neighbors each) flagged.  The fixpoint erodes the column
+        // pairwise from both ends.
+        let mut data = Array3::from_elem((4, 9, 9), 100.0);
+        for t in 0..4 {
+            for y in 2..7 {
+                for x in 3..5 {
+                    data[[t, y, x]] = 65535.0;
+                }
+            }
+        }
+
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        for y in 2..7 {
+            for x in 3..5 {
+                assert!(
+                    mask[[y, x]],
+                    "2-px-wide column pixel ({y}, {x}) must be flagged"
+                );
+            }
+        }
+        assert_eq!(
+            mask.iter().filter(|&&m| m).count(),
+            10,
+            "only the railed column may be flagged"
+        );
+    }
+
+    #[test]
+    fn test_detect_hot_pixels_full_railed_column_caught() {
+        // Regression (#646 review R2, F1 test 3): a full-height 1-px railed
+        // column — every pixel keeps ≥4 background neighbors, so the whole
+        // line is caught in pass 1, exactly as before the fixpoint.
+        let mut data = Array3::from_elem((4, 7, 7), 100.0);
+        for t in 0..4 {
+            for y in 0..7 {
+                data[[t, y, 3]] = 65535.0;
+            }
+        }
+
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        for y in 0..7 {
+            assert!(mask[[y, 3]], "railed column pixel ({y}, 3) must be flagged");
+        }
+        assert_eq!(
+            mask.iter().filter(|&&m| m).count(),
+            7,
+            "only the railed column may be flagged"
+        );
+    }
+
+    #[test]
+    fn test_detect_hot_pixels_large_psf_bright_region_not_eroded() {
+        // Fixpoint safety (#646 review R2, F1 test 5): a LARGE bright scene
+        // region — 20×20 core at 100× background — with the ≥2-px PSF edge
+        // blur that real VENUS scene features have (adjacent-pixel ratios
+        // ≤5× through a 2-px transition ring: 100 → 400 → 2000 → 10000).
+        // Every bright-layer pixel passes the stage-1 global cut (dark
+        // majority: med = ln 100, mad = 0, Poisson-floor sigma = 0.1 →
+        // threshold ≈ 5.21 < ln 400 ≈ 5.99), yet no pixel reaches 10× its
+        // neighbor median, so the erosion never seeds and the fixpoint is
+        // reached with ZERO flags — the region survives intact.
+        let mut data = Array3::from_elem((1, 50, 50), 100.0);
+        for y in 13..37 {
+            for x in 13..37 {
+                data[[0, y, x]] = 400.0; // outer transition ring
+            }
+        }
+        for y in 14..36 {
+            for x in 14..36 {
+                data[[0, y, x]] = 2000.0; // inner transition ring
+            }
+        }
+        for y in 15..35 {
+            for x in 15..35 {
+                data[[0, y, x]] = 10000.0; // 20×20 core at 100× background
+            }
+        }
+
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        assert!(
+            mask.iter().all(|&m| !m),
+            "a PSF-blurred bright scene region must not be eroded at all"
+        );
+    }
+
+    #[test]
+    fn test_detect_hot_pixels_hard_edged_bright_rectangle_corners_only() {
+        // Pins the documented convex-corner caveat AND the fixpoint
+        // no-propagation property (#646 review R2).  A hard-edged (0-px
+        // transition) 20×20 region at 100× background: each sharp convex
+        // corner pixel sees only 3 same-side neighbors (median falls on
+        // the dark side) and flags — pre-existing single-pass behavior,
+        // physically rare in scene (PSF blurs real edges over ≥2 px).
+        // Crucially, the erosion must NOT propagate past the corners: the
+        // corner-adjacent edge pixels keep ≥4 bright unflagged neighbors,
+        // so the fixpoint stops at exactly the 4 corner pixels.
+        let mut data = Array3::from_elem((1, 50, 50), 100.0);
+        for y in 15..35 {
+            for x in 15..35 {
+                data[[0, y, x]] = 10000.0;
+            }
+        }
+
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        for &(y, x) in &[(15, 15), (15, 34), (34, 15), (34, 34)] {
+            assert!(
+                mask[[y, x]],
+                "sharp convex corner ({y}, {x}) flags (documented caveat)"
+            );
+        }
+        assert_eq!(
+            mask.iter().filter(|&&m| m).count(),
+            4,
+            "erosion must not propagate past the convex corners"
+        );
+    }
+
+    #[test]
+    fn test_detect_hot_pixels_1px_bright_line_flagged_by_design() {
+        // Width-1 limitation pin (#646 review R2, F3 — user-decided:
+        // document + pin, no connected-component machinery).  A 1-px-wide
+        // bright SCENE line at ≥10× local contrast is spatially
+        // indistinguishable from a railed line and IS masked — the
+        // accepted trade-off for catching railed rows/columns.  Real VENUS
+        // scene features are PSF-blurred over ≥2 px, so this contrast is
+        // physically rare in scene (see HOT_LOCAL_FACTOR rustdoc).
+        let mut data = Array3::from_elem((1, 9, 9), 100.0);
+        for y in 0..9 {
+            data[[0, y, 4]] = 5000.0; // 50× the local background
+        }
+
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        for y in 0..9 {
+            assert!(
+                mask[[y, 4]],
+                "1-px bright line pixel ({y}, 4) is flagged BY DESIGN"
+            );
+        }
+        assert_eq!(
+            mask.iter().filter(|&&m| m).count(),
+            9,
+            "only the width-1 line may be flagged"
         );
     }
 

--- a/crates/nereids-io/src/normalization.rs
+++ b/crates/nereids-io/src/normalization.rs
@@ -23,10 +23,33 @@
 //!
 //!   σ_T / T = √(1/C_sample + 1/C_ob)
 //!
+//! ## Pixel masks — pipeline integrity only
+//!
+//! The boolean masks produced by [`detect_dead_pixels`],
+//! [`detect_dead_pixels_chunked`], [`detect_hot_pixels`], and
+//! [`detect_bad_pixels`] exist for exactly one purpose: excluding pixels
+//! whose data stream is broken in a way that would corrupt the downstream
+//! pipeline.  Downstream, a mask is a hard exclude — masked pixels are never
+//! fitted and appear as NaN in every result map (`nereids-pipeline`'s
+//! `spatial_map_typed` skips them entirely; see
+//! `crates/nereids-pipeline/src/spatial.rs`).
+//!
+//! The masks are **not** a data-quality or coverage filter:
+//!
+//! - **Low-count pixels are alive and MUST be kept.**  KL-domain fitting
+//!   handles them correctly; a statistical low-count screen was measured to
+//!   reject 13% of an ROI essentially at random (IPTS-37432).
+//! - **Coverage / thickness inhomogeneity is a model concern** (free density
+//!   per region), never a masking concern.
+//! - Deadness/hotness is per-acquisition, so always union the sample and
+//!   open-beam masks — [`detect_bad_pixels`] does this.
+//!
+//! See issue #643 for the methodology discussion.
+//!
 //! ## PLEIADES Reference
 //! - `processing/normalization_ornl.py` — Method 2 implementation
 
-use ndarray::{Array1, Array3, Axis};
+use ndarray::{Array1, Array2, Array3, Axis, Zip};
 
 use crate::error::IoError;
 
@@ -256,7 +279,23 @@ pub fn average_roi(
     Ok(roi.mean_axis(Axis(2)).unwrap().mean_axis(Axis(1)).unwrap())
 }
 
-/// Detect dead pixels (zero counts across all TOF bins).
+/// Detect dead pixels (zero counts across all TOF bins of one stack).
+///
+/// Pipeline-integrity screen only — see the module-level "Pixel masks —
+/// pipeline integrity only" section.  Prefer [`detect_bad_pixels`] as the
+/// validating entry point; this function performs no input validation of its
+/// own (backward compatibility: GUI, Python ABI, persisted masks).
+///
+/// Precondition: `data` has been validated finite and non-negative (e.g. by
+/// [`normalize`]).  Under that invariant the exact `== 0.0` test is
+/// intentional:
+///
+/// - Counts are validated non-negative, and `0.0 × efficiency == 0.0` holds
+///   exactly in IEEE 754, so a `<= 0.0` test would be dead code.
+/// - A NaN bin makes a pixel appear *alive* (`NaN == 0.0` is `false`).  This
+///   is deliberate: corrupt input must be rejected upstream, never silently
+///   masked (house anti-masking rule — cf. the validation rationale comment
+///   in [`normalize`]).  [`detect_bad_pixels`] rejects such input up front.
 ///
 /// # Arguments
 /// * `data` — 3D array with shape (n_tof, height, width).
@@ -276,6 +315,242 @@ pub fn detect_dead_pixels(data: &Array3<f64>) -> ndarray::Array2<bool> {
     }
 
     mask
+}
+
+/// Default MAD multiplier for [`detect_hot_pixels`].
+///
+/// The one-sided Gaussian tail at 6 robust σ is P(Z > 6) ≈ 9.9e-10, i.e.
+/// ~2.6e-4 expected false flags on a full 512×512 frame (262 144 pixels) —
+/// the screen essentially never rejects a statistically plausible pixel,
+/// while a railed pixel sits tens of robust σ above any plausible median.
+/// Real spatial structure (beam profile, sample absorption) only *inflates*
+/// the MAD, making the cut more conservative, never less.
+pub const HOT_PIXEL_K_MAD: f64 = 6.0;
+
+/// Detect dead pixels across acquisition chunks (dead-in-any-chunk).
+///
+/// Catches *intermittent* deadness that [`detect_dead_pixels`] on the summed
+/// stack cannot see: a pixel that was dead for one acquisition chunk but
+/// alive in another has nonzero summed counts, yet its dead-chunk data
+/// corrupts the combined spectrum.  A pixel is flagged iff it is all-zero
+/// (exact `== 0.0` test, same rationale as [`detect_dead_pixels`]) in *any*
+/// chunk.
+///
+/// False-positive control: a live pixel with expected total counts λ within
+/// one chunk is all-zero in that chunk with probability P = e^(−λ) (Poisson);
+/// over m chunks, P(misflag) ≤ m·e^(−λ).  Guidance: chunk the acquisition so
+/// each live pixel has λ ≥ 20 expected counts per chunk — e^(−20) ≈ 2e-9,
+/// i.e. ~5e-4·m expected false flags on a 512² detector.
+///
+/// There is deliberately **no** per-TOF-block zero-run variant.  Within one
+/// TOF-summed stack, wall-clock-intermittent deadness is invisible — the
+/// pixel just shows uniformly reduced counts across all TOF bins, with no
+/// zeros to find.  And any within-stack zero-run cut is a statistical screen
+/// on low-count pixels (a pixel at 0.01 counts/bin normally has ~100-bin
+/// zero runs) — exactly the banned failure mode (see the module-level
+/// "Pixel masks — pipeline integrity only" section).
+///
+/// Chunks may have differing TOF axis lengths (`n_tof`) — ragged event-mode
+/// re-histogramming is fine; deadness is spatial, so only the spatial
+/// dimensions must agree.
+///
+/// # Arguments
+/// * `chunks` — One 3D counts array per acquisition chunk, each with shape
+///   (n_tof, height, width).  `n_tof` may differ between chunks; (height,
+///   width) must not.
+///
+/// # Returns
+/// 2D boolean mask, shape (height, width). `true` = dead in at least one
+/// chunk.
+///
+/// # Errors
+/// Returns `IoError::InvalidParameter` if `chunks` is empty or any chunk
+/// contains a non-finite or negative value, and `IoError::ShapeMismatch` if
+/// the chunks' spatial dimensions differ.
+pub fn detect_dead_pixels_chunked(chunks: &[Array3<f64>]) -> Result<Array2<bool>, IoError> {
+    if chunks.is_empty() {
+        return Err(IoError::InvalidParameter(
+            "detect_dead_pixels_chunked requires at least one chunk".into(),
+        ));
+    }
+
+    let first = chunks[0].shape();
+    let (height, width) = (first[1], first[2]);
+    for (i, chunk) in chunks.iter().enumerate() {
+        let s = chunk.shape();
+        // n_tof (s[0]) may differ between chunks; only spatial dims must agree.
+        if s[1] != height || s[2] != width {
+            return Err(IoError::ShapeMismatch(format!(
+                "chunks[{i}] spatial dims ({}, {}) != chunks[0] spatial dims ({height}, {width})",
+                s[1], s[2],
+            )));
+        }
+        validate_counts(chunk, &format!("chunks[{i}]"))?;
+    }
+
+    let mut mask = Array2::from_elem((height, width), false);
+    for chunk in chunks {
+        let dead = detect_dead_pixels(chunk);
+        Zip::from(&mut mask)
+            .and(&dead)
+            .for_each(|m, &d| *m = *m || d);
+    }
+    Ok(mask)
+}
+
+/// Detect hot (railed / runaway) pixels via a robust one-sided log-space
+/// median + k·MAD screen on per-pixel total counts.
+///
+/// Pipeline-integrity screen only — see the module-level "Pixel masks —
+/// pipeline integrity only" section.  The algorithm:
+///
+/// 1. `totals[y, x] = Σ_t data[t, y, x]`.
+/// 2. The statistics sample is `ln(totals)` over `totals > 0` pixels *only* —
+///    dead pixels are excluded *before* the median/MAD so `ln(0)` never
+///    enters and a large dead population cannot drag the median down.  If no
+///    live pixels exist, every pixel is unflagged (all-`false` mask).
+/// 3. `med = median(ln totals)`, `mad = median(|ln totals − med|)`.
+/// 4. `sigma = max(MAD_TO_SIGMA·mad, exp(−med/2))`.  The second term is the
+///    delta-method Poisson floor of `ln N`: `Var[ln N] ≈ 1/N` evaluated at
+///    `N = exp(med)` (medians commute with monotone maps, so `exp(med)` is
+///    the median total), giving `σ_floor = 1/√exp(med) = exp(−med/2)`.  The
+///    robust scale can never legitimately sit below counting noise; this
+///    guards `mad == 0` on quantized low-count images *without* becoming a
+///    low-count screen — it only ever raises the threshold.  Worked check:
+///    an image where most totals are 1.0 and some are 2.0 has `mad = 0` and
+///    floor `= 1`, so the threshold is `e^6 ≈ 403×` the median — the 2-count
+///    pixels are NOT flagged, while a railed pixel still is.
+/// 5. Flag iff `totals > 0 && ln(total) > med + k_mad·sigma` — **upper tail
+///    only**.  A stuck-low pixel is indistinguishable from a low-count-alive
+///    pixel and is deliberately kept (masking it would be the banned
+///    low-count screen).  Railed/always-max pixels are subsumed by the upper
+///    tail: no fixed saturation value exists after efficiency correction, so
+///    a saturation-constant test would be wrong anyway.
+///
+/// # Arguments
+/// * `data` — 3D counts array with shape (n_tof, height, width).
+/// * `k_mad` — Robust-σ multiplier for the upper-tail cut; use
+///   [`HOT_PIXEL_K_MAD`] unless you have a reason not to.
+///
+/// # Returns
+/// 2D boolean mask, shape (height, width). `true` = hot pixel.
+///
+/// # Errors
+/// Returns `IoError::InvalidParameter` if `data` contains a non-finite or
+/// negative value, or if `k_mad` is not finite and positive.
+pub fn detect_hot_pixels(data: &Array3<f64>, k_mad: f64) -> Result<Array2<bool>, IoError> {
+    validate_counts(data, "data")?;
+    // NaN bypasses `>`, so pair the order comparison with is_finite().
+    if !(k_mad.is_finite() && k_mad > 0.0) {
+        return Err(IoError::InvalidParameter(format!(
+            "k_mad must be finite and > 0, got {k_mad}"
+        )));
+    }
+
+    let totals = data.sum_axis(Axis(0));
+    let mut mask = Array2::from_elem(totals.raw_dim(), false);
+
+    // Statistics over live (totals > 0) pixels only: ln(0) never enters, and
+    // a large dead population cannot drag the median down.
+    let log_totals: Vec<f64> = totals
+        .iter()
+        .filter(|&&t| t > 0.0)
+        .map(|&t| t.ln())
+        .collect();
+    let Some(med) = nereids_core::stats::median(&log_totals) else {
+        // No live pixels at all: nothing to compare against — flag nothing.
+        return Ok(mask);
+    };
+    // unwrap is safe here: median() returned Some, so log_totals is non-empty.
+    let mad = nereids_core::stats::median_abs_deviation(&log_totals, med).unwrap();
+
+    // Delta-method Poisson floor of ln N at the median total (see rustdoc
+    // step 4): the robust scale can never sit below counting noise.
+    let sigma = f64::max(nereids_core::stats::MAD_TO_SIGMA * mad, (-med / 2.0).exp());
+    let threshold = med + k_mad * sigma;
+
+    Zip::from(&mut mask)
+        .and(&totals)
+        .for_each(|m, &t| *m = t > 0.0 && t.ln() > threshold);
+    Ok(mask)
+}
+
+/// Detect all pipeline-corrupting pixels: dead ∪ hot over sample and
+/// (optionally) open beam.
+///
+/// This is the validating entry point that the GUI and Python bindings
+/// should use.  Deadness/hotness is per-acquisition — a pixel dead only in
+/// the open-beam run still corrupts every transmission ratio computed from
+/// it — so the masks of both stacks are unioned:
+///
+/// `mask = dead(sample) ∪ hot(sample) [∪ dead(open_beam) ∪ hot(open_beam)]`
+///
+/// The stacks' TOF axis lengths may differ (deadness is spatial); only the
+/// spatial dimensions must agree.
+///
+/// # Arguments
+/// * `sample` — Sample counts, shape (n_tof, height, width).
+/// * `open_beam` — Optional open-beam counts, shape (n_tof', height, width).
+/// * `hot_k_mad` — `Some(k)` to include the [`detect_hot_pixels`] screen
+///   with multiplier `k` (use [`HOT_PIXEL_K_MAD`]); `None` for dead-only
+///   detection.
+///
+/// # Returns
+/// 2D boolean mask, shape (height, width). `true` = exclude pixel.
+///
+/// # Errors
+/// Returns `IoError::InvalidParameter` if either stack contains a non-finite
+/// or negative value or `hot_k_mad` is `Some` of a non-finite/non-positive
+/// value, and `IoError::ShapeMismatch` if the spatial dimensions differ.
+pub fn detect_bad_pixels(
+    sample: &Array3<f64>,
+    open_beam: Option<&Array3<f64>>,
+    hot_k_mad: Option<f64>,
+) -> Result<Array2<bool>, IoError> {
+    // Validate everything up front (house rule), before any detector runs.
+    // The public detectors called below re-validate; that duplication is one
+    // O(n) sweep and keeps each entry point independently safe.
+    validate_counts(sample, "sample")?;
+    if let Some(ob) = open_beam {
+        validate_counts(ob, "open_beam")?;
+        let (ss, os) = (sample.shape(), ob.shape());
+        // n_tof may differ (deadness is spatial); spatial dims must agree.
+        if ss[1] != os[1] || ss[2] != os[2] {
+            return Err(IoError::ShapeMismatch(format!(
+                "sample spatial dims ({}, {}) != open_beam spatial dims ({}, {})",
+                ss[1], ss[2], os[1], os[2],
+            )));
+        }
+    }
+    if let Some(k) = hot_k_mad {
+        // NaN bypasses `>`, so pair the order comparison with is_finite().
+        if !(k.is_finite() && k > 0.0) {
+            return Err(IoError::InvalidParameter(format!(
+                "hot_k_mad must be finite and > 0, got {k}"
+            )));
+        }
+    }
+
+    let mut mask = detect_dead_pixels(sample);
+    if let Some(k) = hot_k_mad {
+        let hot = detect_hot_pixels(sample, k)?;
+        Zip::from(&mut mask)
+            .and(&hot)
+            .for_each(|m, &h| *m = *m || h);
+    }
+    if let Some(ob) = open_beam {
+        let ob_dead = detect_dead_pixels(ob);
+        Zip::from(&mut mask)
+            .and(&ob_dead)
+            .for_each(|m, &d| *m = *m || d);
+        if let Some(k) = hot_k_mad {
+            let ob_hot = detect_hot_pixels(ob, k)?;
+            Zip::from(&mut mask)
+                .and(&ob_hot)
+                .for_each(|m, &h| *m = *m || h);
+        }
+    }
+    Ok(mask)
 }
 
 #[cfg(test)]
@@ -588,5 +863,291 @@ mod tests {
         assert!(!mask[[0, 1]]); // alive
         assert!(!mask[[1, 0]]); // alive
         assert!(mask[[1, 1]]); // dead
+    }
+
+    #[test]
+    fn test_detect_dead_pixels_chunked_catches_intermittent() {
+        // ACCEPTANCE (#643): pixel (0, 1) is dead throughout chunk 0 but
+        // alive in chunk 1 — intermittent deadness that corrupts the
+        // combined spectrum.
+        let mut chunk0 = Array3::from_elem((3, 2, 2), 5.0);
+        for t in 0..3 {
+            chunk0[[t, 0, 1]] = 0.0;
+        }
+        let chunk1 = Array3::from_elem((3, 2, 2), 5.0);
+
+        let mask = detect_dead_pixels_chunked(&[chunk0.clone(), chunk1.clone()]).unwrap();
+        assert!(mask[[0, 1]], "intermittently dead pixel must be flagged");
+        assert!(!mask[[0, 0]]);
+        assert!(!mask[[1, 0]]);
+        assert!(!mask[[1, 1]]);
+
+        // The gap being closed: on the element-wise summed stack the pixel
+        // has nonzero counts everywhere, so detect_dead_pixels misses it.
+        let summed = &chunk0 + &chunk1;
+        let summed_mask = detect_dead_pixels(&summed);
+        assert!(
+            !summed_mask[[0, 1]],
+            "summed-stack detection cannot see intermittent deadness — \
+             that is exactly why the chunked variant exists"
+        );
+    }
+
+    #[test]
+    fn test_detect_dead_pixels_chunked_low_count_alive_not_flagged() {
+        // ACCEPTANCE (#643): a pixel with a single count per chunk is alive
+        // and must be kept — masks are pipeline-integrity only, never a
+        // low-count screen.
+        let mut chunk0 = Array3::from_elem((4, 2, 2), 5.0);
+        let mut chunk1 = Array3::from_elem((4, 2, 2), 5.0);
+        for t in 0..4 {
+            chunk0[[t, 1, 1]] = 0.0;
+            chunk1[[t, 1, 1]] = 0.0;
+        }
+        chunk0[[2, 1, 1]] = 1.0; // one lone count in chunk 0
+        chunk1[[0, 1, 1]] = 1.0; // one lone count in chunk 1
+
+        let mask = detect_dead_pixels_chunked(&[chunk0, chunk1]).unwrap();
+        assert!(!mask[[1, 1]], "low-count-alive pixel must not be flagged");
+    }
+
+    #[test]
+    fn test_detect_dead_pixels_chunked_empty_slice_err() {
+        let err = detect_dead_pixels_chunked(&[]).unwrap_err();
+        assert!(matches!(err, IoError::InvalidParameter(_)));
+    }
+
+    #[test]
+    fn test_detect_dead_pixels_chunked_spatial_mismatch_err() {
+        let chunk0 = Array3::from_elem((3, 2, 2), 1.0);
+        let chunk1 = Array3::from_elem((3, 2, 3), 1.0);
+        let err = detect_dead_pixels_chunked(&[chunk0, chunk1]).unwrap_err();
+        assert!(matches!(err, IoError::ShapeMismatch(_)));
+    }
+
+    #[test]
+    fn test_detect_dead_pixels_chunked_nan_err() {
+        let chunk0 = Array3::from_elem((3, 2, 2), 1.0);
+        let mut chunk1 = Array3::from_elem((3, 2, 2), 1.0);
+        chunk1[[0, 0, 0]] = f64::NAN;
+        let err = detect_dead_pixels_chunked(&[chunk0, chunk1]).unwrap_err();
+        assert!(matches!(err, IoError::InvalidParameter(_)));
+        assert!(err.to_string().contains("chunks[1]"));
+    }
+
+    #[test]
+    fn test_detect_dead_pixels_chunked_ragged_n_tof_ok() {
+        // Ragged event re-histogramming: n_tof may differ between chunks.
+        let chunk0 = Array3::from_elem((3, 2, 2), 1.0);
+        let chunk1 = Array3::from_elem((7, 2, 2), 1.0);
+        let mask = detect_dead_pixels_chunked(&[chunk0, chunk1]).unwrap();
+        assert!(mask.iter().all(|&m| !m));
+    }
+
+    #[test]
+    fn test_detect_hot_pixels_catches_railed() {
+        // ACCEPTANCE (#643): a railed pixel (65535 counts/bin) amid a
+        // realistic slightly varying background (~100/bin) is flagged;
+        // its neighbors are not.
+        let mut data = Array3::<f64>::zeros((4, 3, 3));
+        for t in 0..4 {
+            for y in 0..3 {
+                for x in 0..3 {
+                    // Background 95..103 counts/bin (totals 380..412).
+                    data[[t, y, x]] = 95.0 + (y * 3 + x) as f64;
+                }
+            }
+        }
+        for t in 0..4 {
+            data[[t, 1, 1]] = 65535.0;
+        }
+
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        assert!(mask[[1, 1]], "railed pixel must be flagged");
+        for y in 0..3 {
+            for x in 0..3 {
+                if (y, x) != (1, 1) {
+                    assert!(!mask[[y, x]], "neighbor ({y}, {x}) must not be flagged");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_detect_hot_pixels_low_count_alive_not_flagged() {
+        // ACCEPTANCE (#643) — the 13%-rejection regression guard: a pixel
+        // with 1 total count amid ~300-count pixels is low-count-ALIVE and
+        // must be kept.  The screen is upper-tail only.
+        let mut data = Array3::from_elem((3, 3, 3), 100.0);
+        for t in 0..3 {
+            data[[t, 0, 2]] = 0.0;
+        }
+        data[[1, 0, 2]] = 1.0; // total 1 count
+
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        assert!(!mask[[0, 2]], "low-count-alive pixel must not be flagged");
+        assert!(mask.iter().all(|&m| !m), "nothing here is hot");
+    }
+
+    #[test]
+    fn test_detect_hot_pixels_uniform_image_poisson_floor_path() {
+        // Perfectly uniform background → MAD == 0 → the delta-method
+        // Poisson floor exp(-med/2) is the active scale.  The railed pixel
+        // must still be flagged, the uniform background must not.
+        let mut data = Array3::from_elem((4, 3, 3), 100.0);
+        for t in 0..4 {
+            data[[t, 2, 0]] = 65535.0;
+        }
+
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        assert!(mask[[2, 0]]);
+        assert_eq!(mask.iter().filter(|&&m| m).count(), 1);
+    }
+
+    #[test]
+    fn test_detect_hot_pixels_quantized_low_counts_none_flagged() {
+        // Worked check from the rustdoc: mostly 1-count totals with some
+        // 2-count totals → mad = 0, floor = 1, threshold = e^6 ≈ 403× the
+        // median — the 2-count pixels are NOT flagged.
+        let mut data = Array3::from_elem((1, 3, 3), 1.0);
+        data[[0, 0, 0]] = 2.0;
+        data[[0, 2, 2]] = 2.0;
+
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        assert!(
+            mask.iter().all(|&m| !m),
+            "quantized low-count image must produce no hot flags"
+        );
+    }
+
+    #[test]
+    fn test_detect_hot_pixels_majority_dead_live_not_flagged() {
+        // A large dead population must not drag the median down and get the
+        // few live pixels flagged: the statistics sample is live-only.
+        let mut data = Array3::<f64>::zeros((1, 4, 4));
+        data[[0, 0, 0]] = 49.0;
+        data[[0, 1, 1]] = 50.0;
+        data[[0, 2, 2]] = 51.0;
+
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        assert!(
+            mask.iter().all(|&m| !m),
+            "live pixels amid a dead majority must not be flagged"
+        );
+    }
+
+    #[test]
+    fn test_detect_hot_pixels_all_dead_all_false() {
+        let data = Array3::<f64>::zeros((3, 2, 2));
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        assert!(mask.iter().all(|&m| !m));
+    }
+
+    #[test]
+    fn test_detect_hot_pixels_nan_err() {
+        let mut data = Array3::from_elem((2, 2, 2), 1.0);
+        data[[1, 1, 0]] = f64::NAN;
+        let err = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap_err();
+        assert!(matches!(err, IoError::InvalidParameter(_)));
+    }
+
+    #[test]
+    fn test_detect_hot_pixels_bad_k_err() {
+        let data = Array3::from_elem((2, 2, 2), 1.0);
+        for bad_k in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            let err = detect_hot_pixels(&data, bad_k).unwrap_err();
+            assert!(
+                matches!(err, IoError::InvalidParameter(_)),
+                "k_mad = {bad_k} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_detect_bad_pixels_union() {
+        // sample: (0,0) dead, (1,2) low-count-alive (1 total count),
+        //         everything else 100 counts/bin.
+        let mut sample = Array3::from_elem((3, 3, 3), 100.0);
+        for t in 0..3 {
+            sample[[t, 0, 0]] = 0.0;
+            sample[[t, 1, 2]] = 0.0;
+        }
+        sample[[0, 1, 2]] = 1.0;
+        // open beam: (0,1) dead, (2,2) railed, everything else 200/bin.
+        let mut ob = Array3::from_elem((3, 3, 3), 200.0);
+        for t in 0..3 {
+            ob[[t, 0, 1]] = 0.0;
+            ob[[t, 2, 2]] = 65535.0;
+        }
+
+        let mask = detect_bad_pixels(&sample, Some(&ob), Some(HOT_PIXEL_K_MAD)).unwrap();
+        assert!(mask[[0, 0]], "dead-in-sample-only must be flagged");
+        assert!(mask[[0, 1]], "dead-in-OB-only must be flagged");
+        assert!(mask[[2, 2]], "hot-in-OB-only must be flagged");
+        assert!(!mask[[1, 2]], "low-count-alive must be kept");
+        assert!(!mask[[1, 1]], "normal pixel must be kept");
+        assert_eq!(mask.iter().filter(|&&m| m).count(), 3);
+    }
+
+    #[test]
+    fn test_detect_bad_pixels_spatial_mismatch_err() {
+        let sample = Array3::from_elem((3, 2, 2), 1.0);
+        let ob = Array3::from_elem((3, 2, 3), 1.0);
+        let err = detect_bad_pixels(&sample, Some(&ob), None).unwrap_err();
+        assert!(matches!(err, IoError::ShapeMismatch(_)));
+    }
+
+    #[test]
+    fn test_detect_bad_pixels_ragged_n_tof_ok() {
+        // Deadness is spatial: sample and OB may have different TOF axes.
+        let sample = Array3::from_elem((3, 2, 2), 1.0);
+        let ob = Array3::from_elem((7, 2, 2), 1.0);
+        let mask = detect_bad_pixels(&sample, Some(&ob), Some(HOT_PIXEL_K_MAD)).unwrap();
+        assert!(mask.iter().all(|&m| !m));
+    }
+
+    #[test]
+    fn test_detect_bad_pixels_hot_k_mad_none_is_dead_only() {
+        let mut sample = Array3::from_elem((3, 3, 3), 100.0);
+        for t in 0..3 {
+            sample[[t, 1, 1]] = 65535.0; // railed
+            sample[[t, 0, 0]] = 0.0; // dead
+        }
+        let dead_only = detect_bad_pixels(&sample, None, None).unwrap();
+        assert!(dead_only[[0, 0]]);
+        assert!(
+            !dead_only[[1, 1]],
+            "hot_k_mad = None must disable the hot screen"
+        );
+
+        let with_hot = detect_bad_pixels(&sample, None, Some(HOT_PIXEL_K_MAD)).unwrap();
+        assert!(with_hot[[0, 0]]);
+        assert!(with_hot[[1, 1]]);
+    }
+
+    #[test]
+    fn test_detect_bad_pixels_bad_k_err() {
+        let sample = Array3::from_elem((2, 2, 2), 1.0);
+        for bad_k in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            let err = detect_bad_pixels(&sample, None, Some(bad_k)).unwrap_err();
+            assert!(
+                matches!(err, IoError::InvalidParameter(_)),
+                "hot_k_mad = {bad_k} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_detect_bad_pixels_nan_err() {
+        let mut sample = Array3::from_elem((2, 2, 2), 1.0);
+        sample[[0, 0, 1]] = f64::NAN;
+        let err = detect_bad_pixels(&sample, None, None).unwrap_err();
+        assert!(err.to_string().contains("sample"));
+
+        let sample = Array3::from_elem((2, 2, 2), 1.0);
+        let mut ob = Array3::from_elem((2, 2, 2), 1.0);
+        ob[[1, 0, 0]] = f64::NEG_INFINITY;
+        let err = detect_bad_pixels(&sample, Some(&ob), None).unwrap_err();
+        assert!(err.to_string().contains("open_beam"));
     }
 }

--- a/crates/nereids-io/src/normalization.rs
+++ b/crates/nereids-io/src/normalization.rs
@@ -296,6 +296,12 @@ pub fn average_roi(
 ///   is deliberate: corrupt input must be rejected upstream, never silently
 ///   masked (house anti-masking rule — cf. the validation rationale comment
 ///   in [`normalize`]).  [`detect_bad_pixels`] rejects such input up front.
+/// - An empty TOF axis (`shape[0] == 0`) makes the all-zero test vacuously
+///   true for *every* pixel — the whole detector would be reported dead.
+///   This non-validating function keeps that behaviour for backward
+///   compatibility; the validating entry points ([`detect_bad_pixels`],
+///   [`detect_dead_pixels_chunked`], [`detect_hot_pixels`]) reject empty
+///   stacks up front.
 ///
 /// # Arguments
 /// * `data` — 3D array with shape (n_tof, height, width).
@@ -317,15 +323,59 @@ pub fn detect_dead_pixels(data: &Array3<f64>) -> ndarray::Array2<bool> {
     mask
 }
 
-/// Default MAD multiplier for [`detect_hot_pixels`].
+/// Default MAD multiplier for the global (stage-1) cut of
+/// [`detect_hot_pixels`].
 ///
 /// The one-sided Gaussian tail at 6 robust σ is P(Z > 6) ≈ 9.9e-10, i.e.
 /// ~2.6e-4 expected false flags on a full 512×512 frame (262 144 pixels) —
-/// the screen essentially never rejects a statistically plausible pixel,
-/// while a railed pixel sits tens of robust σ above any plausible median.
-/// Real spatial structure (beam profile, sample absorption) only *inflates*
-/// the MAD, making the cut more conservative, never less.
+/// on a *unimodal* image the screen essentially never rejects a
+/// statistically plausible pixel, while a railed pixel sits tens of robust
+/// σ above any plausible median.
+///
+/// On a **bimodal** image the global cut alone is not trustworthy: when the
+/// darker population holds the median (a sample covering >50 % of the FOV,
+/// or an aperture-limited open beam), the MAD reflects only the dark
+/// population's internal spread, and *every* bright-region pixel lands
+/// above `med + k·MAD`.  [`detect_hot_pixels`] therefore never flags on the
+/// global cut alone — the local-neighborhood confirmation
+/// ([`HOT_LOCAL_FACTOR`]) must also pass.
 pub const HOT_PIXEL_K_MAD: f64 = 6.0;
+
+/// Local-neighborhood confirmation factor (stage 2) of
+/// [`detect_hot_pixels`].
+///
+/// A pixel that passes the global cut is flagged only if its total also
+/// exceeds `HOT_LOCAL_FACTOR ×` the median total of its available live
+/// 8-neighbors.  The factor separates detector *point defects* from scene
+/// structure:
+///
+/// - A railed/runaway pixel is spatially isolated and typically ≥100× its
+///   neighbors, so it clears 10× with a wide margin.
+/// - Adjacent-pixel scene gradients (beam profile, sample absorption) are
+///   ≤2–3×; even directly across a sharp sample edge only one ring of
+///   neighbors is mixed, and the neighbor *median* stays on the pixel's
+///   own side of the edge.
+/// - A fully-railed row/column segment still leaves each railed pixel with
+///   ≥5 normal neighbors of 8, so the neighbor median stays normal and the
+///   segment IS caught.
+pub const HOT_LOCAL_FACTOR: f64 = 10.0;
+
+/// Reject a stack with an empty TOF axis (`shape[0] == 0`).
+///
+/// Every-bin predicates are vacuously true over zero bins: an empty stack
+/// would mark the whole detector dead (and gives the hot screen an all-zero
+/// totals image) with no error.  Called up front by the validating detector
+/// entry points; [`detect_dead_pixels`] deliberately stays non-validating
+/// (see its rustdoc).
+fn validate_n_tof(data: &Array3<f64>, field: &str) -> Result<(), IoError> {
+    if data.shape()[0] == 0 {
+        return Err(IoError::InvalidParameter(format!(
+            "{field} has an empty TOF axis (shape[0] == 0) — dead/hot detection \
+             over zero bins is vacuous and would mask every pixel"
+        )));
+    }
+    Ok(())
+}
 
 /// Detect dead pixels across acquisition chunks (dead-in-any-chunk).
 ///
@@ -364,9 +414,11 @@ pub const HOT_PIXEL_K_MAD: f64 = 6.0;
 /// chunk.
 ///
 /// # Errors
-/// Returns `IoError::InvalidParameter` if `chunks` is empty or any chunk
-/// contains a non-finite or negative value, and `IoError::ShapeMismatch` if
-/// the chunks' spatial dimensions differ.
+/// Returns `IoError::InvalidParameter` if `chunks` is empty, any chunk has
+/// an empty TOF axis (`shape[0] == 0` — its all-zero test would vacuously
+/// mark every pixel dead), or any chunk contains a non-finite or negative
+/// value, and `IoError::ShapeMismatch` if the chunks' spatial dimensions
+/// differ.
 pub fn detect_dead_pixels_chunked(chunks: &[Array3<f64>]) -> Result<Array2<bool>, IoError> {
     if chunks.is_empty() {
         return Err(IoError::InvalidParameter(
@@ -386,6 +438,7 @@ pub fn detect_dead_pixels_chunked(chunks: &[Array3<f64>]) -> Result<Array2<bool>
             )));
         }
         validate_counts(chunk, &format!("chunks[{i}]"))?;
+        validate_n_tof(chunk, &format!("chunks[{i}]"))?;
     }
 
     let mut mask = Array2::from_elem((height, width), false);
@@ -398,8 +451,10 @@ pub fn detect_dead_pixels_chunked(chunks: &[Array3<f64>]) -> Result<Array2<bool>
     Ok(mask)
 }
 
-/// Detect hot (railed / runaway) pixels via a robust one-sided log-space
-/// median + k·MAD screen on per-pixel total counts.
+/// Detect hot (railed / runaway) pixels via a two-stage criterion: a
+/// robust one-sided log-space median + k·MAD screen on per-pixel total
+/// counts (stage 1, global), confirmed by a local-neighborhood isolation
+/// test (stage 2).
 ///
 /// Pipeline-integrity screen only — see the module-level "Pixel masks —
 /// pipeline integrity only" section.  The algorithm:
@@ -420,16 +475,48 @@ pub fn detect_dead_pixels_chunked(chunks: &[Array3<f64>]) -> Result<Array2<bool>
 ///    an image where most totals are 1.0 and some are 2.0 has `mad = 0` and
 ///    floor `= 1`, so the threshold is `e^6 ≈ 403×` the median — the 2-count
 ///    pixels are NOT flagged, while a railed pixel still is.
-/// 5. Flag iff `totals > 0 && ln(total) > med + k_mad·sigma` — **upper tail
-///    only**.  A stuck-low pixel is indistinguishable from a low-count-alive
-///    pixel and is deliberately kept (masking it would be the banned
-///    low-count screen).  Railed/always-max pixels are subsumed by the upper
-///    tail: no fixed saturation value exists after efficiency correction, so
-///    a saturation-constant test would be wrong anyway.
+/// 5. Stage 1 (global): a pixel is a *candidate* iff `totals > 0 &&
+///    ln(total) > med + k_mad·sigma` — **upper tail only**.  A stuck-low
+///    pixel is indistinguishable from a low-count-alive pixel and is
+///    deliberately kept (masking it would be the banned low-count screen).
+///    Railed/always-max pixels are subsumed by the upper tail: no fixed
+///    saturation value exists after efficiency correction, so a
+///    saturation-constant test would be wrong anyway.
+/// 6. Stage 2 (local confirmation): a candidate is flagged iff its total
+///    also exceeds [`HOT_LOCAL_FACTOR`] × the median total of its available
+///    live (`total > 0`) 8-neighbors.  Edge pixels use whatever neighbors
+///    exist.  If a candidate has *no* live neighbor at all (isolated live
+///    pixel in a dead field), the global verdict stands — there is nothing
+///    local to refute it.
+///
+/// The two stages encode complementary definitions of "hot": stage 1 says
+/// *statistically implausible for this image*, stage 2 says *spatially
+/// isolated*, and a railed/hot pixel is a detector **point defect** — it
+/// must be both.  Stage 2 exists because the global cut alone fails
+/// catastrophically on **bimodal** images: with a dark majority holding the
+/// median (a sample covering >50 % of the FOV, or an aperture-limited open
+/// beam), the MAD reflects only the dark population's internal spread and
+/// the ENTIRE bright minority exceeds `med + k·MAD`.  A contiguous bright
+/// REGION is scene, not a defect — masking it would reject statistically
+/// plausible pixels, the exact failure the module rules ban.  A true point
+/// defect beats its neighbor median by ≥100× and is caught by both stages
+/// even *inside* a bright region and even as part of a short railed
+/// row/column segment (see [`HOT_LOCAL_FACTOR`]).
+///
+/// # Raw counts required
+///
+/// `data` must be **raw detected counts** (unscaled).  The Poisson floor in
+/// step 4 assumes `Var[N] = N`; any prior scaling silently breaks that
+/// identity — down-scaling (proton-charge-normalized rates ≪ 1, per-pixel
+/// gain division) inflates the floor and can suppress real flags, while
+/// up-scaling (event weights > 1) deflates it below true counting noise.
+/// Run the detectors on unscaled counts and normalize afterwards; the GUI
+/// does exactly this (both of its normalization paths pass the raw
+/// sample/open-beam stacks, before any normalization).
 ///
 /// # Arguments
-/// * `data` — 3D counts array with shape (n_tof, height, width).
-/// * `k_mad` — Robust-σ multiplier for the upper-tail cut; use
+/// * `data` — 3D raw-counts array with shape (n_tof, height, width).
+/// * `k_mad` — Robust-σ multiplier for the stage-1 upper-tail cut; use
 ///   [`HOT_PIXEL_K_MAD`] unless you have a reason not to.
 ///
 /// # Returns
@@ -437,9 +524,14 @@ pub fn detect_dead_pixels_chunked(chunks: &[Array3<f64>]) -> Result<Array2<bool>
 ///
 /// # Errors
 /// Returns `IoError::InvalidParameter` if `data` contains a non-finite or
-/// negative value, or if `k_mad` is not finite and positive.
+/// negative value or has an empty TOF axis (`shape[0] == 0`), or if `k_mad`
+/// is not finite and positive.
 pub fn detect_hot_pixels(data: &Array3<f64>, k_mad: f64) -> Result<Array2<bool>, IoError> {
     validate_counts(data, "data")?;
+    // An empty TOF axis would yield an all-zero totals image (empty live
+    // set → all-false mask) rather than corrupt output, but the validating
+    // entry points reject it uniformly (see validate_n_tof).
+    validate_n_tof(data, "data")?;
     // NaN bypasses `>`, so pair the order comparison with is_finite().
     if !(k_mad.is_finite() && k_mad > 0.0) {
         return Err(IoError::InvalidParameter(format!(
@@ -469,9 +561,36 @@ pub fn detect_hot_pixels(data: &Array3<f64>, k_mad: f64) -> Result<Array2<bool>,
     let sigma = f64::max(nereids_core::stats::MAD_TO_SIGMA * mad, (-med / 2.0).exp());
     let threshold = med + k_mad * sigma;
 
-    Zip::from(&mut mask)
-        .and(&totals)
-        .for_each(|m, &t| *m = t > 0.0 && t.ln() > threshold);
+    // Stage 2 (local confirmation): only a spatially ISOLATED excess is a
+    // detector point defect — a contiguous bright region is scene.  This is
+    // what keeps the global cut honest on bimodal images (see rustdoc).
+    let (height, width) = totals.dim();
+    let mut neighbor_totals: Vec<f64> = Vec::with_capacity(8);
+    for y in 0..height {
+        for x in 0..width {
+            let total = totals[[y, x]];
+            // Stage 1 (global robust cut), upper tail only.
+            if !(total > 0.0 && total.ln() > threshold) {
+                continue;
+            }
+            // Live (total > 0) 8-neighbors; edge pixels use what exists.
+            neighbor_totals.clear();
+            for ny in y.saturating_sub(1)..=(y + 1).min(height - 1) {
+                for nx in x.saturating_sub(1)..=(x + 1).min(width - 1) {
+                    let t = totals[[ny, nx]];
+                    if (ny, nx) != (y, x) && t > 0.0 {
+                        neighbor_totals.push(t);
+                    }
+                }
+            }
+            mask[[y, x]] = match nereids_core::stats::median(&neighbor_totals) {
+                Some(local_med) => total > HOT_LOCAL_FACTOR * local_med,
+                // No live neighbor at all (isolated live pixel in a dead
+                // field): nothing local can refute the global verdict.
+                None => true,
+            };
+        }
+    }
     Ok(mask)
 }
 
@@ -488,9 +607,16 @@ pub fn detect_hot_pixels(data: &Array3<f64>, k_mad: f64) -> Result<Array2<bool>,
 /// The stacks' TOF axis lengths may differ (deadness is spatial); only the
 /// spatial dimensions must agree.
 ///
+/// Both stacks must be **raw detected counts** (unscaled) — see the "Raw
+/// counts required" section of [`detect_hot_pixels`]: scaling distorts the
+/// Poisson floor of the hot screen.  The GUI satisfies this: both of its
+/// normalization paths call this function on the raw sample/open-beam
+/// stacks, before any normalization.
+///
 /// # Arguments
-/// * `sample` — Sample counts, shape (n_tof, height, width).
-/// * `open_beam` — Optional open-beam counts, shape (n_tof', height, width).
+/// * `sample` — Raw sample counts, shape (n_tof, height, width).
+/// * `open_beam` — Optional raw open-beam counts, shape
+///   (n_tof', height, width).
 /// * `hot_k_mad` — `Some(k)` to include the [`detect_hot_pixels`] screen
 ///   with multiplier `k` (use [`HOT_PIXEL_K_MAD`]); `None` for dead-only
 ///   detection.
@@ -499,9 +625,11 @@ pub fn detect_hot_pixels(data: &Array3<f64>, k_mad: f64) -> Result<Array2<bool>,
 /// 2D boolean mask, shape (height, width). `true` = exclude pixel.
 ///
 /// # Errors
-/// Returns `IoError::InvalidParameter` if either stack contains a non-finite
-/// or negative value or `hot_k_mad` is `Some` of a non-finite/non-positive
-/// value, and `IoError::ShapeMismatch` if the spatial dimensions differ.
+/// Returns `IoError::InvalidParameter` if either stack contains a
+/// non-finite or negative value or has an empty TOF axis (`shape[0] == 0`
+/// — the dead test over zero bins would vacuously mask every pixel) or
+/// `hot_k_mad` is `Some` of a non-finite/non-positive value, and
+/// `IoError::ShapeMismatch` if the spatial dimensions differ.
 pub fn detect_bad_pixels(
     sample: &Array3<f64>,
     open_beam: Option<&Array3<f64>>,
@@ -511,8 +639,10 @@ pub fn detect_bad_pixels(
     // The public detectors called below re-validate; that duplication is one
     // O(n) sweep and keeps each entry point independently safe.
     validate_counts(sample, "sample")?;
+    validate_n_tof(sample, "sample")?;
     if let Some(ob) = open_beam {
         validate_counts(ob, "open_beam")?;
+        validate_n_tof(ob, "open_beam")?;
         let (ss, os) = (sample.shape(), ob.shape());
         // n_tof may differ (deadness is spatial); spatial dims must agree.
         if ss[1] != os[1] || ss[2] != os[2] {
@@ -918,6 +1048,17 @@ mod tests {
     }
 
     #[test]
+    fn test_detect_dead_pixels_chunked_empty_tof_chunk_err() {
+        // A zero-frame chunk would vacuously mark the whole detector dead.
+        let chunk0 = Array3::from_elem((3, 2, 2), 1.0);
+        let chunk1 = Array3::<f64>::zeros((0, 2, 2));
+        let err = detect_dead_pixels_chunked(&[chunk0, chunk1]).unwrap_err();
+        assert!(matches!(err, IoError::InvalidParameter(_)));
+        assert!(err.to_string().contains("chunks[1]"));
+        assert!(err.to_string().contains("empty TOF axis"));
+    }
+
+    #[test]
     fn test_detect_dead_pixels_chunked_spatial_mismatch_err() {
         let chunk0 = Array3::from_elem((3, 2, 2), 1.0);
         let chunk1 = Array3::from_elem((3, 2, 3), 1.0);
@@ -1044,6 +1185,112 @@ mod tests {
     }
 
     #[test]
+    fn test_detect_hot_pixels_bimodal_bright_region_not_flagged() {
+        // THE PR-#646 P0 regression guard.  Dark-majority bimodal scene:
+        // 60 % of the FOV at 50 counts (sample), a contiguous 40 % bright
+        // region at 5000 counts (open beam past the sample edge).  The dark
+        // population holds the median (med = ln 50) and the MAD is 0 (both
+        // populations are internally uniform), so sigma falls to the Poisson
+        // floor 1/√50 ≈ 0.141 and the stage-1 threshold is
+        // ln 50 + 6·0.141 ≈ 4.76 — EVERY bright pixel (ln 5000 ≈ 8.52)
+        // passes the global cut.  The local confirmation must veto them
+        // all: each bright pixel's neighbor median is 5000, and
+        // 5000 > 10 × 5000 is false.  Bright scene is not a defect.
+        let mut data = Array3::from_elem((1, 10, 10), 50.0);
+        for y in 0..10 {
+            for x in 6..10 {
+                data[[0, y, x]] = 5000.0;
+            }
+        }
+
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        assert!(
+            mask.iter().all(|&m| !m),
+            "no pixel of a bimodal scene may be flagged — the bright \
+             minority region is scene, not a defect"
+        );
+    }
+
+    #[test]
+    fn test_detect_hot_pixels_railed_inside_bright_region_caught() {
+        // Same bimodal scene, but with a genuinely railed pixel INSIDE the
+        // bright region: 1e6 ≈ 200× its bright neighbors.  It must still be
+        // caught (stage 2 compares against the LOCAL median of 5000, not
+        // the global dark median).
+        let mut data = Array3::from_elem((1, 10, 10), 50.0);
+        for y in 0..10 {
+            for x in 6..10 {
+                data[[0, y, x]] = 5000.0;
+            }
+        }
+        data[[0, 5, 8]] = 1.0e6;
+
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        assert!(
+            mask[[5, 8]],
+            "railed pixel inside bright region must be flagged"
+        );
+        assert_eq!(
+            mask.iter().filter(|&&m| m).count(),
+            1,
+            "only the railed pixel may be flagged"
+        );
+    }
+
+    #[test]
+    fn test_detect_hot_pixels_railed_column_segment_caught() {
+        // Three adjacent railed pixels in a column: each has ≥5 normal
+        // neighbors of 8 (the middle one has 6), so the neighbor MEDIAN
+        // stays at the background level and the whole segment is caught.
+        let mut data = Array3::from_elem((4, 7, 7), 100.0);
+        for t in 0..4 {
+            for y in 2..5 {
+                data[[t, y, 3]] = 65535.0;
+            }
+        }
+
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        for y in 2..5 {
+            assert!(mask[[y, 3]], "railed column pixel ({y}, 3) must be flagged");
+        }
+        assert_eq!(
+            mask.iter().filter(|&&m| m).count(),
+            3,
+            "only the railed segment may be flagged"
+        );
+    }
+
+    #[test]
+    fn test_detect_hot_pixels_isolated_live_pixel_keeps_global_verdict() {
+        // A stage-1 candidate whose 8-neighbors are ALL dead has no live
+        // neighbor median to refute the global verdict — it stays flagged.
+        // Scattered far pixels at 50 counts define the global statistics
+        // (med = ln 50, threshold ≈ 4.76); the isolated 1e6 pixel passes.
+        let mut data = Array3::<f64>::zeros((1, 5, 5));
+        for &(y, x) in &[(0, 0), (0, 2), (0, 4), (4, 0), (4, 2), (4, 4)] {
+            data[[0, y, x]] = 50.0;
+        }
+        data[[0, 2, 2]] = 1.0e6;
+
+        let mask = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap();
+        assert!(
+            mask[[2, 2]],
+            "isolated live candidate in a dead field keeps the global verdict"
+        );
+        assert_eq!(mask.iter().filter(|&&m| m).count(), 1);
+    }
+
+    #[test]
+    fn test_detect_hot_pixels_empty_tof_err() {
+        // n_tof == 0: the totals image would be all-zero (vacuous sums) —
+        // validating entry points must reject rather than return all-false.
+        let data = Array3::<f64>::zeros((0, 2, 2));
+        let err = detect_hot_pixels(&data, HOT_PIXEL_K_MAD).unwrap_err();
+        assert!(matches!(err, IoError::InvalidParameter(_)));
+        assert!(err.to_string().contains("empty TOF axis"));
+    }
+
+    #[test]
     fn test_detect_hot_pixels_nan_err() {
         let mut data = Array3::from_elem((2, 2, 2), 1.0);
         data[[1, 1, 0]] = f64::NAN;
@@ -1135,6 +1382,21 @@ mod tests {
                 "hot_k_mad = {bad_k} must be rejected"
             );
         }
+    }
+
+    #[test]
+    fn test_detect_bad_pixels_empty_tof_err() {
+        // An empty stack's all-zero test passes vacuously — without this
+        // guard the whole detector would be masked dead with no error.
+        let empty = Array3::<f64>::zeros((0, 2, 2));
+        let err = detect_bad_pixels(&empty, None, None).unwrap_err();
+        assert!(matches!(err, IoError::InvalidParameter(_)));
+        assert!(err.to_string().contains("sample"));
+
+        let sample = Array3::from_elem((3, 2, 2), 1.0);
+        let err = detect_bad_pixels(&sample, Some(&empty), None).unwrap_err();
+        assert!(matches!(err, IoError::InvalidParameter(_)));
+        assert!(err.to_string().contains("open_beam"));
     }
 
     #[test]

--- a/crates/nereids-io/src/normalization.rs
+++ b/crates/nereids-io/src/normalization.rs
@@ -603,7 +603,8 @@ pub fn detect_dead_pixels_chunked(chunks: &[Array3<f64>]) -> Result<Array2<bool>
 /// gain division) inflates the floor and can suppress real flags, while
 /// up-scaling (event weights > 1) deflates it below true counting noise.
 /// Run the detectors on unscaled counts and normalize afterwards; the GUI
-/// does exactly this (both of its normalization paths pass the raw
+/// does exactly this (all three of its raw-counts paths — TIFF pair,
+/// HDF5 with open beam, HDF5 without open beam — pass the raw
 /// sample/open-beam stacks, before any normalization).
 ///
 /// # Arguments
@@ -754,9 +755,10 @@ pub fn detect_hot_pixels(data: &Array3<f64>, k_mad: f64) -> Result<Array2<bool>,
 ///
 /// Both stacks must be **raw detected counts** (unscaled) — see the "Raw
 /// counts required" section of [`detect_hot_pixels`]: scaling distorts the
-/// Poisson floor of the hot screen.  The GUI satisfies this: both of its
-/// normalization paths call this function on the raw sample/open-beam
-/// stacks, before any normalization.
+/// Poisson floor of the hot screen.  The GUI satisfies this: all three of
+/// its raw-counts paths (TIFF pair, HDF5 with open beam, HDF5 without
+/// open beam) call this function on the raw sample/open-beam stacks,
+/// before any normalization.
 ///
 /// # Arguments
 /// * `sample` — Raw sample counts, shape (n_tof, height, width).

--- a/crates/nereids-io/src/project.rs
+++ b/crates/nereids-io/src/project.rs
@@ -138,6 +138,14 @@ pub struct ProjectSnapshot {
     pub energies: Option<Vec<f64>>,
     /// D-20: Dead-pixel mask (true = dead). Same spatial dimensions as the
     /// transmission data (height × width). `None` when no mask is available.
+    ///
+    /// Since #646 the GUI stores the **declared** mask component only here
+    /// (file-declared or project-declared — `AppState::file_dead_pixels`);
+    /// session detections are recomputed on every normalization and never
+    /// persisted.  The dataset path (`/intermediate/dead_pixels`), dtype,
+    /// and shape are unchanged, so no format marker is needed.  Files
+    /// written before #646 carried the effective mask (declared ∪ detected
+    /// at save time); the GUI promotes those to declared once on load.
     pub dead_pixels: Option<Array2<bool>>,
 
     // -- results (always embedded) --

--- a/crates/nereids-io/src/project.rs
+++ b/crates/nereids-io/src/project.rs
@@ -24,9 +24,11 @@ pub const PROJECT_SCHEMA_VERSION: &str = "1.0";
 /// component (the declared component lives at
 /// `/intermediate/dead_pixels`, unversioned for backward compatibility).
 /// Readers accept exactly this version; a dataset with a missing or
-/// unrecognized `format_version` is ignored — the restore then falls
-/// back to the declared-only behavior that predates the dataset, which
-/// is also the fallback for old files lacking the dataset entirely.
+/// unrecognized `format_version` is ignored, as is a dataset whose
+/// rank is not 2 (the same shape gate the declared-mask reader
+/// applies) — the restore then falls back to the declared-only
+/// behavior that predates the dataset, which is also the fallback for
+/// old files lacking the dataset entirely.
 pub const DETECTED_DEAD_PIXELS_FORMAT_VERSION: u32 = 1;
 
 /// Serialization-friendly snapshot of the full session state.
@@ -1565,9 +1567,10 @@ fn read_intermediate(file: &hdf5::File, snap: &mut ProjectSnapshot) -> Result<()
 
     // #646 R4 P1-1: Load the detected mask component (u8 → bool).  The
     // dataset is versioned; a missing or unrecognized `format_version`
-    // leaves the field `None` (declared-only restore — the documented
-    // fallback for files predating the dataset, see
-    // DETECTED_DEAD_PIXELS_FORMAT_VERSION).
+    // leaves the field `None`, as does a dataset whose rank is not 2 —
+    // the same shape gate as the declared-mask reader above
+    // (declared-only restore — the documented fallback for files
+    // predating the dataset, see DETECTED_DEAD_PIXELS_FORMAT_VERSION).
     if let Ok(det_ds) = inter.dataset("detected_dead_pixels") {
         let version = read_u32_attr_ds_opt(&det_ds, "format_version");
         let shape = det_ds.shape();

--- a/crates/nereids-io/src/project.rs
+++ b/crates/nereids-io/src/project.rs
@@ -17,6 +17,18 @@ use crate::error::IoError;
 /// Current schema version written to `/meta/version`.
 pub const PROJECT_SCHEMA_VERSION: &str = "1.0";
 
+/// Format version written to the `format_version` attribute of the
+/// `/intermediate/detected_dead_pixels` dataset (#646 review R4, P1-1).
+///
+/// The dataset carries the session-scoped *detected* dead/hot mask
+/// component (the declared component lives at
+/// `/intermediate/dead_pixels`, unversioned for backward compatibility).
+/// Readers accept exactly this version; a dataset with a missing or
+/// unrecognized `format_version` is ignored — the restore then falls
+/// back to the declared-only behavior that predates the dataset, which
+/// is also the fallback for old files lacking the dataset entirely.
+pub const DETECTED_DEAD_PIXELS_FORMAT_VERSION: u32 = 1;
+
 /// Serialization-friendly snapshot of the full session state.
 ///
 /// All GUI-specific enums are stored as plain strings so this struct
@@ -141,12 +153,29 @@ pub struct ProjectSnapshot {
     ///
     /// Since #646 the GUI stores the **declared** mask component only here
     /// (file-declared or project-declared — `AppState::file_dead_pixels`);
-    /// session detections are recomputed on every normalization and never
-    /// persisted.  The dataset path (`/intermediate/dead_pixels`), dtype,
-    /// and shape are unchanged, so no format marker is needed.  Files
-    /// written before #646 carried the effective mask (declared ∪ detected
-    /// at save time); the GUI promotes those to declared once on load.
+    /// the detected component travels separately in
+    /// [`ProjectSnapshot::detected_dead_pixels`].  The dataset path
+    /// (`/intermediate/dead_pixels`), dtype, and shape are unchanged, so no
+    /// format marker is needed.  Files written before #646 carried the
+    /// effective mask (declared ∪ detected at save time); the GUI promotes
+    /// those to declared once on load.
     pub dead_pixels: Option<Array2<bool>>,
+    /// Detected dead/hot mask component active at save time (#646 review
+    /// R4, P1-1).  Same spatial dimensions as the transmission data;
+    /// `None` when no detection had run (or for files predating the
+    /// dataset — restore then falls back to the declared component alone).
+    ///
+    /// Persisted as its own session-scoped dataset
+    /// (`/intermediate/detected_dead_pixels`, u8, with a `format_version`
+    /// attribute — see [`DETECTED_DEAD_PIXELS_FORMAT_VERSION`]) because a
+    /// restored project may carry embedded normalized data WITHOUT the raw
+    /// stacks: normalization (and thus detection) never re-runs there, so a
+    /// declared-only restore would silently refit without the dead/hot
+    /// exclusions that were active at save time.  On restore the GUI
+    /// rebuilds the effective mask as declared ∪ persisted-detected, and —
+    /// when raw stacks ARE present — recomputes detection purely to *warn*
+    /// on drift, never to silently replace the persisted component.
+    pub detected_dead_pixels: Option<Array2<bool>>,
 
     // -- results (always embedded) --
     pub density_maps: Option<Vec<Array2<f64>>>,
@@ -267,6 +296,7 @@ impl Default for ProjectSnapshot {
             normalized_uncertainty: None,
             energies: None,
             dead_pixels: None,
+            detected_dead_pixels: None,
             density_maps: None,
             uncertainty_maps: None,
             chi_squared_map: None,
@@ -410,6 +440,22 @@ fn write_u64_attr(loc: &hdf5::Group, name: &str, value: u64) -> Result<(), IoErr
         .create(name)
         .and_then(|a| a.write_scalar(&value))
         .map_err(|e| hdf5_err(name, e))
+}
+
+/// Dataset-attribute variant of [`write_u32_attr`] (the group-typed
+/// helpers above predate any dataset carrying attributes).
+fn write_u32_attr_ds(ds: &hdf5::Dataset, name: &str, value: u32) -> Result<(), IoError> {
+    ds.new_attr::<u32>()
+        .shape(())
+        .create(name)
+        .and_then(|a| a.write_scalar(&value))
+        .map_err(|e| hdf5_err(name, e))
+}
+
+/// Dataset-attribute read: `Some(value)` if present and convertible,
+/// `None` otherwise (mirrors the `read_*_attr_opt` group helpers).
+fn read_u32_attr_ds_opt(ds: &hdf5::Dataset, name: &str) -> Option<u32> {
+    ds.attr(name).ok()?.read_scalar::<u32>().ok()
 }
 
 fn write_meta(file: &hdf5::File, snap: &ProjectSnapshot) -> Result<(), IoError> {
@@ -793,6 +839,24 @@ fn write_intermediate(file: &hdf5::File, snap: &ProjectSnapshot) -> Result<(), I
                 .create("dead_pixels")
                 .and_then(|ds| ds.write_raw(&data))
                 .map_err(|e| hdf5_err("/intermediate/dead_pixels", e))?;
+        }
+    }
+
+    // #646 R4 P1-1: Persist the DETECTED mask component as its own
+    // session-scoped, versioned dataset (u8, 0 = live, 1 = excluded) —
+    // see the field rustdoc on `ProjectSnapshot::detected_dead_pixels`.
+    if let Some(ref det) = snap.detected_dead_pixels {
+        let shape = [det.shape()[0], det.shape()[1]];
+        if !shape.contains(&0) {
+            let data: Vec<u8> = det.iter().map(|&b| u8::from(b)).collect();
+            let ds = inter
+                .new_dataset::<u8>()
+                .shape(shape)
+                .create("detected_dead_pixels")
+                .map_err(|e| hdf5_err("/intermediate/detected_dead_pixels", e))?;
+            ds.write_raw(&data)
+                .map_err(|e| hdf5_err("/intermediate/detected_dead_pixels", e))?;
+            write_u32_attr_ds(&ds, "format_version", DETECTED_DEAD_PIXELS_FORMAT_VERSION)?;
         }
     }
 
@@ -1499,6 +1563,26 @@ fn read_intermediate(file: &hdf5::File, snap: &mut ProjectSnapshot) -> Result<()
         }
     }
 
+    // #646 R4 P1-1: Load the detected mask component (u8 → bool).  The
+    // dataset is versioned; a missing or unrecognized `format_version`
+    // leaves the field `None` (declared-only restore — the documented
+    // fallback for files predating the dataset, see
+    // DETECTED_DEAD_PIXELS_FORMAT_VERSION).
+    if let Ok(det_ds) = inter.dataset("detected_dead_pixels") {
+        let version = read_u32_attr_ds_opt(&det_ds, "format_version");
+        let shape = det_ds.shape();
+        if version == Some(DETECTED_DEAD_PIXELS_FORMAT_VERSION) && shape.len() == 2 {
+            let data: Vec<u8> = det_ds
+                .read_raw()
+                .map_err(|e| hdf5_err("/intermediate/detected_dead_pixels", e))?;
+            let bools: Vec<bool> = data.iter().map(|&v| v != 0).collect();
+            snap.detected_dead_pixels = Some(
+                Array2::from_shape_vec((shape[0], shape[1]), bools)
+                    .map_err(|e| hdf5_err("/intermediate/detected_dead_pixels reshape", e))?,
+            );
+        }
+    }
+
     Ok(())
 }
 
@@ -1888,6 +1972,7 @@ mod tests {
             normalized_uncertainty: None,
             energies: None,
             dead_pixels: None,
+            detected_dead_pixels: None,
             density_maps: None,
             uncertainty_maps: None,
             chi_squared_map: None,
@@ -2300,6 +2385,71 @@ mod tests {
         let en = loaded.energies.unwrap();
         assert_eq!(en.len(), 5);
         assert!((en[2] - 3.0).abs() < 1e-10);
+    }
+
+    /// #646 R4 P1-1: the declared and detected mask components round-trip
+    /// as independent datasets — neither leaks into the other.
+    #[test]
+    fn test_roundtrip_detected_dead_pixels_independent_of_declared() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rt_detected.nrd.h5");
+        let mut snap = minimal_snapshot();
+        let mut declared = Array2::from_elem((3, 4), false);
+        declared[[0, 0]] = true;
+        let mut detected = Array2::from_elem((3, 4), false);
+        detected[[2, 3]] = true;
+        snap.dead_pixels = Some(declared.clone());
+        snap.detected_dead_pixels = Some(detected.clone());
+        save_project(&path, &snap).unwrap();
+        let loaded = load_project(&path).unwrap();
+
+        assert_eq!(loaded.dead_pixels.unwrap(), declared);
+        assert_eq!(loaded.detected_dead_pixels.unwrap(), detected);
+    }
+
+    /// #646 R4 P1-1 backward compat: a file written without the detected
+    /// dataset (any pre-R4 file, or a session with no detection) loads
+    /// with `detected_dead_pixels = None` — the declared-only fallback.
+    #[test]
+    fn test_load_without_detected_dataset_is_declared_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("no_detected.nrd.h5");
+        let mut snap = minimal_snapshot();
+        let mut declared = Array2::from_elem((2, 2), false);
+        declared[[1, 1]] = true;
+        snap.dead_pixels = Some(declared.clone());
+        save_project(&path, &snap).unwrap();
+        let loaded = load_project(&path).unwrap();
+
+        assert_eq!(loaded.dead_pixels.unwrap(), declared);
+        assert!(loaded.detected_dead_pixels.is_none());
+    }
+
+    /// #646 R4 P1-1 forward compat: a detected dataset whose
+    /// `format_version` is unrecognized is ignored (declared-only
+    /// restore), never misread under the current format's semantics.
+    #[test]
+    fn test_detected_dead_pixels_future_format_version_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("future_detected.nrd.h5");
+        let mut snap = minimal_snapshot();
+        let mut detected = Array2::from_elem((2, 2), false);
+        detected[[0, 1]] = true;
+        snap.detected_dead_pixels = Some(detected);
+        save_project(&path, &snap).unwrap();
+
+        // Bump the dataset's format_version past the supported one.
+        {
+            let file = hdf5::File::open_rw(&path).unwrap();
+            let ds = file.dataset("intermediate/detected_dead_pixels").unwrap();
+            ds.attr("format_version")
+                .unwrap()
+                .write_scalar(&(DETECTED_DEAD_PIXELS_FORMAT_VERSION + 1))
+                .unwrap();
+        }
+
+        let loaded = load_project(&path).unwrap();
+        assert!(loaded.detected_dead_pixels.is_none());
     }
 
     #[test]

--- a/docs/guide/src/python-api.md
+++ b/docs/guide/src/python-api.md
@@ -281,6 +281,63 @@ Keyword arguments:
 | `tzero_jacobian="..."` | Select the TZERO Jacobian implementation. |
 | `fit_energy_range=(emin, emax)` | Restrict the cost function to an energy window. |
 
+## Pixel Masks
+
+Pixel masks exist **only to exclude pipeline-corrupting pixels** (dead or
+hot/railed detector defects).  They are not a data-quality or coverage
+filter: low-count pixels are alive and must be kept (the KL-domain fitters
+handle them), and coverage/thickness inhomogeneity is a model concern, not a
+masking concern.  Downstream, a masked pixel is hard-excluded — never
+fitted, `NaN` in the result maps.  Masks are `(height, width)` boolean
+arrays, `True` = exclude, and feed directly into
+`spatial_map(dead_pixels=...)`.
+
+```python
+# Recommended entry point: dead ∪ hot over sample AND open beam.
+mask = nereids.detect_bad_pixels(sample, open_beam=open_beam)
+
+# Individual criteria:
+dead = nereids.detect_dead_pixels(sample)             # exactly zero in every TOF bin
+hot  = nereids.detect_hot_pixels(sample, k_mad=6.0)   # railed/hot point defects
+gone = nereids.detect_dead_pixels_chunked([chunk_a, chunk_b])  # intermittent deadness
+
+result = nereids.spatial_map(cube, energies, isotopes, dead_pixels=mask)
+```
+
+### `detect_bad_pixels(sample, open_beam=None, hot_k_mad=6.0)`
+
+Union mask `dead(sample) ∪ hot(sample) [∪ dead(ob) ∪ hot(ob)]` — deadness
+and hotness are per-acquisition, so a mask built from one stack alone misses
+failures in the other.  This is the validating entry point (rejects
+non-finite/negative counts and empty TOF axes with `ValueError`).
+`hot_k_mad=None` disables the hot screen (dead-only mask).
+
+### `detect_dead_pixels(data)`
+
+Legacy single-stack detector: flags pixels that are exactly `0.0` in every
+TOF bin.  Assumes counts already validated finite and non-negative; prefer
+`detect_bad_pixels` for new code.
+
+### `detect_hot_pixels(data, k_mad=6.0)`
+
+Two-stage hot/railed screen on **raw counts**: a global robust cut on log
+total counts (median + `k_mad` · max(1.4826 · MAD, Poisson floor)) nominates
+candidates, and a local 8-neighbor confirmation (≥ 10× the neighbors'
+median, iterated to a fixpoint) keeps contiguous bright *scene* regions —
+open-beam areas, slit apertures — unmasked while catching isolated point,
+line, and small-cluster defects.  Pass raw detected counts, not
+proton-charge-normalized rates or transmission ratios: scaling breaks the
+Poisson floor.
+
+### `detect_dead_pixels_chunked(chunks)`
+
+Intermittent deadness: a pixel dead for part of the acquisition is invisible
+in a summed stack (uniformly reduced counts, no zeros).  Given per-chunk
+stacks (e.g. per-run splits or event data re-histogrammed in time windows),
+flags pixels all-zero in **any** chunk.  Chunk so that live pixels expect
+λ ≥ 20 counts each (false-flag probability ≤ m·e^(−λ)).  Spatial dims must
+match across chunks; the TOF axis may differ.
+
 ## TIFF and NeXus I/O
 
 ```python

--- a/scripts/python_api_allowlist.txt
+++ b/scripts/python_api_allowlist.txt
@@ -57,12 +57,6 @@ TraceDetectabilityReport
 IsotopeGroup
 
 # ---------------------------------------------------------------------------
-# Dead-pixel detection helper; partially covered by the spatial-mapping
-# "dead_pixels=" kwarg, but the detector itself has no section yet.
-# ---------------------------------------------------------------------------
-detect_dead_pixels
-
-# ---------------------------------------------------------------------------
 # Research-only Jacobian/Fisher evaluator (research follow-up work); no
 # narrative section yet — pdoc reference covers the signature.
 # ---------------------------------------------------------------------------

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -1461,6 +1461,39 @@ class TestPixelMasks:
         assert mask[5, 8]
         assert mask.sum() == 1
 
+    def test_railed_blob_fully_caught_fixpoint(self):
+        """#646 review R2 (F1): the stage-2 fixpoint erodes a 3x3 railed
+        blob from the boundary inward — a single local pass flags only the
+        4 corners (5 background neighbors each) and misses the edge centers
+        and the interior, whose neighbors are railed too."""
+        data = np.full((4, 9, 9), 100.0)
+        data[:, 3:6, 3:6] = 65535.0
+        mask = np.asarray(nereids.detect_hot_pixels(data))
+        assert mask[3:6, 3:6].all(), "3x3 blob must be fully caught"
+        assert mask.sum() == 9, "only the blob may be flagged"
+
+    def test_large_psf_bright_region_not_eroded(self):
+        """#646 review R2 (F1 safety): a large bright scene region (20x20
+        core at 100x background) with the >= 2-px PSF edge blur real VENUS
+        features have (adjacent ratios <= 5x) passes the global cut but
+        never seeds the erosion — zero flags."""
+        data = np.full((1, 50, 50), 100.0)
+        data[:, 13:37, 13:37] = 400.0
+        data[:, 14:36, 14:36] = 2000.0
+        data[:, 15:35, 15:35] = 10000.0
+        assert not np.asarray(nereids.detect_hot_pixels(data)).any()
+
+    def test_1px_bright_line_flagged_by_design(self):
+        """#646 review R2 (F3, pinned): a 1-px-wide bright scene line at
+        >= 10x local contrast is spatially indistinguishable from a railed
+        line and IS masked — the documented, accepted trade-off (real VENUS
+        scene features are PSF-blurred over >= 2 px)."""
+        data = np.full((1, 9, 9), 100.0)
+        data[:, :, 4] = 5000.0
+        mask = np.asarray(nereids.detect_hot_pixels(data))
+        assert mask[:, 4].all(), "width-1 line is flagged by design"
+        assert mask.sum() == 9
+
     def test_empty_tof_axis_raises(self):
         """shape[0] == 0: the all-zero dead test would pass vacuously and
         mask the whole detector — the validating entry points reject it."""

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -1440,6 +1440,40 @@ class TestPixelMasks:
         with pytest.raises(ValueError):
             nereids.detect_dead_pixels_chunked([])
 
+    def test_bimodal_bright_region_not_flagged(self):
+        """PR #646 P0 regression guard: dark-majority bimodal scene (60%
+        of the FOV at ~50 counts, contiguous 40% bright region at ~5000).
+        Every bright pixel passes the global median+MAD cut (the dark
+        population holds the median), but the local-neighborhood
+        confirmation must veto them all — bright scene is not a defect."""
+        data = np.full((1, 10, 10), 50.0)
+        data[:, :, 6:] = 5000.0
+        assert not np.asarray(nereids.detect_hot_pixels(data)).any()
+        assert not np.asarray(nereids.detect_bad_pixels(data)).any()
+
+    def test_bimodal_railed_inside_bright_region_caught(self):
+        """A genuinely railed pixel INSIDE the bright region of a bimodal
+        scene (~200x its bright neighbors) is still caught."""
+        data = np.full((1, 10, 10), 50.0)
+        data[:, :, 6:] = 5000.0
+        data[0, 5, 8] = 1.0e6
+        mask = np.asarray(nereids.detect_hot_pixels(data))
+        assert mask[5, 8]
+        assert mask.sum() == 1
+
+    def test_empty_tof_axis_raises(self):
+        """shape[0] == 0: the all-zero dead test would pass vacuously and
+        mask the whole detector — the validating entry points reject it."""
+        empty = np.empty((0, 2, 2))
+        with pytest.raises(ValueError):
+            nereids.detect_bad_pixels(empty)
+        with pytest.raises(ValueError):
+            nereids.detect_bad_pixels(np.ones((3, 2, 2)), empty)
+        with pytest.raises(ValueError):
+            nereids.detect_hot_pixels(empty)
+        with pytest.raises(ValueError):
+            nereids.detect_dead_pixels_chunked([empty])
+
     def test_mask_round_trips_into_spatial_map(self, u238_data):
         """A detect_bad_pixels mask feeds spatial_map_typed(dead_pixels=...):
         the masked pixel is hard-excluded (NaN in the density map)."""

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -1483,6 +1483,25 @@ class TestPixelMasks:
         data[:, 15:35, 15:35] = 10000.0
         assert not np.asarray(nereids.detect_hot_pixels(data)).any()
 
+    def test_edge_to_edge_2px_band_not_flagged_by_design(self):
+        """#646 review R3 (F1, pinned limitation): an EDGE-TO-EDGE railed
+        band >= 2 px wide (both ends off-detector) exposes no end cap or
+        convex corner, so the fixpoint erosion has no seed and the band is
+        NOT caught — deliberately: a slit-aperture open beam produces a
+        genuine full-width bright scene band indistinguishable from it,
+        and a full-span screen would mask that scene (bimodal failure).
+        Declare such full-span pathologies in a file mask.  The same band
+        with one end cap inside the detector IS fully consumed."""
+        edge_to_edge = np.full((4, 9, 9), 100.0)
+        edge_to_edge[:, 3:5, :] = 65535.0
+        assert not np.asarray(nereids.detect_hot_pixels(edge_to_edge)).any()
+
+        one_end_inside = np.full((4, 9, 9), 100.0)
+        one_end_inside[:, 3:5, :7] = 65535.0
+        mask = np.asarray(nereids.detect_hot_pixels(one_end_inside))
+        assert mask[3:5, :7].all(), "band with an end cap must be caught"
+        assert mask.sum() == 14, "only the railed band may be flagged"
+
     def test_1px_bright_line_flagged_by_design(self):
         """#646 review R2 (F3, pinned): a 1-px-wide bright scene line at
         >= 10x local contrast is spatially indistinguishable from a railed

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -1399,6 +1399,48 @@ class TestPixelMasks:
         assert not mask[0, 2], "low-count-alive pixel must be kept"
         assert mask.sum() == 1
 
+    def test_detect_hot_pixels_mad_scale_decides_stage1_threshold(self):
+        """Mirror of the Rust deciding-branch test (#646 review R4, P1-2):
+        the robust-MAD branch of the stage-1 scale
+        sigma = max(MAD_TO_SIGMA*mad, exp(-med/2)) decides the outcome.
+
+        8x8 single-bin grid; two all-dead 3x3 moats (rows/cols 1-3 and
+        4-6) isolate a probe at (2,2) and a control at (5,5) so their
+        stage-2 reference sample is empty and the flag outcome is decided
+        purely by the stage-1 threshold.  Background: 24 px at A = 8000,
+        22 px at B = 12500 (A*B = 1e8, B/A = 1.25**2).  Worked stage-1
+        arithmetic over the 48 live pixels (ranks pin the statistics):
+
+          med = (ln A + ln B)/2 = ln 1e4         = 9.2103404
+          mad = ln 1.25                          = 0.2231436
+          MAD term = 1.4826022 * 0.2231436       = 0.3308331
+          floor = exp(-med/2) = 1e-2             = 0.01  (MAD wins)
+          threshold = med + 6*sigma              = 11.1953391
+
+        Probe ln 40000 = 10.5966347 < threshold -> kept; under a
+        floor-only mutation the threshold collapses to 9.2703404 and the
+        probe would be flagged.  Control ln 200000 = 12.2060726 >
+        threshold -> flagged.
+        """
+        data = np.zeros((1, 8, 8))
+        data[0, 2, 2] = 40000.0  # probe
+        data[0, 5, 5] = 200000.0  # control
+        filled = 0
+        for y in range(8):
+            for x in range(8):
+                in_moat1 = 1 <= y <= 3 and 1 <= x <= 3
+                in_moat2 = 4 <= y <= 6 and 4 <= x <= 6
+                if in_moat1 or in_moat2:
+                    continue  # dead moat cells stay 0.0
+                data[0, y, x] = 8000.0 if filled < 24 else 12500.0
+                filled += 1
+        assert filled == 46
+
+        mask = np.asarray(nereids.detect_hot_pixels(data))
+        assert not mask[2, 2], "probe below the MAD-driven threshold must be kept"
+        assert mask[5, 5], "control above the MAD-driven threshold must be flagged"
+        assert mask.sum() == 1
+
     def test_detect_dead_pixels_chunked_catches_intermittent(self):
         chunk0 = np.full((3, 2, 2), 5.0)
         chunk0[:, 0, 1] = 0.0  # dead throughout chunk 0 only

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -1344,6 +1344,131 @@ class TestNormalization:
 
 
 # ===========================================================================
+# Pixel masks (pipeline-integrity screens, #643)
+# ===========================================================================
+
+
+class TestPixelMasks:
+    """Tests for detect_dead_pixels, detect_hot_pixels,
+    detect_dead_pixels_chunked, and detect_bad_pixels (#643)."""
+
+    def test_detect_dead_pixels_backcompat(self):
+        """The original all-zero-stack detector is unchanged."""
+        data = np.full((3, 2, 2), 5.0)
+        data[:, 0, 0] = 0.0
+        mask = np.asarray(nereids.detect_dead_pixels(data))
+        assert mask.dtype == np.bool_
+        assert mask.shape == (2, 2)
+        assert mask[0, 0]
+        assert not mask[1, 1]
+
+    def test_detect_bad_pixels_union(self):
+        """dead(sample) | hot(sample) | dead(ob) | hot(ob); low-count kept."""
+        sample = np.full((3, 3, 3), 100.0)
+        sample[:, 0, 0] = 0.0  # dead in sample only
+        sample[:, 1, 2] = 0.0
+        sample[0, 1, 2] = 1.0  # low-count-ALIVE: 1 total count
+        ob = np.full((3, 3, 3), 200.0)
+        ob[:, 0, 1] = 0.0  # dead in OB only
+        ob[:, 2, 2] = 65535.0  # hot (railed) in OB only
+
+        mask = np.asarray(nereids.detect_bad_pixels(sample, ob))
+        assert mask.dtype == np.bool_
+        assert mask.shape == (3, 3)
+        assert mask[0, 0], "dead-in-sample-only must be flagged"
+        assert mask[0, 1], "dead-in-OB-only must be flagged"
+        assert mask[2, 2], "hot-in-OB-only must be flagged"
+        assert not mask[1, 2], "low-count-alive pixel must be kept"
+        assert mask.sum() == 3
+
+    def test_detect_bad_pixels_hot_k_mad_none_disables_hot(self):
+        sample = np.full((3, 3, 3), 100.0)
+        sample[:, 1, 1] = 65535.0  # railed
+        dead_only = np.asarray(nereids.detect_bad_pixels(sample, hot_k_mad=None))
+        assert not dead_only.any()
+        with_hot = np.asarray(nereids.detect_bad_pixels(sample))
+        assert with_hot[1, 1]
+
+    def test_detect_hot_pixels_flags_railed_keeps_low_count(self):
+        data = np.full((3, 3, 3), 100.0)
+        data[:, 2, 0] = 65535.0  # railed
+        data[:, 0, 2] = 0.0
+        data[1, 0, 2] = 1.0  # low-count-alive
+        mask = np.asarray(nereids.detect_hot_pixels(data))
+        assert mask[2, 0], "railed pixel must be flagged"
+        assert not mask[0, 2], "low-count-alive pixel must be kept"
+        assert mask.sum() == 1
+
+    def test_detect_dead_pixels_chunked_catches_intermittent(self):
+        chunk0 = np.full((3, 2, 2), 5.0)
+        chunk0[:, 0, 1] = 0.0  # dead throughout chunk 0 only
+        chunk1 = np.full((3, 2, 2), 5.0)
+        mask = np.asarray(nereids.detect_dead_pixels_chunked([chunk0, chunk1]))
+        assert mask[0, 1]
+        assert mask.sum() == 1
+        # The gap being closed: the summed stack cannot see it.
+        summed_mask = np.asarray(nereids.detect_dead_pixels(chunk0 + chunk1))
+        assert not summed_mask[0, 1]
+
+    def test_shape_mismatch_raises(self):
+        sample = np.ones((3, 2, 2))
+        ob = np.ones((3, 2, 3))
+        with pytest.raises(ValueError, match="[Ss]hape"):
+            nereids.detect_bad_pixels(sample, ob)
+        with pytest.raises(ValueError, match="[Ss]hape"):
+            nereids.detect_dead_pixels_chunked([sample, ob])
+
+    def test_nan_raises(self):
+        data = np.ones((2, 2, 2))
+        data[0, 0, 0] = np.nan
+        with pytest.raises(ValueError):
+            nereids.detect_bad_pixels(data)
+        with pytest.raises(ValueError):
+            nereids.detect_hot_pixels(data)
+        with pytest.raises(ValueError):
+            nereids.detect_dead_pixels_chunked([data])
+
+    def test_bad_k_raises(self):
+        data = np.ones((2, 2, 2))
+        for bad_k in (0.0, -1.0, float("nan"), float("inf")):
+            with pytest.raises(ValueError, match="k_mad"):
+                nereids.detect_hot_pixels(data, k_mad=bad_k)
+            with pytest.raises(ValueError, match="k_mad"):
+                nereids.detect_bad_pixels(data, hot_k_mad=bad_k)
+
+    def test_empty_chunks_raises(self):
+        with pytest.raises(ValueError):
+            nereids.detect_dead_pixels_chunked([])
+
+    def test_mask_round_trips_into_spatial_map(self, u238_data):
+        """A detect_bad_pixels mask feeds spatial_map_typed(dead_pixels=...):
+        the masked pixel is hard-excluded (NaN in the density map)."""
+        energies = np.linspace(1.0, 10.0, 20)
+        n_e = len(energies)
+        h, w = 3, 3
+        sample = np.full((n_e, h, w), 100.0)
+        sample[:, 1, 1] = 0.0  # dead pixel
+        mask = np.asarray(nereids.detect_bad_pixels(sample))
+        assert mask.dtype == np.bool_
+        assert mask[1, 1] and mask.sum() == 1
+
+        t = np.full((n_e, h, w), 0.5)
+        u = np.full((n_e, h, w), 0.01)
+        data = nereids.from_transmission(t, u)
+        result = nereids.spatial_map_typed(
+            data, energies, [u238_data],
+            solver="lm",
+            dead_pixels=mask,
+            max_iter=5,
+        )
+        density = np.asarray(result.density_maps[0])
+        assert density.shape == (h, w)
+        assert np.isnan(density[1, 1]), (
+            "masked pixel must be hard-excluded (NaN in the density map)"
+        )
+
+
+# ===========================================================================
 # TIFF I/O
 # ===========================================================================
 


### PR DESCRIPTION
Closes #643.

## What

Hardens pixel-mask detection per the issue's five points, keeping `detect_dead_pixels` byte-for-byte backward compatible:

1. **Exact-zero test documented as intentional** — counts are validated finite/≥ 0 upstream and `0.0 × efficiency == 0.0` exactly in IEEE 754, so `<= 0.0` would be dead code; a NaN bin makes a pixel look *alive* by design (corrupt input must be rejected upstream, never silently masked). `detect_bad_pixels` is the validating entry point.
2. **Intermittent deadness** — new `detect_dead_pixels_chunked(&[Array3])`: dead-in-ANY-chunk over per-acquisition chunks (exact-zero per chunk; ragged n_tof allowed). Docs carry the false-positive math (P ≤ m·e^(−λ); guidance λ ≥ 20/pixel/chunk) and explain why a within-stack zero-run variant is deliberately NOT provided (it would be a statistical screen on low-count pixels — the banned 13 %-random-rejection failure mode).
3. **Hot/railed pixels** — new `detect_hot_pixels(data, k_mad)`: one-sided (upper-tail-only) robust cut on log total counts, `median + k·max(1.4826·MAD, Poisson floor e^{−med/2})`, dead pixels excluded from the stats sample. Default `HOT_PIXEL_K_MAD = 6` → ~2.6e−4 expected false flags per 512² frame; the Poisson floor guards MAD = 0 on quantized low-count images without becoming a low-count screen. New `nereids-core::stats` module (median, MAD, MAD_TO_SIGMA).
4. **Union semantics** — new `detect_bad_pixels(sample, Some(ob), Some(k))` = dead ∪ hot over sample ∪ OB; the GUI normalization callsite now uses it (previously masked `dead(sample)` only, ignoring the open beam), label reworded to "Masked pixels (dead/hot)".
5. **Docs** — module section "Pixel masks — pipeline integrity only": masks exist ONLY to stop pipeline-corrupting pixels (downstream hard-exclude); NOT a data-quality/coverage filter; low-count pixels are alive and must be kept (KL-domain fitting handles them); inhomogeneity is a model concern.

Python bindings for all three new functions + `.pyi` stubs + pytest coverage (including a mask → `spatial_map` round-trip).

## Acceptance tests (all green)

- Intermittently-dead pixel caught by the chunked variant (and shown NOT caught by the summed-stack legacy test — the gap being closed)
- Hot/railed pixel caught (65535/bin vs ~100 background); neighbors untouched
- Low-count-but-alive pixel NOT flagged (both chunked and hot paths — the 13 %-rejection regression guard)
- Plus: NaN/shape/param validation errors, MAD = 0 paths, dead-excluded-from-stats, union combinations

## Behavior change

GUI normalization masks may include more pixels than before (hot + OB-dead union) — changelog carries the note; persisted masks in existing `.nrd.h5` projects are untouched.

## Verification

- `cargo fmt` / `clippy --workspace --exclude nereids-python --all-targets -- -D warnings` / `cargo test --workspace --exclude nereids-python`: clean, **1102 tests passed, 0 failed** (+26 new)
- Python wheel + `pytest tests/test_nereids.py`: **147 passed, 1 skipped** (TestPixelMasks 10/10)

PR assisted with [Claude Code](https://claude.com/claude-code).