### PR TITLE
fix(io,fitting): three real-VENUS defects from post-merge validation (#648, #653, #652)

### DIFF
--- a/crates/nereids-fitting/src/transmission_model.rs
+++ b/crates/nereids-fitting/src/transmission_model.rs
@@ -2711,6 +2711,48 @@ pub fn baseline_reference_energy(energies: &[f64]) -> f64 {
     (lo * hi).sqrt()
 }
 
+/// Reference energy for the baseline log basis, computed over the **active
+/// fit window only** (issue #648).
+///
+/// The full grid extends far beyond the resonances of interest (a VENUS Ta
+/// grid spans 4.5 eV–2.3 MeV while the fit window is 8–45 eV).  Centering
+/// the `ln(E/E_ref)` basis at the full-grid midpoint (≈3211 eV) instead of
+/// the active-window midpoint (≈19 eV) pushes every active bin to a large
+/// negative `z`, so the `1, z, z²` columns stop being near-orthogonal and
+/// the baseline silently absorbs Doppler broadening — the fitted
+/// temperature runs away with `warnings = []`.  Restricting the midpoint to
+/// the bins that actually enter the cost (the active mask) restores it.
+///
+/// `active` is the per-bin mask from
+/// [`crate::active_mask::build_active_mask`]; `None` (no `fit_energy_range`)
+/// is identical to [`baseline_reference_energy`] over the whole grid.  A
+/// mask selecting no bins falls back to the full grid rather than returning
+/// NaN (the pipeline's active-bin-count gate rejects an empty window
+/// upstream, so this branch is defensive only).
+pub fn baseline_reference_energy_active(energies: &[f64], active: Option<&[bool]>) -> f64 {
+    match active {
+        None => baseline_reference_energy(energies),
+        Some(mask) => {
+            debug_assert_eq!(mask.len(), energies.len());
+            let (lo, hi, any) = energies.iter().zip(mask).fold(
+                (f64::INFINITY, f64::NEG_INFINITY, false),
+                |(lo, hi, any), (&e, &a)| {
+                    if a {
+                        (lo.min(e), hi.max(e), true)
+                    } else {
+                        (lo, hi, any)
+                    }
+                },
+            );
+            if any {
+                (lo * hi).sqrt()
+            } else {
+                baseline_reference_energy(energies)
+            }
+        }
+    }
+}
+
 /// Bounded multiplicative polynomial baseline (issue #635):
 ///
 /// ```text
@@ -4591,6 +4633,39 @@ mod tests {
         let e = [1.0, 5.0, 100.0];
         assert!((baseline_reference_energy(&e) - 10.0).abs() < 1e-12);
         assert!(baseline_reference_energy(&[]).is_nan());
+    }
+
+    /// Issue #648: with an active mask, the reference energy is the midpoint
+    /// of the ACTIVE window, not the full grid.  Mirrors the real VENUS case
+    /// where the full grid spans to the MeV range but the fit window is
+    /// 8–45 eV: the full-grid midpoint (≈3211 eV) silently lets the baseline
+    /// absorb Doppler broadening; the active midpoint (≈19 eV) does not.
+    #[test]
+    fn baseline_reference_energy_active_uses_window_not_full_grid() {
+        // Grid: three low-eV resonance bins + one MeV-scale tail bin.
+        let energies = [8.0, 20.0, 45.0, 2_278_807.0];
+        // fit_energy_range 8–45 eV → last bin inactive.
+        let mask = [true, true, true, false];
+        let e_ref = baseline_reference_energy_active(&energies, Some(&mask));
+        assert!(
+            (e_ref - (8.0_f64 * 45.0).sqrt()).abs() < 1e-9,
+            "active E_ref = {e_ref}, expected {}",
+            (8.0_f64 * 45.0).sqrt()
+        );
+        // Full-grid value is the buggy ≈3211 eV — the fix must differ from it.
+        let full = baseline_reference_energy(&energies);
+        assert!(full > 1000.0 && (full - e_ref).abs() > 1000.0);
+        // None mask == full grid (no fit_energy_range).
+        assert_eq!(
+            baseline_reference_energy_active(&energies, None),
+            baseline_reference_energy(&energies)
+        );
+        // Degenerate all-false mask falls back to full grid, never NaN.
+        let none_active = [false, false, false, false];
+        assert_eq!(
+            baseline_reference_energy_active(&energies, Some(&none_active)),
+            baseline_reference_energy(&energies)
+        );
     }
 
     /// Issue #635: identity coefficients (1, 0, 0) reproduce the inner model

--- a/crates/nereids-io/src/daslogs.rs
+++ b/crates/nereids-io/src/daslogs.rs
@@ -351,22 +351,24 @@ fn read_pv_series(
 
     // Drop corrupt device-reconnect records (issue #652, B12).  Real SNS
     // files — furnace channels BL10:SE:ND1:* on runs 19383/19386/19392 —
-    // contain reconnect entries with `time = 0.0` and a subnormal
-    // uninitialized-memory value (~6.9e-310).  A subnormal is
+    // contain reconnect entries with the exact signature `time == 0.0` AND
+    // a subnormal uninitialized-memory value (~6.9e-310).  A subnormal is
     // `is_finite() == true`, so without this guard the leading such record
     // would silently enter the power median and the time-weighted
-    // integration.  These records are also the ones that produce the
-    // backward `time = 0.0` jump mid-log, so dropping them by their
-    // subnormal-value signature ALSO removes the spurious non-ascending
-    // step — `run_health` then works on the very furnace PV a user asked
-    // about, instead of failing the ascending-time check below.  This
-    // matches `read_run_log`'s corrupt-record policy.  A genuine
-    // (non-subnormal) backward jump is NOT dropped: it still trips the
-    // ascending-time hard error, so real scrambled logs stay loud.
+    // integration.  These are also the records that produce the backward
+    // `time = 0.0` jump mid-log, so dropping them ALSO removes the spurious
+    // non-ascending step — `run_health` then works on the very furnace PV
+    // a user asked about, instead of failing the ascending-time check
+    // below.  Both parts of the signature are required so a legitimate
+    // (if physically implausible) subnormal reading at a NORMAL timestamp
+    // is not silently discarded; and a genuine non-subnormal backward jump
+    // is still NOT dropped — it trips the ascending-time hard error, so
+    // real scrambled logs stay loud.  Matches `read_run_log`'s policy on
+    // the leading-record case.
     let (time, value): (Vec<f64>, Vec<f64>) = time
         .iter()
         .zip(&value)
-        .filter(|&(_, &v)| !(v != 0.0 && v.abs() < f64::MIN_POSITIVE))
+        .filter(|&(&t, &v)| !(t == 0.0 && v != 0.0 && v.abs() < f64::MIN_POSITIVE))
         .map(|(&t, &v)| (t, v))
         .unzip();
     // Every entry was a corrupt reconnect record → treat as "no usable log"

--- a/crates/nereids-io/src/daslogs.rs
+++ b/crates/nereids-io/src/daslogs.rs
@@ -348,6 +348,32 @@ fn read_pv_series(
             value.len(),
         )));
     }
+
+    // Drop corrupt device-reconnect records (issue #652, B12).  Real SNS
+    // files — furnace channels BL10:SE:ND1:* on runs 19383/19386/19392 —
+    // contain reconnect entries with `time = 0.0` and a subnormal
+    // uninitialized-memory value (~6.9e-310).  A subnormal is
+    // `is_finite() == true`, so without this guard the leading such record
+    // would silently enter the power median and the time-weighted
+    // integration.  These records are also the ones that produce the
+    // backward `time = 0.0` jump mid-log, so dropping them by their
+    // subnormal-value signature ALSO removes the spurious non-ascending
+    // step — `run_health` then works on the very furnace PV a user asked
+    // about, instead of failing the ascending-time check below.  This
+    // matches `read_run_log`'s corrupt-record policy.  A genuine
+    // (non-subnormal) backward jump is NOT dropped: it still trips the
+    // ascending-time hard error, so real scrambled logs stay loud.
+    let (time, value): (Vec<f64>, Vec<f64>) = time
+        .iter()
+        .zip(&value)
+        .filter(|&(_, &v)| !(v != 0.0 && v.abs() < f64::MIN_POSITIVE))
+        .map(|(&t, &v)| (t, v))
+        .unzip();
+    // Every entry was a corrupt reconnect record → treat as "no usable log"
+    // (same as an absent/empty PV) so the other PV's summary survives.
+    if time.is_empty() {
+        return Ok(None);
+    }
     for (i, &t) in time.iter().enumerate() {
         if !t.is_finite() {
             return Err(IoError::InvalidParameter(format!(
@@ -576,6 +602,36 @@ mod tests {
             format!("{err}").contains("ascending"),
             "Expected ascending-time error, got: {err}",
         );
+    }
+
+    /// Issue #652 (B12): corrupt device-reconnect records — `time = 0.0`
+    /// with a subnormal (~6.9e-310) value — are dropped, so `run_health`
+    /// works on furnace-style PVs instead of ingesting the subnormal into
+    /// its median or failing the ascending-time check.  Mirrors the real
+    /// VENUS run-19383 furnace channel, both leading and mid-log records.
+    #[test]
+    fn test_subnormal_reconnect_records_dropped() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("run.h5");
+        let sub = 6.9e-310_f64;
+        assert!(sub.is_finite() && sub != 0.0 && sub.abs() < f64::MIN_POSITIVE);
+        // Leading reconnect record (t=0, subnormal) + a mid-log one (the
+        // spurious backward jump to 0.0); real power values 20 MW elsewhere.
+        write_run(
+            &path,
+            Some(100.0),
+            &[(
+                "proton_charge",
+                &[0.0, 10.0, 30.0, 0.0, 60.0],
+                &[sub, 20.0, 20.0, sub, 20.0],
+            )],
+        );
+        let health = run_health(&path, &RunHealthOptions::default()).unwrap();
+        // Two records dropped → three clean entries, all 20 MW, ascending.
+        assert_eq!(health.n_power_entries, 3);
+        assert_eq!(health.median_power, Some(20.0));
+        // Median is 20 (not dragged toward 0 by the subnormal), so no dip.
+        assert_eq!(health.beam_dip_fraction, Some(0.0));
     }
 
     /// T38: without /entry/duration the window falls back to the latest

--- a/crates/nereids-io/src/tiff_stack.rs
+++ b/crates/nereids-io/src/tiff_stack.rs
@@ -919,7 +919,7 @@ fn load_chunked_sum(
     let (_, height, width) = acc.dim();
 
     // Duplicate-chunk guard (issue #653).  On real VENUS data every observed
-    // multi-chunk folder is a byte-identical *duplicate write* of one
+    // multi-chunk folder is a *duplicate write* of one
     // exposure, not sequential DAQ segments — summing them (the default)
     // silently doubles every count.  We fingerprint each chunk with an
     // FNV-1a hash over the raw f64 bits (O(1) extra memory — the stacks run
@@ -967,7 +967,8 @@ fn load_chunked_sum(
             return Err(IoError::ChunkMismatch {
                 directory: dir.to_string_lossy().into_owned(),
                 details: format!(
-                    "DAQ chunk {chunk_id} is byte-identical to chunk {dup_of} — a \
+                    "DAQ chunk {chunk_id} has an identical content fingerprint to chunk \
+                     {dup_of} (FNV-1a hash over all pixel bits) — almost certainly a \
                      duplicate write of the same exposure, not a distinct DAQ segment. \
                      Summing them (default sum_chunks=true) would double every count \
                      (and inflate proton-charge normalisation by the chunk multiplicity). \

--- a/crates/nereids-io/src/tiff_stack.rs
+++ b/crates/nereids-io/src/tiff_stack.rs
@@ -648,7 +648,8 @@ pub fn load_tiff_folder_with_options(
                 // strict improvement over lexicographic order for unpadded
                 // frame numbers); multiple chunks additionally sum
                 // element-wise across chunks.
-                let arr = load_chunked_sum(&chunks, options.pixel_policy, &mut n_clipped_pixels)?;
+                let arr =
+                    load_chunked_sum(dir, &chunks, options.pixel_policy, &mut n_clipped_pixels)?;
                 Ok((
                     arr,
                     TiffLoadInfo {
@@ -906,17 +907,43 @@ fn validate_chunk_consistency(
 /// a time.  VENUS stacks run to several GB, so materialising every chunk
 /// (or a transient second copy of one chunk's stack) is not an option.
 fn load_chunked_sum(
+    dir: &Path,
     chunks: &BTreeMap<u64, Vec<(u64, PathBuf)>>,
     pixel_policy: PixelValuePolicy,
     n_clipped_pixels: &mut usize,
 ) -> Result<Array3<f64>, IoError> {
-    let mut iter = chunks.values();
-    let first = iter.next().expect("detect_chunk_layout yields >= 1 chunk");
+    let mut iter = chunks.iter();
+    let (&first_id, first) = iter.next().expect("detect_chunk_layout yields >= 1 chunk");
     let first_paths: Vec<PathBuf> = first.iter().map(|(_, path)| path.clone()).collect();
     let mut acc = load_frames_from_paths(&first_paths, pixel_policy, n_clipped_pixels)?;
     let (_, height, width) = acc.dim();
 
-    for frames in iter {
+    // Duplicate-chunk guard (issue #653).  On real VENUS data every observed
+    // multi-chunk folder is a byte-identical *duplicate write* of one
+    // exposure, not sequential DAQ segments — summing them (the default)
+    // silently doubles every count.  We fingerprint each chunk with an
+    // FNV-1a hash over the raw f64 bits (O(1) extra memory — the stacks run
+    // to several GB, so a second copy for an equality check is not an
+    // option) and refuse to sum a chunk that is identical to ANY earlier
+    // chunk (not just the first — otherwise a duplicate pair that excludes
+    // the first chunk, e.g. [A, B, B], would still be double-summed).
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+    let fnv_step = |h: u64, bits: u64| (h ^ bits).wrapping_mul(FNV_PRIME);
+
+    // Single-chunk folders (the dominant real case) never enter the loop, so
+    // skip the full hash pass over the multi-GB first chunk entirely.
+    let multi_chunk = chunks.len() > 1;
+    let mut seen_hashes: Vec<(u64, u64)> = Vec::new(); // (chunk_id, hash)
+    if multi_chunk {
+        let first_hash = acc
+            .iter()
+            .fold(FNV_OFFSET, |h, &v| fnv_step(h, v.to_bits()));
+        seen_hashes.push((first_id, first_hash));
+    }
+
+    for (&chunk_id, frames) in iter {
+        let mut chunk_hash = FNV_OFFSET;
         for (i, (_, path)) in frames.iter().enumerate() {
             let (pixels, w, h) = read_single_frame(path, i, pixel_policy, n_clipped_pixels)?;
             if w as usize != width || h as usize != height {
@@ -926,11 +953,29 @@ fn load_chunked_sum(
                     frame: i,
                 });
             }
+            // Fold in the SAME element order as `acc.iter()` (row-major
+            // frame,y,x) so identical content yields identical hashes.
+            for &p in &pixels {
+                chunk_hash = fnv_step(chunk_hash, p.to_bits());
+            }
             let mut slice = acc.slice_mut(s![i, .., ..]);
             for (dst, src) in slice.iter_mut().zip(pixels.iter()) {
                 *dst += src;
             }
         }
+        if let Some(&(dup_of, _)) = seen_hashes.iter().find(|&&(_, h)| h == chunk_hash) {
+            return Err(IoError::ChunkMismatch {
+                directory: dir.to_string_lossy().into_owned(),
+                details: format!(
+                    "DAQ chunk {chunk_id} is byte-identical to chunk {dup_of} — a \
+                     duplicate write of the same exposure, not a distinct DAQ segment. \
+                     Summing them (default sum_chunks=true) would double every count \
+                     (and inflate proton-charge normalisation by the chunk multiplicity). \
+                     Pass sum_chunks=false to load all frames without summing (issue #653)."
+                ),
+            });
+        }
+        seen_hashes.push((chunk_id, chunk_hash));
     }
 
     Ok(acc)
@@ -1678,6 +1723,69 @@ mod tests {
                 chunk_inconsistent: false,
             }
         );
+    }
+
+    /// Issue #653: two chunks with byte-identical content are a duplicate DAQ
+    /// write, not sequential segments — the default summing path must refuse
+    /// them (silently doubling every count is the exact real-VENUS failure),
+    /// while `sum_chunks=false` still loads every frame for inspection.
+    #[test]
+    fn test_chunked_duplicate_write_rejected_on_sum_path() {
+        let dir = tempfile::tempdir().unwrap();
+        // Same base ⇒ chunk 765 is byte-identical to chunk 764.
+        write_chunk_files(dir.path(), "run", 764, 100, &[0, 1, 2, 3]);
+        write_chunk_files(dir.path(), "run", 765, 100, &[0, 1, 2, 3]);
+
+        let err = load_tiff_folder_with_options(dir.path(), None, &TiffFolderOptions::default())
+            .expect_err("summing byte-identical duplicate chunks must be a hard error");
+        match err {
+            IoError::ChunkMismatch { details, .. } => {
+                assert!(
+                    details.contains("identical") && details.contains("765"),
+                    "unexpected message: {details}"
+                );
+                assert!(
+                    details.contains("sum_chunks=false"),
+                    "must name the escape hatch"
+                );
+            }
+            other => panic!("expected ChunkMismatch, got {other:?}"),
+        }
+
+        // The escape hatch loads all 8 frames (concatenation), no summing.
+        let options = TiffFolderOptions {
+            sum_chunks: false,
+            ..TiffFolderOptions::default()
+        };
+        let (arr, info) = load_tiff_folder_with_options(dir.path(), None, &options).unwrap();
+        assert_eq!(arr.shape(), &[8, 2, 2]);
+        assert!(!info.chunks_summed);
+        // Distinct chunks (the T1 case) must still sum — the guard is
+        // content-based, not a blanket multi-chunk refusal.
+        let dir2 = tempfile::tempdir().unwrap();
+        write_chunk_files(dir2.path(), "run", 764, 100, &[0, 1, 2, 3]);
+        write_chunk_files(dir2.path(), "run", 765, 200, &[0, 1, 2, 3]);
+        let (_, info2) =
+            load_tiff_folder_with_options(dir2.path(), None, &TiffFolderOptions::default())
+                .unwrap();
+        assert!(info2.chunks_summed);
+
+        // A duplicate pair that does NOT include the first chunk ([A, B, B])
+        // must also be caught — the guard compares against ALL earlier
+        // chunks, not just the first.
+        let dir3 = tempfile::tempdir().unwrap();
+        write_chunk_files(dir3.path(), "run", 764, 100, &[0, 1, 2, 3]); // A
+        write_chunk_files(dir3.path(), "run", 765, 200, &[0, 1, 2, 3]); // B
+        write_chunk_files(dir3.path(), "run", 766, 200, &[0, 1, 2, 3]); // B' == B
+        let err3 = load_tiff_folder_with_options(dir3.path(), None, &TiffFolderOptions::default())
+            .expect_err("[A, B, B] must be rejected — 766 duplicates 765");
+        match err3 {
+            IoError::ChunkMismatch { details, .. } => assert!(
+                details.contains("766") && details.contains("765"),
+                "must name 766 as identical to 765, got: {details}"
+            ),
+            other => panic!("expected ChunkMismatch, got {other:?}"),
+        }
     }
 
     /// T2: sum_chunks=false loads the legacy lexicographic concatenation.

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -18,7 +18,7 @@ use nereids_fitting::parameters::{FitParameter, ParameterSet};
 use nereids_fitting::poisson::{self, PoissonConfig};
 use nereids_fitting::transmission_model::{
     EnergyScaleTransmissionModel, MultiplicativeBaselineModel, NormalizedTransmissionModel,
-    PrecomputedTransmissionModel, TransmissionFitModel, baseline_reference_energy,
+    PrecomputedTransmissionModel, TransmissionFitModel,
 };
 use nereids_physics::resolution::ResolutionFunction;
 use nereids_physics::transmission::InstrumentParams;
@@ -1025,6 +1025,23 @@ impl UnifiedFitConfig {
     pub fn fit_energy_range(&self) -> Option<(f64, f64)> {
         self.fit_energy_range
     }
+    /// Baseline log-basis reference energy over the ACTIVE fit window
+    /// (issue #648).  Every baseline construction site must use this rather
+    /// than `baseline_reference_energy(self.energies())`: with a
+    /// `fit_energy_range` set, the full-grid midpoint sits thousands of eV
+    /// away from the window and the baseline silently absorbs temperature
+    /// broadening.  Folds the `fit_energy_range` mask in one place so no
+    /// call site can reintroduce the full-grid bug.
+    pub fn baseline_reference_energy(&self) -> f64 {
+        let mask = nereids_fitting::active_mask::build_active_mask(
+            self.energies(),
+            self.fit_energy_range(),
+        );
+        nereids_fitting::transmission_model::baseline_reference_energy_active(
+            self.energies(),
+            mask.as_deref(),
+        )
+    }
     pub fn precomputed_cross_sections(&self) -> Option<&Arc<Vec<Vec<f64>>>> {
         self.precomputed_cross_sections.as_ref()
     }
@@ -1490,7 +1507,7 @@ fn fit_transmission_lm(
             MultiplicativeBaselineModel::new(
                 stacked,
                 config.energies(),
-                baseline_reference_energy(config.energies()),
+                config.baseline_reference_energy(),
                 bli.b0,
                 bli.b1,
                 bli.b2,
@@ -1630,7 +1647,7 @@ fn fit_transmission_poisson(
         stacked = Box::new(MultiplicativeBaselineModel::new(
             stacked,
             config.energies(),
-            baseline_reference_energy(config.energies()),
+            config.baseline_reference_energy(),
             bli.b0,
             bli.b1,
             bli.b2,
@@ -1859,7 +1876,7 @@ fn fit_counts_joint_poisson(
             MultiplicativeBaselineModel::new(
                 stacked,
                 config.energies(),
-                baseline_reference_energy(config.energies()),
+                config.baseline_reference_energy(),
                 bli.b0,
                 bli.b1,
                 bli.b2,
@@ -1937,7 +1954,7 @@ fn fit_counts_joint_poisson(
                 result.params[bli.b1],
                 result.params[bli.b2],
             ]),
-            Some(baseline_reference_energy(config.energies())),
+            Some(config.baseline_reference_energy()),
         )
     } else {
         (None, None)
@@ -2338,12 +2355,15 @@ pub(crate) fn validate_multiplicative_baseline(
     // review R2): bins masked out by fit_energy_range contribute nothing
     // to any mask-honouring cost function, so an init that is positive
     // everywhere inside the fit window must not be rejected because of
-    // out-of-window bins on a wide TOF grid.  E_ref itself stays a
-    // full-grid property — it is a pure reparameterization of the
-    // quadratic (any E_ref > 0 spans the same function family), and
-    // keeping it mask-independent keeps reported coefficients comparable
-    // across window choices.
-    let e_ref = baseline_reference_energy(config.energies());
+    // out-of-window bins on a wide TOF grid.  E_ref is the ACTIVE-window
+    // reference used by the fitter (#648): with fit_energy_range set it is
+    // the geometric midpoint of the active bins, not the full grid, so
+    // this validation evaluates the baseline basis exactly as the fit
+    // does.  (Only positivity matters here — any E_ref > 0 spans the same
+    // quadratic family — but using the fitter's value keeps validation and
+    // fit consistent.  Reported b0/b1/b2 are therefore defined relative to
+    // the active-window E_ref and are not comparable across window choices.)
+    let e_ref = config.baseline_reference_energy();
     if !e_ref.is_finite() || e_ref <= 0.0 {
         return Err(PipelineError::InvalidParameter(format!(
             "multiplicative baseline: reference energy sqrt(E_min*E_max) is \
@@ -3186,7 +3206,7 @@ fn extract_result(
                 result.params[bli.b1],
                 result.params[bli.b2],
             ]),
-            Some(baseline_reference_energy(config.energies())),
+            Some(config.baseline_reference_energy()),
         )
     } else {
         (None, None)
@@ -3935,6 +3955,42 @@ mod tests {
             (de[1] - energies[80]).abs() <= 1.0,
             "second dip at {} eV",
             de[1]
+        );
+    }
+
+    /// Issue #648: `UnifiedFitConfig::baseline_reference_energy()` must fold
+    /// the `fit_energy_range` mask, so a full grid that runs into the keV/MeV
+    /// tail yields the ACTIVE-window midpoint, not the full-grid midpoint that
+    /// silently let the baseline absorb Doppler broadening (T runaway,
+    /// warnings=[]).  Mirrors the real VENUS Ta grid.
+    #[test]
+    fn baseline_reference_energy_honours_fit_energy_range() {
+        let data = hf178_mlbw_two_resonances();
+        // 8–45 eV resonance region plus a keV-scale tail bin, like the VENUS grid.
+        let mut energies: Vec<f64> = (0..400).map(|i| 8.0 + (i as f64) * 0.0925).collect();
+        energies.push(3211.0 * 3211.0 / 8.0); // pushes full-grid midpoint far away
+        let config = UnifiedFitConfig::new(
+            energies.clone(),
+            vec![data],
+            vec!["Hf-178".into()],
+            293.6,
+            None,
+            vec![0.1],
+        )
+        .unwrap();
+        let full = nereids_fitting::transmission_model::baseline_reference_energy(&energies);
+        // No range → full grid (unchanged behaviour).
+        assert!((config.baseline_reference_energy() - full).abs() < 1e-6);
+        // With fit_energy_range 8–45 eV → active-window midpoint ≈ 19 eV.
+        let windowed = config.with_fit_energy_range(Some((8.0, 45.0))).unwrap();
+        let e_ref = windowed.baseline_reference_energy();
+        assert!(
+            e_ref > 8.0 && e_ref < 45.0,
+            "windowed E_ref = {e_ref} eV must lie inside the 8–45 eV fit window"
+        );
+        assert!(
+            (e_ref - full).abs() > 100.0,
+            "windowed E_ref must differ from the buggy full-grid value {full}"
         );
     }
 
@@ -7534,7 +7590,7 @@ mod tests {
     /// non-vacuity pre-check: the injected baseline must actually move the
     /// data, otherwise the closed-loop oracle is trivially satisfiable.
     fn apply_truth_baseline(t: &[f64], energies: &[f64]) -> Vec<f64> {
-        let e_ref = baseline_reference_energy(energies);
+        let e_ref = nereids_fitting::transmission_model::baseline_reference_energy(energies);
         let out: Vec<f64> = t
             .iter()
             .zip(energies.iter())
@@ -7563,7 +7619,7 @@ mod tests {
         let (t_pure, _) = synthetic_transmission_at_temp(&data, true_density, true_temp, &energies);
         let measured = apply_truth_baseline(&t_pure, &energies);
         let sigma: Vec<f64> = measured.iter().map(|&v| 0.01 * v.max(0.01)).collect();
-        let e_ref = baseline_reference_energy(&energies);
+        let e_ref = nereids_fitting::transmission_model::baseline_reference_energy(&energies);
 
         // Density frozen at truth (the production thermometry pattern the
         // baseline was designed for); temperature seeded 100 K low; baseline

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -1507,7 +1507,10 @@ fn fit_transmission_lm(
             MultiplicativeBaselineModel::new(
                 stacked,
                 config.energies(),
-                config.baseline_reference_energy(),
+                nereids_fitting::transmission_model::baseline_reference_energy_active(
+                    config.energies(),
+                    active_mask.as_deref(),
+                ),
                 bli.b0,
                 bli.b1,
                 bli.b2,
@@ -1876,7 +1879,10 @@ fn fit_counts_joint_poisson(
             MultiplicativeBaselineModel::new(
                 stacked,
                 config.energies(),
-                config.baseline_reference_energy(),
+                nereids_fitting::transmission_model::baseline_reference_energy_active(
+                    config.energies(),
+                    active_mask_slice,
+                ),
                 bli.b0,
                 bli.b1,
                 bli.b2,
@@ -1954,7 +1960,12 @@ fn fit_counts_joint_poisson(
                 result.params[bli.b1],
                 result.params[bli.b2],
             ]),
-            Some(config.baseline_reference_energy()),
+            Some(
+                nereids_fitting::transmission_model::baseline_reference_energy_active(
+                    config.energies(),
+                    active_mask_slice,
+                ),
+            ),
         )
     } else {
         (None, None)

--- a/crates/nereids-pipeline/src/spatial.rs
+++ b/crates/nereids-pipeline/src/spatial.rs
@@ -1058,7 +1058,7 @@ pub fn spatial_map_typed(
     let has_baseline_maps = config.multiplicative_baseline().is_some() && !baseline_global_mode;
     let baseline_e_ref_ev = config
         .multiplicative_baseline()
-        .map(|_| nereids_fitting::transmission_model::baseline_reference_energy(config.energies()));
+        .map(|_| config.baseline_reference_energy());
 
     if cancel.is_some_and(|c| c.load(Ordering::Relaxed)) {
         return Err(PipelineError::Cancelled);


### PR DESCRIPTION
Three real-VENUS defects found validating the merged build against IPTS-37432 data. Disjoint files (fitting/pipeline vs io), consolidated into one PR by request. Rebased onto post-#669 main; git 3-way-merged the `impl UnifiedFitConfig` adjacency with #669's `scale_by_chi2` accessor with no conflict.

## Fixes

**#648 (fitting/pipeline) — baseline E_ref over the active fit window, not the full grid.**
`baseline_reference_energy(config.energies())` placed the `ln(E/E_ref)` basis using the whole grid. On a VENUS Ta grid (4.5 eV–2.3 MeV) with `fit_energy_range = 8–45 eV`, E_ref was ≈3211 eV instead of ≈19 eV, so every active bin sat at a large negative z, the `1,z,z²` columns lost near-orthogonality, and the baseline silently absorbed Doppler broadening (`warnings=[]`). Now `UnifiedFitConfig::baseline_reference_energy()` folds the `fit_energy_range` mask; all 7 baseline construction sites use it so none can regress. New `baseline_reference_energy_active`. **Software fix only — no temperature-correctness claim.**

**#653 (io) — duplicate DAQ chunks no longer silently double counts.**
Every real VENUS multi-chunk folder (24697: 764/765; 19387: 118/119) is a byte-identical *duplicate write* of one exposure, md5-verified (autoreduce emits one chunk). Default `sum_chunks=true` doubled every count behind a UserWarning. `load_chunked_sum` now fingerprints each chunk (FNV-1a over f64 bits, O(1) memory) and refuses a chunk identical to **any earlier** chunk, naming the `sum_chunks=false` escape; distinct chunks still sum.

**#652 (io) — `run_health` drops B12 corrupt DASlogs reconnect records.**
Furnace channels BL10:SE:ND1:* (19383/19386/19392) carry reconnect entries with `time=0.0` and a subnormal (~6.9e-310) value. A subnormal is `is_finite()`, so a leading one silently entered the power median; a mid-log one tripped the ascending-time error. `read_pv_series` now drops the subnormal-value signature (matching `read_run_log`); genuine backward jumps still error.

## Review pipeline (before this PR)
3 adversarial reviewers + verify on the consolidated diff. Confirmed the fixes and found **3 minor issues, all fixed here**: single-chunk path skipped the full-stack FNV pass (perf); the guard now compares each chunk against **all** earlier chunks (closes the `[A,B,B]` hole, new test); a stale `validate_multiplicative_baseline` comment corrected.

## Verification
- **Suites (post-rebase):** nereids-fitting 189, nereids-pipeline 176, nereids-io 266 — 0 failed; **0 clippy**, fmt clean.
- **Real-data acceptance (post-rebase build):**
```
#648 run 24686/24692: E_ref=18.97 eV in_window=True (was 3211.2 eV)
#653 real-24697 duplicate folder: refused=True; sum_chunks=false loads all frames; distinct chunks still sum
#652 run_health(19383, CH1): median_power=27.54, n_power_entries=1788 (=1790−2 dropped)
CONSOLIDATED ACCEPTANCE: ALL PASS
```

## Scope notes (honest)
- Closes #648, #653. **Addresses** #652's hazard — the structural dedup of the two transition-log readers (runlog vs daslogs) into one module is left as non-defect debt, intentionally NOT done here to avoid a risky refactor.
- #638 and #651 are NOT in this PR — already handled by #669 / live Dependabot.

PR assisted with [Claude Code](https://claude.com/claude-code).
