### PR TITLE
ci(security): wire up Dependabot + cargo-audit (RustSec) scanning

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,15 @@
+# cargo-audit configuration — the reviewable record of accepted Rust advisories.
+# Every ignore needs a reason and a revisit condition. Vulnerabilities that are
+# fixable in our tree are bumped (see Dependabot / cargo update), not ignored.
+[advisories]
+ignore = [
+  # quick-xml 0.38 is a *build-time, deep-transitive* dependency of the Linux
+  # GUI stack: wayland-scanner (proc-macro) -> winit -> eframe -> nereids-gui.
+  # wayland-scanner uses quick-xml only to parse the *bundled, trusted* Wayland
+  # protocol XML at build time — it never parses untrusted input at runtime, so
+  # these XML-parsing DoS advisories are not reachable in NEREIDS. The fix
+  # (quick-xml >= 0.41) is not installable until the winit/wayland stack bumps
+  # its requirement; Dependabot will pull it once that lands. Revisit then.
+  "RUSTSEC-2026-0195", # quick-xml: unbounded namespace-declaration allocation (DoS)
+  "RUSTSEC-2026-0194", # quick-xml: quadratic run time on duplicate attribute names (DoS)
+]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# Dependabot version updates. (Vulnerability *alerts* are a separate repo
+# setting and are already enabled.) Grouped minor/patch bumps keep PR volume
+# manageable across the multi-crate Cargo workspace.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates
+version: 2
+updates:
+  # Rust crates — the cargo workspace (crates/*, bindings/python, apps/gui)
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      cargo-minor-patch:
+        update-types: ["minor", "patch"]
+
+  # Python bindings — PEP 621 dependencies in pyproject.toml
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # GitHub Actions referenced by the workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,31 @@
+name: Security audit
+
+# Scans the Cargo dependency tree against the RustSec advisory database.
+# Runs on dependency/lockfile changes, on every PR, and weekly so that newly
+# published advisories are caught even when the lockfile has not changed.
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-audit:
+    name: cargo audit (RustSec)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2.82.9
+        with:
+          tool: cargo-audit
+      # Fails on unignored vulnerabilities. Accepted-risk advisories (with a
+      # reason + revisit condition) live in .cargo/audit.toml. Unmaintained/
+      # unsound/yanked crates are reported as warnings and do not fail the gate.
+      - name: cargo audit
+        run: cargo audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3888,9 +3888,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
NEREIDS had no security scanning configured. This adds the standard suite for a Rust+Python repo.

## What's added
- **`.github/dependabot.yml`** — weekly version updates for **cargo** (the workspace), **pip** (pyproject bindings deps), and **github-actions**. Cargo minor/patch bumps are grouped to keep PR volume sane. (Dependabot vulnerability *alerts* are already enabled at the repo level.)
- **`.github/workflows/security.yml`** — `cargo audit` (RustSec) on PRs, pushes to `main`, and a **weekly cron** (catches newly published advisories against an unchanged lockfile — the Rust analog of the fleet's Grype gate). Actions SHA-pinned per repo convention.
- **`.cargo/audit.toml`** — the reviewable accepted-risk record.

## Baseline cleanup (so the gate lands green)
The scan surfaced **3 vulnerabilities + 7 warnings**. Handling:
- ✅ **Fixed:** `quinn-proto 0.11.14 → 0.11.15` (`RUSTSEC-2026-0185`, remote memory exhaustion) — the one advisory fixable in-tree today.
- 📝 **Documented (ignored w/ reason):** the two `quick-xml` DoS advisories (`RUSTSEC-2026-0195`/`0194`). quick-xml is a **build-time, deep-transitive** dep of the Linux GUI stack (`wayland-scanner → winit → eframe → nereids-gui`), used only to parse the **bundled, trusted** Wayland protocol XML at build time — never untrusted runtime input — so the XML-parsing DoS is not reachable here. The fix (`>=0.41`) isn't installable until the winit/wayland stack bumps; Dependabot will pull it once it lands. Revisit then.
- ℹ️ The 7 warnings (unmaintained/unsound/yanked: `anyhow`, `memmap2`, `ttf-parser`, `paste`, `proc-macro-error2`, `core2`) are reported but do **not** fail the gate (standard cargo-audit behavior).

## Verification
Local (cargo-audit): `cargo audit` exits **0** with this config. The full Rust CI (check/clippy/test) will validate the `quinn-proto` bump on this PR.

Assisted-With: Claude Opus 4.8 (1M context)