### PR TITLE
ci: SHA-pin all actions/* (supersedes #655/#657/#658)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
@@ -49,7 +49,7 @@ jobs:
     name: Formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
@@ -69,7 +69,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
@@ -89,7 +89,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
@@ -105,7 +105,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
@@ -123,8 +123,8 @@ jobs:
     name: Docs drift gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.10"
       - run: python scripts/check_python_api_drift.py
@@ -135,7 +135,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
@@ -153,7 +153,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,14 +34,14 @@ jobs:
     #                              doc) + doc-python (pdoc on installed
     #                              wheel)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Fail fast on drift between the PyO3 type stubs and the curated
       # python-api.md page (issue #533).  The script is stdlib-only;
       # running it BEFORE the (slow) rust + mdbook + pixi setup avoids
       # paying ~1 min of environment-install cost when the drift gate
       # fails.
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.10"
       - name: Check curated Python API page is in sync with .pyi stubs
@@ -72,7 +72,7 @@ jobs:
           RUSTDOCFLAGS: -D warnings
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: target/book
 
@@ -87,4 +87,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,11 +38,11 @@ jobs:
             target: x86_64-pc-windows-msvc
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python versions
         if: runner.os != 'Linux'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: |
             3.10
@@ -65,7 +65,7 @@ jobs:
         run: ./scripts/check_wheel_policy.sh dist/*.whl
 
       - name: Upload wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheel-${{ matrix.target }}
           path: dist/*.whl
@@ -75,7 +75,7 @@ jobs:
     name: Source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Build sdist
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
@@ -84,7 +84,7 @@ jobs:
           args: --out dist -m bindings/python/Cargo.toml
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sdist
           path: dist/*.tar.gz
@@ -116,11 +116,11 @@ jobs:
             target: aarch64-apple-darwin
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python versions
         if: runner.os != 'Linux'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: |
             3.10
@@ -148,7 +148,7 @@ jobs:
 
       # maturin working-directory puts output in apps/gui/dist
       - name: Upload GUI wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gui-wheel-${{ matrix.target }}
           path: apps/gui/dist/*.whl
@@ -158,7 +158,7 @@ jobs:
     name: macOS App Bundle
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -191,7 +191,7 @@ jobs:
             nereids-${VERSION}-macos-arm64.dmg
 
       - name: Upload DMG
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gui-macos-app
           path: "*.dmg"
@@ -208,14 +208,14 @@ jobs:
       url: https://pypi.org/p/nereids
     steps:
       - name: Download wheels
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           pattern: wheel-*
           merge-multiple: true
 
       - name: Download sdist
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sdist
           path: dist-sdist
@@ -243,7 +243,7 @@ jobs:
       url: https://pypi.org/p/nereids-gui
     steps:
       - name: Download GUI wheels
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           pattern: gui-wheel-*
@@ -267,7 +267,7 @@ jobs:
       name: crates-io
       url: https://crates.io/crates/nereids-core
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -302,30 +302,30 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Download all wheel artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist/wheels
           pattern: wheel-*
           merge-multiple: true
 
       - name: Download sdist
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sdist
           path: dist/wheels
 
       - name: Download GUI wheels
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist/gui
           pattern: gui-wheel-*
           merge-multiple: true
 
       - name: Download macOS app DMG
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist/dmg
           pattern: gui-macos-app

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
     name: cargo audit (RustSec)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2.82.9
         with:

--- a/.github/workflows/wheel-policy.yml
+++ b/.github/workflows/wheel-policy.yml
@@ -32,7 +32,7 @@ jobs:
     name: GUI wheel builds on manylinux_2_28
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Same action SHA, container selection, before-script, and args
       # as publish.yml's build-gui job — the gate must reproduce the
@@ -55,7 +55,7 @@ jobs:
         run: ./scripts/check_wheel_policy.sh apps/gui/dist/*.whl
 
       - name: Upload wheel for inspection
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gui-wheel-manylinux-2-28-pr
           path: apps/gui/dist/*.whl
@@ -65,7 +65,7 @@ jobs:
     name: Bindings wheel builds on manylinux_2_28
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Same action SHA, container selection, before-script, and args
       # as publish.yml's build-wheels Linux matrix entry — the gate
@@ -86,7 +86,7 @@ jobs:
         run: ./scripts/check_wheel_policy.sh dist/*.whl
 
       - name: Upload wheel for inspection
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bindings-wheel-manylinux-2-28-pr
           path: dist/*.whl


### PR DESCRIPTION
## What
Pin every `actions/*` reference to a full commit SHA with a `# vX.Y.Z` comment, matching the org supply-chain convention and the already-pinned third-party actions (dtolnay, Swatinem, PyO3, codecov, …). Mutable major tags can be silently repointed; SHA pins can't.

## Why (supersedes the 3 open Dependabot bumps)
Dependabot opened #655/#657/#658 bumping these to **tags** (`@v7`/`@v6`). Rather than merge tag refs, this folds those bumps in **as SHA pins**:

| action | was | now |
|---|---|---|
| actions/checkout | @v4 | `9c091bb…` # v7.0.0 |
| actions/upload-artifact | @v4 | `043fb46…` # v7.0.1 |
| actions/setup-python | @v5 | `ece7cb0…` # v6.3.0 |
| actions/download-artifact | @v8 | `3e5f45b…` # v8.0.1 |
| actions/upload-pages-artifact | @v5 | `fc324d3…` # v5.0.0 |
| actions/deploy-pages | @v4 | `d6db901…` # v4.0.5 |

37 refs across 5 workflow files. `checkout`/`upload-artifact`/`setup-python` move to the major Dependabot targeted; the rest are pinned at their current major (no untested jumps — e.g. deploy-pages stays v4). Dependabot maintains SHA pins + comments going forward.

Closes #655, closes #657, closes #658.

Assisted-With: Claude Opus 4.8 (1M context)