### PR TITLE
feat(io): beam-state event filtering — DASlogs intervals + NXevent_data bank spectra (#637)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Beam-state event filtering for NXevent_data banks** (#637):
+  `read_run_log(path, pv)` reads `/entry/DASlogs/<pv>` as a transition
+  log (SNS logs record transitions, not uniform samples — the entry-mean
+  of a real VENUS `pause` log read 0.43 while the time-weighted truth
+  was 0.90); `intervals_where` derives `(t_start, t_end)` intervals with
+  correct step-function semantics (last value persists to
+  `/entry/duration`, pre-log time and NaN never match);
+  `intervals_intersect` composes conditions across PVs.
+  `load_nexus_bank_spectrum(path, bank, ..., keep_intervals=None)` loads
+  one facility NXevent_data bank (e.g. `monitor1`) as a 1-D TOF spectrum
+  keeping only pulses whose `event_time_zero` falls in the intervals
+  (half-open, same run-start clock as DASlogs at SNS), with pulse/event
+  retention statistics and clock-epoch attributes for cross-checking.
+  `units` attributes are required on both `event_time_offset` and
+  `event_time_zero` (#554: NXevent_data declares no defaults — never
+  guess a scale); corrupt device-reconnect records in DASlogs (backward
+  time jumps and subnormal uninitialized-memory payloads, both seen on
+  real VENUS furnace channels) are dropped and counted in
+  `RunLog.n_dropped_corrupt`; empty banks — the normal state of every VENUS
+  imaging-detector bank, since tpx1 is frame-mode — load gracefully to a
+  zero spectrum.  The rustpix `/entry/neutrons` event path is NOT
+  filtered: that schema carries no per-event wall-clock time; filtering
+  there stays out of scope until a producer demonstrably writes one.
+
 - **Bounded multiplicative baseline `B(E)` in every fitter** (#635): a
   smooth, box-bounded normalization
   `B(E) = b0 + b1·ln(E/E_ref) + b2·ln²(E/E_ref)` (E_ref = geometric

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -882,6 +882,47 @@ def load_nexus_histogram(
     """
     ...
 
+class RunLog:
+    """A slow-control PV from ``/entry/DASlogs/<pv>`` as a transition log.
+
+    ``values[i]`` takes effect at ``times[i]`` and persists until the next
+    entry (the last value persists to ``duration_s``).  Do NOT average
+    ``values`` directly — use :func:`intervals_where` (issue #637).
+    """
+
+    @property
+    def times(self) -> NDArray[np.float64]: ...
+    @property
+    def values(self) -> NDArray[np.float64]: ...
+    @property
+    def duration_s(self) -> float: ...
+    @property
+    def offset_iso(self) -> str | None: ...
+    @property
+    def n_dropped_corrupt(self) -> int: ...
+
+class BankSpectrum:
+    """1-D TOF spectrum from one NXevent_data bank plus retention stats."""
+
+    @property
+    def tof_edges_us(self) -> NDArray[np.float64]: ...
+    @property
+    def counts(self) -> NDArray[np.uint64]: ...
+    @property
+    def pulses_total(self) -> int: ...
+    @property
+    def pulses_kept(self) -> int: ...
+    @property
+    def events_total(self) -> int: ...
+    @property
+    def events_kept(self) -> int: ...
+    @property
+    def dropped_tof_range(self) -> int: ...
+    @property
+    def dropped_non_finite(self) -> int: ...
+    @property
+    def pulse_time_offset_iso(self) -> str | None: ...
+
 def load_nexus_events(
     path: str,
     n_bins: int,
@@ -894,6 +935,52 @@ def load_nexus_events(
 
     Reads ``/entry/neutrons/event_time_offset``, ``/x``, ``/y`` and bins
     events into a linear TOF grid.
+    """
+    ...
+
+def read_run_log(path: str, pv: str) -> RunLog:
+    """Read a DASlogs PV from a NeXus file as a transition log (issue #637).
+
+    SNS DASlogs record TRANSITIONS, not uniform samples: on a real VENUS
+    run the entry-mean of the ``pause`` log read 0.43 while the
+    time-weighted truth was 0.90.  Derive intervals with
+    :func:`intervals_where` instead of averaging ``values``.
+    """
+    ...
+
+def intervals_where(
+    times: NDArray[np.float64] | list[float],
+    values: NDArray[np.float64] | list[float],
+    duration_s: float,
+    min_value: float | None = None,
+    max_value: float | None = None,
+) -> list[tuple[float, float]]:
+    """Intervals where ``min_value <= value <= max_value`` under correct
+    step-function semantics (issue #637).  Time before the first log entry
+    never matches; NaN never matches; adjacent segments merge.
+    """
+    ...
+
+def intervals_intersect(
+    a: list[tuple[float, float]],
+    b: list[tuple[float, float]],
+) -> list[tuple[float, float]]:
+    """Intersect two sorted interval lists, e.g. pause==0 AND power>1.5 MW."""
+    ...
+
+def load_nexus_bank_spectrum(
+    path: str,
+    bank: str,
+    n_bins: int,
+    tof_min_us: float,
+    tof_max_us: float,
+    keep_intervals: list[tuple[float, float]] | None = None,
+) -> BankSpectrum:
+    """Load one NXevent_data bank (e.g. ``"monitor1"``) as a 1-D TOF
+    spectrum, keeping only pulses inside ``keep_intervals`` (seconds on the
+    pulse clock = DASlogs clock at SNS).  Empty banks load gracefully to a
+    zero spectrum; ``units`` attrs are required on both event datasets
+    (issue #637).
     """
     ...
 

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -965,7 +965,11 @@ def intervals_intersect(
     a: list[tuple[float, float]],
     b: list[tuple[float, float]],
 ) -> list[tuple[float, float]]:
-    """Intersect two sorted interval lists, e.g. pause==0 AND power>1.5 MW."""
+    """Intersect two interval lists, e.g. pause==0 AND power>1.5 MW.
+
+    Inputs may be unsorted/overlapping (normalised by sort+merge first);
+    every pair must be finite with t_end > t_start.
+    """
     ...
 
 def load_nexus_bank_spectrum(

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -3396,6 +3396,302 @@ fn load_nexus_events(
     Ok(nexus_data_to_py(py, data))
 }
 
+/// A slow-control PV read from `/entry/DASlogs/<pv>` as a transition log.
+#[pyclass(name = "RunLog")]
+struct PyRunLog {
+    times: Py<PyArray1<f64>>,
+    values: Py<PyArray1<f64>>,
+    duration_s: f64,
+    offset_iso: Option<String>,
+    n_dropped_corrupt: usize,
+}
+
+#[pymethods]
+impl PyRunLog {
+    /// Transition times in seconds relative to run start (ascending).
+    #[getter]
+    fn times<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        self.times.bind(py).clone()
+    }
+
+    /// Value taking effect at the matching `times` entry.
+    #[getter]
+    fn values<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        self.values.bind(py).clone()
+    }
+
+    /// Total run duration in seconds (`/entry/duration`).
+    #[getter]
+    fn duration_s(&self) -> f64 {
+        self.duration_s
+    }
+
+    /// ISO-8601 epoch of the time axis, when recorded.  Compare with
+    /// `BankSpectrum.pulse_time_offset_iso` to confirm both clocks share
+    /// a zero point.
+    #[getter]
+    fn offset_iso(&self) -> Option<String> {
+        self.offset_iso.clone()
+    }
+
+    /// Entries dropped as corrupt device-reconnect records (backward time
+    /// jump or subnormal value payload, both seen in real SNS files).
+    /// Non-zero is worth a mention in run-health screens.
+    #[getter]
+    fn n_dropped_corrupt(&self) -> usize {
+        self.n_dropped_corrupt
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> String {
+        let offset = match &self.offset_iso {
+            Some(o) => format!("{o:?}"),
+            None => "None".to_string(),
+        };
+        format!(
+            "RunLog(n_entries={}, duration_s={}, offset={}, n_dropped_corrupt={})",
+            self.times.bind(py).len(),
+            self.duration_s,
+            offset,
+            self.n_dropped_corrupt,
+        )
+    }
+}
+
+/// Read a DASlogs PV from a NeXus file as a transition log (issue #637).
+///
+/// SNS/HFIR DASlogs are **transition logs**, not uniformly-sampled time
+/// series: `values[i]` takes effect at `times[i]` and persists until the
+/// next entry (the last value persists to the end of the run).  Averaging
+/// `values` directly is therefore wrong whenever entries are unevenly
+/// spaced — on a real VENUS run the entry-mean of the `pause` log read
+/// 0.43 while the time-weighted truth was 0.90.  Use `intervals_where`
+/// to derive time intervals with the correct step-function semantics.
+///
+/// Args:
+///     path: Path to the NeXus/HDF5 file.
+///     pv: PV name under `/entry/DASlogs/` (e.g. "pause",
+///         "BL10:Det:rtdl:BeamPowerAvg").
+///
+/// Returns:
+///     RunLog with times (s, relative to run start), values, duration_s,
+///     the ISO-8601 epoch of the time axis when recorded, and
+///     n_dropped_corrupt — the number of corrupt device-reconnect
+///     records (backward time jump or subnormal value payload) dropped.
+#[pyfunction]
+#[pyo3(signature = (path, pv))]
+fn read_run_log(py: Python<'_>, path: &str, pv: &str) -> PyResult<PyRunLog> {
+    let log =
+        nereids_io::runlog::read_run_log(std::path::Path::new(path), pv).map_err(map_io_error)?;
+    Ok(PyRunLog {
+        times: PyArray1::from_vec(py, log.times).unbind(),
+        values: PyArray1::from_vec(py, log.values).unbind(),
+        duration_s: log.duration_s,
+        offset_iso: log.offset_iso,
+        n_dropped_corrupt: log.n_dropped_corrupt,
+    })
+}
+
+/// Derive run-time intervals where a transition-log PV satisfies
+/// `min_value <= value <= max_value` (issue #637).
+///
+/// Uses the correct step-function semantics: `values[i]` holds on
+/// `[times[i], times[i+1])` and the last value holds to `duration_s`.
+/// Time before the first log entry is treated as NOT matching (the state
+/// is unrecorded — the conservative choice for a keep-filter), and NaN
+/// values never match.  Adjacent matching segments are merged.
+///
+/// Example — beam-state filtering for a paused run::
+///
+///     pause = read_run_log(path, "pause")
+///     live = intervals_where(pause.times, pause.values,
+///                            pause.duration_s, max_value=0.5)
+///     power = read_run_log(path, "BL10:Det:rtdl:BeamPowerAvg")
+///     stable = intervals_where(power.times, power.values,
+///                              power.duration_s, min_value=1.5)
+///     keep = intervals_intersect(live, stable)
+///
+/// Args:
+///     times: Transition times in seconds (ascending).
+///     values: PV values taking effect at each time.
+///     duration_s: Total run duration in seconds.
+///     min_value: Keep intervals where value >= min_value (optional).
+///     max_value: Keep intervals where value <= max_value (optional).
+///
+/// Returns:
+///     List of (t_start, t_end) tuples in seconds, sorted, non-overlapping.
+#[pyfunction]
+#[pyo3(signature = (times, values, duration_s, min_value=None, max_value=None))]
+fn intervals_where(
+    times: Vec<f64>,
+    values: Vec<f64>,
+    duration_s: f64,
+    min_value: Option<f64>,
+    max_value: Option<f64>,
+) -> PyResult<Vec<(f64, f64)>> {
+    nereids_io::runlog::intervals_where(&times, &values, duration_s, min_value, max_value)
+        .map_err(map_io_error)
+}
+
+/// Intersect two interval lists (issue #637).
+///
+/// Composes conditions across PVs, e.g. `pause == 0` AND
+/// `beam_power > 1.5 MW`.  Inputs are lists of (t_start, t_end) tuples;
+/// unsorted or overlapping lists are normalised first (every pair must be
+/// finite with t_end > t_start).  The output is sorted, non-overlapping,
+/// and drops empty intersections.
+#[pyfunction]
+#[pyo3(signature = (a, b))]
+fn intervals_intersect(a: Vec<(f64, f64)>, b: Vec<(f64, f64)>) -> PyResult<Vec<(f64, f64)>> {
+    nereids_io::runlog::intervals_intersect(&a, &b).map_err(map_io_error)
+}
+
+/// A 1-D TOF spectrum from one NXevent_data bank, with pulse/event
+/// retention statistics.
+#[pyclass(name = "BankSpectrum")]
+struct PyBankSpectrum {
+    tof_edges_us: Py<PyArray1<f64>>,
+    counts: Py<PyArray1<u64>>,
+    pulses_total: usize,
+    pulses_kept: usize,
+    events_total: usize,
+    events_kept: usize,
+    dropped_tof_range: usize,
+    dropped_non_finite: usize,
+    pulse_time_offset_iso: Option<String>,
+}
+
+#[pymethods]
+impl PyBankSpectrum {
+    /// TOF bin edges in microseconds (length = n_bins + 1).
+    #[getter]
+    fn tof_edges_us<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        self.tof_edges_us.bind(py).clone()
+    }
+
+    /// Event counts per TOF bin (length = n_bins).
+    #[getter]
+    fn counts<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<u64>> {
+        self.counts.bind(py).clone()
+    }
+
+    /// Total pulses recorded in the bank.
+    #[getter]
+    fn pulses_total(&self) -> usize {
+        self.pulses_total
+    }
+
+    /// Pulses inside keep_intervals (= pulses_total when unfiltered).
+    #[getter]
+    fn pulses_kept(&self) -> usize {
+        self.pulses_kept
+    }
+
+    /// Total events recorded in the bank.
+    #[getter]
+    fn events_total(&self) -> usize {
+        self.events_total
+    }
+
+    /// Events on kept pulses inside the TOF window.
+    #[getter]
+    fn events_kept(&self) -> usize {
+        self.events_kept
+    }
+
+    /// Events on kept pulses dropped for TOF outside the window.
+    #[getter]
+    fn dropped_tof_range(&self) -> usize {
+        self.dropped_tof_range
+    }
+
+    /// Events on kept pulses dropped for non-finite TOF.
+    #[getter]
+    fn dropped_non_finite(&self) -> usize {
+        self.dropped_non_finite
+    }
+
+    /// ISO-8601 epoch of the pulse clock, when recorded.  Compare with
+    /// `RunLog.offset_iso` to confirm both clocks share a zero point.
+    #[getter]
+    fn pulse_time_offset_iso(&self) -> Option<String> {
+        self.pulse_time_offset_iso.clone()
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> String {
+        format!(
+            "BankSpectrum(n_bins={}, pulses={}/{}, events={}/{})",
+            self.counts.bind(py).len(),
+            self.pulses_kept,
+            self.pulses_total,
+            self.events_kept,
+            self.events_total,
+        )
+    }
+}
+
+/// Load one NXevent_data bank (e.g. a beam monitor) as a 1-D TOF spectrum,
+/// optionally keeping only pulses inside wall-clock intervals (issue #637).
+///
+/// Reads `/entry/<bank>/{event_time_offset, event_index, event_time_zero}`
+/// (the facility NeXus convention).  The `units` attributes on
+/// `event_time_offset` AND `event_time_zero` are required — NXevent_data
+/// specifies no defaults, and refusing to guess closes the #554
+/// silent-rescale class.
+/// A bank with zero events loads to an all-zero spectrum with correct
+/// pulse statistics — it never errors (on VENUS every imaging-detector
+/// bank is empty because tpx1 is frame-mode; only monitors carry events).
+///
+/// Args:
+///     path: Path to the NeXus/HDF5 file.
+///     bank: Bank group name under `/entry` (e.g. "monitor1",
+///         "bank100_events").
+///     n_bins: Number of TOF bins.
+///     tof_min_us: Minimum TOF in microseconds (inclusive).
+///     tof_max_us: Maximum TOF in microseconds (exclusive).
+///     keep_intervals: Optional list of (t_start, t_end) pairs in seconds
+///         on the pulse clock (at SNS: seconds since run start, the same
+///         clock as DASlogs times — pass the output of `intervals_where`
+///         / `intervals_intersect` directly).  A pulse is kept iff
+///         t_start <= event_time_zero < t_end for some interval.
+///
+/// Returns:
+///     BankSpectrum with tof_edges_us, counts, and pulse/event stats.
+#[pyfunction]
+#[pyo3(signature = (path, bank, n_bins, tof_min_us, tof_max_us, keep_intervals=None))]
+fn load_nexus_bank_spectrum(
+    py: Python<'_>,
+    path: &str,
+    bank: &str,
+    n_bins: usize,
+    tof_min_us: f64,
+    tof_max_us: f64,
+    keep_intervals: Option<Vec<(f64, f64)>>,
+) -> PyResult<PyBankSpectrum> {
+    let params = nereids_io::nexus::BankBinningParams {
+        n_bins,
+        tof_min_us,
+        tof_max_us,
+    };
+    let s = nereids_io::nexus::load_nexus_bank_spectrum(
+        std::path::Path::new(path),
+        bank,
+        &params,
+        keep_intervals.as_deref(),
+    )
+    .map_err(map_io_error)?;
+    Ok(PyBankSpectrum {
+        tof_edges_us: PyArray1::from_vec(py, s.tof_edges_us).unbind(),
+        counts: PyArray1::from_vec(py, s.counts).unbind(),
+        pulses_total: s.pulses_total,
+        pulses_kept: s.pulses_kept,
+        events_total: s.events_total,
+        events_kept: s.events_kept,
+        dropped_tof_range: s.dropped_tof_range,
+        dropped_non_finite: s.dropped_non_finite,
+        pulse_time_offset_iso: s.pulse_time_offset_iso,
+    })
+}
+
 /// Convert Rust NexusHistogramData to Python PyNexusData.
 fn nexus_data_to_py(py: Python<'_>, data: nereids_io::nexus::NexusHistogramData) -> PyNexusData {
     let (event_total, event_kept) = data
@@ -3447,6 +3743,12 @@ fn nereids(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(probe_nexus, m)?)?;
     m.add_function(wrap_pyfunction!(load_nexus_histogram, m)?)?;
     m.add_function(wrap_pyfunction!(load_nexus_events, m)?)?;
+    m.add_class::<PyRunLog>()?;
+    m.add_class::<PyBankSpectrum>()?;
+    m.add_function(wrap_pyfunction!(read_run_log, m)?)?;
+    m.add_function(wrap_pyfunction!(intervals_where, m)?)?;
+    m.add_function(wrap_pyfunction!(intervals_intersect, m)?)?;
+    m.add_function(wrap_pyfunction!(load_nexus_bank_spectrum, m)?)?;
     m.add_function(wrap_pyfunction!(normalize, m)?)?;
     m.add_function(wrap_pyfunction!(tof_to_energy_centers, m)?)?;
     m.add_function(wrap_pyfunction!(py_element_symbol, m)?)?;

--- a/crates/nereids-io/src/lib.rs
+++ b/crates/nereids-io/src/lib.rs
@@ -26,6 +26,8 @@ pub mod normalization;
 #[cfg(feature = "hdf5")]
 pub mod project;
 pub mod rebin;
+#[cfg(feature = "hdf5")]
+pub mod runlog;
 pub mod spectrum;
 pub mod tiff_stack;
 pub mod tof;

--- a/crates/nereids-io/src/lib.rs
+++ b/crates/nereids-io/src/lib.rs
@@ -10,6 +10,9 @@
 //! - [`normalization`] — Raw + open beam → transmission (Method 2), dead/hot pixel masks (pipeline-integrity), ROI
 //! - `project` — Project file save/load for `.nrd.h5` archives (`hdf5` feature)
 //! - [`rebin`] — Energy rebinning (coarsen the TOF/energy axis by an integer factor)
+//! - `runlog` — DASlogs transition logs → beam-state intervals for event
+//!   filtering (`hdf5` feature; not an intra-doc link so default-feature
+//!   doc builds stay warning-free)
 //! - [`spectrum`] — Spectrum file parser for TOF/energy bin edges or centers
 //! - [`tiff_stack`] — Multi-frame TIFF stack loading → 3D arrays (tof, y, x)
 //! - [`tof`] — TOF bin edges → energy conversion for imaging data

--- a/crates/nereids-io/src/nexus.rs
+++ b/crates/nereids-io/src/nexus.rs
@@ -123,7 +123,10 @@ fn tof_scale_to_us(units: Option<&str>) -> Result<f64, IoError> {
 /// becoming "attribute missing".  This was a latent bug:
 /// the previous implementation mapped *every* `attr()` failure to
 /// `Ok(None)`, including non-"not found" errors.
-fn read_string_attr(loc: &hdf5::Location, name: &str) -> Result<Option<String>, IoError> {
+pub(crate) fn read_string_attr(
+    loc: &hdf5::Location,
+    name: &str,
+) -> Result<Option<String>, IoError> {
     // Probe the attribute table first.  `attr_names()` is the only
     // discriminator the hdf5-metno 0.12 `Error` enum exposes for
     // "absent vs. other failure" — its `Error` is a flat
@@ -142,12 +145,60 @@ fn read_string_attr(loc: &hdf5::Location, name: &str) -> Result<Option<String>, 
             "Failed to open attribute {name:?} (listed but unreadable): {e}"
         ))
     })?;
-    let value: VarLenUnicode = attr.read_scalar().map_err(|e| {
-        IoError::InvalidParameter(format!(
-            "Failed to read string attribute {name:?}: {e} (expected a UTF-8 string)"
-        ))
+    // Producers disagree on string storage: rustpix writes variable-length
+    // UTF-8, while SNS/ADARA facility files write fixed-length ASCII
+    // (e.g. the 35-byte ISO timestamp on `event_time_zero@offset`).
+    // Dispatch on the stored type descriptor instead of assuming one
+    // (issue #637; previously only variable-length UTF-8 was readable).
+    use hdf5::types::{FixedAscii, FixedUnicode, TypeDescriptor, VarLenAscii};
+    let td = attr.dtype().and_then(|d| d.to_descriptor()).map_err(|e| {
+        IoError::InvalidParameter(format!("Failed to inspect type of attribute {name:?}: {e}"))
     })?;
-    Ok(Some(value.as_str().to_string()))
+    let read_err = |e: hdf5::Error| {
+        IoError::InvalidParameter(format!(
+            "Failed to read string attribute {name:?}: {e} (stored as {td:?})"
+        ))
+    };
+    let value = match td {
+        TypeDescriptor::VarLenUnicode => attr
+            .read_scalar::<VarLenUnicode>()
+            .map_err(read_err)?
+            .as_str()
+            .to_string(),
+        TypeDescriptor::VarLenAscii => attr
+            .read_scalar::<VarLenAscii>()
+            .map_err(read_err)?
+            .as_str()
+            .to_string(),
+        // Fixed-length strings: HDF5's string-to-string soft conversion
+        // repacks any length into this generous fixed buffer; trim the
+        // NUL/space padding it leaves behind.
+        TypeDescriptor::FixedAscii(n) | TypeDescriptor::FixedUnicode(n) if n <= 1024 => match td {
+            TypeDescriptor::FixedAscii(_) => attr
+                .read_scalar::<FixedAscii<1024>>()
+                .map_err(read_err)?
+                .as_str()
+                .to_string(),
+            _ => attr
+                .read_scalar::<FixedUnicode<1024>>()
+                .map_err(read_err)?
+                .as_str()
+                .to_string(),
+        },
+        TypeDescriptor::FixedAscii(n) | TypeDescriptor::FixedUnicode(n) => {
+            return Err(IoError::InvalidParameter(format!(
+                "String attribute {name:?} is {n} bytes, exceeding the supported \
+                 fixed-string read buffer (1024)"
+            )));
+        }
+        other => {
+            return Err(IoError::InvalidParameter(format!(
+                "Attribute {name:?} is not a string (stored as {other:?})"
+            )));
+        }
+    };
+    let value = value.trim_end_matches(['\0', ' ']).to_string();
+    Ok(Some(value))
 }
 
 /// Metadata probed from a NeXus/HDF5 file without loading full data.
@@ -2008,5 +2059,521 @@ mod tests {
             msg.contains("Unsupported NeXus TOF units") && msg.contains("clock-ticks"),
             "error should name the offending value, got: {msg}"
         );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// NXevent_data bank spectra with wall-clock interval filtering (issue #637)
+// ---------------------------------------------------------------------------
+
+/// TOF binning parameters for a 1-D NXevent_data bank spectrum (issue #637).
+///
+/// NXevent_data banks (facility NeXus convention: `/entry/<bank>/` with
+/// `event_time_offset`, `event_index`, `event_time_zero`) have no per-event
+/// pixel coordinates in the general case (monitors never do), so the result
+/// is a 1-D TOF spectrum rather than a `(tof, y, x)` cube.
+#[derive(Debug, Clone, Copy)]
+pub struct BankBinningParams {
+    /// Number of TOF bins.
+    pub n_bins: usize,
+    /// Minimum TOF in microseconds (inclusive).
+    pub tof_min_us: f64,
+    /// Maximum TOF in microseconds (exclusive).
+    pub tof_max_us: f64,
+}
+
+/// Result of [`load_nexus_bank_spectrum`]: a 1-D TOF spectrum plus pulse and
+/// event retention statistics.
+///
+/// The drop counters (`dropped_tof_range`, `dropped_non_finite`) cover only
+/// events belonging to **kept** pulses; events on pulses excluded by
+/// `keep_intervals` are accounted for as `events_total - events_kept -
+/// dropped_tof_range - dropped_non_finite` and are not itemised.
+#[derive(Debug, Clone)]
+pub struct BankSpectrum {
+    /// TOF bin edges in microseconds (`n_bins + 1` values, linear grid).
+    pub tof_edges_us: Vec<f64>,
+    /// Histogrammed event counts per TOF bin (`n_bins` values).
+    pub counts: Vec<u64>,
+    /// Total number of pulses recorded in the bank.
+    pub pulses_total: usize,
+    /// Pulses whose `event_time_zero` fell inside `keep_intervals`
+    /// (equals `pulses_total` when no filter was given).
+    pub pulses_kept: usize,
+    /// Total number of events recorded in the bank.
+    pub events_total: usize,
+    /// Events on kept pulses that landed inside the TOF window.
+    pub events_kept: usize,
+    /// Events on kept pulses dropped for TOF outside `[tof_min_us, tof_max_us)`.
+    pub dropped_tof_range: usize,
+    /// Events on kept pulses dropped for non-finite TOF.
+    pub dropped_non_finite: usize,
+    /// ISO-8601 `offset` attribute of `event_time_zero`, when recorded —
+    /// the absolute wall-clock epoch that pulse times are relative to.
+    /// Compare with [`crate::runlog::RunLog::offset_iso`] to confirm that
+    /// interval and pulse clocks share a zero point (at SNS both are
+    /// seconds since run start and the attributes match exactly).
+    pub pulse_time_offset_iso: Option<String>,
+}
+
+/// Load one NXevent_data bank (e.g. a beam monitor) as a 1-D TOF spectrum,
+/// optionally keeping only pulses inside wall-clock `keep_intervals`
+/// (issue #637).
+///
+/// Reads `/entry/<bank>/{event_time_offset, event_index, event_time_zero}`:
+///
+/// - `event_time_offset` — TOF per event; its `units` attribute is
+///   **required** on this path (facility files always write it; refusing to
+///   guess closes the #554 silent-rescale class).  Recognised values are
+///   the module-level table (ns/us/ms/s), scaled to canonical µs.
+/// - `event_index` — cumulative first-event index per pulse (validated
+///   non-decreasing, last entry ≤ total events).  Events of pulse `p` are
+///   `event_index[p] .. event_index[p+1]` (last pulse runs to the end).
+/// - `event_time_zero` — pulse wall-clock times; its `units` attribute is
+///   also required (NXevent_data specifies no default; SNS writes
+///   `"second"`), accepted via the same table and rescaled to seconds.
+///
+/// `keep_intervals` are `(t_start, t_end)` pairs in seconds on the same
+/// clock as `event_time_zero` (at SNS: seconds since run start — the same
+/// clock as `/entry/DASlogs/<pv>/time`, so lists from
+/// [`crate::runlog::intervals_where`] /
+/// [`crate::runlog::intervals_intersect`] apply directly).  Pulse `p` is
+/// kept iff `t_start <= event_time_zero[p] < t_end` for some interval;
+/// the list may be unsorted/overlapping (it is normalised internally), but
+/// every pair must be finite with `t_end > t_start`.
+///
+/// **Empty-bank grace (issue #637)**: a bank with zero events (the normal
+/// state of every imaging-detector bank on VENUS, where tpx1 is frame-mode)
+/// loads to an all-zero spectrum with correct pulse statistics — it never
+/// errors.
+pub fn load_nexus_bank_spectrum(
+    path: &Path,
+    bank: &str,
+    params: &BankBinningParams,
+    keep_intervals: Option<&[(f64, f64)]>,
+) -> Result<BankSpectrum, IoError> {
+    if params.n_bins == 0 {
+        return Err(IoError::InvalidParameter("n_bins must be positive".into()));
+    }
+    if !params.tof_min_us.is_finite() || !params.tof_max_us.is_finite() {
+        return Err(IoError::InvalidParameter(
+            "TOF bounds must be finite".into(),
+        ));
+    }
+    if params.tof_max_us <= params.tof_min_us {
+        return Err(IoError::InvalidParameter(format!(
+            "tof_max_us ({}) must be greater than tof_min_us ({})",
+            params.tof_max_us, params.tof_min_us
+        )));
+    }
+    // Normalise the keep-list once: validate pairs, sort, merge overlaps.
+    let intervals: Option<Vec<(f64, f64)>> = match keep_intervals {
+        None => None,
+        Some(raw) => Some(crate::runlog::normalize_intervals(raw)?),
+    };
+
+    let file = hdf5::File::open(path).map_err(|e| {
+        IoError::FileNotFound(
+            path.display().to_string(),
+            std::io::Error::other(e.to_string()),
+        )
+    })?;
+    let group = file
+        .group(&format!("entry/{bank}"))
+        .map_err(|e| IoError::InvalidParameter(format!("Missing /entry/{bank} group: {e}")))?;
+
+    let etz_ds = group.dataset("event_time_zero").map_err(|e| {
+        IoError::InvalidParameter(format!("Missing /entry/{bank}/event_time_zero: {e}"))
+    })?;
+    // NXevent_data specifies only the unit CATEGORY (NX_TIME) with no
+    // default, so a missing attribute is an error, not a guess — the same
+    // policy #554 established for event_time_offset.  Every surveyed SNS
+    // file writes units="second" here.
+    let etz_to_s = match read_string_attr(&etz_ds, "units")? {
+        None => {
+            return Err(IoError::InvalidParameter(format!(
+                "/entry/{bank}/event_time_zero has no units attribute; refusing to \
+                 guess a time scale (issues #554/#637)"
+            )));
+        }
+        Some(u) => tof_scale_to_us(Some(&u))? * 1e-6,
+    };
+    let event_time_zero: Vec<f64> = etz_ds
+        .read_1d::<f64>()
+        .map_err(|e| IoError::Hdf5Error(format!("Failed to read {bank}/event_time_zero: {e}")))?
+        .to_vec()
+        .into_iter()
+        .map(|t| t * etz_to_s)
+        .collect();
+    let pulse_time_offset_iso = read_string_attr(&etz_ds, "offset")?;
+
+    let event_index: Vec<u64> = group
+        .dataset("event_index")
+        .map_err(|e| IoError::InvalidParameter(format!("Missing /entry/{bank}/event_index: {e}")))?
+        .read_1d::<u64>()
+        .map_err(|e| IoError::Hdf5Error(format!("Failed to read {bank}/event_index: {e}")))?
+        .to_vec();
+    if event_index.len() != event_time_zero.len() {
+        return Err(IoError::ShapeMismatch(format!(
+            "{bank}: event_index has {} entries but event_time_zero has {}",
+            event_index.len(),
+            event_time_zero.len()
+        )));
+    }
+    if event_index.windows(2).any(|w| w[1] < w[0]) {
+        return Err(IoError::InvalidParameter(format!(
+            "{bank}/event_index must be non-decreasing (cumulative first-event index per pulse)"
+        )));
+    }
+
+    let eto_ds = group.dataset("event_time_offset").map_err(|e| {
+        IoError::InvalidParameter(format!("Missing /entry/{bank}/event_time_offset: {e}"))
+    })?;
+    let tof_scale = match read_string_attr(&eto_ds, "units")? {
+        Some(u) => tof_scale_to_us(Some(&u))?,
+        None => {
+            return Err(IoError::InvalidParameter(format!(
+                "/entry/{bank}/event_time_offset has no units attribute; NXevent_data \
+                 producers declare TOF units explicitly and this loader refuses to \
+                 guess a scale factor (issues #554/#637)"
+            )));
+        }
+    };
+    let tof_raw: Vec<f64> = eto_ds
+        .read_1d::<f64>()
+        .map_err(|e| IoError::Hdf5Error(format!("Failed to read {bank}/event_time_offset: {e}")))?
+        .to_vec();
+    let events_total = tof_raw.len();
+    if let Some(&last) = event_index.last()
+        && last as usize > events_total
+    {
+        return Err(IoError::InvalidParameter(format!(
+            "{bank}/event_index last entry ({last}) exceeds total event count ({events_total})"
+        )));
+    }
+    // Retention accounting must be exact: every event belongs to a pulse
+    // slice or a drop counter.  A first index > 0 (events preceding the
+    // first pulse) or events without any pulse record would vanish
+    // silently — fail loud instead (issue #637).
+    match event_index.first() {
+        Some(&first) if first != 0 => {
+            return Err(IoError::InvalidParameter(format!(
+                "{bank}/event_index first entry ({first}) must be 0: {first} event(s) \
+                 precede the first pulse and would be silently dropped"
+            )));
+        }
+        None if events_total > 0 => {
+            return Err(IoError::InvalidParameter(format!(
+                "{bank} has {events_total} events but no pulses (empty event_index)"
+            )));
+        }
+        _ => {}
+    }
+
+    let pulses_total = event_time_zero.len();
+    let bin_w = (params.tof_max_us - params.tof_min_us) / params.n_bins as f64;
+    let keep_pulse = |t: f64| -> bool {
+        // Normalise -0.0 to +0.0: membership is defined numerically, but
+        // total_cmp (needed for NaN robustness) orders -0.0 below +0.0.
+        let t = if t == 0.0 { 0.0 } else { t };
+        match &intervals {
+            None => true,
+            Some(iv) => match iv.binary_search_by(|&(a, _)| a.total_cmp(&t)) {
+                Ok(i) => t < iv[i].1,
+                Err(0) => false,
+                Err(i) => t < iv[i - 1].1,
+            },
+        }
+    };
+
+    let mut counts = vec![0u64; params.n_bins];
+    let mut pulses_kept = 0usize;
+    let mut events_kept = 0usize;
+    let mut dropped_tof_range = 0usize;
+    let mut dropped_non_finite = 0usize;
+    for p in 0..pulses_total {
+        if !keep_pulse(event_time_zero[p]) {
+            continue;
+        }
+        pulses_kept += 1;
+        let e0 = event_index[p] as usize;
+        let e1 = if p + 1 < pulses_total {
+            event_index[p + 1] as usize
+        } else {
+            events_total
+        };
+        for &raw in &tof_raw[e0..e1] {
+            let tof = raw * tof_scale;
+            if !tof.is_finite() {
+                dropped_non_finite += 1;
+                continue;
+            }
+            if tof < params.tof_min_us || tof >= params.tof_max_us {
+                dropped_tof_range += 1;
+                continue;
+            }
+            // Guard the floating-point upper edge: tof < max is checked, but
+            // (tof - min) / bin_w can still round up to n_bins.
+            let bin = (((tof - params.tof_min_us) / bin_w) as usize).min(params.n_bins - 1);
+            counts[bin] += 1;
+            events_kept += 1;
+        }
+    }
+    let tof_edges_us = (0..=params.n_bins)
+        .map(|i| params.tof_min_us + i as f64 * bin_w)
+        .collect();
+    Ok(BankSpectrum {
+        tof_edges_us,
+        counts,
+        pulses_total,
+        pulses_kept,
+        events_total,
+        events_kept,
+        dropped_tof_range,
+        dropped_non_finite,
+        pulse_time_offset_iso,
+    })
+}
+
+#[cfg(test)]
+mod bank_tests {
+    use super::*;
+
+    /// Write a synthetic NXevent_data bank: per-pulse wall times (s) and
+    /// per-pulse event TOF lists (µs, stored in the given units).
+    fn create_test_bank(
+        path: &Path,
+        bank: &str,
+        pulse_times_s: &[f64],
+        events_per_pulse: &[Vec<f64>],
+        tof_units: Option<&str>,
+        tof_store_scale: f64,
+    ) {
+        assert_eq!(pulse_times_s.len(), events_per_pulse.len());
+        let file = hdf5::File::create(path).expect("create test file");
+        let entry = if let Ok(g) = file.group("entry") {
+            g
+        } else {
+            file.create_group("entry").expect("create entry")
+        };
+        let g = entry.create_group(bank).expect("create bank");
+        let mut index: Vec<u64> = Vec::new();
+        let mut tofs: Vec<f64> = Vec::new();
+        for evs in events_per_pulse {
+            index.push(tofs.len() as u64);
+            tofs.extend(evs.iter().map(|t| t * tof_store_scale));
+        }
+        let etz = g
+            .new_dataset_builder()
+            .with_data(pulse_times_s)
+            .create("event_time_zero")
+            .expect("etz");
+        etz.new_attr::<hdf5::types::VarLenUnicode>()
+            .create("units")
+            .expect("attr")
+            .write_scalar(&"second".parse::<hdf5::types::VarLenUnicode>().unwrap())
+            .expect("write");
+        etz.new_attr::<hdf5::types::VarLenUnicode>()
+            .create("offset")
+            .expect("attr")
+            .write_scalar(
+                &"2026-06-22T19:01:07.183368667-04:00"
+                    .parse::<hdf5::types::VarLenUnicode>()
+                    .unwrap(),
+            )
+            .expect("write");
+        g.new_dataset_builder()
+            .with_data(&index)
+            .create("event_index")
+            .expect("ei");
+        let eto = g
+            .new_dataset_builder()
+            .with_data(&tofs)
+            .create("event_time_offset")
+            .expect("eto");
+        if let Some(u) = tof_units {
+            eto.new_attr::<hdf5::types::VarLenUnicode>()
+                .create("units")
+                .expect("attr")
+                .write_scalar(&u.parse::<hdf5::types::VarLenUnicode>().unwrap())
+                .expect("write");
+        }
+    }
+
+    fn params(n_bins: usize, lo: f64, hi: f64) -> BankBinningParams {
+        BankBinningParams {
+            n_bins,
+            tof_min_us: lo,
+            tof_max_us: hi,
+        }
+    }
+
+    #[test]
+    fn unfiltered_spectrum_counts_all_events() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bank.h5");
+        create_test_bank(
+            &path,
+            "monitor1",
+            &[0.0, 1.0, 2.0],
+            &[vec![100.0, 900.0], vec![500.0], vec![100.0, 500.0, 900.0]],
+            Some("microsecond"),
+            1.0,
+        );
+        let s = load_nexus_bank_spectrum(&path, "monitor1", &params(2, 0.0, 1000.0), None)
+            .expect("load");
+        assert_eq!(s.pulses_total, 3);
+        assert_eq!(s.pulses_kept, 3);
+        assert_eq!(s.events_total, 6);
+        assert_eq!(s.events_kept, 6);
+        assert_eq!(s.counts, vec![2, 4]); // [0,500): the two 100s; [500,1000): 500,500,900,900
+        assert_eq!(s.tof_edges_us, vec![0.0, 500.0, 1000.0]);
+        assert!(s.pulse_time_offset_iso.unwrap().starts_with("2026-06-22"));
+    }
+
+    #[test]
+    fn interval_filter_keeps_only_matching_pulses_with_boundary_semantics() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bank.h5");
+        // Pulses at t = 0, 10, 20, 30 s with 1, 2, 4, 8 events.
+        create_test_bank(
+            &path,
+            "monitor1",
+            &[0.0, 10.0, 20.0, 30.0],
+            &[vec![50.0], vec![50.0; 2], vec![50.0; 4], vec![50.0; 8]],
+            Some("microsecond"),
+            1.0,
+        );
+        // Half-open [10, 30): keeps pulses at 10 and 20, not 0 and not 30.
+        let s = load_nexus_bank_spectrum(
+            &path,
+            "monitor1",
+            &params(1, 0.0, 100.0),
+            Some(&[(10.0, 30.0)]),
+        )
+        .expect("load");
+        assert_eq!(s.pulses_kept, 2);
+        assert_eq!(s.events_kept, 6);
+        assert_eq!(s.counts, vec![6]);
+        // Unsorted, overlapping intervals normalise to the same union.
+        let s2 = load_nexus_bank_spectrum(
+            &path,
+            "monitor1",
+            &params(1, 0.0, 100.0),
+            Some(&[(15.0, 30.0), (10.0, 20.0)]),
+        )
+        .expect("load");
+        assert_eq!(s2.events_kept, 6);
+        // Empty keep-list keeps nothing.
+        let s3 = load_nexus_bank_spectrum(&path, "monitor1", &params(1, 0.0, 100.0), Some(&[]))
+            .expect("load");
+        assert_eq!((s3.pulses_kept, s3.events_kept), (0, 0));
+        assert_eq!(s3.counts, vec![0]);
+    }
+
+    #[test]
+    fn empty_bank_loads_gracefully() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bank.h5");
+        // The VENUS reality: pulses recorded, zero events (frame-mode tpx1).
+        create_test_bank(
+            &path,
+            "bank100_events",
+            &[0.0, 1.0, 2.0],
+            &[vec![], vec![], vec![]],
+            Some("microsecond"),
+            1.0,
+        );
+        let s = load_nexus_bank_spectrum(
+            &path,
+            "bank100_events",
+            &params(4, 0.0, 1000.0),
+            Some(&[(0.5, 2.5)]),
+        )
+        .expect("empty bank must load");
+        assert_eq!(s.pulses_total, 3);
+        assert_eq!(s.pulses_kept, 2);
+        assert_eq!(s.events_total, 0);
+        assert_eq!(s.counts, vec![0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn tof_units_are_scaled_and_required() {
+        let dir = tempfile::tempdir().unwrap();
+        // Nanosecond storage scales to the same µs spectrum.
+        let p_ns = dir.path().join("ns.h5");
+        create_test_bank(&p_ns, "m", &[0.0], &[vec![250.0, 750.0]], Some("ns"), 1e3);
+        let s = load_nexus_bank_spectrum(&p_ns, "m", &params(2, 0.0, 1000.0), None).unwrap();
+        assert_eq!(s.counts, vec![1, 1]);
+        // Missing units attribute on this path is an error, not a guess.
+        let p_none = dir.path().join("none.h5");
+        create_test_bank(&p_none, "m", &[0.0], &[vec![250.0]], None, 1.0);
+        let err = load_nexus_bank_spectrum(&p_none, "m", &params(2, 0.0, 1000.0), None)
+            .expect_err("must refuse to guess units");
+        assert!(err.to_string().contains("units"), "{err}");
+    }
+
+    #[test]
+    fn fixed_length_ascii_attributes_read_correctly() {
+        // SNS/ADARA facility files store attributes as FIXED-length ASCII
+        // (rustpix uses variable-length UTF-8) — both must read (issue #637).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fixed.h5");
+        create_test_bank(&path, "m", &[0.0], &[vec![250.0, 750.0]], None, 1.0);
+        {
+            let file = hdf5::File::open_rw(&path).expect("reopen");
+            let eto = file.dataset("entry/m/event_time_offset").expect("eto");
+            let units = hdf5::types::FixedAscii::<16>::from_ascii(b"microsecond").unwrap();
+            eto.new_attr::<hdf5::types::FixedAscii<16>>()
+                .create("units")
+                .expect("attr")
+                .write_scalar(&units)
+                .expect("write");
+        }
+        let s = load_nexus_bank_spectrum(&path, "m", &params(2, 0.0, 1000.0), None)
+            .expect("fixed-ascii units must parse");
+        assert_eq!(s.counts, vec![1, 1]);
+    }
+
+    #[test]
+    fn orphan_head_events_fail_loud() {
+        // event_index[0] != 0 means events precede the first pulse; they
+        // belong to no pulse slice and would vanish from the accounting.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("orphan.h5");
+        create_test_bank(&path, "m", &[0.0], &[vec![100.0, 200.0]], Some("us"), 1.0);
+        {
+            let file = hdf5::File::open_rw(&path).expect("reopen");
+            let ei = file.dataset("entry/m/event_index").expect("ei");
+            ei.write(&ndarray::arr1(&[1u64])).expect("overwrite");
+        }
+        let err = load_nexus_bank_spectrum(&path, "m", &params(1, 0.0, 1000.0), None)
+            .expect_err("orphan head events must error");
+        assert!(err.to_string().contains("precede the first pulse"), "{err}");
+    }
+
+    #[test]
+    fn malformed_inputs_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bank.h5");
+        create_test_bank(
+            &path,
+            "m",
+            &[0.0, 1.0],
+            &[vec![1.0], vec![2.0]],
+            Some("us"),
+            1.0,
+        );
+        // Bad interval pairs.
+        for bad in [(5.0, 5.0), (5.0, 1.0), (f64::NAN, 1.0)] {
+            assert!(
+                load_nexus_bank_spectrum(&path, "m", &params(1, 0.0, 10.0), Some(&[bad])).is_err()
+            );
+        }
+        // Bad binning params.
+        assert!(load_nexus_bank_spectrum(&path, "m", &params(0, 0.0, 10.0), None).is_err());
+        assert!(load_nexus_bank_spectrum(&path, "m", &params(1, 10.0, 10.0), None).is_err());
+        // Missing bank.
+        assert!(load_nexus_bank_spectrum(&path, "nope", &params(1, 0.0, 10.0), None).is_err());
     }
 }

--- a/crates/nereids-io/src/nexus.rs
+++ b/crates/nereids-io/src/nexus.rs
@@ -113,8 +113,11 @@ fn tof_scale_to_us(units: Option<&str>) -> Result<f64, IoError> {
 
 /// Read a string-valued attribute from an HDF5 `Location` (Group or
 /// Dataset both deref to `Location`), returning `None` if the
-/// attribute is absent and `Err` only if the attribute exists but
-/// cannot be decoded as a UTF-8 string.
+/// attribute is absent.  Both storage conventions decode: variable-length
+/// (rustpix) and fixed-length (SNS/ADARA) strings, ASCII or UTF-8, with
+/// trailing NUL/space padding trimmed.  `Err` when the attribute exists
+/// but is not a string, is a fixed string longer than the 1024-byte read
+/// buffer, or cannot be read/decoded.
 ///
 /// Absence is detected via [`Location::attr_names`] (rather than
 /// catching any error from [`Location::attr`]) so that genuine HDF5
@@ -2205,6 +2208,17 @@ pub fn load_nexus_bank_spectrum(
         .into_iter()
         .map(|t| t * etz_to_s)
         .collect();
+    // Retention accounting must be exact (same policy as the
+    // event_index guards below): a pulse with a non-finite wall-clock
+    // time can never match a keep-interval, so its events would vanish
+    // from the counts without being tallied — fail loud instead.
+    if let Some(i) = event_time_zero.iter().position(|t| !t.is_finite()) {
+        return Err(IoError::InvalidParameter(format!(
+            "{bank}/event_time_zero[{i}] is not finite ({}); corrupt pulse \
+             times would silently exclude events from the accounting",
+            event_time_zero[i]
+        )));
+    }
     let pulse_time_offset_iso = read_string_attr(&etz_ds, "offset")?;
 
     let event_index: Vec<u64> = group
@@ -2533,6 +2547,25 @@ mod bank_tests {
         let s = load_nexus_bank_spectrum(&path, "m", &params(2, 0.0, 1000.0), None)
             .expect("fixed-ascii units must parse");
         assert_eq!(s.counts, vec![1, 1]);
+    }
+
+    #[test]
+    fn non_finite_pulse_time_fails_loud() {
+        // A NaN event_time_zero can never match a keep-interval, so its
+        // events would silently vanish from the retention accounting.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nanpulse.h5");
+        create_test_bank(
+            &path,
+            "m",
+            &[0.0, f64::NAN],
+            &[vec![100.0], vec![200.0]],
+            Some("us"),
+            1.0,
+        );
+        let err = load_nexus_bank_spectrum(&path, "m", &params(1, 0.0, 1000.0), None)
+            .expect_err("non-finite pulse time must error");
+        assert!(err.to_string().contains("not finite"), "{err}");
     }
 
     #[test]

--- a/crates/nereids-io/src/runlog.rs
+++ b/crates/nereids-io/src/runlog.rs
@@ -1,0 +1,481 @@
+//! DASlogs run-log reading and beam-state interval derivation (issue #637).
+//!
+//! SNS/HFIR NeXus files record slow-control PVs under
+//! `/entry/DASlogs/<pv>/{time, value}`.  These are **transition logs**, not
+//! uniformly-sampled time series: each `value[i]` takes effect at `time[i]`
+//! (seconds relative to run start) and persists until `time[i+1]` (the last
+//! value persists to the end of the run).  Averaging the `value` array
+//! directly is therefore wrong whenever entries are unevenly spaced — on a
+//! real VENUS run the entry-mean of the `pause` log read 0.43 while the
+//! time-weighted truth was 0.90.  [`intervals_where`] encodes the correct
+//! step-function semantics once, so callers never re-derive them.
+//!
+//! Real SNS logs occasionally contain **corrupt records**: device
+//! reconnects write entries with `time = 0.0` and an uninitialized-memory
+//! payload (a subnormal double, ~6.9e-310), observed both mid-log (where
+//! the time jumps backward) and as the leading entry (where it does not)
+//! on VENUS furnace channels `BL10:SE:ND1:*` in 3 of 59 IPTS-37432 runs.
+//! [`read_run_log`] drops entries whose time jumps backward or whose
+//! value is subnormal and reports the count in
+//! [`RunLog::n_dropped_corrupt`], so the step function is never fed
+//! garbage and the anomaly stays visible.
+//!
+//! The derived `(t_start, t_end)` interval lists feed
+//! [`crate::nexus::load_nexus_bank_spectrum`]'s `keep_intervals` event
+//! filter and compose across PVs via [`intervals_intersect`] (e.g.
+//! `pause == 0` ∩ `beam_power > 1.5 MW`).  Facility-specific PV names never
+//! appear in this crate — they belong to caller code and docstrings.
+
+use crate::error::IoError;
+use std::path::Path;
+
+/// One slow-control PV read from `/entry/DASlogs/<pv>` plus the run length.
+#[derive(Debug, Clone)]
+pub struct RunLog {
+    /// Transition times in seconds relative to run start (ascending).
+    pub times: Vec<f64>,
+    /// Value taking effect at the matching `times` entry.
+    pub values: Vec<f64>,
+    /// Total run duration in seconds (`/entry/duration`), the implicit end
+    /// of the last transition segment.
+    pub duration_s: f64,
+    /// ISO-8601 epoch of the `time` axis (the `start` or `offset` attribute),
+    /// when recorded.  Compare with
+    /// [`crate::nexus::BankSpectrum::pulse_time_offset_iso`] to confirm the
+    /// log clock and the pulse clock share a zero point (at SNS both are
+    /// seconds since run start and the attributes match exactly).
+    pub offset_iso: Option<String>,
+    /// Entries dropped as corrupt reconnect records — backward time jump
+    /// or subnormal value payload (see the module docs).  Non-zero is
+    /// worth a mention in run-health screens; retained entries are
+    /// unaffected.
+    pub n_dropped_corrupt: usize,
+}
+
+/// Read a DASlogs PV as a transition log (issue #637).
+///
+/// Reads `/entry/DASlogs/<pv>/time` and `/value` (numeric) and
+/// `/entry/duration`.  Times are seconds since run start (the same epoch
+/// the NXevent_data `event_time_zero` values are relative to, so derived
+/// intervals feed [`crate::nexus::load_nexus_bank_spectrum`] directly).
+/// Corrupt reconnect records — backward/NaN time or subnormal value
+/// payload — are dropped and counted in [`RunLog::n_dropped_corrupt`]
+/// (real SNS files contain both shapes; module docs).
+///
+/// # Errors
+/// [`IoError::FileNotFound`] when the file cannot be opened;
+/// [`IoError::InvalidParameter`] when the PV group or datasets are missing
+/// or non-numeric; [`IoError::ShapeMismatch`] when `time` and `value`
+/// lengths differ.
+pub fn read_run_log(path: &Path, pv: &str) -> Result<RunLog, IoError> {
+    let file = hdf5::File::open(path).map_err(|e| {
+        IoError::FileNotFound(
+            path.display().to_string(),
+            std::io::Error::other(e.to_string()),
+        )
+    })?;
+    let group = file.group(&format!("entry/DASlogs/{pv}")).map_err(|e| {
+        IoError::InvalidParameter(format!("Missing /entry/DASlogs/{pv} group: {e}"))
+    })?;
+    let time_ds = group
+        .dataset("time")
+        .map_err(|e| IoError::InvalidParameter(format!("Missing {pv}/time dataset: {e}")))?;
+    let times: Vec<f64> = time_ds
+        .read_1d()
+        .map_err(|e| IoError::InvalidParameter(format!("Failed to read {pv}/time: {e}")))?
+        .to_vec();
+    let offset_iso = match crate::nexus::read_string_attr(&time_ds, "start")? {
+        Some(v) => Some(v),
+        None => crate::nexus::read_string_attr(&time_ds, "offset")?,
+    };
+    let values: Vec<f64> = group
+        .dataset("value")
+        .map_err(|e| IoError::InvalidParameter(format!("Missing {pv}/value dataset: {e}")))?
+        .read_1d()
+        .map_err(|e| {
+            IoError::InvalidParameter(format!(
+                "Failed to read {pv}/value as a 1-D numeric array (string-valued and \
+                 multi-dimensional PVs are not supported): {e}"
+            ))
+        })?
+        .to_vec();
+    if times.len() != values.len() {
+        return Err(IoError::ShapeMismatch(format!(
+            "{pv}: time has {} entries but value has {}",
+            times.len(),
+            values.len()
+        )));
+    }
+    // Drop corrupt reconnect records — see module docs.  Two signatures:
+    // a backward-jumping (or NaN) time, and a subnormal value payload
+    // (0 < |v| < f64::MIN_POSITIVE — uninitialized memory, not a
+    // measurement; observed as the LEADING entry where no backward jump
+    // exists to catch it).  The count is reported, never hidden.
+    let mut clean_times = Vec::with_capacity(times.len());
+    let mut clean_values = Vec::with_capacity(values.len());
+    let mut running_max = f64::NEG_INFINITY;
+    for (&t, &v) in times.iter().zip(&values) {
+        let subnormal_payload = v != 0.0 && v.abs() < f64::MIN_POSITIVE;
+        if t.is_finite() && t >= running_max && !subnormal_payload {
+            running_max = t;
+            clean_times.push(t);
+            clean_values.push(v);
+        }
+    }
+    let n_dropped_corrupt = times.len() - clean_times.len();
+    let (times, values) = (clean_times, clean_values);
+    let duration_s: f64 = {
+        let ds = file
+            .dataset("entry/duration")
+            .map_err(|e| IoError::InvalidParameter(format!("Missing /entry/duration: {e}")))?;
+        // SNS writes duration as shape (1,); tolerate a scalar () too.
+        if ds.ndim() == 0 {
+            ds.read_scalar::<f64>()
+                .map_err(|e| IoError::InvalidParameter(format!("Failed to read duration: {e}")))?
+        } else {
+            let v: Vec<f64> = ds
+                .read_1d()
+                .map_err(|e| IoError::InvalidParameter(format!("Failed to read duration: {e}")))?
+                .to_vec();
+            *v.first()
+                .ok_or_else(|| IoError::InvalidParameter("/entry/duration is empty".to_string()))?
+        }
+    };
+    Ok(RunLog {
+        times,
+        values,
+        duration_s,
+        offset_iso,
+        n_dropped_corrupt,
+    })
+}
+
+/// Derive the run-time intervals on which a transition-log PV satisfies
+/// `min_value <= value <= max_value` (either bound optional), using the
+/// correct step-function semantics (issue #637): `values[i]` holds on
+/// `[times[i], times[i+1])`, the last value holds to `duration_s`.
+///
+/// Time before the first transition entry is treated as **not** matching
+/// (the state is unrecorded; excluding it is the conservative choice for a
+/// keep-filter).  `NaN` values never match.  Adjacent/overlapping matching
+/// segments are merged; empty segments (`t_end <= t_start`) are dropped.
+/// The final segment's end is padded by one f32 ULP above `duration_s`
+/// because SNS records `/entry/duration` in float32 while pulse times are
+/// float64 — without the pad, a keep-everything filter drops the final
+/// pulse of roughly half of real runs.
+///
+/// # Errors
+/// [`IoError::InvalidParameter`] on non-finite/negative `duration_s`,
+/// descending `times`, mismatched lengths, or a bound pair with
+/// `min_value > max_value`.
+pub fn intervals_where(
+    times: &[f64],
+    values: &[f64],
+    duration_s: f64,
+    min_value: Option<f64>,
+    max_value: Option<f64>,
+) -> Result<Vec<(f64, f64)>, IoError> {
+    if !duration_s.is_finite() || duration_s < 0.0 {
+        return Err(IoError::InvalidParameter(format!(
+            "duration_s must be finite and non-negative, got {duration_s}"
+        )));
+    }
+    if times.len() != values.len() {
+        return Err(IoError::ShapeMismatch(format!(
+            "times has {} entries but values has {}",
+            times.len(),
+            values.len()
+        )));
+    }
+    if times.windows(2).any(|w| {
+        matches!(
+            w[0].partial_cmp(&w[1]),
+            None | Some(std::cmp::Ordering::Greater)
+        )
+    }) {
+        return Err(IoError::InvalidParameter(
+            "times must be ascending (transition log)".to_string(),
+        ));
+    }
+    if let (Some(lo), Some(hi)) = (min_value, max_value)
+        && lo > hi
+    {
+        return Err(IoError::InvalidParameter(format!(
+            "min_value ({lo}) must not exceed max_value ({hi})"
+        )));
+    }
+    let matches = |v: f64| -> bool {
+        v.is_finite() && min_value.is_none_or(|lo| v >= lo) && max_value.is_none_or(|hi| v <= hi)
+    };
+    // /entry/duration is float32-quantized in SNS files while pulse times
+    // (event_time_zero) are float64: the final pulse of ~half of surveyed
+    // real runs is time-stamped within one f32 ULP ABOVE the recorded
+    // duration.  Pad the run end by one f32 ULP so the final segment does
+    // not spuriously exclude it (issue #637).
+    let run_end = duration_s.max(((duration_s as f32).next_up()) as f64);
+    let mut out: Vec<(f64, f64)> = Vec::new();
+    for i in 0..times.len() {
+        if !matches(values[i]) {
+            continue;
+        }
+        let t0 = times[i].max(0.0);
+        let t1 = if i + 1 < times.len() {
+            times[i + 1].min(duration_s)
+        } else {
+            run_end
+        };
+        if t1 <= t0 {
+            continue;
+        }
+        match out.last_mut() {
+            // Merge segments that touch (shared transition point).
+            Some(last) if t0 <= last.1 => last.1 = last.1.max(t1),
+            _ => out.push((t0, t1)),
+        }
+    }
+    Ok(out)
+}
+
+/// Intersect two interval lists — e.g. `pause == 0` ∩ `beam_power > 1.5 MW`.
+///
+/// Inputs may be unsorted/overlapping (each side is normalised by
+/// sort-and-merge first, the same policy as
+/// [`crate::nexus::load_nexus_bank_spectrum`]'s `keep_intervals`); every
+/// pair must be finite with `t_end > t_start`.  Output is sorted,
+/// non-overlapping, and drops empty intersections.
+///
+/// # Errors
+/// [`IoError::InvalidParameter`] on a non-finite or empty/inverted pair.
+pub fn intervals_intersect(a: &[(f64, f64)], b: &[(f64, f64)]) -> Result<Vec<(f64, f64)>, IoError> {
+    let a = normalize_intervals(a)?;
+    let b = normalize_intervals(b)?;
+    let mut out = Vec::new();
+    let (mut i, mut j) = (0usize, 0usize);
+    while i < a.len() && j < b.len() {
+        let lo = a[i].0.max(b[j].0);
+        let hi = a[i].1.min(b[j].1);
+        if hi > lo {
+            out.push((lo, hi));
+        }
+        if a[i].1 <= b[j].1 {
+            i += 1;
+        } else {
+            j += 1;
+        }
+    }
+    Ok(out)
+}
+
+/// Validate interval pairs (finite, `t_end > t_start`) and normalise the
+/// list to sorted non-overlapping form by sort-and-merge.
+pub(crate) fn normalize_intervals(raw: &[(f64, f64)]) -> Result<Vec<(f64, f64)>, IoError> {
+    for &(a, b) in raw {
+        if !a.is_finite() || !b.is_finite() || b <= a {
+            return Err(IoError::InvalidParameter(format!(
+                "interval entries must be finite with t_end > t_start, got ({a}, {b})"
+            )));
+        }
+    }
+    let mut v = raw.to_vec();
+    v.sort_by(|x, y| x.0.total_cmp(&y.0));
+    let mut merged: Vec<(f64, f64)> = Vec::new();
+    for (a, b) in v {
+        match merged.last_mut() {
+            Some(last) if a <= last.1 => last.1 = last.1.max(b),
+            _ => merged.push((a, b)),
+        }
+    }
+    Ok(merged)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The motivating real-world case (issue #637): a `pause` transition log
+    /// [0, 1, 0, 1, 0, 1, 0] whose entry-mean (0.43) wildly understates the
+    /// time-weighted pause fraction (0.90).  `intervals_where(pause == 0)`
+    /// must return the four short LIVE segments, not 57 % of the run.
+    #[test]
+    fn step_semantics_pause_transition_log() {
+        let times = [0.0, 1000.0, 20000.0, 21500.0, 42589.0, 44100.0, 44338.0];
+        // value:    0     1        0        1        0        1        0
+        let values = [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0];
+        let live = intervals_where(&times, &values, 44339.0, Some(-0.5), Some(0.5)).unwrap();
+        assert_eq!(live.len(), 4);
+        assert_eq!(live[0], (0.0, 1000.0));
+        assert_eq!(live[1], (20000.0, 21500.0));
+        assert_eq!(live[2], (42589.0, 44100.0));
+        assert_eq!(live[3].0, 44338.0);
+        assert!(live[3].1 >= 44339.0); // padded run end (f32 ULP)
+        let live_total: f64 = live.iter().map(|(a, b)| b - a).sum();
+        let entry_mean = values.iter().sum::<f64>() / values.len() as f64;
+        // Entry-mean says ~43 % paused; time-weighting says ~90 % paused.
+        assert!((entry_mean - 3.0 / 7.0).abs() < 1e-12);
+        assert!(live_total / 44339.0 < 0.11, "live fraction {live_total}");
+    }
+
+    #[test]
+    fn last_value_persists_to_duration_and_pre_log_time_excluded() {
+        // Log starts at t = 100 s: state before that is unrecorded -> excluded.
+        let iv = intervals_where(&[100.0], &[1.0], 500.0, Some(0.5), None).unwrap();
+        assert_eq!(iv.len(), 1);
+        assert_eq!(iv[0].0, 100.0);
+        assert!(iv[0].1 >= 500.0 && iv[0].1 < 500.001); // padded run end
+    }
+
+    #[test]
+    fn adjacent_matching_segments_merge() {
+        let iv =
+            intervals_where(&[0.0, 10.0, 20.0], &[1.0, 2.0, 0.0], 30.0, Some(0.5), None).unwrap();
+        assert_eq!(iv, vec![(0.0, 20.0)]);
+    }
+
+    #[test]
+    fn nan_values_never_match_and_bounds_validate() {
+        let iv = intervals_where(&[0.0, 10.0], &[f64::NAN, 1.0], 20.0, Some(0.0), None).unwrap();
+        assert_eq!(iv[0].0, 10.0);
+        assert!(iv[0].1 >= 20.0);
+        assert!(intervals_where(&[0.0], &[1.0], 10.0, Some(2.0), Some(1.0)).is_err());
+        assert!(intervals_where(&[0.0], &[1.0], f64::NAN, None, None).is_err());
+        assert!(intervals_where(&[10.0, 5.0], &[1.0, 1.0], 20.0, None, None).is_err());
+    }
+
+    fn create_test_daslogs(path: &std::path::Path, pv: &str, times: &[f64], values: &[f64]) {
+        let file = hdf5::File::create(path).expect("create test file");
+        let entry = file.create_group("entry").expect("entry");
+        entry
+            .new_dataset_builder()
+            .with_data(&[44339.29_f64])
+            .create("duration")
+            .expect("duration");
+        let g = entry
+            .create_group(&format!("DASlogs/{pv}"))
+            .expect("pv group");
+        let t = g
+            .new_dataset_builder()
+            .with_data(times)
+            .create("time")
+            .expect("time");
+        t.new_attr::<hdf5::types::VarLenUnicode>()
+            .create("start")
+            .expect("attr")
+            .write_scalar(
+                &"2026-06-22T19:01:07.183368667-04:00"
+                    .parse::<hdf5::types::VarLenUnicode>()
+                    .unwrap(),
+            )
+            .expect("write");
+        g.new_dataset_builder()
+            .with_data(values)
+            .create("value")
+            .expect("value");
+    }
+
+    #[test]
+    fn corrupt_reconnect_record_dropped_and_counted() {
+        // Mirror of VENUS run 19383 BL10:SE:ND1:CH1:PV — device reconnects
+        // write (time=0.0, value=subnormal garbage) records BOTH as the
+        // leading entry (no backward jump to catch it) and mid-log; the
+        // clock resumes on the run clock immediately after.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("reconnect.h5");
+        create_test_daslogs(
+            &path,
+            "ch1",
+            &[0.0, 2.0, 1194.96, 1226.96, 0.0, 1228.99],
+            &[6.9e-310, 27.7, 27.75, 27.79, 6.9e-310, 27.78],
+        );
+        let log = read_run_log(&path, "ch1").expect("must read despite reconnect records");
+        assert_eq!(log.n_dropped_corrupt, 2);
+        assert_eq!(log.times.len(), 4);
+        assert!(!log.values.contains(&6.9e-310));
+        // The cleaned log is valid intervals_where input.
+        let iv = intervals_where(&log.times, &log.values, log.duration_s, Some(27.0), None)
+            .expect("cleaned log must be ascending");
+        assert_eq!(iv.len(), 1);
+        // The state on [0, 2) was recorded only by the garbage record, so
+        // it is treated as unrecorded — the interval starts at the first
+        // clean entry.
+        assert_eq!(iv[0].0, 2.0);
+    }
+
+    #[test]
+    fn read_run_log_round_trip_and_missing_pv() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("das.h5");
+        create_test_daslogs(&path, "pause", &[0.0, 3622.9, 43720.9], &[0.0, 1.0, 0.0]);
+        let log = read_run_log(&path, "pause").expect("read");
+        assert_eq!(log.times.len(), 3);
+        assert_eq!(log.n_dropped_corrupt, 0); // exact 0.0 values are NOT corrupt
+        assert_eq!(log.values, vec![0.0, 1.0, 0.0]);
+        assert!((log.duration_s - 44339.29).abs() < 1e-9);
+        assert!(log.offset_iso.unwrap().starts_with("2026-06-22"));
+        // End-to-end: transition log -> live intervals (pause == 0).
+        let live = intervals_where(
+            &log.times,
+            &log.values,
+            log.duration_s,
+            Some(-0.5),
+            Some(0.5),
+        )
+        .unwrap();
+        assert_eq!(live.len(), 2);
+        assert!((live[0].1 - 3622.9).abs() < 1e-9);
+        assert!(live[1].1 >= 44339.29); // padded run end
+        // Missing PV is a clear error.
+        assert!(read_run_log(&path, "no_such_pv").is_err());
+    }
+
+    #[test]
+    fn final_pulse_survives_f32_duration_quantization() {
+        // Real shape (VENUS run 19373): /entry/duration is f32
+        // (10.883509635925293 after promotion) while the last pulse's
+        // event_time_zero is f64 10.88351 — strictly above it.  The final
+        // segment must still contain that pulse.
+        let duration_f32 = 10.883_51_f32 as f64; // 10.883509635925293
+        let last_pulse = 10.883_51_f64;
+        assert!(last_pulse > duration_f32);
+        let iv = intervals_where(&[0.0], &[0.0], duration_f32, Some(-0.5), Some(0.5)).unwrap();
+        assert_eq!(iv.len(), 1);
+        assert!(
+            iv[0].1 > last_pulse,
+            "padded end {} <= pulse {last_pulse}",
+            iv[0].1
+        );
+    }
+
+    #[test]
+    fn intersect_basic_disjoint_nested_touching_and_unsorted() {
+        let a = [(0.0, 10.0), (20.0, 30.0)];
+        let b = [(5.0, 25.0)];
+        assert_eq!(
+            intervals_intersect(&a, &b).unwrap(),
+            vec![(5.0, 10.0), (20.0, 25.0)]
+        );
+        assert_eq!(intervals_intersect(&a, &[]).unwrap(), vec![]);
+        // Touching endpoints produce no (empty) interval.
+        assert_eq!(
+            intervals_intersect(&[(0.0, 5.0)], &[(5.0, 9.0)]).unwrap(),
+            vec![]
+        );
+        // Nested.
+        assert_eq!(
+            intervals_intersect(&[(0.0, 100.0)], &[(10.0, 20.0), (30.0, 40.0)]).unwrap(),
+            vec![(10.0, 20.0), (30.0, 40.0)]
+        );
+        // Unsorted input is normalised, not silently corrupted.
+        assert_eq!(
+            intervals_intersect(&[(20.0, 30.0), (0.0, 10.0)], &[(5.0, 25.0)]).unwrap(),
+            vec![(5.0, 10.0), (20.0, 25.0)]
+        );
+        // Sorted-but-overlapping input merges; postcondition holds.
+        assert_eq!(
+            intervals_intersect(&[(0.0, 10.0), (5.0, 20.0)], &[(0.0, 20.0)]).unwrap(),
+            vec![(0.0, 20.0)]
+        );
+        // Invalid pairs error.
+        assert!(intervals_intersect(&[(5.0, 5.0)], &[(0.0, 1.0)]).is_err());
+        assert!(intervals_intersect(&[(f64::NAN, 1.0)], &[(0.0, 1.0)]).is_err());
+    }
+}

--- a/crates/nereids-io/src/runlog.rs
+++ b/crates/nereids-io/src/runlog.rs
@@ -187,12 +187,16 @@ pub fn intervals_where(
             values.len()
         )));
     }
-    if times.windows(2).any(|w| {
-        matches!(
-            w[0].partial_cmp(&w[1]),
-            None | Some(std::cmp::Ordering::Greater)
-        )
-    }) {
+    // Explicit finiteness check so a single-entry log gets the same
+    // validation as longer ones (a windows(2)-only check would let a lone
+    // NaN time through, to be silently clamped by max(0.0) below).
+    if let Some(i) = times.iter().position(|t| !t.is_finite()) {
+        return Err(IoError::InvalidParameter(format!(
+            "times[{i}] is not finite ({})",
+            times[i]
+        )));
+    }
+    if times.windows(2).any(|w| w[1] < w[0]) {
         return Err(IoError::InvalidParameter(
             "times must be ascending (transition log)".to_string(),
         ));
@@ -339,6 +343,8 @@ mod tests {
         assert!(intervals_where(&[0.0], &[1.0], 10.0, Some(2.0), Some(1.0)).is_err());
         assert!(intervals_where(&[0.0], &[1.0], f64::NAN, None, None).is_err());
         assert!(intervals_where(&[10.0, 5.0], &[1.0, 1.0], 20.0, None, None).is_err());
+        // Single-entry logs get the same finiteness validation.
+        assert!(intervals_where(&[f64::NAN], &[1.0], 10.0, None, None).is_err());
     }
 
     fn create_test_daslogs(path: &std::path::Path, pv: &str, times: &[f64], values: &[f64]) {

--- a/docs/guide/src/python-api.md
+++ b/docs/guide/src/python-api.md
@@ -354,6 +354,67 @@ energies = nereids.tof_to_energy_centers(
 
 See [Data I/O and NeXus/TOF](./data-io.md) for ordering and pairing rules.
 
+## Beam-State Filtering (DASlogs and Event Banks)
+
+Facility NeXus files record slow-control PVs under `/entry/DASlogs/<pv>` as
+**transition logs**: each value takes effect at its timestamp and persists
+until the next entry.  Averaging the value array directly is wrong whenever
+entries are unevenly spaced — on a real VENUS run the entry-mean of the
+`pause` log read 0.43 while the time-weighted pause fraction was 0.90.
+
+### `read_run_log(path, pv)`
+
+Returns a `RunLog` with `times` (seconds since run start), `values`,
+`duration_s`, `offset_iso` (ISO-8601 epoch of the clock), and
+`n_dropped_corrupt` — the number of corrupt device-reconnect records
+(backward time jumps or subnormal garbage payloads, both seen in real SNS
+files) dropped from the log.
+
+### `intervals_where(times, values, duration_s, min_value=None, max_value=None)`
+
+Derives `(t_start, t_end)` intervals where the PV satisfies the bounds,
+under correct step-function semantics: the last value persists to
+`duration_s` (padded one f32 ULP — SNS records duration in float32 while
+pulse times are float64, and the final pulse of about half of real runs is
+stamped just beyond it), time before the first entry never matches, `NaN`
+never matches, and adjacent segments merge.
+
+### `intervals_intersect(a, b)`
+
+Composes conditions across PVs (e.g. not-paused AND beam power above
+threshold).  Inputs are validated and normalised (sorted, merged).
+
+### `load_nexus_bank_spectrum(path, bank, n_bins, tof_min_us, tof_max_us, keep_intervals=None)`
+
+Loads one NXevent_data bank (e.g. `"monitor1"`) as a `BankSpectrum` — a 1-D
+TOF spectrum (`tof_edges_us`, `counts`) with retention statistics
+(`pulses_total`/`pulses_kept`, `events_total`/`events_kept`, drop counters,
+`pulse_time_offset_iso`).  With `keep_intervals`, only pulses whose
+`event_time_zero` falls inside the intervals (half-open, DASlogs clock)
+are histogrammed.  `units` attributes are required on both event datasets
+(never guess a scale); a bank with zero events loads gracefully to a zero
+spectrum — on VENUS every imaging-detector bank is empty because tpx1 is
+frame-mode, and only monitors carry events.
+
+```python
+pause = nereids.read_run_log("run.nxs.h5", "pause")
+live = nereids.intervals_where(
+    pause.times, pause.values, pause.duration_s, max_value=0.5
+)
+power = nereids.read_run_log("run.nxs.h5", "BL10:Det:rtdl:BeamPowerAvg")
+stable = nereids.intervals_where(
+    power.times, power.values, power.duration_s, min_value=1.5
+)
+keep = nereids.intervals_intersect(live, stable)
+
+mon = nereids.load_nexus_bank_spectrum(
+    "run.nxs.h5", "monitor1",
+    n_bins=500, tof_min_us=0.0, tof_max_us=16667.0,
+    keep_intervals=keep,
+)
+print(mon.pulses_kept, "/", mon.pulses_total, "pulses in stable beam")
+```
+
 ## Element and Utility APIs
 
 ```python

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -4169,7 +4169,8 @@ class TestMultiplicativeBaseline:
         ), f"per-pixel b0 off truth: {b0_map}"
 
 def _create_synthetic_nxevent_bank(
-    path, pulse_times_s, events_per_pulse_us, tof_units="microsecond"
+    path, pulse_times_s, events_per_pulse_us, tof_units="microsecond",
+    etz_units="second",
 ):
     """Create a facility-schema NXevent_data bank (issue #637).
 
@@ -4197,7 +4198,8 @@ def _create_synthetic_nxevent_bank(
             "event_time_zero", data=np.asarray(pulse_times_s, dtype=np.float64)
         )
         # fixed-length ASCII attrs, exactly like SNS/ADARA facility files
-        etz.attrs["units"] = np.bytes_("second")
+        if etz_units is not None:
+            etz.attrs["units"] = np.bytes_(etz_units)
         etz.attrs["offset"] = np.bytes_("2026-06-22T19:01:07.183368667-04:00")
         bank.create_dataset("event_index", data=np.asarray(index, dtype=np.uint64))
         # f32 like real SNS files
@@ -4343,12 +4345,20 @@ class TestRunLogAndBankSpectrum:
         assert s.events_total == 0 and s.events_kept == 0
         assert list(s.counts) == [0, 0, 0, 0]
 
-    def test_missing_tof_units_is_an_error(self, tmp_path):
+    def test_missing_units_is_an_error_on_both_event_datasets(self, tmp_path):
+        # event_time_offset without units
         path = str(tmp_path / "nounits.h5")
         _create_synthetic_nxevent_bank(path, [0.0], [[250.0]], tof_units=None)
         with pytest.raises(ValueError, match="units"):
             nereids.load_nexus_bank_spectrum(
                 path, "monitor1", n_bins=2, tof_min_us=0.0, tof_max_us=1000.0
+            )
+        # event_time_zero without units (same #554 policy, separate check)
+        path2 = str(tmp_path / "nounits_etz.h5")
+        _create_synthetic_nxevent_bank(path2, [0.0], [[250.0]], etz_units=None)
+        with pytest.raises(ValueError, match="event_time_zero"):
+            nereids.load_nexus_bank_spectrum(
+                path2, "monitor1", n_bins=2, tof_min_us=0.0, tof_max_us=1000.0
             )
 
     def test_bad_keep_intervals_rejected(self, tmp_path):

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -4167,3 +4167,196 @@ class TestMultiplicativeBaseline:
         assert np.all(
             np.abs(b0_map[converged] - _BL_TRUE[0]) < 5e-2
         ), f"per-pixel b0 off truth: {b0_map}"
+
+def _create_synthetic_nxevent_bank(
+    path, pulse_times_s, events_per_pulse_us, tof_units="microsecond"
+):
+    """Create a facility-schema NXevent_data bank (issue #637).
+
+    Mirrors the SNS layout: ``/entry/<bank>/{event_time_offset,
+    event_index, event_time_zero}`` where ``event_index`` is the
+    cumulative first-event index per pulse and ``event_time_zero`` is
+    seconds since run start.  Also writes a matching ``pause`` DASlogs
+    transition log and ``/entry/duration`` so the full
+    read_run_log -> intervals_where -> load_nexus_bank_spectrum chain
+    can be exercised on one file.
+    """
+    import h5py
+
+    with h5py.File(path, "w") as f:
+        entry = f.create_group("entry")
+        entry.create_dataset(
+            "duration", data=np.array([len(pulse_times_s)], dtype=np.float32)
+        )
+        bank = entry.create_group("monitor1")
+        index, tofs = [], []
+        for evs in events_per_pulse_us:
+            index.append(len(tofs))
+            tofs.extend(evs)
+        etz = bank.create_dataset(
+            "event_time_zero", data=np.asarray(pulse_times_s, dtype=np.float64)
+        )
+        # fixed-length ASCII attrs, exactly like SNS/ADARA facility files
+        etz.attrs["units"] = np.bytes_("second")
+        etz.attrs["offset"] = np.bytes_("2026-06-22T19:01:07.183368667-04:00")
+        bank.create_dataset("event_index", data=np.asarray(index, dtype=np.uint64))
+        # f32 like real SNS files
+        eto = bank.create_dataset(
+            "event_time_offset", data=np.asarray(tofs, dtype=np.float32)
+        )
+        if tof_units is not None:
+            eto.attrs["units"] = np.bytes_(tof_units)
+        # pause transition log: paused (value 1) during the middle third
+        n = len(pulse_times_s)
+        logs = entry.create_group("DASlogs")
+        pause = logs.create_group("pause")
+        t = pause.create_dataset(
+            "time", data=np.array([0.0, n / 3.0, 2.0 * n / 3.0])
+        )
+        t.attrs["start"] = np.bytes_("2026-06-22T19:01:07.183368667-04:00")
+        # uint16, like the real SNS pause PV
+        pause.create_dataset("value", data=np.array([0, 1, 0], dtype=np.uint16))
+
+
+@pytest.mark.skipif(not HAS_H5PY, reason="h5py not installed")
+class TestRunLogAndBankSpectrum:
+    """Beam-state filtering: DASlogs intervals + NXevent_data banks (#637)."""
+
+    def test_read_run_log_and_step_semantics(self, tmp_path):
+        path = str(tmp_path / "bank.h5")
+        _create_synthetic_nxevent_bank(path, [0.0, 1.0, 2.0], [[100.0]] * 3)
+        log = nereids.read_run_log(path, "pause")
+        assert isinstance(log, nereids.RunLog)
+        assert log.times.shape == (3,)
+        assert log.n_dropped_corrupt == 0
+        assert "Some(" not in repr(log)
+        assert log.duration_s == pytest.approx(3.0)
+        assert log.offset_iso.startswith("2026-06-22")
+        # Step semantics: pause==0 on [0, 1) and [2, 3) (last value
+        # persists to duration) — the middle third is paused.
+        live = nereids.intervals_where(
+            log.times, log.values, log.duration_s, max_value=0.5
+        )
+        assert len(live) == 2
+        assert live[0] == (0.0, pytest.approx(1.0))
+        assert live[1][0] == pytest.approx(2.0)
+        assert live[1][1] >= 3.0  # final segment padded past f32 duration
+        with pytest.raises((IOError, ValueError)):
+            nereids.read_run_log(path, "no_such_pv")
+
+    def test_corrupt_reconnect_record_dropped(self, tmp_path):
+        # Mirror of VENUS run 19383 BL10:SE:ND1:CH1:PV — a reconnect
+        # appends (time=0.0, value=denormal garbage) mid-log.
+        import h5py
+
+        path = str(tmp_path / "reconnect.h5")
+        with h5py.File(path, "w") as f:
+            entry = f.create_group("entry")
+            entry.create_dataset("duration", data=np.array([2000.0], dtype=np.float32))
+            g = entry.create_group("DASlogs/ch1")
+            g.create_dataset(
+                "time", data=np.array([0.0, 2.0, 1194.96, 1226.96, 0.0, 1228.99])
+            )
+            g.create_dataset(
+                "value", data=np.array([6.9e-310, 27.7, 27.75, 27.79, 6.9e-310, 27.78])
+            )
+        log = nereids.read_run_log(path, "ch1")
+        assert log.n_dropped_corrupt == 2
+        assert log.times.shape == (4,)
+        assert not np.any(log.values < 1.0)
+        # Cleaned log feeds intervals_where without error.  The state on
+        # [0, 2) was recorded only by the garbage record, so the interval
+        # starts at the first clean entry; the end is the f32-ULP-padded
+        # run end.
+        iv = nereids.intervals_where(log.times, log.values, log.duration_s, min_value=27.0)
+        assert len(iv) == 1
+        assert iv[0][0] == pytest.approx(2.0)
+        assert iv[0][1] >= 2000.0
+
+    def test_intervals_where_entry_mean_trap(self):
+        # The motivating case: entry-mean of the log reads 3/7 = 0.43
+        # "paused" while the time-weighted pause fraction is ~0.90.
+        times = [0.0, 1000.0, 20000.0, 21500.0, 42589.0, 44100.0, 44338.0]
+        values = [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0]
+        live = nereids.intervals_where(times, values, 44339.0, max_value=0.5)
+        live_s = sum(b - a for a, b in live)
+        assert np.mean(values) == pytest.approx(3.0 / 7.0)
+        assert live_s / 44339.0 < 0.11
+        with pytest.raises(ValueError):
+            nereids.intervals_where(times, values, 44339.0, min_value=2.0, max_value=1.0)
+
+    def test_intervals_intersect(self):
+        keep = nereids.intervals_intersect(
+            [(0.0, 10.0), (20.0, 30.0)], [(5.0, 25.0)]
+        )
+        assert keep == [(5.0, 10.0), (20.0, 25.0)]
+        assert nereids.intervals_intersect([(0.0, 5.0)], [(5.0, 9.0)]) == []
+        # Unsorted input is normalised, not silently corrupted.
+        assert nereids.intervals_intersect(
+            [(20.0, 30.0), (0.0, 10.0)], [(5.0, 25.0)]
+        ) == [(5.0, 10.0), (20.0, 25.0)]
+        with pytest.raises(ValueError):
+            nereids.intervals_intersect([(5.0, 5.0)], [(0.0, 1.0)])
+
+    def test_load_bank_spectrum_unfiltered_and_filtered(self, tmp_path):
+        path = str(tmp_path / "bank.h5")
+        # 6 pulses at t = 0..5 s; pulse p carries p events at TOF 500 µs.
+        _create_synthetic_nxevent_bank(
+            path, [float(t) for t in range(6)], [[500.0] * p for p in range(6)]
+        )
+        s = nereids.load_nexus_bank_spectrum(
+            path, "monitor1", n_bins=2, tof_min_us=0.0, tof_max_us=1000.0
+        )
+        assert isinstance(s, nereids.BankSpectrum)
+        assert s.pulses_total == 6 and s.pulses_kept == 6
+        assert s.events_total == 15 and s.events_kept == 15
+        assert list(s.counts) == [0, 15]
+        assert s.tof_edges_us.shape == (3,)
+        assert s.pulse_time_offset_iso.startswith("2026-06-22")
+        # Filter to the live intervals derived from the pause log:
+        # [0, 2) and [4, 6) keep pulses 0, 1, 4, 5 -> 0+1+4+5 = 10 events.
+        log = nereids.read_run_log(path, "pause")
+        live = nereids.intervals_where(
+            log.times, log.values, log.duration_s, max_value=0.5
+        )
+        sf = nereids.load_nexus_bank_spectrum(
+            path,
+            "monitor1",
+            n_bins=2,
+            tof_min_us=0.0,
+            tof_max_us=1000.0,
+            keep_intervals=live,
+        )
+        assert sf.pulses_kept == 4
+        assert sf.events_kept == 10
+        assert list(sf.counts) == [0, 10]
+
+    def test_empty_bank_grace(self, tmp_path):
+        # The VENUS reality: pulses recorded, zero events (frame-mode tpx1).
+        path = str(tmp_path / "empty.h5")
+        _create_synthetic_nxevent_bank(path, [0.0, 1.0, 2.0], [[], [], []])
+        s = nereids.load_nexus_bank_spectrum(
+            path, "monitor1", n_bins=4, tof_min_us=0.0, tof_max_us=1000.0,
+            keep_intervals=[(0.5, 2.5)],
+        )
+        assert s.pulses_total == 3 and s.pulses_kept == 2
+        assert s.events_total == 0 and s.events_kept == 0
+        assert list(s.counts) == [0, 0, 0, 0]
+
+    def test_missing_tof_units_is_an_error(self, tmp_path):
+        path = str(tmp_path / "nounits.h5")
+        _create_synthetic_nxevent_bank(path, [0.0], [[250.0]], tof_units=None)
+        with pytest.raises(ValueError, match="units"):
+            nereids.load_nexus_bank_spectrum(
+                path, "monitor1", n_bins=2, tof_min_us=0.0, tof_max_us=1000.0
+            )
+
+    def test_bad_keep_intervals_rejected(self, tmp_path):
+        path = str(tmp_path / "bank.h5")
+        _create_synthetic_nxevent_bank(path, [0.0], [[250.0]])
+        for bad in [(5.0, 5.0), (5.0, 1.0), (float("nan"), 1.0)]:
+            with pytest.raises(ValueError):
+                nereids.load_nexus_bank_spectrum(
+                    path, "monitor1", n_bins=2, tof_min_us=0.0,
+                    tof_max_us=1000.0, keep_intervals=[bad],
+                )


### PR DESCRIPTION
Closes #637.

## What this adds

Beam-state event filtering, scoped to the schema that actually carries per-event wall-clock time at SNS — the facility NXevent_data banks — plus the DASlogs machinery to derive the intervals correctly:

| API | Purpose |
|---|---|
| `read_run_log(path, pv)` | `/entry/DASlogs/<pv>` as a **transition log** (`times`, `values`, `duration_s`, `offset_iso`, `n_dropped_corrupt`) |
| `intervals_where(times, values, duration_s, min_value=None, max_value=None)` | step-function semantics → `(t_start, t_end)` list |
| `intervals_intersect(a, b)` | compose conditions across PVs (inputs validated + normalised) |
| `load_nexus_bank_spectrum(path, bank, n_bins, tof_min_us, tof_max_us, keep_intervals=None)` | `/entry/<bank>/{event_time_offset, event_index, event_time_zero}` → 1-D TOF spectrum + retention stats |

Design notes:

- **Step semantics are the point.** SNS DASlogs record transitions, not uniform samples: on the motivating run the entry-mean of `pause` reads 0.43 while the time-weighted truth is 0.90. `intervals_where` encodes value-holds-until-next-entry (last value to `/entry/duration`), pre-log time and NaN never match, adjacent segments merge. Unit-tested against that exact trap.
- **`units` attrs are required on both event datasets** — NXevent_data declares no defaults; refusing to guess extends the #554 no-silent-rescale policy. (All 103 surveyed VENUS files write them.)
- **Empty-bank grace**: every VENUS imaging bank has 0 events (tpx1 is frame-mode), so an empty bank loads to a zero spectrum with correct pulse stats — never errors.
- **Fixed-length string attributes now read** (`read_string_attr` dispatches on the stored type descriptor): SNS/ADARA writes fixed-length ASCII, rustpix writes variable-length UTF-8; previously only the latter parsed. Found on first contact with a real facility file.
- **Deliberately out of scope**: `keep_intervals` on the rustpix `/entry/neutrons` path. That schema carries no per-event wall-clock dataset (verified across rustpix exports); plumbing a filter that can never fire would be API noise.
- Interval lists are validated (finite, `t_end > t_start`) then sorted/merged; pulse membership is half-open `[t_start, t_end)` via binary search (−0.0 normalised). `event_index` is validated non-decreasing, last entry ≤ total events, **and first entry = 0** — orphan head events fail loud instead of vanishing from the retention accounting.
- `RunLog.offset_iso` / `BankSpectrum.pulse_time_offset_iso` expose the clock epochs; across 103 VENUS files they match exactly (0 mismatches, 0 missing).

## Review pipeline findings, fixed in this PR

Two independent adversarial reviewers + a sweep over 103 real VENUS NeXus files, before pushing:

1. **Furnace-channel clock-reset records** (3 of 59 IPTS-37432 runs, e.g. 19383 `BL10:SE:ND1:CH1:PV`): device reconnects write `(time=0.0, value≈6.9e-310)` garbage records — both mid-log (backward time jump) and as the *leading* entry (subnormal payload only). A strict-ascending validator would reject exactly the PVs this feature targets. `read_run_log` drops both signatures and reports `n_dropped_corrupt`; exact 0.0 values are never touched.
2. **Final-pulse loss from f32 duration quantization**: `/entry/duration` is float32 while `event_time_zero` is float64 — the final pulse sits *beyond* the recorded duration on 6 of 12 surveyed runs, so even a keep-everything filter dropped it. The final segment is now padded one f32 ULP past `duration_s` (real-file regression: VENUS_19373, 654/654 pulses retained).
3. **`intervals_intersect` silently corrupted unsorted/overlapping input** (dropped true overlaps, violated its own postcondition). Now validates and normalises both sides, same policy as `keep_intervals`.
4. **Orphan head events** (`event_index[0] != 0`) silently vanished from the accounting → now fail loud.
5. −0.0 pulse-time membership edge (total_cmp vs numeric semantics) → normalised.
6. Misleading error for >1024-byte fixed strings; `RunLog.__repr__` leaked Rust `Option` syntax; doc/prose fixes.

Known accepted behaviours: array getters return the live numpy buffer (mutations persist) — consistent with the existing `NexusData` getters; a numeric `(n,1)`-shaped PV errors with the string-PV wording (no numeric 2-D PVs exist in 103 surveyed files).

## Tests

- 16 Rust unit tests (`runlog::tests`, `nexus::bank_tests`) incl. the 0.43-vs-0.90 oracle, f32-duration padding, reconnect-record drops, orphan fail-loud, fixed-ASCII attrs, unsorted-intersect normalisation, boundary semantics, empty-bank grace, malformed-input rejection. Crate suite: 214 passed.
- 8 Python tests (`TestRunLogAndBankSpectrum`) over a facility-faithful fixture (fixed-length ASCII attrs, f32 `event_time_offset`, u64 `event_index`, u16 PV values, f32 duration) incl. the full `read_run_log → intervals_where → load_nexus_bank_spectrum` chain. Full Python suite: 193 passed.

## Real-data acceptance (SNS side)

```
VENUS_24685 (90%-paused overnight run):
A: duration=44339.3s live=4239.3s frac_live=0.0956 (entry-mean trap: 0.429)
B: stable(>=1.5 MW)∩live = 3622.2s (8.2% of wall clock, 1 interval)
C: unfiltered pulses=254354/254354 events=374839/374839
   filtered   pulses=217328/254354 events=341444 | rate/pulse: all=1.474 kept=1.571
D: independent h5py/numpy reference: counts match BIT-FOR-BIT
E: bank100_events (imaging, empty): loads gracefully, 0 events
F: RunLog.offset_iso == BankSpectrum.pulse_time_offset_iso (exact)
G: VENUS_19373: last pulse beyond f32 duration; keep-everything filter retains 654/654
H: VENUS_19383 furnace CH1: n_dropped_corrupt=2, clock monotone, T range [26.95, 27.79] C
```

Physics cross-checks: kept-pulse rate in the live∩stable window is exactly 60.0 Hz; 91% of monitor events sit in 8.2% of wall-clock — the run really was ~90% dead time, and the filter recovers the good part. Kept-pulse fraction (85%) intentionally ≠ kept-time fraction (8.2%): ADARA suppresses pulse recording while paused.

Schema-fidelity sweep: all 103 VENUS NeXus files under IPTS-37432/35817 — duration always `(1,)` f32, epochs always present and matched, `intervals_where` matches an independent numpy step-function on every checked log, bank counts match `np.histogram` on every checked bank.

PR assisted with [Claude Code](https://claude.com/claude-code).
