### PR TITLE
chore(ci): fix crossbeam-epoch RUSTSEC advisory + de-duplicate coverage test run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,11 @@ jobs:
       - run: cargo clippy --workspace --exclude nereids-python --all-targets -- -D warnings
 
   # ── Tests (cross-platform) ─────────────────────────────────────────
+  # ubuntu-latest is deliberately NOT in this matrix: the `coverage` job below
+  # already runs the full `cargo test --workspace` suite on ubuntu (under
+  # cargo-llvm-cov, which fails the job on any test failure), so listing ubuntu
+  # here would run the identical suite a second time. This matrix covers only
+  # the platforms the coverage job does not (macOS, Windows).
   test:
     name: Test (${{ matrix.os }})
     needs: check
@@ -87,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Two repo-wide CI issues found while working on #669 — they affect **main and every open PR**, not any one feature branch.

## 1. Security gate failing — `crossbeam-epoch` RUSTSEC-2026-0204

The `cargo audit (RustSec)` check (added in #651) fails on **RUSTSEC-2026-0204**: `crossbeam-epoch` 0.9.18 (transitive via rayon → image → eframe), an invalid pointer dereference in the `fmt::Pointer` impl. Bumped to **0.9.20** — the advisory's stated fix — per `.cargo/audit.toml`'s own policy of *bumping* fixable vulnerabilities rather than ignoring them. Lockfile-only, semver-compatible.

The other advisories in the audit output (`core2`, `paste`, `proc-macro-error2`, `ttf-parser` unmaintained; `anyhow` unsoundness) are **warnings** and do not fail the gate, so they need no action here.

## 2. Slow CI — the Rust suite ran 4× per PR

The `test` matrix ran on ubuntu + macOS + Windows, **and** a separate `coverage` job re-ran the entire instrumented suite on ubuntu — so the workspace suite ran four times, with the ubuntu run duplicated.

`cargo llvm-cov` already runs `cargo test --workspace` (and fails the job on any test failure), so the `coverage` job **is** the ubuntu test run. Dropped `ubuntu-latest` from the `test` matrix; macOS/Windows keep plain `cargo test`. This removes one full redundant suite run every CI while preserving cross-platform coverage and the coverage report.

## Verification
- `crossbeam-epoch` now `0.9.20` in `Cargo.lock` (≥ the advisory fix); CI's `cargo audit` confirms.
- `ci.yml` YAML validated; main has no branch protection, so no required-check name is broken by the matrix change.

PR assisted with [Claude Code](https://claude.com/claude-code).