### PR TITLE
security: ignore private agent workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ Thumbs.db
 # Local development worklog (NOT tracked)
 /worklog/
 
+# Local agent task state and private investigation artifacts (NOT tracked)
+/.harness/
+/investigation/
+
 # Python
 __pycache__/
 *.pyc


### PR DESCRIPTION
## Summary

- ignore local agent task state
- ignore private investigation workspaces
- prevent either workspace from appearing in normal staging operations

## Security boundary

The two workspaces remain available locally but are not tracked by Git. This PR contains only the protective `.gitignore` rules; it contains no task, investigation, experiment, or identity-bearing content.

The prior public `main` commit from #706 was separately removed with a leased history rewrite before this PR was opened.

## Verification

```text
changed tracked paths: .gitignore only
tracked files in protected workspaces: 0
ignore check for both protected workspaces: PASS
git diff --check: PASS
```
