### PR TITLE
chore(post-merge): prune stale worktree registrations in cleanup step

### DIFF
--- a/.claude/skills/post-merge/SKILL.md
+++ b/.claude/skills/post-merge/SKILL.md
@@ -32,7 +32,13 @@ If not already on main, stash or warn before switching.
    - Check if its branch is merged into main (`git branch --merged main`)
    - If merged: `git worktree remove {path}` then `git branch -d {branch}`
    - If not merged: warn the user — do NOT force-delete
-3. Prune stale remote-tracking branches:
+3. **Prune stale worktree registrations**: `git worktree prune -v`, then
+   `git worktree list` to confirm. A `git worktree remove` that is
+   interrupted (e.g. slow NFS `target/` deletes) can leave the directory
+   gone but the admin registration behind (shows as `prunable`); the stale
+   entry makes VSCode/Git report "too many active changes". Always prune
+   after the removal loop.
+4. Prune stale remote-tracking branches:
    ```bash
    git fetch --prune origin
    git branch -vv | grep ': gone]' | awk '{print $1}'


### PR DESCRIPTION
Adds `git worktree prune -v` to the `/post-merge` skill's Step 2 cleanup.

An interrupted `git worktree remove` (common on this repo's NFS storage, where a merged worktree's `target/` is multi-GB and the delete can time out) leaves the working directory gone but the git admin registration behind — it shows as `prunable` in `git worktree list`, and the stale entry makes VSCode/Git report "too many active changes." The cleanup step now prunes those registrations and re-lists to confirm.

Skill-doc only; no code impact.

PR assisted with [Claude Code](https://claude.com/claude-code).