### PR TITLE
Add supported aggregate room-to-hot fitting workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,8 @@ Thumbs.db
 /worklog/
 
 # Local agent task state and private investigation artifacts (NOT tracked)
-/.harness/
-/investigation/
+/.harness
+/investigation
 
 # Python
 __pycache__/
@@ -63,5 +63,5 @@ tmp/
 # do not track manuscript folders
 .manuscripts/
 
-# Session-local agent-harness state (task contracts, verify gates)
-.harness/
+# Session-local agent-harness state (task contracts, verify gates) is covered
+# by the root-level rule above, including when a worktree uses a symlink.

--- a/README.md
+++ b/README.md
@@ -134,13 +134,8 @@ Minimal spectrum manifest:
     "isotopes": [
       {"isotope": "Hf-177", "endf_file": "Hf-177.endf", "initial_density": 1e-5}
     ],
-    "fit": {"solver": "lm", "fit_domain": "transmission", "max_iter": 100},
-    "resolution": {
-      "kind": "gaussian",
-      "flight_path_m": 25.0,
-      "delta_t_us": 0.5,
-      "delta_l_m": 0.005
-    },
+    "fit": {"solver": "auto", "fit_domain": "counts", "max_iter": 100},
+    "resolution": {"kind": "none"},
     "output": {"directory": "output"}
   }
 }

--- a/apps/gui/Cargo.toml
+++ b/apps/gui/Cargo.toml
@@ -54,6 +54,7 @@ winit = { version = "0.30", default-features = false, features = ["wayland-dlope
 
 [dev-dependencies]
 tempfile = { workspace = true }
+nereids-endf = { workspace = true, features = ["test-support"] }
 
 # macOS app bundle configuration for cargo-bundle
 [package.metadata.bundle]

--- a/apps/gui/src/app.rs
+++ b/apps/gui/src/app.rs
@@ -275,18 +275,18 @@ fn poll_pending_tasks(state: &mut AppState) {
             }
             Ok(Err(err_msg)) => {
                 tracing::error!(error = %err_msg, "spatial map failed");
+                state.clear_spatial_fit_output();
                 state.status_message = format!("Spatial map error: {err_msg}");
                 state.is_fitting = false;
                 state.fitting_progress = None;
-                state.residuals_cache = None;
                 state.pending_spatial = None;
             }
             Err(std::sync::mpsc::TryRecvError::Disconnected) => {
                 tracing::error!("spatial map task disconnected without result");
+                state.clear_spatial_fit_output();
                 state.status_message = "Spatial map task failed".into();
                 state.is_fitting = false;
                 state.fitting_progress = None;
-                state.residuals_cache = None;
                 state.pending_spatial = None;
             }
             Err(std::sync::mpsc::TryRecvError::Empty) => {} // Still running
@@ -634,5 +634,67 @@ fn poll_pending_tasks(state: &mut AppState) {
             }
             Err(std::sync::mpsc::TryRecvError::Empty) => {} // Still saving
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::Array2;
+    use nereids_pipeline::spatial::SpatialResult;
+    use std::sync::mpsc;
+
+    fn stale_spatial_result() -> SpatialResult {
+        let map = || Array2::from_elem((1, 1), 9.9);
+        SpatialResult {
+            density_maps: vec![map()],
+            uncertainty_maps: vec![map()],
+            chi_squared_map: map(),
+            deviance_per_dof_map: None,
+            converged_map: Array2::from_elem((1, 1), true),
+            temperature_map: None,
+            temperature_uncertainty_map: None,
+            isotope_labels: vec!["U-238".into()],
+            anorm_map: None,
+            background_maps: None,
+            back_d_map: None,
+            back_f_map: None,
+            t0_us_map: None,
+            l_scale_map: None,
+            energy_scale_flight_path_m: None,
+            baseline_global: None,
+            baseline_e_ref_ev: None,
+            baseline_maps: None,
+            warnings: Vec::new(),
+            n_converged: 1,
+            n_total: 1,
+            n_failed: 0,
+        }
+    }
+
+    #[test]
+    fn spatial_worker_error_clears_stale_map_and_export_state() {
+        let mut state = AppState {
+            spatial_result: Some(stale_spatial_result()),
+            export_status: Some("old export".into()),
+            is_fitting: true,
+            ..Default::default()
+        };
+        let (tx, rx) = mpsc::channel();
+        tx.send(Err("counts-resolution route rejected".into()))
+            .expect("test receiver is live");
+        state.pending_spatial = Some(rx);
+
+        poll_pending_tasks(&mut state);
+
+        assert!(state.spatial_result.is_none());
+        assert!(state.export_status.is_none());
+        assert!(state.pending_spatial.is_none());
+        assert!(!state.is_fitting);
+        assert!(
+            state
+                .status_message
+                .contains("counts-resolution route rejected")
+        );
     }
 }

--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -174,8 +174,15 @@ fn ensure_selected_pixel(state: &mut AppState) {
 
 // ---- Fit Controls ----
 
+fn invalidate_if_solver_method_changed(state: &mut AppState, previous: SolverMethod) {
+    if state.solver_method != previous {
+        state.invalidate_analysis_outputs();
+    }
+}
+
 fn fit_controls(ui: &mut egui::Ui, state: &mut AppState, available_height_hint: f32) {
     // -- Solver configuration --
+    let prev_solver_method = state.solver_method;
     let method_text = match state.solver_method {
         SolverMethod::LevenbergMarquardt => "Levenberg-Marquardt",
         SolverMethod::PoissonKL => "Poisson KL",
@@ -212,6 +219,7 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState, available_height_hint: 
         ui.horizontal(|ui| draw_method(ui, state));
         ui.horizontal(|ui| draw_max_iter(ui, state));
     }
+    invalidate_if_solver_method_changed(state, prev_solver_method);
 
     // Advanced solver controls (collapsible)
     let auto_show_advanced = available_height_hint > 300.0;
@@ -1090,11 +1098,7 @@ fn apply_roi_editor_result(state: &mut AppState, result: RoiEditorResult) {
 
 /// Clear downstream fit results when ROI changes.
 fn clear_analyze_downstream(state: &mut AppState) {
-    state.pixel_fit_result = None;
-    state.spatial_result = None;
-    state.last_fit_feedback = None;
-    state.fitting_rois.clear();
-    state.show_analyze_fit_info = false;
+    state.invalidate_analysis_outputs();
 }
 
 // ---- Spectrum Panel (Column 3) ----
@@ -1469,40 +1473,54 @@ fn spectrum_panel(ui: &mut egui::Ui, state: &mut AppState) {
     // and the SAMMY 6-term background polynomial
     // (BackA + BackB/√E + BackC·√E + BackD·exp(-BackF/√E)) before
     // multiplying by the counts scale, so the overlay reflects the
-    // full forward model the solver fit — not just bare T·c·OB.
+    // full forward model the solver fit — not just bare T·c·OB.  That
+    // reconstruction is disabled below when resolution is active because
+    // c·OB·R[T] is not the required two-arm count response.
     let fit_result_for_overlay = match selection {
         SpectrumSelection::Pixel { y, x } => selected_pixel_fit_result_for_overlay(state, y, x),
         SpectrumSelection::Roi { .. } => state.pixel_fit_result.clone(),
     };
-    let fit_line = fit_result_for_overlay.as_ref().and_then(|result| {
-        let energies = state.energies.as_ref()?;
-        let (all_rd, density_indices, density_ratios) =
-            design::collect_all_resonance_data_with_mapping(state);
-        let instrument = design::build_resolution_function(
-            state.resolution_enabled,
-            &state.resolution_mode,
-            state.beamline.flight_path_m,
-        )
-        .ok()
-        .flatten()
-        .map(|r| Arc::new(nereids_physics::transmission::InstrumentParams { resolution: r }));
-        design::build_fit_line(&design::FitLineParams {
-            result,
-            resonance_data: &all_rd,
-            density_indices: &density_indices,
-            density_ratios: &density_ratios,
-            energies,
-            temperature_k: state.temperature_k,
-            x_values: &x_values,
-            n_plot,
-            instrument,
-            y_multiplier: if show_counts {
-                Some(&counts_scale)
-            } else {
-                None
-            },
+    let count_resolution_overlay_unsupported =
+        design::counts_resolution_overlay_unsupported(show_counts, state.resolution_enabled);
+    if count_resolution_overlay_unsupported {
+        ui.colored_label(
+            crate::theme::semantic::ORANGE,
+            design::COUNTS_RESOLUTION_OVERLAY_MESSAGE,
+        );
+    }
+    let fit_line = if count_resolution_overlay_unsupported {
+        None
+    } else {
+        fit_result_for_overlay.as_ref().and_then(|result| {
+            let energies = state.energies.as_ref()?;
+            let (all_rd, density_indices, density_ratios) =
+                design::collect_all_resonance_data_with_mapping(state);
+            let instrument = design::build_resolution_function(
+                state.resolution_enabled,
+                &state.resolution_mode,
+                state.beamline.flight_path_m,
+            )
+            .ok()
+            .flatten()
+            .map(|r| Arc::new(nereids_physics::transmission::InstrumentParams { resolution: r }));
+            design::build_fit_line(&design::FitLineParams {
+                result,
+                resonance_data: &all_rd,
+                density_indices: &density_indices,
+                density_ratios: &density_ratios,
+                energies,
+                temperature_k: state.temperature_k,
+                x_values: &x_values,
+                n_plot,
+                instrument,
+                y_multiplier: if show_counts {
+                    Some(&counts_scale)
+                } else {
+                    None
+                },
+            })
         })
-    });
+    };
 
     // TOF position marker x-value
     let tof_marker_x = x_values
@@ -2339,7 +2357,10 @@ fn build_fit_config(state: &AppState) -> Result<(UnifiedFitConfig, Range<usize>)
 }
 
 fn fit_pixel(state: &mut AppState) {
-    state.last_fit_feedback = None;
+    // A new attempt owns the pixel/ROI result slot immediately.  Clear the
+    // previous fit before validation so every early return and solver error
+    // leaves no stale curve or fit-details payload behind.
+    state.clear_pixel_fit_output();
 
     let (config, energy_range) = match build_fit_config(state) {
         Ok(c) => c,
@@ -2489,7 +2510,9 @@ fn fit_pixel(state: &mut AppState) {
 }
 
 fn fit_roi(state: &mut AppState) {
-    state.last_fit_feedback = None;
+    // Pixel and ROI fits share `pixel_fit_result`; claim the slot before any
+    // validation so a rejected ROI run cannot fall back to the previous one.
+    state.clear_pixel_fit_output();
 
     let (config, energy_range) = match build_fit_config(state) {
         Ok(c) => c,
@@ -2684,6 +2707,9 @@ fn fit_roi(state: &mut AppState) {
 }
 
 pub fn run_spatial_map(state: &mut AppState) {
+    // Results/export must stop seeing the previous map as soon as a new run is
+    // requested, including when config validation or the worker later fails.
+    state.clear_spatial_fit_output();
     state.last_fit_feedback = None;
 
     let (config, energy_range) = match build_fit_config(state) {
@@ -2852,4 +2878,180 @@ pub fn run_spatial_map(state: &mut AppState) {
             }
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{EndfStatus, ResolutionMode};
+    use ndarray::{Array2, Array3};
+    use nereids_endf::resonance::test_support::synthetic_single_resonance;
+    use nereids_io::normalization::NormalizedData;
+    use nereids_pipeline::spatial::SpatialResult;
+    use std::time::Duration;
+
+    fn stale_spectrum_result() -> SpectrumFitResult {
+        SpectrumFitResult {
+            densities: vec![9.9],
+            uncertainties: Some(vec![0.1]),
+            reduced_chi_squared: 1.0,
+            converged: true,
+            iterations: 1,
+            temperature_k: None,
+            temperature_k_unc: None,
+            anorm: 1.0,
+            background: [0.0; 3],
+            back_d: None,
+            back_f: None,
+            t0_us: None,
+            l_scale: None,
+            energy_scale_flight_path_m: None,
+            deviance_per_dof: None,
+            baseline: None,
+            baseline_e_ref_ev: None,
+            warnings: Vec::new(),
+        }
+    }
+
+    fn stale_spatial_result() -> SpatialResult {
+        let map = || Array2::from_elem((1, 1), 9.9);
+        SpatialResult {
+            density_maps: vec![map()],
+            uncertainty_maps: vec![map()],
+            chi_squared_map: map(),
+            deviance_per_dof_map: None,
+            converged_map: Array2::from_elem((1, 1), true),
+            temperature_map: None,
+            temperature_uncertainty_map: None,
+            isotope_labels: vec!["U-238".into()],
+            anorm_map: None,
+            background_maps: None,
+            back_d_map: None,
+            back_f_map: None,
+            t0_us_map: None,
+            l_scale_map: None,
+            energy_scale_flight_path_m: None,
+            baseline_global: None,
+            baseline_e_ref_ev: None,
+            baseline_maps: None,
+            warnings: Vec::new(),
+            n_converged: 1,
+            n_total: 1,
+            n_failed: 0,
+        }
+    }
+
+    fn rejected_counts_resolution_state() -> AppState {
+        let n = 32;
+        let sample = Arc::new(Array3::from_elem((n, 1, 1), 900.0));
+        let open_beam = Arc::new(Array3::from_elem((n, 1, 1), 1000.0));
+        let normalized = Arc::new(NormalizedData {
+            transmission: Array3::from_elem((n, 1, 1), 0.9),
+            uncertainty: Array3::from_elem((n, 1, 1), 0.02),
+        });
+        AppState {
+            sample_data: Some(sample),
+            open_beam_data: Some(open_beam),
+            normalized: Some(normalized),
+            energies: Some((1..=n).map(|i| i as f64).collect()),
+            isotope_entries: vec![IsotopeEntry {
+                z: 92,
+                a: 238,
+                symbol: "U-238".into(),
+                initial_density: 0.001,
+                resonance_data: Some(synthetic_single_resonance(92, 238, 236.0, 7.0)),
+                enabled: true,
+                endf_status: EndfStatus::Loaded,
+            }],
+            resolution_enabled: true,
+            resolution_mode: ResolutionMode::Gaussian {
+                delta_t_us: 1.0,
+                delta_l_m: 0.01,
+            },
+            solver_method: SolverMethod::PoissonKL,
+            selected_pixel: Some((0, 0)),
+            rois: vec![RoiSelection {
+                y_start: 0,
+                y_end: 1,
+                x_start: 0,
+                x_end: 1,
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn solver_method_change_clears_fit_outputs_but_preserves_inputs() {
+        let mut state = rejected_counts_resolution_state();
+        state.pixel_fit_result = Some(stale_spectrum_result());
+        state.spatial_result = Some(stale_spatial_result());
+        state.export_status = Some("old export".into());
+        state.is_fetching_endf = true;
+        let unrelated_cancel_token = Arc::clone(&state.cancel_token);
+        let previous = state.solver_method;
+        state.solver_method = SolverMethod::LevenbergMarquardt;
+
+        invalidate_if_solver_method_changed(&mut state, previous);
+
+        assert!(state.pixel_fit_result.is_none());
+        assert!(state.spatial_result.is_none());
+        assert!(state.export_status.is_none());
+        assert!(state.normalized.is_some());
+        assert!(state.sample_data.is_some());
+        assert!(state.open_beam_data.is_some());
+        assert!(state.energies.is_some());
+        assert_eq!(state.selected_pixel, Some((0, 0)));
+        assert_eq!(state.rois.len(), 1);
+        assert!(state.is_fetching_endf);
+        assert!(Arc::ptr_eq(&state.cancel_token, &unrelated_cancel_token));
+    }
+
+    #[test]
+    fn rejected_counts_resolution_pixel_and_roi_clear_stale_result() {
+        let mut pixel_state = rejected_counts_resolution_state();
+        pixel_state.pixel_fit_result = Some(stale_spectrum_result());
+        fit_pixel(&mut pixel_state);
+        assert!(pixel_state.pixel_fit_result.is_none());
+        assert!(
+            pixel_state
+                .last_fit_feedback
+                .as_ref()
+                .is_some_and(|f| f.summary.contains("separate open/sample response arms"))
+        );
+
+        let mut roi_state = rejected_counts_resolution_state();
+        roi_state.pixel_fit_result = Some(stale_spectrum_result());
+        fit_roi(&mut roi_state);
+        assert!(roi_state.pixel_fit_result.is_none());
+        assert!(
+            roi_state
+                .last_fit_feedback
+                .as_ref()
+                .is_some_and(|f| f.summary.contains("separate open/sample response arms"))
+        );
+    }
+
+    #[test]
+    fn rejected_counts_resolution_spatial_attempt_clears_stale_map() {
+        let mut state = rejected_counts_resolution_state();
+        state.spatial_result = Some(stale_spatial_result());
+        state.export_status = Some("old export".into());
+
+        run_spatial_map(&mut state);
+
+        assert!(state.spatial_result.is_none());
+        assert!(state.export_status.is_none());
+        let rx = state
+            .pending_spatial
+            .take()
+            .expect("rejected spatial run should still report its worker error");
+        let err = rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("spatial worker should reject counts plus resolution")
+            .expect_err("counts plus resolution must fail closed");
+        assert!(err.contains("separate open/sample response arms"), "{err}");
+        assert!(state.normalized.is_some());
+        assert_eq!(state.selected_pixel, Some((0, 0)));
+        assert_eq!(state.rois.len(), 1);
+    }
 }

--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -1198,6 +1198,10 @@ fn selected_pixel_fit_result_for_overlay(
             .or(result.baseline_global),
         baseline_e_ref_ev: result.baseline_e_ref_ev,
         warnings: result.warnings.clone(),
+        prediction_energies_ev: Vec::new(),
+        signal_prediction: Vec::new(),
+        background_prediction: Vec::new(),
+        model_prediction: Vec::new(),
     })
 }
 
@@ -2922,6 +2926,10 @@ mod tests {
             baseline: None,
             baseline_e_ref_ev: None,
             warnings: Vec::new(),
+            prediction_energies_ev: Vec::new(),
+            signal_prediction: Vec::new(),
+            background_prediction: Vec::new(),
+            model_prediction: Vec::new(),
         }
     }
 

--- a/apps/gui/src/guided/analyze.rs
+++ b/apps/gui/src/guided/analyze.rs
@@ -188,6 +188,7 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState, available_height_hint: 
         SolverMethod::PoissonKL => "Poisson KL",
     };
     let draw_method = |ui: &mut egui::Ui, state: &mut AppState| {
+        let counts_available = display_as_counts(state);
         ui.label("Method:");
         egui::ComboBox::from_id_salt("solver_method")
             .selected_text(method_text)
@@ -197,12 +198,17 @@ fn fit_controls(ui: &mut egui::Ui, state: &mut AppState, available_height_hint: 
                     SolverMethod::LevenbergMarquardt,
                     "Levenberg-Marquardt",
                 );
-                ui.selectable_value(
-                    &mut state.solver_method,
-                    SolverMethod::PoissonKL,
-                    "Poisson KL",
-                );
+                ui.add_enabled_ui(counts_available, |ui| {
+                    ui.selectable_value(
+                        &mut state.solver_method,
+                        SolverMethod::PoissonKL,
+                        "Poisson KL (raw counts)",
+                    );
+                });
             });
+        if !counts_available {
+            ui.weak("Poisson KL needs separate sample and open-beam counts");
+        }
     };
     let draw_max_iter = |ui: &mut egui::Ui, state: &mut AppState| {
         ui.label("Max iter:");
@@ -1106,11 +1112,10 @@ fn clear_analyze_downstream(state: &mut AppState) {
 /// Whether the Analyze panels should display raw sample counts +
 /// open-beam reference rather than the normalised transmission ratio.
 ///
-/// The rule is **input-data-driven**, not solver-driven: KL works with
-/// either domain.  Counts mode requires both sample + OB to be loaded
-/// (so the c·OB reference line and counts-scale fit overlay are
-/// computable), and the input mode must not be `TransmissionTiff` (a
-/// pre-normalised transmission stack — its raw input *is* a ratio).
+/// Counts mode requires both sample + OB to be loaded (so the c·OB reference
+/// line and counts-scale fit overlay are computable), and the input mode must
+/// not be `TransmissionTiff` (a pre-normalized transmission stack — its raw
+/// input is already a ratio).
 fn display_as_counts(state: &AppState) -> bool {
     state.sample_data.is_some()
         && state.open_beam_data.is_some()
@@ -2100,6 +2105,13 @@ fn build_fit_config(state: &AppState) -> Result<(UnifiedFitConfig, Range<usize>)
     // index `data[[e, y, x]]` for `e >= shape[0]`.  This belongs in
     // `build_fit_config` so all three call sites benefit (#514).
     let n_energies = full_energies.len();
+    if matches!(state.solver_method, SolverMethod::PoissonKL) && !display_as_counts(state) {
+        return Err(
+            "Poisson KL requires separate sample and open-beam count cubes; \
+             normalized transmission can only use Levenberg-Marquardt"
+                .to_string(),
+        );
+    }
     if let Some(norm) = state.normalized.as_ref() {
         let shape = norm.transmission.shape();
         if shape[0] != n_energies {
@@ -2440,8 +2452,8 @@ fn fit_pixel(state: &mut AppState) {
         }
     }
 
-    // Use counts-domain input only when the solver is Poisson KL AND both
-    // sample and open beam are available. LM always uses Transmission.
+    // The config builder already proved both count arms are present for KL.
+    // LM deliberately uses the separately normalized transmission path.
     let use_counts = matches!(state.solver_method, SolverMethod::PoissonKL);
     let input = if use_counts
         && let (Some(sample), Some(open_beam)) = (&state.sample_data, &state.open_beam_data)
@@ -2620,8 +2632,8 @@ fn fit_roi(state: &mut AppState) {
         }
     }
 
-    // Use counts-domain only when the solver is Poisson KL AND both
-    // sample and open beam are available. LM always uses Transmission.
+    // The config builder already proved both count arms are present for KL.
+    // LM deliberately uses the separately normalized transmission path.
     let use_counts = matches!(state.solver_method, SolverMethod::PoissonKL);
     let roi_input = if use_counts
         && let (Some(sample), Some(open_beam)) = (&state.sample_data, &state.open_beam_data)
@@ -2829,8 +2841,8 @@ pub fn run_spatial_map(state: &mut AppState) {
 
         // Run spatial_map_typed on the dedicated pool so its par_iter doesn't
         // share the global pool with inner physics par_iter calls.
-        // Use counts-domain only when the solver is Poisson KL AND both
-        // sample and open beam are available. LM always uses Transmission.
+        // The config builder already proved both count arms are present for
+        // KL. LM deliberately uses normalized transmission.
         //
         // SAMMY EMIN/EMAX-equivalent fit-energy-range restriction (#514):
         // when `state.fit_energy_range` is set, `build_fit_config` slices
@@ -3007,6 +3019,20 @@ mod tests {
     }
 
     #[test]
+    fn transmission_only_input_rejects_poisson_solver_before_fit() {
+        let mut state = rejected_counts_resolution_state();
+        state.input_mode = InputMode::TransmissionTiff;
+        state.sample_data = None;
+        state.open_beam_data = None;
+        state.resolution_enabled = false;
+
+        let error = build_fit_config(&state)
+            .expect_err("transmission-only data must not enter a count likelihood");
+
+        assert!(error.contains("requires separate sample and open-beam count cubes"));
+    }
+
+    #[test]
     fn rejected_counts_resolution_pixel_and_roi_clear_stale_result() {
         let mut pixel_state = rejected_counts_resolution_state();
         pixel_state.pixel_fit_result = Some(stale_spectrum_result());
@@ -3016,7 +3042,7 @@ mod tests {
             pixel_state
                 .last_fit_feedback
                 .as_ref()
-                .is_some_and(|f| f.summary.contains("separate open/sample response arms"))
+                .is_some_and(|f| f.summary.contains("exact separate-arm model"))
         );
 
         let mut roi_state = rejected_counts_resolution_state();
@@ -3027,7 +3053,7 @@ mod tests {
             roi_state
                 .last_fit_feedback
                 .as_ref()
-                .is_some_and(|f| f.summary.contains("separate open/sample response arms"))
+                .is_some_and(|f| f.summary.contains("exact separate-arm model"))
         );
     }
 
@@ -3049,7 +3075,7 @@ mod tests {
             .recv_timeout(Duration::from_secs(2))
             .expect("spatial worker should reject counts plus resolution")
             .expect_err("counts plus resolution must fail closed");
-        assert!(err.contains("separate open/sample response arms"), "{err}");
+        assert!(err.contains("exact separate-arm model"), "{err}");
         assert!(state.normalized.is_some());
         assert_eq!(state.selected_pixel, Some((0, 0)));
         assert_eq!(state.rois.len(), 1);

--- a/apps/gui/src/project.rs
+++ b/apps/gui/src/project.rs
@@ -1316,6 +1316,12 @@ fn state_from_snapshot(snap: ProjectSnapshot, state: &mut AppState, path: &Path)
             baseline: snap.single_fit_baseline,
             baseline_e_ref_ev: snap.single_fit_baseline_e_ref_ev,
             warnings: Vec::new(),
+            // Older project snapshots did not persist fitted curve arrays.
+            // The overlay can still rebuild the curve from the fitted values.
+            prediction_energies_ev: Vec::new(),
+            signal_prediction: Vec::new(),
+            background_prediction: Vec::new(),
+            model_prediction: Vec::new(),
         };
         // Rebuild FitFeedback from the restored result
         if let Some(ref labels) = snap.single_fit_labels {

--- a/apps/gui/src/state.rs
+++ b/apps/gui/src/state.rs
@@ -1352,12 +1352,42 @@ impl AppState {
     pub fn invalidate_fit_results(&mut self) {
         self.cancel_pending_tasks();
         self.normalized = None;
+        self.clear_pixel_fit_output();
+        self.clear_spatial_fit_output();
+    }
+
+    /// Clear the cached single-spectrum result before starting a new pixel or
+    /// ROI fit.  Input data, normalization, selection, and spatial-map results
+    /// remain valid and are deliberately preserved.
+    pub fn clear_pixel_fit_output(&mut self) {
         self.pixel_fit_result = None;
         self.residuals_cache = None;
-        self.spatial_result = None;
         self.last_fit_feedback = None;
+        self.show_analyze_fit_info = false;
+    }
+
+    /// Clear the cached map before starting a new spatial fit.  This prevents
+    /// Results and export actions from reusing an older map while the new run
+    /// is pending or after it fails.
+    pub fn clear_spatial_fit_output(&mut self) {
+        self.pending_spatial = None;
+        self.is_fitting = false;
+        self.fitting_progress = None;
+        self.spatial_result = None;
+        self.residuals_cache = None;
         self.fitting_rois.clear();
         self.export_status = None;
+    }
+
+    /// Invalidate all fit outputs after a fit-control change while preserving
+    /// loaded inputs, normalization, energy grid, pixel selection, and ROIs.
+    /// Any in-flight spatial receiver is detached so its old-configuration
+    /// result cannot arrive after the invalidation.  The shared cancellation
+    /// token is deliberately left alone because it also belongs to unrelated
+    /// ENDF, forward-model, and detectability workers.
+    pub fn invalidate_analysis_outputs(&mut self) {
+        self.clear_pixel_fit_output();
+        self.clear_spatial_fit_output();
     }
 
     /// Recompute the effective pixel mask FROM SCRATCH (#646):

--- a/apps/gui/src/studio/mod.rs
+++ b/apps/gui/src/studio/mod.rs
@@ -9,7 +9,7 @@
 use std::sync::Arc;
 
 use crate::guided::{detectability, forward_model, result_widgets};
-use crate::state::{AppState, Colormap, EndfStatus, SpectrumAxis, StudioDocTab};
+use crate::state::{AppState, Colormap, EndfStatus, InputMode, SpectrumAxis, StudioDocTab};
 use crate::theme::ThemeColors;
 use crate::widgets::design;
 use crate::widgets::image_view::show_colormapped_image;
@@ -1242,6 +1242,9 @@ fn solver_card(ui: &mut egui::Ui, state: &mut AppState) {
     use crate::state::{GuidedStep, SolverMethod};
 
     design::card_with_header(ui, "Solver", None, |ui| {
+        let counts_available = state.sample_data.is_some()
+            && state.open_beam_data.is_some()
+            && !matches!(state.input_mode, InputMode::TransmissionTiff);
         ui.horizontal(|ui| {
             ui.label("Method:");
             let prev = state.solver_method;
@@ -1257,16 +1260,21 @@ fn solver_card(ui: &mut egui::Ui, state: &mut AppState) {
                         SolverMethod::LevenbergMarquardt,
                         "Levenberg-Marquardt",
                     );
-                    ui.selectable_value(
-                        &mut state.solver_method,
-                        SolverMethod::PoissonKL,
-                        "Poisson KL",
-                    );
+                    ui.add_enabled_ui(counts_available, |ui| {
+                        ui.selectable_value(
+                            &mut state.solver_method,
+                            SolverMethod::PoissonKL,
+                            "Poisson KL (raw counts)",
+                        );
+                    });
                 });
             if state.solver_method != prev {
                 state.mark_dirty(GuidedStep::Analyze);
             }
         });
+        if !counts_available {
+            ui.weak("Poisson KL needs separate sample and open-beam counts");
+        }
 
         ui.horizontal(|ui| {
             ui.label("Max iter:");

--- a/apps/gui/src/widgets/design.rs
+++ b/apps/gui/src/widgets/design.rs
@@ -1073,9 +1073,10 @@ pub(crate) fn counts_resolution_overlay_unsupported(
 }
 
 pub(crate) const COUNTS_RESOLUTION_OVERLAY_MESSAGE: &str = "Count fit overlay hidden: instrument resolution needs separate open/sample response arms \
-     R[Phi] and R[Phi*T]. Multiplying c*OB by R[T] is not a physical count model. Supply \
-     pre-normalized transmission, or disable instrument resolution until an exact count \
-     response is implemented.";
+     R[Phi] and R[Phi*T]. Multiplying c*OB by R[T] is not a physical count model. This GUI \
+     does not yet collect the source weights and detector-time edges required by the exact \
+     count fitter; use the direct Python API, pre-normalized transmission, or disable \
+     instrument resolution.";
 
 /// Build a fit overlay line from a `SpectrumFitResult`.
 ///

--- a/apps/gui/src/widgets/design.rs
+++ b/apps/gui/src/widgets/design.rs
@@ -1063,6 +1063,20 @@ pub(crate) struct FitLineParams<'a> {
     pub y_multiplier: Option<&'a [f64]>,
 }
 
+/// Counts and instrument resolution cannot share the transmission-only fit
+/// overlay until the detector response has separate open/sample arms.
+pub(crate) fn counts_resolution_overlay_unsupported(
+    shows_counts: bool,
+    has_instrument_resolution: bool,
+) -> bool {
+    shows_counts && has_instrument_resolution
+}
+
+pub(crate) const COUNTS_RESOLUTION_OVERLAY_MESSAGE: &str = "Count fit overlay hidden: instrument resolution needs separate open/sample response arms \
+     R[Phi] and R[Phi*T]. Multiplying c*OB by R[T] is not a physical count model. Supply \
+     pre-normalized transmission, or disable instrument resolution until an exact count \
+     response is implemented.";
+
 /// Build a fit overlay line from a `SpectrumFitResult`.
 ///
 /// Returns `None` if the fit didn't converge, no resonance data is provided,
@@ -1072,6 +1086,9 @@ pub(crate) struct FitLineParams<'a> {
 /// (individual isotopes + group members). `density_indices` and `density_ratios`
 /// map each resonance data entry to a density parameter index and its abundance ratio.
 pub(crate) fn build_fit_line(p: &FitLineParams<'_>) -> Option<Line<'static>> {
+    if counts_resolution_overlay_unsupported(p.y_multiplier.is_some(), p.instrument.is_some()) {
+        return None;
+    }
     if !p.result.converged {
         return None;
     }
@@ -1202,4 +1219,17 @@ pub(crate) fn collect_all_resonance_data_with_mapping(
         }
     }
     (all_rd, indices, ratios)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::counts_resolution_overlay_unsupported;
+
+    #[test]
+    fn count_overlay_is_suppressed_only_with_active_resolution() {
+        assert!(counts_resolution_overlay_unsupported(true, true));
+        assert!(!counts_resolution_overlay_unsupported(true, false));
+        assert!(!counts_resolution_overlay_unsupported(false, true));
+        assert!(!counts_resolution_overlay_unsupported(false, false));
+    }
 }

--- a/bindings/python/python/nereids/__init__.py
+++ b/bindings/python/python/nereids/__init__.py
@@ -1,3 +1,15 @@
 # NEREIDS Python bindings
 # The native module is compiled from Rust via PyO3/maturin.
 from nereids.nereids import *  # noqa: F401,F403
+from nereids.aggregated_1d import (  # noqa: F401
+    Aggregated1DCalibration,
+    Aggregated1DFitResult,
+    IcShapeProfile,
+    SourceInferenceResult,
+    VENUS_UDR_MATCHED_IC_PROFILE,
+    calibrate_aggregated_1d,
+    fit_frozen_aggregated_1d,
+    profiled_two_arm_residual,
+    select_energy_ordered_detector_bins,
+    solid_debye_effective_temperature,
+)

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -946,6 +946,24 @@ def apply_resolution(
     """Apply tabulated resolution broadening to a spectrum."""
     ...
 
+def two_arm_count_response(
+    true_energies_ev: NDArray[np.float64],
+    incident_fluence_weights: NDArray[np.float64],
+    transmission: NDArray[np.float64],
+    detector_time_edges_us: NDArray[np.float64],
+    resolution: TabulatedResolution | IkedaCarpenter,
+    timing_offset_us: float = 0.0,
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Predict open-beam and sample counts on detector-time bins.
+
+    ``incident_fluence_weights[j]`` is the incident flux density at true
+    energy ``j`` multiplied by the caller's energy-integration weight. The
+    validated response is applied to the open and attenuated sample arms
+    separately. Probability outside the supplied acquisition window is not
+    renormalized into that window.
+    """
+    ...
+
 def load_tiff_stack(
     path: str,
     pixel_policy: str = "reject",

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -964,6 +964,78 @@ def two_arm_count_response(
     """
     ...
 
+class TwoArmBackgroundFitResult:
+    """Fixed-signal fit of independently supplied count-background templates."""
+
+    @property
+    def names(self) -> list[str]: ...
+
+    @property
+    def amplitudes(self) -> NDArray[np.float64]: ...
+
+    @property
+    def amplitude_uncertainties(self) -> NDArray[np.float64]: ...
+
+    @property
+    def amplitudes_identifiable(self) -> bool:
+        """Whether every named component amount is separately determined."""
+        ...
+
+    @property
+    def open_neutron_signal(self) -> NDArray[np.float64]: ...
+
+    @property
+    def open_background(self) -> NDArray[np.float64]: ...
+
+    @property
+    def open_total(self) -> NDArray[np.float64]: ...
+
+    @property
+    def sample_neutron_signal(self) -> NDArray[np.float64]: ...
+
+    @property
+    def sample_background(self) -> NDArray[np.float64]: ...
+
+    @property
+    def sample_total(self) -> NDArray[np.float64]: ...
+
+    @property
+    def poisson_deviance(self) -> float: ...
+
+    @property
+    def deviance_per_dof(self) -> float: ...
+
+    @property
+    def converged(self) -> bool: ...
+
+    @property
+    def iterations(self) -> int: ...
+
+def fit_two_arm_background_templates(
+    observed_open_counts: NDArray[np.float64],
+    observed_sample_counts: NDArray[np.float64],
+    open_neutron_signal: NDArray[np.float64],
+    sample_neutron_signal: NDArray[np.float64],
+    open_exposure_scale: float,
+    sample_exposure_scale: float,
+    template_names: list[str],
+    open_background_templates: NDArray[np.float64],
+    sample_background_templates: NDArray[np.float64],
+    initial_amplitudes: NDArray[np.float64],
+    max_iter: int = 200,
+) -> TwoArmBackgroundFitResult:
+    """Fit non-negative amplitudes of independent detector-bin templates.
+
+    Each row of the two template matrices is one named component. Templates
+    are expected counts per unit amplitude in the measured detector bins and
+    are added after the neutron response. The required exposure scales convert
+    the common reference signal into expected counts for each acquisition.
+    This model is separate from SAMMY's transmission-level background. When
+    ``amplitudes_identifiable`` is false, only the summed background and total
+    prediction are determined; individual component amounts are arbitrary.
+    """
+    ...
+
 def load_tiff_stack(
     path: str,
     pixel_policy: str = "reject",
@@ -1859,8 +1931,12 @@ def fit_counts_spectrum_typed(
             or ``'lm'``.
         background: Enable the SAMMY-style transmission-background
             wrapper inside the counts-KL fit (A_n + B_A + B_B/√E + B_C√E).
-        detector_background: Optional detector/counts background reference
-            (for LM-converted path only; counts-KL rejects non-zero values).
+        detector_background: Reserved detector/counts background reference.
+            Production per-spectrum fitting currently rejects every non-zero
+            value: counts-KL has not wired its scale into the joint likelihood,
+            and the LM-converted path does not accept nuisance spectra. Use
+            ``fit_two_arm_background_templates`` to fit independently supplied
+            detector-bin templates against a fixed exact two-arm signal.
         fit_alpha_1: Research-only; rejected by the counts-KL dispatch
             because the profile λ̂ absorbs the global flux scale.
         fit_alpha_2: Research-only; rejected by the counts-KL dispatch

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -385,6 +385,19 @@ class IkedaCarpenter:
         """
         ...
 
+    def detector_bin_probabilities(
+        self,
+        true_energy_ev: float,
+        detector_time_edges_us: list[float],
+        timing_offset_us: float,
+    ) -> list[float]:
+        """Probability in each detector-time bin for one true energy.
+
+        The probabilities are not renormalized when the supplied time window
+        omits part of the pulse.
+        """
+        ...
+
     @property
     def flight_path_m(self) -> float:
         """Flight path length in meters."""

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -7,6 +7,19 @@ from typing import Any, Literal, overload
 import numpy as np
 from numpy.typing import NDArray
 
+from .aggregated_1d import (
+    Aggregated1DCalibration as Aggregated1DCalibration,
+    Aggregated1DFitResult as Aggregated1DFitResult,
+    IcShapeProfile as IcShapeProfile,
+    SourceInferenceResult as SourceInferenceResult,
+    VENUS_UDR_MATCHED_IC_PROFILE as VENUS_UDR_MATCHED_IC_PROFILE,
+    calibrate_aggregated_1d as calibrate_aggregated_1d,
+    fit_frozen_aggregated_1d as fit_frozen_aggregated_1d,
+    profiled_two_arm_residual as profiled_two_arm_residual,
+    select_energy_ordered_detector_bins as select_energy_ordered_detector_bins,
+    solid_debye_effective_temperature as solid_debye_effective_temperature,
+)
+
 # ---------------------------------------------------------------------------
 # Classes
 # ---------------------------------------------------------------------------
@@ -189,6 +202,26 @@ class FitResult:
     @property
     def anorm(self) -> float:
         """Fitted normalization factor (1.0 if background not enabled)."""
+        ...
+
+    @property
+    def prediction_energies_ev(self) -> NDArray[np.float64]:
+        """Energy coordinate for the complete fitted prediction."""
+        ...
+
+    @property
+    def signal_prediction(self) -> NDArray[np.float64]:
+        """Fitted signal contribution excluding the explicit additive background."""
+        ...
+
+    @property
+    def background_prediction(self) -> NDArray[np.float64]:
+        """Explicit additive background contribution to the fitted curve."""
+        ...
+
+    @property
+    def model_prediction(self) -> NDArray[np.float64]:
+        """Complete fitted curve in measured-bin order."""
         ...
 
     @property
@@ -962,6 +995,54 @@ def two_arm_count_response(
     renormalized into that window.
     """
     ...
+
+class DetectorResponseMatrix:
+    """Reusable compact detector-time response matrix.
+
+    The matrix is built once for fixed true energies, detector-time edges,
+    timing offset, and an analytical IC or loaded tabulated response. Outputs
+    are in increasing detector-time bin order.
+    """
+
+    def __init__(
+        self,
+        true_energies_ev: NDArray[np.float64],
+        detector_time_edges_us: NDArray[np.float64],
+        resolution: TabulatedResolution | IkedaCarpenter,
+        timing_offset_us: float = 0.0,
+    ) -> None: ...
+
+    @property
+    def n_true_energies(self) -> int: ...
+
+    @property
+    def n_detector_bins(self) -> int: ...
+
+    @property
+    def nonzero_probabilities(self) -> int: ...
+
+    @property
+    def storage_bytes(self) -> int: ...
+
+    def project(
+        self, true_energy_weights: NDArray[np.float64]
+    ) -> NDArray[np.float64]: ...
+
+    def transpose_project(
+        self, detector_bin_values: NDArray[np.float64]
+    ) -> NDArray[np.float64]: ...
+
+    def apply(
+        self,
+        incident_fluence_weights: NDArray[np.float64],
+        transmission: NDArray[np.float64],
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64]]: ...
+
+    def collapse_true_energy_groups(
+        self,
+        quadrature_weights: NDArray[np.float64],
+        group_size: int,
+    ) -> DetectorResponseMatrix: ...
 
 class TwoArmBackgroundFitResult:
     """Fixed-signal fit of independently supplied count-background templates."""

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -371,6 +371,7 @@ class IkedaCarpenter:
         n_tau: int = 600,
         burst_sigma_us: float | None = None,
         channel_fwhm_us: float | None = None,
+        beta_law: EnergyLaw | None = None,
     ) -> None: ...
     def as_tabulated(self) -> TabulatedResolution:
         """The synthesized tabulated kernel (usable as a resolution file)."""

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -319,6 +319,20 @@ class TabulatedResolution:
         """Number of points per kernel."""
         ...
 
+    def detector_bin_probabilities(
+        self,
+        true_energy_ev: float,
+        detector_time_edges_us: list[float],
+        timing_offset_us: float,
+    ) -> list[float]:
+        """Probability in each adjacent detector-time bin.
+
+        The loaded tabulated response is evaluated at ``true_energy_ev``.
+        Probability outside the supplied time window is not renormalized into
+        the window.
+        """
+        ...
+
 class EnergyLaw:
     """Energy-dependence law for an Ikeda-Carpenter parameter.
 

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -239,9 +239,8 @@ class FitResult:
         Primary goodness-of-fit for ``solver='kl'`` (or the
         ``'poisson'`` / ``'joint_poisson'`` aliases) on counts data —
         replaces the fixed-flux Pearson chi-squared
-        that scaled with ``c``.  ``None`` for LM fits and for
-        transmission + PoissonKL (those populate
-        ``reduced_chi_squared`` with Pearson chi-squared / (n - k)).
+        that scaled with ``c``. ``None`` for LM transmission fits, which
+        populate ``reduced_chi_squared`` with Pearson chi-squared / (n - k).
         """
         ...
 
@@ -1614,16 +1613,13 @@ def from_counts_with_nuisance(
     flux: NDArray[np.float64],
     background: NDArray[np.float64],
 ) -> InputData:
-    """Create InputData from raw detector counts plus explicit nuisance spectra.
+    """Legacy input wrapper retained for compatibility.
 
-    Use this when the detector/counts background spectrum has been
-    estimated outside NEREIDS and should be supplied explicitly
-    alongside the open-beam flux.  Routes through the counts-KL
-    (joint-Poisson) dispatch when passed to ``spatial_map_typed``
-    with ``solver="auto"`` / ``"kl"``.  (Per-spectrum counts fitting
-    uses ``fit_counts_spectrum_typed``, which takes the raw 1D
-    ``sample_counts`` / ``open_beam_counts`` / ``detector_background``
-    arrays directly rather than an ``InputData`` wrapper.)
+    The production joint-Poisson fitter rejects a nonzero ``background``
+    because that spectrum is not connected to the physical two-arm likelihood.
+    New code should use ``from_counts`` for spatial fitting and
+    ``fit_two_arm_background_templates`` for independently measured
+    detector-bin background shapes.
 
     Args:
         sample_counts: 3D float64 array (n_energies, height, width).
@@ -1643,8 +1639,8 @@ def from_transmission(
 ) -> InputData:
     """Create InputData from normalized transmission and uncertainty.
 
-    The fitting engine uses LM by default. Pass solver="kl" to
-    spatial_map_typed() for low-count transmission data.
+    The fitting engine uses LM. Poisson/KL is rejected because normalized
+    transmission no longer contains the separate open/sample count arms.
     """
     ...
 
@@ -1704,18 +1700,19 @@ def spatial_map_typed(
     When ``groups`` is provided, each group maps to one fitted density parameter.
 
     Dispatches per-pixel fitting based on InputData type:
-      - from_counts / from_counts_with_nuisance + solver="kl" / "auto"
+      - from_counts + solver="kl" / "auto"
         -> counts-KL (joint-Poisson deviance) — the counts-path solver,
         validated against synthetic counts benchmarks and locked by a
         real-VENUS counts regression test on the committed aggregated-Hf
         fixture.
-      - from_transmission + solver="lm" (default for transmission) -> LM.
-      - from_transmission + solver="kl" -> Poisson NLL on transmission values
-        (legacy niche).
+      - from_transmission + solver="lm" or "auto" -> LM.
+      - from_transmission + a Poisson/KL solver -> rejected, because a ratio is
+        not Poisson count data.
 
     Args:
-        data: InputData from `from_counts()`, `from_counts_with_nuisance()`,
-            or `from_transmission()`.
+        data: InputData from `from_counts()` or `from_transmission()`.
+            `from_counts_with_nuisance()` is compatibility-only and rejects a
+            nonzero background in production fitting.
         fix_densities: Freeze all densities at their initial values across
             every pixel (per-pixel temperature-only fits with a known
             calibration-foil density — the fastest thermometry path).
@@ -1735,8 +1732,8 @@ def spatial_map_typed(
             and BackD becomes a constant duplicate of BackA at
             BackF ≈ 0).
         c: Proton-charge ratio ``Q_s / Q_ob`` for the counts-KL dispatch.
-            Default 1.0 (assumes caller PC-normalized
-            the flux already).  Ignored for LM / transmission-KL paths.
+            Default 1.0 (assumes caller PC-normalized the flux already).
+            Ignored for transmission LM.
         enable_polish: Override the Nelder-Mead polish flag.  ``None``
             (default) = the dispatcher auto-disables polish when
             ``n_pixels > 1`` (polish costs ~1000 s per pixel
@@ -1754,8 +1751,8 @@ def spatial_map_typed(
             ``sqrt(chi2/dof)`` at the converged point, turning the inverse-Fisher
             lower bound into a goodness-of-fit-scaled estimate. Sigma is scaled
             by sqrt of the goodness-of-fit each pixel's result reports (Gaussian
-            reduced-chi2 on the transmission paths incl. Poisson-KL,
-            deviance-per-dof on the counts joint-Poisson path). No-op on the
+            reduced-chi2 on the transmission LM path, deviance-per-dof on the
+            counts joint-Poisson path). No-op on the
             already-chi2-scaled LM transmission path. Default ``False``
             (issue #638).
 
@@ -1827,7 +1824,8 @@ def fit_spectrum_typed(
         temperature_k: Sample temperature in Kelvin (default 293.6).
         fit_temperature: Whether to fit temperature (default False).
         max_iter: Maximum iterations (default 200).
-        solver: 'lm' (default), 'kl', or 'auto'.
+        solver: ``'lm'`` (default) or ``'auto'``. Count-likelihood names are
+            rejected for normalized transmission.
         background: Enable SAMMY transmission background.
         resolution: Optional resolution function.
         groups: List of IsotopeGroup objects (mutually exclusive with isotopes).
@@ -1839,12 +1837,9 @@ def fit_spectrum_typed(
         density_free: Per-density free/fixed mask (``free[i] == False`` freezes
             density ``i``); length must equal the number of density parameters.
             Mutually exclusive with ``fix_densities``.
-        scale_by_chi2: Inflate covariance-only uncertainties by
-            ``sqrt(chi2/dof)`` (issue #638), scaling sigma by sqrt of the
-            Gaussian ``reduced_chi_squared`` this result reports. No-op on this
-            function's default LM transmission path (already chi2-scaled); with
-            an explicit ``solver='kl'`` it opts the raw inverse-Fisher sigma into
-            the same Gaussian reduced-chi2 scaling. Default ``False``.
+        scale_by_chi2: Compatibility flag. LM already scales its covariance by
+            Gaussian ``reduced_chi_squared``, so this is a no-op for normalized
+            transmission. Default ``False``.
     """
     ...
 
@@ -1874,7 +1869,10 @@ def fit_counts_spectrum_typed(
     alpha_1_init: float = 1.0,
     alpha_2_init: float = 1.0,
     c: float = 1.0,
-    resolution: TabulatedResolution | None = None,
+    resolution: TabulatedResolution | IkedaCarpenter | None = None,
+    incident_fluence_weights: NDArray[np.float64] | None = None,
+    detector_time_edges_us: NDArray[np.float64] | None = None,
+    timing_offset_us: float = 0.0,
     flight_path_m: float | None = None,
     delta_t_us: float | None = None,
     delta_l_m: float | None = None,
@@ -1909,9 +1907,8 @@ def fit_counts_spectrum_typed(
       ``FitResult.deviance_per_dof`` as the primary GOF.
       ``'joint_poisson'`` is kept as a compatibility alias; prefer ``'kl'``
       for new code.
-    - ``'lm'`` converts counts to transmission internally and runs
-      Levenberg-Marquardt on the resulting ratio (information-lossy
-      fallback).
+    - ``'lm'`` is rejected because converting the two count arms into a ratio
+      loses open-beam uncertainty and the original count statistics.
 
     For pre-normalized transmission data, use ``fit_spectrum_typed(...)``.
 
@@ -1927,8 +1924,8 @@ def fit_counts_spectrum_typed(
         fit_temperature: Whether to fit temperature (default False).
         max_iter: Maximum iterations (default 200).
         solver: ``'auto'`` (default), ``'kl'`` / ``'poisson'`` /
-            ``'joint_poisson'`` (all equivalent — counts-KL dispatch),
-            or ``'lm'``.
+            ``'joint_poisson'`` (all equivalent — counts-KL dispatch).
+            ``'lm'`` is rejected for raw counts.
         background: Enable the SAMMY-style transmission-background
             wrapper inside the counts-KL fit (A_n + B_A + B_B/√E + B_C√E).
         detector_background: Reserved detector/counts background reference.
@@ -1949,7 +1946,15 @@ def fit_counts_spectrum_typed(
             For raw VENUS-style counts, set this to the actual ratio
             (typically ~5–6).  Used by the counts-KL dispatch; ignored
             by the LM path.
-        resolution: Optional resolution function.
+        resolution: Exact detector-time response. Resolved raw-count fitting
+            accepts ``TabulatedResolution`` or ``IkedaCarpenter``.
+        incident_fluence_weights: Incident fluence integrated over each
+            true-energy quadrature point. Required with ``resolution`` for
+            resolved raw counts.
+        detector_time_edges_us: Measured detector-time bin edges. Its length
+            must be ``len(sample_counts) + 1``. Required with
+            ``incident_fluence_weights``.
+        timing_offset_us: Fixed detector-clock offset applied by the response.
         groups: List of IsotopeGroup objects (mutually exclusive with isotopes).
         initial_densities: Initial density guesses when using groups.
         fix_densities: Freeze all densities at their initial values and fit

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -385,6 +385,13 @@ class IkedaCarpenter:
         """
         ...
 
+    def source_pulse_at(self, true_energy_ev: float) -> tuple[list[float], list[float]]:
+        """Physical ``(moderator_delay_us, density)`` at one true energy.
+
+        Unlike :meth:`kernel_at`, this keeps the pulse's time origin.
+        """
+        ...
+
     def detector_bin_probabilities(
         self,
         true_energy_ev: float,

--- a/bindings/python/python/nereids/aggregated_1d.py
+++ b/bindings/python/python/nereids/aggregated_1d.py
@@ -1,0 +1,1160 @@
+"""Aggregate 1D room calibration followed by a frozen hot-spectrum fit.
+
+This module is the supported version of the workflow developed for VENUS.  It
+keeps open-beam and sample counts as separate measurements, integrates the
+instrument response over the actual detector-time bins, infers the incident
+source from the open beam only, and returns the complete fitted curve.  The hot
+fit reuses the room response and source without recalibrating either one.
+
+The functions never edit measured counts or evaluated nuclear data.  Energy
+selection only chooses which unchanged bins contribute to the objective; the
+response is still evaluated on the full supplied acquisition interval.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import math
+from typing import Any, Callable, Sequence
+
+import numpy as np
+from numpy.typing import NDArray
+from scipy.integrate import quad
+from scipy.optimize import least_squares, lsq_linear, minimize
+
+from .nereids import (
+    DetectorResponseMatrix,
+    EnergyLaw,
+    IkedaCarpenter,
+    energy_to_tof,
+    precompute_cross_sections,
+    tof_to_energy,
+    tof_to_energy_centers,
+)
+
+
+FloatArray = NDArray[np.float64]
+
+
+@dataclass(frozen=True)
+class IcShapeProfile:
+    """Fixed energy law for an analytical Ikeda-Carpenter response.
+
+    ``alpha`` and ``beta`` are inverse-microsecond rates.  Their coefficients
+    use ``rate(E) = sqrt_coefficient * sqrt(E/eV) + offset``.  ``slow_fraction``
+    is the fraction assigned to the slow storage component.
+    """
+
+    alpha_sqrt_coefficient: float
+    alpha_offset: float
+    beta_sqrt_coefficient: float
+    beta_offset: float
+    slow_fraction: float
+    channel_fwhm_us: float
+    pivot_energy_ev: float = 20.0
+    synthesis_energies: int = 48
+    synthesis_times: int = 400
+
+
+# Analytical approximation inferred from the archived VENUS UDR shapes.  It is
+# a compact instrument model, not a replacement for the high-fidelity UDR and
+# not a change to any nuclear evaluation.
+VENUS_UDR_MATCHED_IC_PROFILE = IcShapeProfile(
+    alpha_sqrt_coefficient=0.6450616623046456,
+    alpha_offset=2.223255165220424,
+    beta_sqrt_coefficient=0.08670235276707496,
+    beta_offset=0.12226218901463583,
+    slow_fraction=0.23645799735769557,
+    channel_fwhm_us=0.350,
+)
+
+
+@dataclass(frozen=True)
+class SourceInferenceResult:
+    """Open-beam-only incident-source estimate and numerical diagnostics."""
+
+    weights: FloatArray
+    expected_open_counts: FloatArray
+    observed_open_counts: FloatArray
+    converged: bool
+    message: str
+    iterations: int
+    reduced_poisson_deviance: float
+    max_abs_scaled_projected_gradient: float
+
+
+@dataclass(frozen=True)
+class Aggregated1DFitResult:
+    """Complete aggregate-spectrum fit result in increasing-energy order."""
+
+    energy_ev: FloatArray
+    measured_transmission: FloatArray
+    poisson_uncertainty: FloatArray
+    uncertainty: FloatArray
+    signal_prediction: FloatArray
+    background_prediction: FloatArray
+    model_prediction: FloatArray
+    poisson_residual: FloatArray
+    residual: FloatArray
+    objective_residual: FloatArray
+    fit_mask: NDArray[np.bool_]
+    fit_energy_range_ev: tuple[float, float]
+    open_variance_factor: float
+    sample_variance_factor: float
+    parameters: dict[str, float]
+    converged: bool
+    message: str
+    function_evaluations: int
+    bound_hits: tuple[str, ...]
+    max_abs_residual: float
+    rms_residual: float
+    bins_above_five: int
+
+
+@dataclass(frozen=True)
+class Aggregated1DCalibration:
+    """Room result plus the frozen objects required by a later hot fit."""
+
+    fit: Aggregated1DFitResult
+    instrument_parameters: dict[str, float]
+    source: SourceInferenceResult
+    detector_time_edges_us: FloatArray
+    reference_energy_ev: FloatArray
+    energy_cell_edges_ev: FloatArray
+    quadrature_points_ev: FloatArray
+    quadrature_weights: FloatArray
+    response_matrix: Any = field(repr=False)
+    isotopes: tuple[Any, ...] = field(repr=False)
+    atomic_fractions: FloatArray = field(repr=False)
+    ic_profile: IcShapeProfile = field(repr=False)
+    room_temperature_k: float
+    debye_temperature_k: float | None
+    open_variance_factor: float
+    room_variance_factor: float
+
+
+def solid_debye_effective_temperature(
+    thermodynamic_temperature_k: float, debye_temperature_k: float
+) -> float:
+    """Return the effective free-gas temperature for a Debye solid.
+
+    This maps a solid's thermodynamic temperature onto the mean kinetic energy
+    used by the free-gas Doppler model.  It changes only Doppler broadening; it
+    does not alter resonance parameters.
+    """
+
+    temperature = float(thermodynamic_temperature_k)
+    debye = float(debye_temperature_k)
+    if not math.isfinite(temperature) or temperature <= 0.0:
+        raise ValueError("thermodynamic_temperature_k must be finite and positive")
+    if not math.isfinite(debye) or debye <= 0.0:
+        raise ValueError("debye_temperature_k must be finite and positive")
+    upper = debye / temperature
+
+    def integrand(value: float) -> float:
+        return 0.0 if value == 0.0 else value**3 / math.expm1(value)
+
+    integral, _ = quad(integrand, 0.0, upper, epsabs=1.0e-12, epsrel=1.0e-12)
+    ratio = 3.0 * debye / (8.0 * temperature) + 3.0 * (
+        temperature / debye
+    ) ** 3 * integral
+    return temperature * ratio
+
+
+def profiled_two_arm_residual(
+    open_counts: Sequence[float] | FloatArray,
+    sample_counts: Sequence[float] | FloatArray,
+    sample_over_open_exposure: float,
+    apparent_transmission: Sequence[float] | FloatArray,
+) -> FloatArray:
+    """Signed square root of the two-arm Poisson deviance.
+
+    The unknown incident intensity in each measured bin is removed exactly.
+    No transmission ratio or Gaussian error approximation is used in this
+    objective.
+    """
+
+    open_array = _one_dimensional("open_counts", open_counts)
+    sample_array = _one_dimensional("sample_counts", sample_counts)
+    apparent = _one_dimensional("apparent_transmission", apparent_transmission)
+    if open_array.shape != sample_array.shape or open_array.shape != apparent.shape:
+        raise ValueError("open, sample, and apparent-transmission arrays must match")
+    if np.any(open_array < 0.0) or np.any(sample_array < 0.0):
+        raise ValueError("counts must be nonnegative")
+    exposure = float(sample_over_open_exposure)
+    if not math.isfinite(exposure) or exposure <= 0.0:
+        raise ValueError("sample_over_open_exposure must be finite and positive")
+    if np.any(apparent <= 0.0):
+        raise ValueError("apparent_transmission must be positive")
+
+    total = open_array + sample_array
+    odds = exposure * apparent
+    probability = odds / (1.0 + odds)
+    expected_sample = total * probability
+    expected_open = total - expected_sample
+    contribution = np.zeros_like(total)
+    sample_positive = sample_array > 0.0
+    open_positive = open_array > 0.0
+    contribution[sample_positive] += sample_array[sample_positive] * np.log(
+        sample_array[sample_positive] / expected_sample[sample_positive]
+    )
+    contribution[open_positive] += open_array[open_positive] * np.log(
+        open_array[open_positive] / expected_open[open_positive]
+    )
+    sign = np.sign(sample_array - expected_sample)
+    return sign * np.sqrt(np.maximum(2.0 * contribution, 0.0))
+
+
+def select_energy_ordered_detector_bins(
+    detector_time_edges_us: Sequence[float] | FloatArray,
+    reference_energy_ev: Sequence[float] | FloatArray,
+    arrays: Sequence[Sequence[float] | FloatArray],
+    energy_range_ev: tuple[float, float],
+) -> tuple[FloatArray, FloatArray, tuple[FloatArray, ...]]:
+    """Select one contiguous energy interval and its matching TOF edges.
+
+    Input spectra and ``reference_energy_ev`` are in increasing-energy order;
+    detector-time edges are in increasing-time order.  The returned spectra
+    remain in increasing-energy order.  This helper prevents the common
+    off-by-one and accidental-axis-reversal errors in notebook preprocessing.
+    """
+
+    edges = _one_dimensional("detector_time_edges_us", detector_time_edges_us)
+    energy = _one_dimensional("reference_energy_ev", reference_energy_ev)
+    if edges.size != energy.size + 1 or np.any(np.diff(edges) <= 0.0):
+        raise ValueError("detector edges must bracket every reference-energy bin")
+    if np.any(np.diff(energy) <= 0.0):
+        raise ValueError("reference_energy_ev must be strictly increasing")
+    mask = _energy_mask(energy, energy_range_ev)
+    indices = np.flatnonzero(mask)
+    if np.any(np.diff(indices) != 1):
+        raise ValueError("energy_range_ev did not select one contiguous interval")
+    n_bins = energy.size
+    first_time_bin = n_bins - 1 - int(indices[-1])
+    last_time_bin = n_bins - 1 - int(indices[0])
+    selected_edges = np.ascontiguousarray(edges[first_time_bin : last_time_bin + 2])
+    selected_arrays: list[FloatArray] = []
+    for index, values in enumerate(arrays):
+        array = _one_dimensional(f"arrays[{index}]", values)
+        if array.shape != energy.shape:
+            raise ValueError(f"arrays[{index}] must match reference_energy_ev")
+        selected_arrays.append(np.ascontiguousarray(array[mask]))
+    return selected_edges, np.ascontiguousarray(energy[mask]), tuple(selected_arrays)
+
+
+def calibrate_aggregated_1d(
+    *,
+    detector_time_edges_us: Sequence[float] | FloatArray,
+    open_counts: Sequence[float] | FloatArray,
+    room_counts: Sequence[float] | FloatArray,
+    sample_over_open_exposure: float,
+    isotopes: Sequence[Any],
+    room_temperature_k: float,
+    reference_flight_path_m: float,
+    reference_timing_offset_us: float,
+    initial_physical_parameters: Sequence[float],
+    fit_energy_range_ev: tuple[float, float],
+    ic_profile: IcShapeProfile,
+    physical_lower_bounds: Sequence[float],
+    physical_upper_bounds: Sequence[float],
+    initial_background_parameters: Sequence[float] = (1.0, 0.0, 0.0, 0.0),
+    atomic_fractions: Sequence[float] | None = None,
+    debye_temperature_k: float | None = None,
+    background_lower_bounds: Sequence[float] = (0.5, -0.5, -0.5, -0.5),
+    background_upper_bounds: Sequence[float] = (2.0, 0.5, 0.5, 0.5),
+    physical_scale: Sequence[float] | None = None,
+    outer_max_evaluations: int = 40,
+    inner_max_evaluations: int = 200,
+    source_max_iterations: int = 10_000,
+    open_variance_factor: float = 1.0,
+    room_variance_factor: float = 1.0,
+    progress: Callable[[str, dict[str, float]], None] | None = None,
+) -> Aggregated1DCalibration:
+    """Calibrate the analytical IC instrument using room data only.
+
+    Counts must be in increasing-energy order.  ``detector_time_edges_us``
+    must be in increasing-time order and therefore describes those same bins
+    in reverse.  The four physical parameters are timing offset (microseconds),
+    effective centroid path (metres), response width scale, and areal density
+    (atoms/barn).  Background parameters are normalization, BackA, BackB, and
+    BackC from the SAMMY apparent-transmission equation.
+
+    The IC profile, fit range, and physical bounds are explicit because they
+    are instrument- and experiment-specific. The hot spectrum is not an
+    argument and cannot influence this calibration.
+    """
+
+    detector_edges, open_array, room_array = _validate_aggregate_inputs(
+        detector_time_edges_us, open_counts, room_counts
+    )
+    exposure = _positive_scalar("sample_over_open_exposure", sample_over_open_exposure)
+    room_temperature = _positive_scalar("room_temperature_k", room_temperature_k)
+    reference_path = _positive_scalar("reference_flight_path_m", reference_flight_path_m)
+    reference_t0 = _finite_scalar("reference_timing_offset_us", reference_timing_offset_us)
+    open_factor = _positive_scalar("open_variance_factor", open_variance_factor)
+    room_factor = _positive_scalar("room_variance_factor", room_variance_factor)
+    source_iterations = _positive_integer("source_max_iterations", source_max_iterations)
+    physical_start = _fixed_vector("initial_physical_parameters", initial_physical_parameters, 4)
+    background_start = _fixed_vector(
+        "initial_background_parameters", initial_background_parameters, 4
+    )
+    physical_lower = _fixed_vector("physical_lower_bounds", physical_lower_bounds, 4)
+    physical_upper = _fixed_vector("physical_upper_bounds", physical_upper_bounds, 4)
+    background_lower = _fixed_vector(
+        "background_lower_bounds", background_lower_bounds, 4
+    )
+    background_upper = _fixed_vector(
+        "background_upper_bounds", background_upper_bounds, 4
+    )
+    _validate_bounds(physical_start, physical_lower, physical_upper, "physical")
+    _validate_bounds(background_start, background_lower, background_upper, "background")
+    if physical_scale is None:
+        scale = np.array(
+            [1.0, 0.05, 0.5, max(abs(physical_start[3]), 1.0e-6)], dtype=float
+        )
+    else:
+        scale = _fixed_vector("physical_scale", physical_scale, 4)
+        if np.any(scale <= 0.0):
+            raise ValueError("physical_scale values must be positive")
+
+    reference_energy = np.asarray(
+        tof_to_energy_centers(detector_edges, reference_path, reference_t0),
+        dtype=float,
+    )
+    energy_edges = np.array(
+        [
+            tof_to_energy(float(time - reference_t0), reference_path)
+            for time in detector_edges[::-1]
+        ],
+        dtype=float,
+    )
+    if np.any(np.diff(reference_energy) <= 0.0) or np.any(np.diff(energy_edges) <= 0.0):
+        raise ValueError("reference conversion did not produce increasing-energy bins")
+    fit_mask = _energy_mask(reference_energy, fit_energy_range_ev)
+    points, weights = _kronrod_15_cells(energy_edges)
+    isotope_tuple, fractions = _validate_material(isotopes, atomic_fractions)
+    doppler_temperature = (
+        room_temperature
+        if debye_temperature_k is None
+        else solid_debye_effective_temperature(room_temperature, debye_temperature_k)
+    )
+    room_cross_section = _total_cross_section(
+        points.ravel(), isotope_tuple, fractions, doppler_temperature
+    ).reshape(points.shape)
+    measured = room_array / open_array / exposure
+    uncertainty = measured * np.sqrt(
+        room_factor / room_array + open_factor / open_array
+    )
+    poisson_uncertainty = measured * np.sqrt(1.0 / room_array + 1.0 / open_array)
+    response_cache: dict[bytes, dict[str, Any]] = {}
+    profile_cache: dict[bytes, dict[str, Any]] = {}
+
+    def response_record(parameters: FloatArray) -> dict[str, Any]:
+        key = np.ascontiguousarray(parameters[:3], dtype=float).tobytes()
+        if key in response_cache:
+            return response_cache[key]
+        resolution, physical = _build_ic(
+            ic_profile, float(energy_edges[0]), float(energy_edges[-1]), parameters
+        )
+        operator = _CellResponse(points, weights, detector_edges, resolution, parameters[0])
+        source = _infer_source(operator, open_array, source_iterations)
+        record = {
+            "operator": operator,
+            "source": source,
+            "physical": physical,
+        }
+        response_cache[key] = record
+        if progress is not None:
+            progress(
+                "room_response",
+                {
+                    "response_builds": float(len(response_cache)),
+                    "source_iterations": float(source.iterations),
+                    "source_reduced_poisson_deviance": source.reduced_poisson_deviance,
+                },
+            )
+        return record
+
+    def profile(parameters: FloatArray) -> dict[str, Any]:
+        key = np.ascontiguousarray(parameters, dtype=float).tobytes()
+        if key in profile_cache:
+            return profile_cache[key]
+        response = response_record(parameters)
+        operator: _CellResponse = response["operator"]
+        source: SourceInferenceResult = response["source"]
+        transmission = np.exp(-float(parameters[3]) * room_cross_section)
+        sample_prediction = operator.project_points(
+            np.repeat(source.weights, points.shape[1]) * transmission.ravel()
+        )
+        ratio = sample_prediction / np.maximum(
+            source.expected_open_counts, np.finfo(float).tiny
+        )
+        detector_energy = _detector_energy_axis(
+            detector_edges, float(parameters[0]), float(response["physical"]["physical_path_m"])
+        )
+        basis = np.column_stack(
+            (ratio, np.ones_like(ratio), 1.0 / np.sqrt(detector_energy), np.sqrt(detector_energy))
+        )
+
+        def inner_residual(coefficients: FloatArray) -> FloatArray:
+            model = basis @ coefficients
+            return profiled_two_arm_residual(open_array, room_array, exposure, model)[fit_mask]
+
+        inner = least_squares(
+            inner_residual,
+            background_start,
+            jac="3-point",
+            diff_step=np.array([1.0e-4, 1.0e-4, 1.0e-4, 1.0e-5])
+            / np.maximum(np.abs(background_start), np.finfo(float).tiny),
+            bounds=(background_lower, background_upper),
+            x_scale=np.array([0.2, 0.1, 0.1, 0.01]),
+            max_nfev=int(inner_max_evaluations),
+            xtol=1.0e-8,
+            ftol=1.0e-8,
+            gtol=1.0e-8,
+        )
+        signal = inner.x[0] * ratio
+        background = basis[:, 1:] @ inner.x[1:]
+        model = signal + background
+        record = {
+            "response": response,
+            "ratio": ratio,
+            "detector_energy": detector_energy,
+            "inner": inner,
+            "signal": signal,
+            "background": background,
+            "model": model,
+            "objective_residual": profiled_two_arm_residual(
+                open_array, room_array, exposure, model
+            ),
+        }
+        profile_cache[key] = record
+        return record
+
+    absolute_steps = np.array(
+        [0.01, 0.01, 0.01 * physical_start[2], 0.01 * physical_start[3]], dtype=float
+    )
+
+    def outer_residual(parameters: FloatArray) -> FloatArray:
+        selected = np.asarray(
+            profile(parameters)["objective_residual"], dtype=float
+        )[fit_mask]
+        if progress is not None:
+            progress(
+                "room_fit",
+                {
+                    "profile_evaluations": float(len(profile_cache)),
+                    "rms_objective_residual": float(np.sqrt(np.mean(selected * selected))),
+                    "max_abs_objective_residual": float(np.max(np.abs(selected))),
+                },
+            )
+        return selected
+
+    def outer_jacobian(parameters: FloatArray) -> FloatArray:
+        columns: list[FloatArray] = []
+        for index, step in enumerate(absolute_steps):
+            plus = parameters.copy()
+            minus = parameters.copy()
+            plus[index] += step
+            minus[index] -= step
+            if minus[index] <= physical_lower[index] or plus[index] >= physical_upper[index]:
+                raise ValueError("fixed room derivative step crossed a parameter bound")
+            columns.append((outer_residual(plus) - outer_residual(minus)) / (2.0 * step))
+        return np.column_stack(columns)
+
+    outer = least_squares(
+        outer_residual,
+        physical_start,
+        jac=outer_jacobian,
+        bounds=(physical_lower, physical_upper),
+        x_scale=scale,
+        max_nfev=int(outer_max_evaluations),
+        xtol=1.0e-8,
+        ftol=1.0e-8,
+        gtol=1.0e-8,
+    )
+    final = profile(np.asarray(outer.x, dtype=float))
+    inner = final["inner"]
+    parameters = np.concatenate((outer.x, inner.x))
+    names = (
+        "timing_offset_us",
+        "effective_centroid_path_m",
+        "width_scale",
+        "density_atoms_per_barn",
+        "anorm",
+        "back_a",
+        "back_b",
+        "back_c",
+    )
+    lower = np.concatenate((physical_lower, background_lower))
+    upper = np.concatenate((physical_upper, background_upper))
+    bound_hits = _bound_hits(names, parameters, lower, upper)
+    standardized = (measured - final["model"]) / uncertainty
+    response = final["response"]
+    result = _fit_result(
+        energy=np.asarray(final["detector_energy"], dtype=float),
+        measured=measured,
+        poisson_uncertainty=poisson_uncertainty,
+        uncertainty=uncertainty,
+        signal=np.asarray(final["signal"], dtype=float),
+        background=np.asarray(final["background"], dtype=float),
+        objective=np.asarray(final["objective_residual"], dtype=float),
+        standardized=standardized,
+        fit_mask=fit_mask,
+        names=names,
+        values=parameters,
+        converged=bool(outer.success and inner.success and response["source"].converged),
+        message=(
+            f"outer: {outer.message}; background: {inner.message}; "
+            f"source: {response['source'].message}"
+        ),
+        evaluations=int(outer.nfev),
+        bound_hits=bound_hits,
+        fit_energy_range_ev=fit_energy_range_ev,
+        open_variance_factor=open_factor,
+        sample_variance_factor=room_factor,
+    )
+    physical = dict(response["physical"])
+    instrument_parameters = {
+        name: float(value) for name, value in zip(names, parameters, strict=True)
+    }
+    return Aggregated1DCalibration(
+        fit=result,
+        instrument_parameters={**instrument_parameters, **physical},
+        source=response["source"],
+        detector_time_edges_us=detector_edges,
+        reference_energy_ev=reference_energy,
+        energy_cell_edges_ev=energy_edges,
+        quadrature_points_ev=points,
+        quadrature_weights=weights,
+        response_matrix=response["operator"].matrix,
+        isotopes=isotope_tuple,
+        atomic_fractions=fractions,
+        ic_profile=ic_profile,
+        room_temperature_k=room_temperature,
+        debye_temperature_k=debye_temperature_k,
+        open_variance_factor=open_factor,
+        room_variance_factor=room_factor,
+    )
+
+
+def fit_frozen_aggregated_1d(
+    calibration: Aggregated1DCalibration,
+    *,
+    hot_counts: Sequence[float] | FloatArray,
+    sample_over_open_exposure: float,
+    initial_temperature_k: float,
+    initial_density_atoms_per_barn: float,
+    hot_variance_factor: float = 1.0,
+    temperature_bounds_k: tuple[float, float] = (1.0, 5000.0),
+    density_bounds_atoms_per_barn: tuple[float, float] = (0.0, 0.01),
+    background_lower_bounds: Sequence[float] = (0.5, -0.5, -0.5, -0.5),
+    background_upper_bounds: Sequence[float] = (2.0, 0.5, 0.5, 0.5),
+    temperature_derivative_step_k: float = 5.0,
+    density_derivative_step_atoms_per_barn: float | None = None,
+    max_evaluations: int = 40,
+    progress: Callable[[str, dict[str, float]], None] | None = None,
+) -> Aggregated1DFitResult:
+    """Fit temperature and amount with the room instrument fully frozen."""
+
+    hot = _one_dimensional("hot_counts", hot_counts)
+    if not calibration.source.converged:
+        raise RuntimeError(
+            "the frozen room calibration has a non-converged open-beam source; "
+            "the hot fit cannot use it"
+        )
+    # The observed open counts, rather than their fitted expectation, define
+    # both the reported transmission and its propagated uncertainty.  Recover
+    # them exactly from the room result and room exposure-independent ratio.
+    # They are stored on the source result below by the calibration constructor.
+    open_array = np.asarray(calibration.source.observed_open_counts, dtype=float)
+    if hot.shape != open_array.shape:
+        raise ValueError("hot_counts must match the calibrated detector bins")
+    if np.any(hot <= 0.0):
+        raise ValueError("hot_counts must be positive on the aggregate fit interval")
+    exposure = _positive_scalar("sample_over_open_exposure", sample_over_open_exposure)
+    hot_factor = _positive_scalar("hot_variance_factor", hot_variance_factor)
+    temperature_start = _positive_scalar("initial_temperature_k", initial_temperature_k)
+    density_start = _positive_scalar(
+        "initial_density_atoms_per_barn", initial_density_atoms_per_barn
+    )
+    background_lower = _fixed_vector(
+        "background_lower_bounds", background_lower_bounds, 4
+    )
+    background_upper = _fixed_vector(
+        "background_upper_bounds", background_upper_bounds, 4
+    )
+    measured = hot / open_array / exposure
+    uncertainty = measured * np.sqrt(
+        hot_factor / hot + calibration.open_variance_factor / open_array
+    )
+    poisson_uncertainty = measured * np.sqrt(1.0 / hot + 1.0 / open_array)
+    points = calibration.quadrature_points_ev
+    weights = calibration.quadrature_weights
+    operator = _CellResponse.from_existing(
+        points, weights, calibration.response_matrix
+    )
+    source = calibration.source.weights
+    predicted_open = calibration.source.expected_open_counts
+    detector_energy = calibration.fit.energy_ev
+    fit_mask = calibration.fit.fit_mask
+    sigma_cache: dict[bytes, FloatArray] = {}
+    profile_cache: dict[bytes, dict[str, Any]] = {}
+
+    def cross_section(temperature_k: float) -> FloatArray:
+        key = np.asarray([temperature_k], dtype=np.float64).tobytes()
+        if key not in sigma_cache:
+            effective = (
+                temperature_k
+                if calibration.debye_temperature_k is None
+                else solid_debye_effective_temperature(
+                    temperature_k, calibration.debye_temperature_k
+                )
+            )
+            sigma_cache[key] = _total_cross_section(
+                points.ravel(), calibration.isotopes, calibration.atomic_fractions, effective
+            ).reshape(points.shape)
+        return sigma_cache[key]
+
+    def profile(parameters: FloatArray) -> dict[str, Any]:
+        key = np.ascontiguousarray(parameters, dtype=float).tobytes()
+        if key in profile_cache:
+            return profile_cache[key]
+        temperature, density = map(float, parameters)
+        transmission = np.exp(-density * cross_section(temperature))
+        sample_prediction = operator.project_points(
+            np.repeat(source, points.shape[1]) * transmission.ravel()
+        )
+        ratio = sample_prediction / np.maximum(predicted_open, np.finfo(float).tiny)
+        basis = np.column_stack(
+            (
+                ratio[fit_mask],
+                np.ones(int(fit_mask.sum())),
+                1.0 / np.sqrt(detector_energy[fit_mask]),
+                np.sqrt(detector_energy[fit_mask]),
+            )
+        )
+        background_fit = lsq_linear(
+            basis / uncertainty[fit_mask, None],
+            measured[fit_mask] / uncertainty[fit_mask],
+            bounds=(background_lower, background_upper),
+            method="trf",
+            tol=1.0e-12,
+            max_iter=500,
+        )
+        if not background_fit.success:
+            raise RuntimeError(f"hot background fit failed: {background_fit.message}")
+        signal = background_fit.x[0] * ratio
+        background = (
+            background_fit.x[1]
+            + background_fit.x[2] / np.sqrt(detector_energy)
+            + background_fit.x[3] * np.sqrt(detector_energy)
+        )
+        model = signal + background
+        record = {
+            "background_fit": background_fit,
+            "signal": signal,
+            "background": background,
+            "model": model,
+            "residual": (measured - model) / uncertainty,
+        }
+        profile_cache[key] = record
+        return record
+
+    start = np.array([temperature_start, density_start], dtype=float)
+    lower = np.array([temperature_bounds_k[0], density_bounds_atoms_per_barn[0]], dtype=float)
+    upper = np.array([temperature_bounds_k[1], density_bounds_atoms_per_barn[1]], dtype=float)
+    _validate_bounds(start, lower, upper, "hot")
+    density_step = (
+        0.01 * density_start
+        if density_derivative_step_atoms_per_barn is None
+        else _positive_scalar(
+            "density_derivative_step_atoms_per_barn",
+            density_derivative_step_atoms_per_barn,
+        )
+    )
+    steps = np.array(
+        [
+            _positive_scalar(
+                "temperature_derivative_step_k", temperature_derivative_step_k
+            ),
+            density_step,
+        ]
+    )
+
+    def residual(parameters: FloatArray) -> FloatArray:
+        selected = np.asarray(profile(parameters)["residual"], dtype=float)[fit_mask]
+        if progress is not None:
+            progress(
+                "hot_fit",
+                {
+                    "profile_evaluations": float(len(profile_cache)),
+                    "rms_residual": float(np.sqrt(np.mean(selected * selected))),
+                    "max_abs_residual": float(np.max(np.abs(selected))),
+                },
+            )
+        return selected
+
+    def jacobian(parameters: FloatArray) -> FloatArray:
+        columns: list[FloatArray] = []
+        for index, step in enumerate(steps):
+            plus = parameters.copy()
+            minus = parameters.copy()
+            plus[index] += step
+            minus[index] -= step
+            if minus[index] <= lower[index] or plus[index] >= upper[index]:
+                raise ValueError("fixed hot derivative step crossed a parameter bound")
+            columns.append((residual(plus) - residual(minus)) / (2.0 * step))
+        return np.column_stack(columns)
+
+    outer = least_squares(
+        residual,
+        start,
+        jac=jacobian,
+        bounds=(lower, upper),
+        x_scale=np.array([500.0, max(density_start, 1.0e-6)]),
+        max_nfev=int(max_evaluations),
+        xtol=1.0e-8,
+        ftol=1.0e-8,
+        gtol=1.0e-8,
+    )
+    final = profile(np.asarray(outer.x, dtype=float))
+    background_fit = final["background_fit"]
+    values = np.concatenate((outer.x, background_fit.x))
+    names = (
+        "temperature_k",
+        "density_atoms_per_barn",
+        "anorm",
+        "back_a",
+        "back_b",
+        "back_c",
+    )
+    all_lower = np.concatenate((lower, background_lower))
+    all_upper = np.concatenate((upper, background_upper))
+    return _fit_result(
+        energy=detector_energy,
+        measured=measured,
+        poisson_uncertainty=poisson_uncertainty,
+        uncertainty=uncertainty,
+        signal=np.asarray(final["signal"], dtype=float),
+        background=np.asarray(final["background"], dtype=float),
+        objective=np.asarray(final["residual"], dtype=float),
+        standardized=np.asarray(final["residual"], dtype=float),
+        fit_mask=fit_mask,
+        names=names,
+        values=values,
+        converged=bool(outer.success and background_fit.success),
+        message=f"outer: {outer.message}; background: {background_fit.message}",
+        evaluations=int(outer.nfev),
+        bound_hits=_bound_hits(names, values, all_lower, all_upper),
+        fit_energy_range_ev=calibration.fit.fit_energy_range_ev,
+        open_variance_factor=calibration.open_variance_factor,
+        sample_variance_factor=hot_factor,
+    )
+
+
+class _CellResponse:
+    def __init__(
+        self,
+        points: FloatArray,
+        weights: FloatArray,
+        detector_edges: FloatArray,
+        resolution: Any,
+        timing_offset_us: float,
+    ) -> None:
+        self.points = points
+        self.weights = weights
+        self.matrix = DetectorResponseMatrix(
+            np.ascontiguousarray(points.ravel()),
+            np.ascontiguousarray(detector_edges),
+            resolution,
+            float(timing_offset_us),
+        )
+        self.cell_matrix = self.matrix.collapse_true_energy_groups(
+            np.ascontiguousarray(weights.ravel()), points.shape[1]
+        )
+
+    @classmethod
+    def from_existing(
+        cls, points: FloatArray, weights: FloatArray, matrix: Any
+    ) -> _CellResponse:
+        value = cls.__new__(cls)
+        value.points = points
+        value.weights = weights
+        value.matrix = matrix
+        value.cell_matrix = None
+        return value
+
+    def project_points(self, point_values: FloatArray) -> FloatArray:
+        weighted = np.asarray(point_values, dtype=float) * self.weights.ravel()
+        return np.asarray(self.matrix.project(np.ascontiguousarray(weighted)), dtype=float)[::-1]
+
+    def transpose_cells(self, energy_ordered_detector_values: FloatArray) -> FloatArray:
+        if self.cell_matrix is None:
+            raise RuntimeError("cell response is unavailable on a sample-only operator")
+        time_ordered = np.ascontiguousarray(energy_ordered_detector_values[::-1])
+        return np.asarray(self.cell_matrix.transpose_project(time_ordered), dtype=float)
+
+    def project_cells(self, cell_values: FloatArray) -> FloatArray:
+        if self.cell_matrix is None:
+            raise RuntimeError("cell response is unavailable on a sample-only operator")
+        return np.asarray(
+            self.cell_matrix.project(np.ascontiguousarray(cell_values)), dtype=float
+        )[::-1]
+
+
+def _infer_source(
+    operator: _CellResponse, observed_open: FloatArray, max_iterations: int
+) -> SourceInferenceResult:
+    column_mass = operator.transpose_cells(np.ones_like(observed_open))
+    if np.any(column_mass <= 0.0):
+        raise RuntimeError("instrument response contains an unobservable source cell")
+    scale = float(np.median(observed_open))
+    if scale <= 0.0:
+        raise ValueError("median open count must be positive")
+    start = np.maximum(observed_open / column_mass / scale, np.finfo(float).tiny)
+    n_bins = observed_open.size
+
+    def objective_and_gradient(value: FloatArray) -> tuple[float, FloatArray]:
+        expected = operator.project_cells(value * scale)
+        safe = np.maximum(expected, np.finfo(float).tiny)
+        objective = _poisson_deviance(observed_open, safe) / n_bins
+        gradient = (
+            2.0
+            * scale
+            * operator.transpose_cells(1.0 - observed_open / safe)
+            / n_bins
+        )
+        return objective, gradient
+
+    initial = minimize(
+        objective_and_gradient,
+        start,
+        method="L-BFGS-B",
+        jac=True,
+        bounds=[(0.0, None)] * n_bins,
+        options={
+            "maxiter": min(2_000, int(max_iterations)),
+            "ftol": 1.0e-12,
+            "gtol": 1.0e-8,
+            "maxls": 40,
+        },
+    )
+    # Continue the same convex objective with a larger correction history.
+    # The two stages reproduce the validated VENUS workflow while keeping the
+    # source entirely open-beam-only.
+    result = minimize(
+        objective_and_gradient,
+        np.asarray(initial.x, dtype=float),
+        method="L-BFGS-B",
+        jac=True,
+        bounds=[(0.0, None)] * n_bins,
+        options={
+            "maxiter": int(max_iterations),
+            "ftol": 1.0e-12,
+            "gtol": 1.0e-8,
+            "maxls": 40,
+            "maxcor": 50,
+        },
+    )
+    weights = np.asarray(result.x, dtype=float) * scale
+    expected = operator.project_cells(weights)
+    _, gradient = objective_and_gradient(np.asarray(result.x, dtype=float))
+    projected = gradient.copy()
+    at_lower = np.asarray(result.x) <= 1.0e-14
+    projected[at_lower] = np.minimum(projected[at_lower], 0.0)
+    return SourceInferenceResult(
+        weights=weights,
+        expected_open_counts=expected,
+        observed_open_counts=np.asarray(observed_open, dtype=float),
+        converged=bool(result.success),
+        message=str(result.message),
+        iterations=int(initial.nit + result.nit),
+        reduced_poisson_deviance=float(result.fun),
+        max_abs_scaled_projected_gradient=float(np.max(np.abs(projected))),
+    )
+
+
+def _build_ic(
+    profile: IcShapeProfile,
+    minimum_energy_ev: float,
+    maximum_energy_ev: float,
+    physical_parameters: FloatArray,
+) -> tuple[Any, dict[str, float]]:
+    timing_offset, effective_path, width_scale, _density = map(float, physical_parameters)
+    if width_scale <= 0.0:
+        raise ValueError("IC width scale must be positive")
+    alpha_sqrt = profile.alpha_sqrt_coefficient / width_scale
+    alpha_offset = profile.alpha_offset / width_scale
+    beta_sqrt = profile.beta_sqrt_coefficient / width_scale
+    beta_offset = profile.beta_offset / width_scale
+    root_pivot = math.sqrt(profile.pivot_energy_ev)
+    alpha_pivot = alpha_sqrt * root_pivot + alpha_offset
+    beta_pivot = beta_sqrt * root_pivot + beta_offset
+    mean_delay = 3.0 / alpha_pivot + profile.slow_fraction / beta_pivot
+    # energy_to_tof is proportional to path; this converts the mean delay at
+    # the pivot into the equivalent extra flight path without a copied constant.
+    one_metre_tof = energy_to_tof(profile.pivot_energy_ev, 1.0)
+    equivalent_path = mean_delay / one_metre_tof
+    physical_path = effective_path - equivalent_path
+    if physical_path <= 0.0:
+        raise ValueError("IC physical flight path became non-positive")
+    resolution = IkedaCarpenter(
+        flight_path_m=physical_path,
+        e_min_ev=minimum_energy_ev * (1.0 - 1.0e-12),
+        e_max_ev=maximum_energy_ev * (1.0 + 1.0e-12),
+        alpha=EnergyLaw.sqrt_e(alpha_sqrt, alpha_offset),
+        beta=1.0,
+        beta_law=EnergyLaw.sqrt_e(beta_sqrt, beta_offset),
+        r=EnergyLaw.const(profile.slow_fraction),
+        n_energies=int(profile.synthesis_energies),
+        n_tau=int(profile.synthesis_times),
+        channel_fwhm_us=profile.channel_fwhm_us,
+    )
+    return resolution, {
+        "timing_offset_us": timing_offset,
+        "effective_centroid_path_m": effective_path,
+        "physical_path_m": physical_path,
+        "width_scale": width_scale,
+        "mean_delay_at_pivot_us": mean_delay,
+        "mean_equivalent_path_at_pivot_m": equivalent_path,
+        "alpha_sqrt_coefficient": alpha_sqrt,
+        "alpha_offset": alpha_offset,
+        "beta_sqrt_coefficient": beta_sqrt,
+        "beta_offset": beta_offset,
+        "slow_fraction": profile.slow_fraction,
+    }
+
+
+def _kronrod_15_cells(energy_edges: FloatArray) -> tuple[FloatArray, FloatArray]:
+    positive_nodes = np.array(
+        [
+            0.9914553711208126,
+            0.9491079123427585,
+            0.8648644233597691,
+            0.7415311855993945,
+            0.5860872354676911,
+            0.4058451513773972,
+            0.2077849550078985,
+        ]
+    )
+    positive_weights = np.array(
+        [
+            0.02293532201052922,
+            0.06309209262997855,
+            0.1047900103222502,
+            0.1406532597155259,
+            0.1690047266392679,
+            0.1903505780647854,
+            0.2044329400752989,
+        ]
+    )
+    nodes = np.concatenate((-positive_nodes, [0.0], positive_nodes[::-1]))
+    weights = np.concatenate((positive_weights, [0.2094821410847278], positive_weights[::-1]))
+    order = np.argsort(nodes)
+    nodes = nodes[order]
+    weights = weights[order]
+    lower = energy_edges[:-1, None]
+    upper = energy_edges[1:, None]
+    points = 0.5 * ((upper - lower) * nodes[None, :] + upper + lower)
+    normalized_weights = np.broadcast_to(0.5 * weights[None, :], points.shape).copy()
+    return np.ascontiguousarray(points), np.ascontiguousarray(normalized_weights)
+
+
+def _total_cross_section(
+    energies: FloatArray,
+    isotopes: tuple[Any, ...],
+    fractions: FloatArray,
+    temperature_k: float,
+) -> FloatArray:
+    components = precompute_cross_sections(
+        np.ascontiguousarray(energies), list(isotopes), temperature_k=float(temperature_k)
+    )
+    arrays = np.vstack([np.asarray(component, dtype=float) for component in components])
+    if np.any(~np.isfinite(arrays)) or np.any(arrays < 0.0):
+        raise RuntimeError("cross-section calculation returned an invalid value")
+    return np.asarray(fractions @ arrays, dtype=float)
+
+
+def _detector_energy_axis(
+    detector_edges_us: FloatArray, timing_offset_us: float, flight_path_m: float
+) -> FloatArray:
+    centers = 0.5 * (detector_edges_us[:-1] + detector_edges_us[1:])
+    corrected = centers[::-1] - timing_offset_us
+    if np.any(corrected <= 0.0):
+        raise ValueError("timing offset makes a detector-bin time non-positive")
+    return np.array([tof_to_energy(float(value), flight_path_m) for value in corrected])
+
+
+def _fit_result(
+    *,
+    energy: FloatArray,
+    measured: FloatArray,
+    poisson_uncertainty: FloatArray,
+    uncertainty: FloatArray,
+    signal: FloatArray,
+    background: FloatArray,
+    objective: FloatArray,
+    standardized: FloatArray,
+    fit_mask: NDArray[np.bool_],
+    names: Sequence[str],
+    values: FloatArray,
+    converged: bool,
+    message: str,
+    evaluations: int,
+    bound_hits: tuple[str, ...],
+    fit_energy_range_ev: tuple[float, float],
+    open_variance_factor: float,
+    sample_variance_factor: float,
+) -> Aggregated1DFitResult:
+    selected = np.asarray(standardized, dtype=float)[fit_mask]
+    model = np.asarray(signal + background, dtype=float)
+    return Aggregated1DFitResult(
+        energy_ev=np.asarray(energy, dtype=float),
+        measured_transmission=np.asarray(measured, dtype=float),
+        poisson_uncertainty=np.asarray(poisson_uncertainty, dtype=float),
+        uncertainty=np.asarray(uncertainty, dtype=float),
+        signal_prediction=np.asarray(signal, dtype=float),
+        background_prediction=np.asarray(background, dtype=float),
+        model_prediction=model,
+        poisson_residual=np.asarray((measured - model) / poisson_uncertainty, dtype=float),
+        residual=np.asarray(standardized, dtype=float),
+        objective_residual=np.asarray(objective, dtype=float),
+        fit_mask=np.asarray(fit_mask, dtype=bool),
+        fit_energy_range_ev=tuple(map(float, fit_energy_range_ev)),
+        open_variance_factor=float(open_variance_factor),
+        sample_variance_factor=float(sample_variance_factor),
+        parameters={name: float(value) for name, value in zip(names, values, strict=True)},
+        converged=converged,
+        message=message,
+        function_evaluations=evaluations,
+        bound_hits=bound_hits,
+        max_abs_residual=float(np.max(np.abs(selected))),
+        rms_residual=float(np.sqrt(np.mean(selected * selected))),
+        bins_above_five=int(np.count_nonzero(np.abs(selected) > 5.0)),
+    )
+
+
+def _poisson_deviance(observed: FloatArray, expected: FloatArray) -> float:
+    safe = np.maximum(expected, np.finfo(float).tiny)
+    terms = safe - observed
+    positive = observed > 0.0
+    terms[positive] += observed[positive] * np.log(observed[positive] / safe[positive])
+    return float(2.0 * np.sum(terms))
+
+
+def _validate_aggregate_inputs(
+    detector_edges: Sequence[float] | FloatArray,
+    open_counts: Sequence[float] | FloatArray,
+    sample_counts: Sequence[float] | FloatArray,
+) -> tuple[FloatArray, FloatArray, FloatArray]:
+    edges = _one_dimensional("detector_time_edges_us", detector_edges)
+    open_array = _one_dimensional("open_counts", open_counts)
+    sample_array = _one_dimensional("sample_counts", sample_counts)
+    if edges.size != open_array.size + 1 or sample_array.shape != open_array.shape:
+        raise ValueError("detector edges must bracket every matching open/sample count bin")
+    if np.any(np.diff(edges) <= 0.0):
+        raise ValueError("detector_time_edges_us must be strictly increasing")
+    if np.any(open_array <= 0.0) or np.any(sample_array <= 0.0):
+        raise ValueError("aggregate open and sample counts must be positive")
+    return edges, open_array, sample_array
+
+
+def _validate_material(
+    isotopes: Sequence[Any], atomic_fractions: Sequence[float] | None
+) -> tuple[tuple[Any, ...], FloatArray]:
+    values = tuple(isotopes)
+    if not values:
+        raise ValueError("isotopes must not be empty")
+    if atomic_fractions is None:
+        if len(values) != 1:
+            raise ValueError("atomic_fractions are required for multiple isotopes")
+        fractions = np.ones(1, dtype=float)
+    else:
+        fractions = _fixed_vector("atomic_fractions", atomic_fractions, len(values))
+        if np.any(fractions < 0.0) or not np.isclose(np.sum(fractions), 1.0, atol=1.0e-12):
+            raise ValueError("atomic_fractions must be nonnegative and sum to one")
+    return values, fractions
+
+
+def _one_dimensional(name: str, values: Sequence[float] | FloatArray) -> FloatArray:
+    # Always copy so a calibration remains frozen if the caller later mutates
+    # an input array that was already contiguous and float64.
+    array = np.array(values, dtype=float, order="C", copy=True)
+    if array.ndim != 1 or array.size == 0:
+        raise ValueError(f"{name} must be a nonempty one-dimensional array")
+    if np.any(~np.isfinite(array)):
+        raise ValueError(f"{name} must contain only finite values")
+    return array
+
+
+def _fixed_vector(name: str, values: Sequence[float], length: int) -> FloatArray:
+    array = _one_dimensional(name, values)
+    if array.size != length:
+        raise ValueError(f"{name} must contain exactly {length} values")
+    return array
+
+
+def _finite_scalar(name: str, value: float) -> float:
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _positive_scalar(name: str, value: float) -> float:
+    result = _finite_scalar(name, value)
+    if result <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return result
+
+
+def _positive_integer(name: str, value: int) -> int:
+    result = int(value)
+    if result != value or result <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return result
+
+
+def _energy_mask(energy: FloatArray, limits: tuple[float, float]) -> NDArray[np.bool_]:
+    lower, upper = map(float, limits)
+    if not (math.isfinite(lower) and math.isfinite(upper) and 0.0 < lower < upper):
+        raise ValueError("fit_energy_range_ev must be finite, positive, and increasing")
+    mask = (energy >= lower) & (energy <= upper)
+    if not np.any(mask):
+        raise ValueError("fit_energy_range_ev selects no detector bins")
+    return mask
+
+
+def _validate_bounds(
+    start: FloatArray, lower: FloatArray, upper: FloatArray, label: str
+) -> None:
+    if np.any(lower >= upper):
+        raise ValueError(f"{label} lower bounds must be below upper bounds")
+    if np.any(start <= lower) or np.any(start >= upper):
+        raise ValueError(f"{label} initial values must be strictly inside their bounds")
+
+
+def _bound_hits(
+    names: Sequence[str], values: FloatArray, lower: FloatArray, upper: FloatArray
+) -> tuple[str, ...]:
+    return tuple(
+        name
+        for name, value, low, high in zip(names, values, lower, upper, strict=True)
+        if np.isclose(value, low, rtol=0.0, atol=1.0e-8 * max(1.0, abs(low)))
+        or np.isclose(value, high, rtol=0.0, atol=1.0e-8 * max(1.0, abs(high)))
+    )
+
+
+__all__ = [
+    "Aggregated1DCalibration",
+    "Aggregated1DFitResult",
+    "IcShapeProfile",
+    "SourceInferenceResult",
+    "VENUS_UDR_MATCHED_IC_PROFILE",
+    "calibrate_aggregated_1d",
+    "fit_frozen_aggregated_1d",
+    "profiled_two_arm_residual",
+    "select_energy_ordered_detector_bins",
+    "solid_debye_effective_temperature",
+]

--- a/bindings/python/python/nereids/mcp/server.py
+++ b/bindings/python/python/nereids/mcp/server.py
@@ -695,6 +695,13 @@ def _process_single_spectrum(
                 "the conversion discards open-beam count uncertainty; use "
                 "fit_domain='counts' with solver='auto' or solver='kl'"
             )
+        requested_solver = str(fit_config.get("solver", "auto")).lower()
+        if requested_solver == "lm":
+            raise ValueError(
+                "raw count input cannot use solver='lm': the least-squares "
+                "transmission engine would discard open-beam count uncertainty; "
+                "use solver='auto' or solver='kl'"
+            )
         kwargs = _single_fit_kwargs(fit_config, resolution, counts=True)
         kwargs["c"] = float(fit_config.get("c", c))
         result = nereids.fit_counts_spectrum_typed(
@@ -714,6 +721,12 @@ def _process_single_spectrum(
             raise ValueError(
                 "normalized transmission input must use fit_domain='transmission' "
                 "with solver='auto' or solver='lm'"
+            )
+        requested_solver = str(fit_config.get("solver", "auto")).lower()
+        if requested_solver in {"kl", "poisson", "poisson_kl"}:
+            raise ValueError(
+                "normalized transmission input cannot use a Poisson/KL count "
+                "likelihood; use solver='auto' or solver='lm'"
             )
         trans_key = data_config.get("transmission_key", "transmission")
         unc_key = data_config.get("uncertainty_key", "uncertainty")

--- a/bindings/python/python/nereids/mcp/server.py
+++ b/bindings/python/python/nereids/mcp/server.py
@@ -723,7 +723,7 @@ def _process_single_spectrum(
                 "with solver='auto' or solver='lm'"
             )
         requested_solver = str(fit_config.get("solver", "auto")).lower()
-        if requested_solver in {"kl", "poisson", "poisson_kl"}:
+        if requested_solver in {"kl", "poisson", "poisson_kl", "joint_poisson"}:
             raise ValueError(
                 "normalized transmission input cannot use a Poisson/KL count "
                 "likelihood; use solver='auto' or solver='lm'"

--- a/bindings/python/python/nereids/mcp/server.py
+++ b/bindings/python/python/nereids/mcp/server.py
@@ -35,11 +35,11 @@ _MANIFEST_NAMES = (
 )
 
 _COUNTS_RESOLUTION_UNSUPPORTED = (
-    "counts input with instrument resolution is unsupported: the current counts "
-    "path broadens transmission as R[T], but the physical detector model requires "
-    "separate open/sample response arms R[Phi] and R[Phi*T]. Supply pre-normalized "
-    "transmission, or disable instrument resolution until an exact counts response "
-    "is implemented."
+    "counts input with instrument resolution is not available through the MCP "
+    "manifest: an exact count fit requires incident fluence weights and measured "
+    "detector-time bin edges, which this manifest schema does not carry. Use the "
+    "direct Python fit_counts_spectrum_typed exact-count arguments, supply "
+    "pre-normalized transmission, or disable instrument resolution."
 )
 _SAFE_KEY = re.compile(r"[^A-Za-z0-9_]+")
 
@@ -669,8 +669,6 @@ def _process_single_spectrum(
         entries, base, default_library=str(config.get("library", "endf8.1"))
     )
     resolution = _resolution_kwargs(base, config)
-    solver = str(fit_config.get("solver", "lm")).lower()
-
     if kind in {"counts_npz", "counts"}:
         sample_key = data_config.get("sample_key", "sample_counts")
         open_beam_key = data_config.get("open_beam_key", "open_beam_counts")
@@ -690,40 +688,33 @@ def _process_single_spectrum(
         if sample.ndim != 1 or open_beam.ndim != 1:
             raise ValueError("single_spectrum counts arrays must be 1D or 3D")
         c = float(data_config.get("pc_ratio", arrays.get("pc_ratio", 1.0)))
-        fit_domain = str(
-            fit_config.get(
-                "fit_domain",
-                "transmission" if solver == "lm" else "counts",
+        fit_domain = str(fit_config.get("fit_domain", "counts")).lower()
+        if fit_domain != "counts":
+            raise ValueError(
+                "raw count input cannot be fit in the transmission domain: "
+                "the conversion discards open-beam count uncertainty; use "
+                "fit_domain='counts' with solver='auto' or solver='kl'"
             )
-        ).lower()
-        if fit_domain == "counts":
-            kwargs = _single_fit_kwargs(fit_config, resolution, counts=True)
-            kwargs["c"] = float(fit_config.get("c", c))
-            result = nereids.fit_counts_spectrum_typed(
-                sample_counts=sample,
-                open_beam_counts=open_beam,
-                energies=energies,
-                isotopes=isotopes,
-                **kwargs,
-            )
-            transmission = sample / np.maximum(kwargs["c"] * open_beam, 1.0)
-            uncertainty = transmission * np.sqrt(
-                1.0 / np.maximum(sample, 1.0) + 1.0 / np.maximum(open_beam, 1.0)
-            )
-        else:
-            transmission = sample / np.maximum(c * open_beam, 1.0)
-            uncertainty = transmission * np.sqrt(
-                1.0 / np.maximum(sample, 1.0) + 1.0 / np.maximum(open_beam, 1.0)
-            )
-            kwargs = _single_fit_kwargs(fit_config, resolution, counts=False)
-            result = nereids.fit_spectrum_typed(
-                transmission=transmission,
-                uncertainty=uncertainty,
-                energies=energies,
-                isotopes=isotopes,
-                **kwargs,
-            )
+        kwargs = _single_fit_kwargs(fit_config, resolution, counts=True)
+        kwargs["c"] = float(fit_config.get("c", c))
+        result = nereids.fit_counts_spectrum_typed(
+            sample_counts=sample,
+            open_beam_counts=open_beam,
+            energies=energies,
+            isotopes=isotopes,
+            **kwargs,
+        )
+        transmission = sample / np.maximum(kwargs["c"] * open_beam, 1.0)
+        uncertainty = transmission * np.sqrt(
+            1.0 / np.maximum(sample, 1.0) + 1.0 / np.maximum(open_beam, 1.0)
+        )
     elif kind in {"transmission_npz", "transmission", "spectrum"}:
+        fit_domain = str(fit_config.get("fit_domain", "transmission")).lower()
+        if fit_domain != "transmission":
+            raise ValueError(
+                "normalized transmission input must use fit_domain='transmission' "
+                "with solver='auto' or solver='lm'"
+            )
         trans_key = data_config.get("transmission_key", "transmission")
         unc_key = data_config.get("uncertainty_key", "uncertainty")
         _require_npz_keys(
@@ -950,6 +941,22 @@ def _process_density_map(
     initial_densities = [density for _, density in isotopes]
     isotope_data = [data for data, _ in isotopes]
     kwargs = _spatial_fit_kwargs(fit_config, _resolution_kwargs(base, config))
+    requested_solver = str(fit_config.get("solver", "auto")).lower()
+    if input_kind == "counts" and requested_solver == "lm":
+        raise ValueError(
+            "raw count maps cannot use solver='lm': use solver='auto' or "
+            "solver='kl' so the separate sample/open-beam arms are preserved"
+        )
+    if input_kind == "transmission" and requested_solver in {
+        "kl",
+        "poisson",
+        "poisson_kl",
+        "joint_poisson",
+    }:
+        raise ValueError(
+            "normalized transmission maps cannot use a Poisson/KL count "
+            "likelihood; use solver='auto' or solver='lm'"
+        )
     if c is not None and "c" not in kwargs:
         kwargs["c"] = c
     result = nereids.spatial_map_typed(
@@ -1155,10 +1162,9 @@ def _validate_workflow(manifest: dict[str, Any]) -> dict[str, Any]:
     elif resolution is None and mode in {"density_map", "spatial_map"}:
         warnings.append("no resolution configured; OK for synthetic/demo data")
 
-    # Raw count inputs need two separately broadened response arms:
-    # R[Phi] for the open beam and R[Phi*T] for the sample.  The current
-    # fitting API only has R[T], so approving this manifest would make a
-    # dry run disagree with the production pipeline's fail-closed gate.
+    # Raw count inputs need two separately evaluated response arms. The direct
+    # Python fitter supports this when source weights and detector-time edges
+    # are supplied, but the MCP manifest schema does not carry those inputs.
     counts_input = effective_kind in {
         "counts_npz",
         "counts",

--- a/bindings/python/python/nereids/mcp/server.py
+++ b/bindings/python/python/nereids/mcp/server.py
@@ -33,6 +33,14 @@ _MANIFEST_NAMES = (
     "nereids_mcp.json",
     "analysis.json",
 )
+
+_COUNTS_RESOLUTION_UNSUPPORTED = (
+    "counts input with instrument resolution is unsupported: the current counts "
+    "path broadens transmission as R[T], but the physical detector model requires "
+    "separate open/sample response arms R[Phi] and R[Phi*T]. Supply pre-normalized "
+    "transmission, or disable instrument resolution until an exact counts response "
+    "is implemented."
+)
 _SAFE_KEY = re.compile(r"[^A-Za-z0-9_]+")
 
 
@@ -1133,16 +1141,33 @@ def _validate_workflow(manifest: dict[str, Any]) -> dict[str, Any]:
             errors.append(f"isotope entry is missing isotope/z/a/endf_file: {entry}")
 
     resolution = config.get("resolution")
+    resolution_kind: str | None = None
     if isinstance(resolution, dict):
-        kind = _normalise_kind(resolution.get("kind", "none"), "none")
-        if kind in {"tabulated", "file", "resolution_file"}:
+        resolution_kind = _normalise_kind(resolution.get("kind", "none"), "none")
+        if resolution_kind in {"tabulated", "file", "resolution_file"}:
             path = _resolve_path(base, resolution.get("path"))
             if path is None or not path.exists():
                 errors.append(f"resolution file does not exist: {path}")
-        if kind in {"none", "disabled", "false"}:
+        if resolution_kind in {"none", "disabled", "false"}:
             warnings.append("resolution disabled; appropriate for synthetic data")
+    elif isinstance(resolution, str):
+        resolution_kind = _normalise_kind(resolution, "none")
     elif resolution is None and mode in {"density_map", "spatial_map"}:
         warnings.append("no resolution configured; OK for synthetic/demo data")
+
+    # Raw count inputs need two separately broadened response arms:
+    # R[Phi] for the open beam and R[Phi*T] for the sample.  The current
+    # fitting API only has R[T], so approving this manifest would make a
+    # dry run disagree with the production pipeline's fail-closed gate.
+    counts_input = effective_kind in {
+        "counts_npz",
+        "counts",
+        "nexus_histogram",
+        "nexus",
+    }
+    resolution_active = resolution_kind not in {None, "none", "disabled", "false"}
+    if counts_input and resolution_active:
+        errors.append(_COUNTS_RESOLUTION_UNSUPPORTED)
 
     return {
         "valid": not errors,

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -65,6 +65,10 @@ use nereids_physics::resolution::{
 use nereids_physics::transmission::{self, InstrumentParams, SampleParams};
 use nereids_pipeline::detectability;
 
+// PyO3 needs a literal here to expose the real default through
+// `inspect.signature`; keep that public literal locked to the core default.
+const _: () = assert!(DEFAULT_PSR_FWHM_NS == 350.0);
+
 /// Python wrapper for ENDF resonance data.
 ///
 /// Uses `Arc` internally so that `.clone()` in `py.detach()` closures is O(1)
@@ -1493,7 +1497,7 @@ impl PyResolutionCalibration {
     restarts=1, ic_n_energies=64, ic_n_tau=500,
     fit_t0=false, fit_l_scale=false, t0_center_us=0.0, l_scale_center=1.0,
     t0_prior_us=None, l_scale_prior=None,
-    psr_fwhm_ns=DEFAULT_PSR_FWHM_NS, fit_psr=false
+    psr_fwhm_ns=350.0, fit_psr=false
 ))]
 #[allow(clippy::too_many_arguments)]
 fn calibrate_resolution(

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -775,9 +775,11 @@ impl PyEnergyLaw {
 /// the *same* broadening path as a Monte-Carlo file, so the IC-vs-tabulated
 /// comparison differs only in kernel source.
 ///
-/// Parameters: `alpha`/`r` are [`EnergyLaw`]s (fixed-or-fit general case),
-/// `beta` (1/µs) is the storage rate; optional `burst_sigma_us` (Gaussian) and
-/// `channel_fwhm_us` (triangle) fold in the proton-burst and chopper terms.
+/// Parameters: `alpha`/`r` are [`EnergyLaw`]s (fixed-or-fit general case).
+/// `beta` keeps the original constant-rate API; the optional trailing
+/// `beta_law` overrides it with an energy-dependent rate. Optional
+/// `burst_sigma_us` (Gaussian) and `channel_fwhm_us` (triangle) fold in the
+/// proton-burst and chopper terms.
 #[pyclass(name = "IkedaCarpenter", skip_from_py_object)]
 #[derive(Clone)]
 struct PyIkedaCarpenter {
@@ -798,6 +800,7 @@ impl PyIkedaCarpenter {
         n_tau = 600,
         burst_sigma_us = None,
         channel_fwhm_us = None,
+        beta_law = None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -811,6 +814,7 @@ impl PyIkedaCarpenter {
         n_tau: usize,
         burst_sigma_us: Option<f64>,
         channel_fwhm_us: Option<f64>,
+        beta_law: Option<PyEnergyLaw>,
     ) -> PyResult<Self> {
         for (name, v) in [
             ("burst_sigma_us", burst_sigma_us),
@@ -826,7 +830,7 @@ impl PyIkedaCarpenter {
         }
         let params = IkedaCarpenterParams {
             alpha: alpha.inner,
-            beta,
+            beta: beta_law.map_or(EnergyLaw::Const(beta), |law| law.inner),
             r: r.inner,
             burst_sigma_us,
             channel_fwhm_us,
@@ -1381,7 +1385,9 @@ impl PyResolutionCalibration {
                         d.set_item("a0", *a0)?;
                         d.set_item("a1", *a1)?;
                     }
-                    d.set_item("beta", p.beta)?;
+                    if let EnergyLaw::Const(beta) = p.beta {
+                        d.set_item("beta", beta)?;
+                    }
                     if let EnergyLaw::Const(r) = &p.r {
                         d.set_item("r", *r)?;
                     }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -15,7 +15,7 @@
 //! then pass to `spatial_map_typed()` for per-pixel fitting:
 //!
 //! - **Counts** → Poisson KL (statistically optimal for raw detector counts)
-//! - **Transmission** → LM (default) or KL (opt-in via `solver="kl"`)
+//! - **Transmission** → LM only; a count likelihood is not valid for ratios
 //!
 //! ## Usage
 //! ```python
@@ -509,7 +509,7 @@ impl PyFitResult {
     /// 1-sigma uncertainty on fitted temperature in Kelvin (``None`` when
     /// ``fit_temperature=False``).
     ///
-    /// For the raw-covariance solver paths (Poisson-KL, joint-Poisson) this is a
+    /// For the raw-count joint-Poisson path this is a
     /// **covariance-only lower bound**: it is `sqrt` of the temperature diagonal
     /// of the inverse Fisher matrix and omits baseline/model noise, so on real
     /// data it can underestimate the observed per-superpixel scatter by ~3–4×.
@@ -604,7 +604,7 @@ impl PyFitResult {
     ///
     /// Primary goodness-of-fit statistic for ``solver="kl"`` on counts
     /// data — replaces the fixed-flux Pearson χ² that scaled with ``c``.
-    /// Returns ``None`` for LM fits and for transmission + PoissonKL;
+    /// Returns ``None`` for LM transmission fits;
     /// those populate ``reduced_chi_squared`` with Pearson χ² / (n − k).
     #[getter]
     fn deviance_per_dof(&self) -> Option<f64> {
@@ -1010,7 +1010,7 @@ impl PySpatialResult {
     /// Primary goodness-of-fit for ``solver="kl"`` on counts data
     /// (replaces the fixed-flux Pearson that scaled
     /// with ``c``).  Returns ``None`` for LM fits and transmission +
-    /// PoissonKL; those populate ``chi_squared_map`` with Pearson χ² /
+    /// LM transmission fits; those populate ``chi_squared_map`` with Pearson χ² /
     /// (n − k) instead.
     #[getter]
     fn deviance_per_dof_map<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyArray2<f64>>> {
@@ -1058,7 +1058,7 @@ impl PySpatialResult {
     /// Per-pixel temperature uncertainty map (None when fit_temperature=False).
     /// Entries are NaN where uncertainty was unavailable for that pixel.
     ///
-    /// For the raw-covariance solver paths (Poisson-KL, joint-Poisson) each σ_T
+    /// For the raw-count joint-Poisson path each σ_T
     /// is a **covariance-only lower bound** (`sqrt` of the temperature diagonal
     /// of the inverse Fisher matrix): it omits baseline/model noise and on real
     /// data can underestimate the observed per-superpixel scatter by ~3–4×.
@@ -2095,6 +2095,19 @@ fn build_resolution(
     }
 }
 
+/// Extract a detector-time response that has exact bin probabilities.
+fn extract_detector_time_resolution(resolution: &Bound<'_, PyAny>) -> PyResult<ResolutionFunction> {
+    if let Ok(tabulated) = resolution.extract::<PyRef<'_, PyTabulatedResolution>>() {
+        Ok(ResolutionFunction::Tabulated(Arc::clone(&tabulated.inner)))
+    } else if let Ok(ic) = resolution.extract::<PyRef<'_, PyIkedaCarpenter>>() {
+        Ok(ResolutionFunction::IkedaCarpenter(Arc::clone(&ic.inner)))
+    } else {
+        Err(pyo3::exceptions::PyTypeError::new_err(
+            "resolution must be a TabulatedResolution or IkedaCarpenter",
+        ))
+    }
+}
+
 /// Apply Free Gas Model (FGM) Doppler broadening to a cross-section array.
 ///
 /// Convolves the input cross-sections with a Gaussian kernel whose width
@@ -2321,15 +2334,7 @@ fn py_two_arm_count_response<'py>(
     resolution: &Bound<'_, PyAny>,
     timing_offset_us: f64,
 ) -> PyResult<(Bound<'py, PyArray1<f64>>, Bound<'py, PyArray1<f64>>)> {
-    let response = if let Ok(tabulated) = resolution.extract::<PyRef<'_, PyTabulatedResolution>>() {
-        ResolutionFunction::Tabulated(Arc::clone(&tabulated.inner))
-    } else if let Ok(ic) = resolution.extract::<PyRef<'_, PyIkedaCarpenter>>() {
-        ResolutionFunction::IkedaCarpenter(Arc::clone(&ic.inner))
-    } else {
-        return Err(pyo3::exceptions::PyTypeError::new_err(
-            "resolution must be a TabulatedResolution or IkedaCarpenter",
-        ));
-    };
+    let response = extract_detector_time_resolution(resolution)?;
 
     let energies = true_energies_ev.as_slice()?.to_vec();
     let fluence = incident_fluence_weights.as_slice()?.to_vec();
@@ -4635,10 +4640,12 @@ fn py_from_counts<'py>(
     })
 }
 
-/// Create InputData from raw detector counts plus explicit nuisance spectra.
+/// Legacy raw-count nuisance wrapper retained for compatibility.
 ///
-/// Use this when the detector/counts background spectrum has been estimated
-/// outside NEREIDS and should be supplied explicitly.
+/// Production fitting rejects a nonzero background because this legacy array
+/// is not connected to the physical two-arm likelihood. New code should use
+/// `from_counts` and fit independently measured detector-bin shapes with
+/// `fit_two_arm_background_templates`.
 #[pyfunction]
 #[pyo3(name = "from_counts_with_nuisance")]
 fn py_from_counts_with_nuisance<'py>(
@@ -4678,8 +4685,9 @@ fn py_from_counts_with_nuisance<'py>(
 
 /// Create InputData from normalized transmission and uncertainty.
 ///
-/// The fitting engine will use LM by default. Pass solver="kl" to use
-/// Poisson KL instead (for low-count transmission data).
+/// The fitting engine uses LM. A Poisson/KL count likelihood is rejected for
+/// normalized transmission because the separate count arms are no longer
+/// available.
 ///
 /// **Note:** Both arrays must have dtype `np.float64`. Call `.astype(np.float64)`
 /// if your arrays are a different type.
@@ -4744,6 +4752,11 @@ fn parse_solver_config(
                 )
             }
         }
+        "lm" if is_counts => Err(pyo3::exceptions::PyValueError::new_err(
+            "raw sample/open-beam counts cannot use solver='lm': dividing the \
+             count arms into transmission loses count statistics; use \
+             solver='auto' or solver='kl'",
+        )),
         "lm" => Ok(
             nereids_pipeline::pipeline::SolverConfig::LevenbergMarquardt(
                 nereids_fitting::lm::LmConfig {
@@ -4758,6 +4771,13 @@ fn parse_solver_config(
         // implementation IS the KL solver.  No runtime deprecation
         // warning is emitted; the aliases simply accept the older name
         // strings so existing user scripts keep working.
+        "kl" | "poisson" | "joint_poisson" if !is_counts => {
+            Err(pyo3::exceptions::PyValueError::new_err(
+                "normalized transmission cannot use a Poisson/KL count \
+                 likelihood because the separate open/sample count arms are \
+                 unavailable; use solver='auto' or solver='lm'",
+            ))
+        }
         "kl" | "poisson" | "joint_poisson" => {
             Ok(nereids_pipeline::pipeline::SolverConfig::PoissonKL(
                 nereids_fitting::poisson::PoissonConfig {
@@ -5012,7 +5032,7 @@ fn spatial_result_to_py(
 ///
 /// Dispatches per-pixel fitting based on the InputData type:
 ///   - from_counts → Poisson KL on raw counts (statistically optimal)
-///   - from_transmission → LM by default, KL opt-in via solver="kl"
+///   - from_transmission → LM; Poisson/KL is rejected for ratios
 ///
 /// Either `isotopes` or `groups` must be provided, but not both.
 /// When `groups` is provided, each group maps to one fitted density parameter.
@@ -5488,7 +5508,8 @@ fn py_spatial_map_typed<'py>(
 ///     temperature_k: Sample temperature in Kelvin (default 293.6).
 ///     fit_temperature: Whether to fit temperature (default False).
 ///     max_iter: Maximum iterations (default 200).
-///     solver: "auto" (default), "kl", "poisson", "joint_poisson", or "lm".
+///     solver: "auto" (default), "kl", "poisson", or "joint_poisson".
+///         "lm" is rejected for raw counts.
 ///     background: Enable the SAMMY-style transmission background inside the
 ///         counts likelihood. This is not detector-count background.
 ///     detector_background: Reserved detector/counts background reference.
@@ -5501,7 +5522,13 @@ fn py_spatial_map_typed<'py>(
 ///         production counts fitting.
 ///     alpha_1_init: Initial value for `alpha_1` (default 1.0).
 ///     alpha_2_init: Initial value for `alpha_2` (default 1.0).
-///     resolution: Optional resolution function.
+///     resolution: Exact detector-time response. Resolved raw-count fitting
+///         accepts a TabulatedResolution or IkedaCarpenter.
+///     incident_fluence_weights: Incident fluence integrated over each point
+///         of the true-energy quadrature. Required with detector_time_edges_us.
+///     detector_time_edges_us: Actual measured detector-time bin edges. Its
+///         length must be one greater than the sample/open count arrays.
+///     timing_offset_us: Fixed detector-clock offset applied by the response.
 ///     groups: list of IsotopeGroup objects (mutually exclusive with isotopes).
 ///     initial_densities: Initial density guesses when using groups (default 0.001 each).
 ///     enable_polish: Override the Nelder-Mead polish phase on the
@@ -5559,6 +5586,9 @@ fn py_spatial_map_typed<'py>(
     alpha_2_init = 1.0,
     c = 1.0,
     resolution = None,
+    incident_fluence_weights = None,
+    detector_time_edges_us = None,
+    timing_offset_us = 0.0,
     flight_path_m = None,
     delta_t_us = None,
     delta_l_m = None,
@@ -5607,7 +5637,10 @@ fn py_fit_counts_spectrum_typed<'py>(
     alpha_1_init: f64,
     alpha_2_init: f64,
     c: f64,
-    resolution: Option<PyTabulatedResolution>,
+    resolution: Option<&Bound<'py, PyAny>>,
+    incident_fluence_weights: Option<PyReadonlyArray1<'py, f64>>,
+    detector_time_edges_us: Option<PyReadonlyArray1<'py, f64>>,
+    timing_offset_us: f64,
     flight_path_m: Option<f64>,
     delta_t_us: Option<f64>,
     delta_l_m: Option<f64>,
@@ -5632,7 +5665,8 @@ fn py_fit_counts_spectrum_typed<'py>(
     scale_by_chi2: bool,
 ) -> PyResult<PyFitResult> {
     use nereids_pipeline::pipeline::{
-        CountsBackgroundConfig, InputData, UnifiedFitConfig, fit_spectrum_typed,
+        CountsBackgroundConfig, ExactCountResponseConfig, InputData, UnifiedFitConfig,
+        fit_spectrum_typed,
     };
 
     let has_isotopes = isotopes.is_some();
@@ -5658,11 +5692,51 @@ fn py_fit_counts_spectrum_typed<'py>(
             ob_slice.len(),
         )));
     }
-    if sample_slice.len() != e_slice.len() {
+    let exact_source = incident_fluence_weights
+        .map(|values| values.as_slice().map(<[f64]>::to_vec))
+        .transpose()?;
+    let exact_edges = detector_time_edges_us
+        .map(|values| values.as_slice().map(<[f64]>::to_vec))
+        .transpose()?;
+    let exact_requested = exact_source.is_some() || exact_edges.is_some();
+    if exact_source.is_some() != exact_edges.is_some() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "incident_fluence_weights and detector_time_edges_us must be supplied together",
+        ));
+    }
+    if !exact_requested && timing_offset_us != 0.0 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "timing_offset_us requires incident_fluence_weights and detector_time_edges_us",
+        ));
+    }
+    if !exact_requested && sample_slice.len() != e_slice.len() {
         return Err(pyo3::exceptions::PyValueError::new_err(format!(
             "sample_counts length ({}) must match energies length ({})",
             sample_slice.len(),
             e_slice.len(),
+        )));
+    }
+    if let Some(source) = exact_source.as_ref()
+        && source.len() != e_slice.len()
+    {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "incident_fluence_weights length ({}) must match the true-energy grid length ({})",
+            source.len(),
+            e_slice.len(),
+        )));
+    }
+    if let Some(edges) = exact_edges.as_ref()
+        && edges.len() != sample_slice.len() + 1
+    {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "detector_time_edges_us length ({}) must be one greater than the measured count-bin length ({})",
+            edges.len(),
+            sample_slice.len(),
+        )));
+    }
+    if exact_requested && !timing_offset_us.is_finite() {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "timing_offset_us must be finite, got {timing_offset_us}",
         )));
     }
     require_non_empty_energy_grid(e_slice)?;
@@ -5714,7 +5788,17 @@ fn py_fit_counts_spectrum_typed<'py>(
     }
 
     let energies_vec = e_slice.to_vec();
-    let res_fn = build_resolution(flight_path_m, delta_t_us, delta_l_m, resolution, None)?;
+    let has_gaussian = flight_path_m.is_some() || delta_t_us.is_some() || delta_l_m.is_some();
+    if has_gaussian && resolution.is_some() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "Cannot specify both Gaussian resolution parameters and resolution",
+        ));
+    }
+    let res_fn = if let Some(response) = resolution {
+        Some(extract_detector_time_resolution(response)?)
+    } else {
+        build_resolution(flight_path_m, delta_t_us, delta_l_m, None, None)?
+    };
 
     let mut config = if let Some(isotopes) = isotopes {
         let iso_names: Vec<String> = isotopes
@@ -5757,6 +5841,20 @@ fn py_fit_counts_spectrum_typed<'py>(
     };
 
     config = config.with_solver(parse_solver_config(solver, true, max_iter)?);
+    if let (Some(incident_fluence_weights), Some(detector_time_edges_us)) =
+        (exact_source, exact_edges)
+    {
+        if config.resolution().is_none() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "exact resolved counts require resolution=TabulatedResolution or IkedaCarpenter",
+            ));
+        }
+        config = config.with_exact_count_response(ExactCountResponseConfig {
+            incident_fluence_weights,
+            detector_time_edges_us,
+            timing_offset_us,
+        });
+    }
     // Issue #638: χ²-scaled uncertainties (no-op on the LM transmission path).
     config = config.with_scale_by_chi2(scale_by_chi2);
     if fit_temperature {
@@ -6270,7 +6368,8 @@ fn apply_baseline(
 ///     temperature_k: Sample temperature in Kelvin (default 293.6).
 ///     fit_temperature: Whether to fit temperature (default False).
 ///     max_iter: Maximum iterations (default 200).
-///     solver: "lm" (default), "kl", or "auto".
+///     solver: "lm" (default) or "auto". Count-likelihood names are rejected
+///         for normalized transmission.
 ///     background: Enable SAMMY transmission background.
 ///     resolution: Optional resolution function.
 ///     groups: list of IsotopeGroup objects (mutually exclusive with isotopes).
@@ -6483,12 +6582,9 @@ fn py_fit_spectrum_typed<'py>(
     let solver_config = parse_solver_config(solver, false, max_iter)?;
     config = config.with_solver(solver_config);
 
-    // Issue #638: χ²-scaled uncertainties. This function takes TRANSMISSION
-    // input. Its default solver resolves to the LM transmission path, which is
-    // already χ²-scaled, so the flag is a no-op there; with ``solver='kl'`` it
-    // routes to the transmission Poisson-KL path, where the flag opts the raw
-    // inverse-Fisher σ into the SAME Gaussian reduced-χ² scaling the LM path
-    // uses (see `pipeline::poisson_to_lm_result`).
+    // Issue #638: this function takes transmission input and therefore always
+    // uses LM. LM already scales its covariance by reduced chi-squared, so this
+    // compatibility flag is a no-op here.
     config = config.with_scale_by_chi2(scale_by_chi2);
 
     // Temperature fitting

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -697,6 +697,21 @@ impl PyTabulatedResolution {
             .unwrap_or(0)
     }
 
+    /// Probability that a neutron at one true energy is recorded in each
+    /// adjacent detector-time bin. The tabulated UDR is evaluated directly;
+    /// the result is not renormalized when the supplied time window omits part
+    /// of the pulse.
+    fn detector_bin_probabilities(
+        &self,
+        true_energy_ev: f64,
+        detector_time_edges_us: Vec<f64>,
+        timing_offset_us: f64,
+    ) -> PyResult<Vec<f64>> {
+        self.inner
+            .detector_bin_probabilities(true_energy_ev, &detector_time_edges_us, timing_offset_us)
+            .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))
+    }
+
     fn __repr__(&self) -> String {
         let (lo, hi) = self.energy_range();
         format!(

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -2095,7 +2095,7 @@ fn build_resolution(
     }
 }
 
-/// Extract a detector-time response that has exact bin probabilities.
+/// Extract a response that can integrate over caller-supplied detector bins.
 fn extract_detector_time_resolution(resolution: &Bound<'_, PyAny>) -> PyResult<ResolutionFunction> {
     if let Ok(tabulated) = resolution.extract::<PyRef<'_, PyTabulatedResolution>>() {
         Ok(ResolutionFunction::Tabulated(Arc::clone(&tabulated.inner)))

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -869,6 +869,14 @@ impl PyIkedaCarpenter {
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
+    /// `(moderator_delay_us, density)` for the physical source pulse at one
+    /// true energy. Unlike `kernel_at`, this keeps the pulse's time origin.
+    fn source_pulse_at(&self, true_energy_ev: f64) -> PyResult<(Vec<f64>, Vec<f64>)> {
+        self.inner
+            .source_pulse_at(true_energy_ev)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+    }
+
     /// Probability that a neutron at one true energy is recorded in each
     /// adjacent detector-time bin. The result is not renormalized when the
     /// supplied time window omits part of the pulse.

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -457,6 +457,17 @@ struct PyFitResult {
     /// Structured fit-configuration warnings (e.g. the degenerate
     /// free-Anorm + free-temperature + free-density trio).
     warnings: Vec<String>,
+    /// Energy coordinate for the complete fitted prediction, in measured-bin
+    /// order.
+    prediction_energies_ev: Vec<f64>,
+    /// Signal contribution after response and normalization, excluding the
+    /// explicit additive SAMMY background.
+    signal_prediction: Vec<f64>,
+    /// Explicit additive SAMMY background contribution.
+    background_prediction: Vec<f64>,
+    /// Complete fitted curve.  This is always signal_prediction plus
+    /// background_prediction.
+    model_prediction: Vec<f64>,
 }
 
 #[pymethods]
@@ -526,6 +537,30 @@ impl PyFitResult {
     #[getter]
     fn anorm(&self) -> f64 {
         self.anorm
+    }
+
+    /// Energy coordinate for the fitted prediction, in measured-bin order.
+    #[getter]
+    fn prediction_energies_ev<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        PyArray1::from_vec(py, self.prediction_energies_ev.clone())
+    }
+
+    /// Fitted signal contribution excluding the explicit additive background.
+    #[getter]
+    fn signal_prediction<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        PyArray1::from_vec(py, self.signal_prediction.clone())
+    }
+
+    /// Explicit additive background contribution to the fitted curve.
+    #[getter]
+    fn background_prediction<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        PyArray1::from_vec(py, self.background_prediction.clone())
+    }
+
+    /// Complete fitted curve in measured-bin order.
+    #[getter]
+    fn model_prediction<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        PyArray1::from_vec(py, self.model_prediction.clone())
     }
 
     /// Fitted background parameter triplet.
@@ -2357,6 +2392,174 @@ fn py_two_arm_count_response<'py>(
         PyArray1::from_vec(py, result.open_beam),
         PyArray1::from_vec(py, result.sample),
     ))
+}
+
+/// Reusable compact detector response for repeated aggregate-spectrum work.
+///
+/// Rows in the underlying native matrix are true-energy points and output
+/// bins are consecutive intervals in ``detector_time_edges_us``.  The matrix
+/// stores every strictly positive probability without a numerical cutoff.
+#[pyclass(name = "DetectorResponseMatrix")]
+struct PyDetectorResponseMatrix {
+    inner: counts_response::DetectorBinResponseMatrix,
+}
+
+#[pymethods]
+impl PyDetectorResponseMatrix {
+    #[new]
+    #[pyo3(signature = (
+        true_energies_ev,
+        detector_time_edges_us,
+        resolution,
+        timing_offset_us = 0.0,
+    ))]
+    fn new(
+        py: Python<'_>,
+        true_energies_ev: PyReadonlyArray1<f64>,
+        detector_time_edges_us: PyReadonlyArray1<f64>,
+        resolution: &Bound<'_, PyAny>,
+        timing_offset_us: f64,
+    ) -> PyResult<Self> {
+        let response = extract_detector_time_resolution(resolution)?;
+        let energies = true_energies_ev.as_slice()?.to_vec();
+        let detector_edges = detector_time_edges_us.as_slice()?.to_vec();
+        let inner = py.detach(move || {
+            counts_response::DetectorBinResponseMatrix::new(
+                &energies,
+                &detector_edges,
+                timing_offset_us,
+                &response,
+            )
+        });
+        let inner = inner.map_err(|error| {
+            pyo3::exceptions::PyValueError::new_err(format!("detector response matrix: {error}"))
+        })?;
+        Ok(Self { inner })
+    }
+
+    #[getter]
+    fn n_true_energies(&self) -> usize {
+        self.inner.n_true_energies()
+    }
+
+    #[getter]
+    fn n_detector_bins(&self) -> usize {
+        self.inner.n_detector_bins()
+    }
+
+    #[getter]
+    fn nonzero_probabilities(&self) -> usize {
+        self.inner.nnz()
+    }
+
+    #[getter]
+    fn storage_bytes(&self) -> usize {
+        self.inner.storage_bytes()
+    }
+
+    /// Apply the response to one nonnegative true-energy weight vector.
+    fn project<'py>(
+        &self,
+        py: Python<'py>,
+        true_energy_weights: PyReadonlyArray1<f64>,
+    ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let weights = true_energy_weights.as_slice()?;
+        let transmission = vec![1.0; self.inner.n_true_energies()];
+        let result = self.inner.apply(weights, &transmission).map_err(|error| {
+            pyo3::exceptions::PyValueError::new_err(format!(
+                "detector response projection: {error}"
+            ))
+        })?;
+        Ok(PyArray1::from_vec(py, result.open_beam))
+    }
+
+    /// Apply the transpose response to detector-bin values.
+    ///
+    /// This operation accepts signed finite values because it is also the
+    /// gradient operation used by nonnegative source inference.
+    fn transpose_project<'py>(
+        &self,
+        py: Python<'py>,
+        detector_bin_values: PyReadonlyArray1<f64>,
+    ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let values = detector_bin_values.as_slice()?;
+        if values.len() != self.inner.n_detector_bins() {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "detector_bin_values length ({}) must match n_detector_bins ({})",
+                values.len(),
+                self.inner.n_detector_bins(),
+            )));
+        }
+        if let Some((index, value)) = values
+            .iter()
+            .copied()
+            .enumerate()
+            .find(|(_, value)| !value.is_finite())
+        {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "detector_bin_values[{index}] must be finite, got {value}"
+            )));
+        }
+        let mut projected = vec![0.0; self.inner.n_true_energies()];
+        for (true_index, output) in projected.iter_mut().enumerate() {
+            *output = self
+                .inner
+                .row_entries(true_index)
+                .map(|(detector_bin, probability)| probability * values[detector_bin])
+                .sum();
+        }
+        Ok(PyArray1::from_vec(py, projected))
+    }
+
+    /// Apply the response to open and attenuated sample weights separately.
+    fn apply<'py>(
+        &self,
+        py: Python<'py>,
+        incident_fluence_weights: PyReadonlyArray1<f64>,
+        transmission: PyReadonlyArray1<f64>,
+    ) -> PyResult<(Bound<'py, PyArray1<f64>>, Bound<'py, PyArray1<f64>>)> {
+        let result = self
+            .inner
+            .apply(
+                incident_fluence_weights.as_slice()?,
+                transmission.as_slice()?,
+            )
+            .map_err(|error| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "detector response application: {error}"
+                ))
+            })?;
+        Ok((
+            PyArray1::from_vec(py, result.open_beam),
+            PyArray1::from_vec(py, result.sample),
+        ))
+    }
+
+    /// Combine consecutive true-energy rows into exact quadrature cells.
+    fn collapse_true_energy_groups(
+        &self,
+        quadrature_weights: PyReadonlyArray1<f64>,
+        group_size: usize,
+    ) -> PyResult<Self> {
+        let inner = self
+            .inner
+            .collapse_true_energy_groups(quadrature_weights.as_slice()?, group_size)
+            .map_err(|error| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "collapse detector response groups: {error}"
+                ))
+            })?;
+        Ok(Self { inner })
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "DetectorResponseMatrix(n_true_energies={}, n_detector_bins={}, nnz={})",
+            self.inner.n_true_energies(),
+            self.inner.n_detector_bins(),
+            self.inner.nnz(),
+        )
+    }
 }
 
 /// Python result for a fixed-signal, measured-template count-background fit.
@@ -4492,6 +4695,7 @@ fn nereids(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyTabulatedResolution>()?;
     m.add_class::<PyEnergyLaw>()?;
     m.add_class::<PyIkedaCarpenter>()?;
+    m.add_class::<PyDetectorResponseMatrix>()?;
     m.add_class::<PyTwoArmBackgroundFitResult>()?;
     m.add_class::<PyResolutionCalibration>()?;
     m.add_class::<PySpatialResult>()?;
@@ -5998,6 +6202,10 @@ fn py_fit_counts_spectrum_typed<'py>(
         baseline: result.baseline,
         baseline_e_ref_ev: result.baseline_e_ref_ev,
         warnings: result.warnings,
+        prediction_energies_ev: result.prediction_energies_ev,
+        signal_prediction: result.signal_prediction,
+        background_prediction: result.background_prediction,
+        model_prediction: result.model_prediction,
     })
 }
 
@@ -6703,5 +6911,9 @@ fn py_fit_spectrum_typed<'py>(
         baseline: result.baseline,
         baseline_e_ref_ev: result.baseline_e_ref_ev,
         warnings: result.warnings,
+        prediction_energies_ev: result.prediction_energies_ev,
+        signal_prediction: result.signal_prediction,
+        background_prediction: result.background_prediction,
+        model_prediction: result.model_prediction,
     })
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -869,6 +869,20 @@ impl PyIkedaCarpenter {
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
+    /// Probability that a neutron at one true energy is recorded in each
+    /// adjacent detector-time bin. The result is not renormalized when the
+    /// supplied time window omits part of the pulse.
+    fn detector_bin_probabilities(
+        &self,
+        true_energy_ev: f64,
+        detector_time_edges_us: Vec<f64>,
+        timing_offset_us: f64,
+    ) -> PyResult<Vec<f64>> {
+        self.inner
+            .detector_bin_probabilities(true_energy_ev, &detector_time_edges_us, timing_offset_us)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+    }
+
     /// Flight path length in meters.
     #[getter]
     fn flight_path_m(&self) -> f64 {

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -2354,6 +2354,229 @@ fn py_two_arm_count_response<'py>(
     ))
 }
 
+/// Python result for a fixed-signal, measured-template count-background fit.
+#[pyclass(name = "TwoArmBackgroundFitResult")]
+struct PyTwoArmBackgroundFitResult {
+    names: Vec<String>,
+    amplitudes: Vec<f64>,
+    amplitude_uncertainties: Option<Vec<f64>>,
+    amplitudes_identifiable: bool,
+    open_neutron_signal: Vec<f64>,
+    open_background: Vec<f64>,
+    open_total: Vec<f64>,
+    sample_neutron_signal: Vec<f64>,
+    sample_background: Vec<f64>,
+    sample_total: Vec<f64>,
+    poisson_deviance: f64,
+    deviance_per_dof: f64,
+    converged: bool,
+    iterations: usize,
+}
+
+#[pymethods]
+impl PyTwoArmBackgroundFitResult {
+    #[getter]
+    fn names(&self) -> Vec<String> {
+        self.names.clone()
+    }
+
+    #[getter]
+    fn amplitudes<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        PyArray1::from_vec(py, self.amplitudes.clone())
+    }
+
+    #[getter]
+    fn amplitude_uncertainties<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        PyArray1::from_vec(
+            py,
+            self.amplitude_uncertainties
+                .clone()
+                .unwrap_or_else(|| vec![f64::NAN; self.amplitudes.len()]),
+        )
+    }
+
+    #[getter]
+    fn amplitudes_identifiable(&self) -> bool {
+        self.amplitudes_identifiable
+    }
+
+    #[getter]
+    fn open_neutron_signal<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        PyArray1::from_vec(py, self.open_neutron_signal.clone())
+    }
+
+    #[getter]
+    fn open_background<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        PyArray1::from_vec(py, self.open_background.clone())
+    }
+
+    #[getter]
+    fn open_total<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        PyArray1::from_vec(py, self.open_total.clone())
+    }
+
+    #[getter]
+    fn sample_neutron_signal<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        PyArray1::from_vec(py, self.sample_neutron_signal.clone())
+    }
+
+    #[getter]
+    fn sample_background<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        PyArray1::from_vec(py, self.sample_background.clone())
+    }
+
+    #[getter]
+    fn sample_total<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        PyArray1::from_vec(py, self.sample_total.clone())
+    }
+
+    #[getter]
+    fn poisson_deviance(&self) -> f64 {
+        self.poisson_deviance
+    }
+
+    #[getter]
+    fn deviance_per_dof(&self) -> f64 {
+        self.deviance_per_dof
+    }
+
+    #[getter]
+    fn converged(&self) -> bool {
+        self.converged
+    }
+
+    #[getter]
+    fn iterations(&self) -> usize {
+        self.iterations
+    }
+}
+
+/// Fit non-negative amplitudes for independently measured count backgrounds.
+///
+/// Each row of the two template matrices is one named component. Templates
+/// must already be normalized into the detector bins of the corresponding
+/// complete acquisition. Only amplitudes are fitted; shapes and neutron
+/// signals remain fixed. The two required exposure scales convert the common
+/// reference signal into expected counts for each complete acquisition.
+#[pyfunction]
+#[pyo3(signature = (
+    observed_open_counts,
+    observed_sample_counts,
+    open_neutron_signal,
+    sample_neutron_signal,
+    open_exposure_scale,
+    sample_exposure_scale,
+    template_names,
+    open_background_templates,
+    sample_background_templates,
+    initial_amplitudes,
+    max_iter = 200,
+))]
+#[allow(clippy::too_many_arguments)]
+fn fit_two_arm_background_templates<'py>(
+    py: Python<'py>,
+    observed_open_counts: PyReadonlyArray1<'py, f64>,
+    observed_sample_counts: PyReadonlyArray1<'py, f64>,
+    open_neutron_signal: PyReadonlyArray1<'py, f64>,
+    sample_neutron_signal: PyReadonlyArray1<'py, f64>,
+    open_exposure_scale: f64,
+    sample_exposure_scale: f64,
+    template_names: Vec<String>,
+    open_background_templates: PyReadonlyArray2<'py, f64>,
+    sample_background_templates: PyReadonlyArray2<'py, f64>,
+    initial_amplitudes: PyReadonlyArray1<'py, f64>,
+    max_iter: usize,
+) -> PyResult<PyTwoArmBackgroundFitResult> {
+    use nereids_fitting::count_background::{
+        TwoArmBackgroundTemplate, fit_two_arm_background_templates as rust_fit_background,
+    };
+    use nereids_fitting::poisson::PoissonConfig;
+    use nereids_physics::counts_response::TwoArmCounts;
+
+    let open_template_array = open_background_templates.as_array();
+    let sample_template_array = sample_background_templates.as_array();
+    let open_shape = open_template_array.shape();
+    let sample_shape = sample_template_array.shape();
+    if open_shape != sample_shape {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "open_background_templates shape {:?} must match sample_background_templates shape {:?}",
+            open_shape, sample_shape
+        )));
+    }
+    if template_names.len() != open_shape[0] {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "template_names length ({}) must match template rows ({})",
+            template_names.len(),
+            open_shape[0]
+        )));
+    }
+    let initial = initial_amplitudes.as_slice()?.to_vec();
+    if initial.len() != open_shape[0] {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "initial_amplitudes length ({}) must match template rows ({})",
+            initial.len(),
+            open_shape[0]
+        )));
+    }
+
+    let templates: Vec<TwoArmBackgroundTemplate> = template_names
+        .into_iter()
+        .zip(open_template_array.outer_iter())
+        .zip(sample_template_array.outer_iter())
+        .map(|((name, open_beam), sample)| TwoArmBackgroundTemplate {
+            name,
+            open_beam: open_beam.to_vec(),
+            sample: sample.to_vec(),
+        })
+        .collect();
+    let observed = TwoArmCounts {
+        open_beam: observed_open_counts.as_slice()?.to_vec(),
+        sample: observed_sample_counts.as_slice()?.to_vec(),
+    };
+    let signal = TwoArmCounts {
+        open_beam: open_neutron_signal.as_slice()?.to_vec(),
+        sample: sample_neutron_signal.as_slice()?.to_vec(),
+    };
+    let config = PoissonConfig {
+        max_iter,
+        ..PoissonConfig::default()
+    };
+    let result = py.detach(move || {
+        rust_fit_background(
+            &observed,
+            signal,
+            open_exposure_scale,
+            sample_exposure_scale,
+            &templates,
+            &initial,
+            &config,
+        )
+    });
+    let result = result.map_err(|error| match error {
+        nereids_fitting::error::FittingError::EvaluationFailed(_) => {
+            pyo3::exceptions::PyRuntimeError::new_err(error.to_string())
+        }
+        _ => pyo3::exceptions::PyValueError::new_err(error.to_string()),
+    })?;
+
+    Ok(PyTwoArmBackgroundFitResult {
+        names: result.names,
+        amplitudes: result.amplitudes,
+        amplitude_uncertainties: result.amplitude_uncertainties,
+        amplitudes_identifiable: result.amplitudes_identifiable,
+        open_neutron_signal: result.prediction.open_beam.neutron_signal,
+        open_background: result.prediction.open_beam.background,
+        open_total: result.prediction.open_beam.total,
+        sample_neutron_signal: result.prediction.sample.neutron_signal,
+        sample_background: result.prediction.sample.background,
+        sample_total: result.prediction.sample.total,
+        poisson_deviance: result.poisson_deviance,
+        deviance_per_dof: result.deviance_per_dof,
+        converged: result.converged,
+        iterations: result.iterations,
+    })
+}
+
 /// Parse a Python-facing pixel-value policy string.
 ///
 /// Accepted values: ``"reject"`` (default — negative or non-finite pixels
@@ -4264,6 +4487,7 @@ fn nereids(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyTabulatedResolution>()?;
     m.add_class::<PyEnergyLaw>()?;
     m.add_class::<PyIkedaCarpenter>()?;
+    m.add_class::<PyTwoArmBackgroundFitResult>()?;
     m.add_class::<PyResolutionCalibration>()?;
     m.add_class::<PySpatialResult>()?;
     m.add_class::<PyTraceDetectabilityReport>()?;
@@ -4281,6 +4505,7 @@ fn nereids(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(load_resolution, m)?)?;
     m.add_function(wrap_pyfunction!(py_apply_resolution, m)?)?;
     m.add_function(wrap_pyfunction!(py_two_arm_count_response, m)?)?;
+    m.add_function(wrap_pyfunction!(fit_two_arm_background_templates, m)?)?;
     m.add_function(wrap_pyfunction!(load_tiff_stack, m)?)?;
     m.add_function(wrap_pyfunction!(load_tiff_folder, m)?)?;
     m.add_function(wrap_pyfunction!(read_tof_sidecar, m)?)?;
@@ -5263,11 +5488,17 @@ fn py_spatial_map_typed<'py>(
 ///     temperature_k: Sample temperature in Kelvin (default 293.6).
 ///     fit_temperature: Whether to fit temperature (default False).
 ///     max_iter: Maximum iterations (default 200).
-///     solver: "lm" (default), "kl", or "auto".
-///     background: Enable transmission-lift background inside the counts fit.
-///     detector_background: Optional detector/counts background reference.
-///     fit_alpha_1: Fit flux-scale nuisance parameter `alpha_1`.
-///     fit_alpha_2: Fit detector-background scale nuisance parameter `alpha_2`.
+///     solver: "auto" (default), "kl", "poisson", "joint_poisson", or "lm".
+///     background: Enable the SAMMY-style transmission background inside the
+///         counts likelihood. This is not detector-count background.
+///     detector_background: Reserved detector/counts background reference.
+///         Production fitting currently rejects every non-zero value; use
+///         `fit_two_arm_background_templates` against a fixed exact two-arm
+///         neutron signal instead.
+///     fit_alpha_1: Research-only flux-scale parameter; rejected by production
+///         counts fitting.
+///     fit_alpha_2: Research-only detector-background scale; rejected by
+///         production counts fitting.
 ///     alpha_1_init: Initial value for `alpha_1` (default 1.0).
 ///     alpha_2_init: Initial value for `alpha_2` (default 1.0).
 ///     resolution: Optional resolution function.

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -55,6 +55,7 @@ use nereids_fitting::resolution_calib::{
 };
 use nereids_io::normalization::{self as norm, NormalizationParams};
 use nereids_io::tof::BeamlineParams;
+use nereids_physics::counts_response;
 use nereids_physics::doppler::{self, DopplerParams};
 use nereids_physics::ikeda_carpenter::{
     EnergyLaw, IkedaCarpenter, IkedaCarpenterParams, SynthesisGrid,
@@ -2296,6 +2297,63 @@ fn py_apply_resolution<'py>(
     Ok(PyArray1::from_vec(py, result))
 }
 
+/// Predict separate open-beam and sample counts on actual detector-time bins.
+///
+/// ``incident_fluence_weights[j]`` is the incident flux density at true energy
+/// ``j`` multiplied by the caller's energy-integration weight. The response is
+/// applied to the open and attenuated sample arms separately; this function
+/// never broadens a transmission ratio.
+#[pyfunction]
+#[pyo3(name = "two_arm_count_response", signature = (
+    true_energies_ev,
+    incident_fluence_weights,
+    transmission,
+    detector_time_edges_us,
+    resolution,
+    timing_offset_us = 0.0,
+))]
+fn py_two_arm_count_response<'py>(
+    py: Python<'py>,
+    true_energies_ev: PyReadonlyArray1<f64>,
+    incident_fluence_weights: PyReadonlyArray1<f64>,
+    transmission: PyReadonlyArray1<f64>,
+    detector_time_edges_us: PyReadonlyArray1<f64>,
+    resolution: &Bound<'_, PyAny>,
+    timing_offset_us: f64,
+) -> PyResult<(Bound<'py, PyArray1<f64>>, Bound<'py, PyArray1<f64>>)> {
+    let response = if let Ok(tabulated) = resolution.extract::<PyRef<'_, PyTabulatedResolution>>() {
+        ResolutionFunction::Tabulated(Arc::clone(&tabulated.inner))
+    } else if let Ok(ic) = resolution.extract::<PyRef<'_, PyIkedaCarpenter>>() {
+        ResolutionFunction::IkedaCarpenter(Arc::clone(&ic.inner))
+    } else {
+        return Err(pyo3::exceptions::PyTypeError::new_err(
+            "resolution must be a TabulatedResolution or IkedaCarpenter",
+        ));
+    };
+
+    let energies = true_energies_ev.as_slice()?.to_vec();
+    let fluence = incident_fluence_weights.as_slice()?.to_vec();
+    let transmission = transmission.as_slice()?.to_vec();
+    let detector_edges = detector_time_edges_us.as_slice()?.to_vec();
+    let result = py.detach(move || {
+        counts_response::two_arm_count_response(
+            &energies,
+            &fluence,
+            &transmission,
+            &detector_edges,
+            timing_offset_us,
+            &response,
+        )
+    });
+    let result = result.map_err(|error| {
+        pyo3::exceptions::PyValueError::new_err(format!("two-arm count response: {error}"))
+    })?;
+    Ok((
+        PyArray1::from_vec(py, result.open_beam),
+        PyArray1::from_vec(py, result.sample),
+    ))
+}
+
 /// Parse a Python-facing pixel-value policy string.
 ///
 /// Accepted values: ``"reject"`` (default — negative or non-finite pixels
@@ -4222,6 +4280,7 @@ fn nereids(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(resolution_broaden, m)?)?;
     m.add_function(wrap_pyfunction!(load_resolution, m)?)?;
     m.add_function(wrap_pyfunction!(py_apply_resolution, m)?)?;
+    m.add_function(wrap_pyfunction!(py_two_arm_count_response, m)?)?;
     m.add_function(wrap_pyfunction!(load_tiff_stack, m)?)?;
     m.add_function(wrap_pyfunction!(load_tiff_folder, m)?)?;
     m.add_function(wrap_pyfunction!(read_tof_sidecar, m)?)?;

--- a/crates/nereids-fitting/src/count_background.rs
+++ b/crates/nereids-fitting/src/count_background.rs
@@ -1,0 +1,775 @@
+//! Non-negative additive background templates for two-arm count measurements.
+//!
+//! The neutron signal is evaluated before entering this module. A background
+//! template is an expected detector-bin shape from an independent source such
+//! as a blocked-beam or detector-only measurement. Its fitted amplitude is
+//! non-negative, and the background is added after the neutron response.
+//!
+//! This module deliberately provides no smooth-curve generator. Fitting a
+//! flexible curve to the same residual it is meant to explain would not
+//! identify a physical background. The SAMMY transmission-level background is
+//! also a separate model with different placement and meaning.
+
+use std::collections::HashSet;
+
+use nereids_physics::counts_response::{
+    TwoArmCountPrediction, TwoArmCounts, add_count_backgrounds,
+};
+
+use crate::error::FittingError;
+use crate::lm::{FlatMatrix, invert_matrix};
+use crate::poisson::PoissonConfig;
+
+/// One independently supplied detector-bin background shape.
+///
+/// A single non-negative amplitude multiplies both arms. For a component that
+/// exists in only one acquisition, supply zeros for the other arm. Arrays are
+/// counts per unit amplitude, already normalized to the corresponding run.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TwoArmBackgroundTemplate {
+    /// Stable component name retained in fit output.
+    pub name: String,
+    /// Open-beam background counts per unit amplitude.
+    pub open_beam: Vec<f64>,
+    /// Sample background counts per unit amplitude.
+    pub sample: Vec<f64>,
+}
+
+/// Result of fitting fixed neutron signals plus background templates.
+#[derive(Debug, Clone)]
+pub struct TwoArmBackgroundFitResult {
+    /// Component names in the same order as `amplitudes`.
+    pub names: Vec<String>,
+    /// Fitted non-negative template amplitudes.
+    pub amplitudes: Vec<f64>,
+    /// Local one-sigma amplitude uncertainties, when available.
+    pub amplitude_uncertainties: Option<Vec<f64>>,
+    /// Whether every named template amplitude is separately determined.
+    ///
+    /// `false` means that at least two supplied shapes are linearly dependent:
+    /// the total fitted background can be valid, but the individual amplitudes
+    /// are not physically interpretable. In that case uncertainties are not
+    /// reported.
+    pub amplitudes_identifiable: bool,
+    /// Neutron signal, fitted background, and total for both arms.
+    pub prediction: TwoArmCountPrediction,
+    /// Poisson deviance for the concatenated open and sample arrays.
+    pub poisson_deviance: f64,
+    /// Deviance divided by `2 * n_bins - template_rank`.
+    pub deviance_per_dof: f64,
+    /// Whether the bounded optimizer converged.
+    pub converged: bool,
+    /// Optimizer iterations.
+    pub iterations: usize,
+}
+
+/// Fit amplitudes of independently supplied detector-bin templates.
+///
+/// The neutron signal and every template shape remain fixed. This tests
+/// whether an independently chosen shape explains the counts, but cannot prove
+/// its provenance; callers must retain the independent measurement record.
+pub fn fit_two_arm_background_templates(
+    observed: &TwoArmCounts,
+    neutron_signal: TwoArmCounts,
+    open_exposure_scale: f64,
+    sample_exposure_scale: f64,
+    templates: &[TwoArmBackgroundTemplate],
+    initial_amplitudes: &[f64],
+    config: &PoissonConfig,
+) -> Result<TwoArmBackgroundFitResult, FittingError> {
+    validate_fit_inputs(
+        observed,
+        &neutron_signal,
+        open_exposure_scale,
+        sample_exposure_scale,
+        templates,
+        initial_amplitudes,
+    )?;
+    let neutron_signal =
+        scale_neutron_signal(neutron_signal, open_exposure_scale, sample_exposure_scale)?;
+    let n_bins = observed.open_beam.len();
+    let mut observed_joined = Vec::with_capacity(2 * n_bins);
+    observed_joined.extend_from_slice(&observed.open_beam);
+    observed_joined.extend_from_slice(&observed.sample);
+
+    // Fit a contribution measured in counts, rather than the caller's
+    // arbitrary template units.  Without this normalization, multiplying a
+    // template by (say) 1e-8 and its amplitude by 1e8 changes the optimizer's
+    // stopping test even though the physical prediction is unchanged.
+    let (normalized_templates, template_scales) = normalize_templates(templates);
+    let normalized_initial_amplitudes: Vec<f64> = initial_amplitudes
+        .iter()
+        .zip(&template_scales)
+        .map(|(&amplitude, &scale)| amplitude * scale)
+        .collect();
+    if normalized_initial_amplitudes
+        .iter()
+        .any(|value| !value.is_finite())
+    {
+        return Err(FittingError::InvalidConfig(
+            "initial amplitude times template scale must be finite".into(),
+        ));
+    }
+
+    let mut neutron_joined = Vec::with_capacity(2 * n_bins);
+    neutron_joined.extend_from_slice(&neutron_signal.open_beam);
+    neutron_joined.extend_from_slice(&neutron_signal.sample);
+    let normalized_basis: Vec<Vec<f64>> = normalized_templates
+        .iter()
+        .map(|template| {
+            let mut joined = Vec::with_capacity(2 * n_bins);
+            joined.extend_from_slice(&template.open_beam);
+            joined.extend_from_slice(&template.sample);
+            joined
+        })
+        .collect();
+    let template_rank = background_template_rank(&normalized_basis);
+    let amplitudes_identifiable = template_rank == normalized_basis.len();
+    let fit = fit_non_negative_poisson_linear(
+        &observed_joined,
+        &neutron_joined,
+        &normalized_basis,
+        &normalized_initial_amplitudes,
+        config,
+    )?;
+
+    let amplitudes: Vec<f64> = fit
+        .amplitudes
+        .iter()
+        .zip(&template_scales)
+        .map(|(&normalized_amplitude, &scale)| normalized_amplitude / scale)
+        .collect();
+    if amplitudes.iter().any(|amplitude| !amplitude.is_finite()) {
+        return Err(FittingError::EvaluationFailed(
+            "a fitted amplitude cannot be represented in the supplied template units; rescale the template counts"
+                .into(),
+        ));
+    }
+    let amplitude_uncertainties = amplitudes_identifiable
+        .then(|| {
+            fit.uncertainties.map(|uncertainties| {
+                uncertainties
+                    .iter()
+                    .zip(&template_scales)
+                    .map(|(&uncertainty, &scale)| {
+                        let caller_units = uncertainty / scale;
+                        if caller_units.is_finite() && caller_units > 0.0 {
+                            caller_units
+                        } else {
+                            f64::NAN
+                        }
+                    })
+                    .collect()
+            })
+        })
+        .flatten();
+
+    let mut open_background = vec![0.0; n_bins];
+    let mut sample_background = vec![0.0; n_bins];
+    for (&amplitude, template) in fit.amplitudes.iter().zip(&normalized_templates) {
+        add_scaled(&mut open_background, &template.open_beam, amplitude);
+        add_scaled(&mut sample_background, &template.sample, amplitude);
+    }
+    let prediction = add_count_backgrounds(neutron_signal, &open_background, &sample_background)
+        .map_err(|error| FittingError::EvaluationFailed(error.to_string()))?;
+    let mut predicted_joined = Vec::with_capacity(2 * n_bins);
+    predicted_joined.extend_from_slice(&prediction.open_beam.total);
+    predicted_joined.extend_from_slice(&prediction.sample.total);
+    let poisson_deviance = poisson_deviance(&observed_joined, &predicted_joined);
+    // Dependent shapes add only `rank` independent fitted directions. Counting
+    // every named row would understate the degrees of freedom.
+    let dof = 2 * n_bins - template_rank;
+
+    Ok(TwoArmBackgroundFitResult {
+        names: templates
+            .iter()
+            .map(|template| template.name.clone())
+            .collect(),
+        amplitudes,
+        amplitude_uncertainties,
+        amplitudes_identifiable,
+        prediction,
+        poisson_deviance,
+        deviance_per_dof: poisson_deviance / dof as f64,
+        converged: fit.converged,
+        iterations: fit.iterations,
+    })
+}
+
+fn scale_neutron_signal(
+    mut signal: TwoArmCounts,
+    open_exposure_scale: f64,
+    sample_exposure_scale: f64,
+) -> Result<TwoArmCounts, FittingError> {
+    for value in &mut signal.open_beam {
+        *value *= open_exposure_scale;
+    }
+    for value in &mut signal.sample {
+        *value *= sample_exposure_scale;
+    }
+    if signal
+        .open_beam
+        .iter()
+        .chain(&signal.sample)
+        .any(|value| !value.is_finite())
+    {
+        return Err(FittingError::InvalidConfig(
+            "exposure-scaled neutron signal must remain finite; rescale the reference signal"
+                .into(),
+        ));
+    }
+    Ok(signal)
+}
+
+struct LinearPoissonFit {
+    amplitudes: Vec<f64>,
+    uncertainties: Option<Vec<f64>>,
+    converged: bool,
+    iterations: usize,
+}
+
+/// Minimize the exact count likelihood for a non-negative linear background.
+///
+/// With fixed neutron counts `s`, fixed non-negative templates `B`, and
+/// non-negative amplitudes `a`, the expectation is `mu = s + B a`. Its
+/// Poisson objective is convex. Each coordinate therefore has one bounded
+/// minimum, found here from the analytical derivative. Repeated coordinate
+/// minimization converges to the joint constrained minimum.
+fn fit_non_negative_poisson_linear(
+    observed: &[f64],
+    neutron_signal: &[f64],
+    basis: &[Vec<f64>],
+    initial_amplitudes: &[f64],
+    config: &PoissonConfig,
+) -> Result<LinearPoissonFit, FittingError> {
+    let mut amplitudes = initial_amplitudes.to_vec();
+    for (amplitude, template) in amplitudes.iter_mut().zip(basis) {
+        let upper = amplitude_upper_bound(observed, template)?;
+        *amplitude = amplitude.min(upper);
+    }
+    let mut converged = false;
+    let mut iterations = 0;
+
+    for iteration in 0..config.max_iter {
+        for component in 0..basis.len() {
+            let base =
+                linear_prediction_without_component(neutron_signal, basis, &amplitudes, component)?;
+            amplitudes[component] =
+                coordinate_minimum(observed, &base, &basis[component], amplitudes[component])?;
+        }
+        iterations = iteration + 1;
+
+        let prediction = linear_prediction(neutron_signal, basis, &amplitudes)?;
+        let maximum_violation = basis
+            .iter()
+            .enumerate()
+            .map(|(component, template)| {
+                let gradient = poisson_coordinate_gradient(observed, &prediction, template);
+                let violation = if amplitudes[component] == 0.0 {
+                    (-gradient).max(0.0)
+                } else {
+                    gradient.abs()
+                };
+                violation / template.iter().sum::<f64>()
+            })
+            .fold(0.0_f64, f64::max);
+        if maximum_violation <= config.tol_param {
+            converged = true;
+            break;
+        }
+    }
+
+    let prediction = linear_prediction(neutron_signal, basis, &amplitudes)?;
+    let uncertainties = if converged && config.compute_covariance {
+        poisson_linear_uncertainties(observed, &prediction, basis)
+    } else {
+        None
+    };
+    Ok(LinearPoissonFit {
+        amplitudes,
+        uncertainties,
+        converged,
+        iterations,
+    })
+}
+
+fn coordinate_minimum(
+    observed: &[f64],
+    base: &[f64],
+    template: &[f64],
+    initial: f64,
+) -> Result<f64, FittingError> {
+    let gradient_at_zero = poisson_coordinate_gradient_at(observed, base, template, 0.0);
+    if gradient_at_zero >= 0.0 {
+        return Ok(0.0);
+    }
+
+    // For base >= 0, this is a mathematical upper bound on the root:
+    // b*y/(base+x*b) <= y/x for every bin with b>0.
+    let mut upper = amplitude_upper_bound(observed, template)?;
+    if upper <= 0.0 {
+        return Err(FittingError::EvaluationFailed(
+            "could not form a finite upper bound for a background amplitude".into(),
+        ));
+    }
+    let mut lower = 0.0;
+    let mut value = initial.clamp(lower, upper);
+
+    // Safeguarded Newton solves the monotone analytical derivative. The
+    // bracket makes the result deterministic at a zero boundary and across
+    // large changes in curvature.
+    for _ in 0..80 {
+        let (gradient, curvature) =
+            poisson_coordinate_gradient_and_curvature_at(observed, base, template, value);
+        if gradient == 0.0 {
+            return Ok(value);
+        }
+        if gradient < 0.0 {
+            lower = value;
+        } else {
+            upper = value;
+        }
+        let newton = value - gradient / curvature;
+        let next = if curvature.is_finite()
+            && curvature > 0.0
+            && newton.is_finite()
+            && newton > lower
+            && newton < upper
+        {
+            newton
+        } else {
+            lower + 0.5 * (upper - lower)
+        };
+        if next == value {
+            return Ok(next);
+        }
+        value = next;
+    }
+    Ok(value)
+}
+
+/// A finite upper bound for one normalized template amplitude.
+///
+/// Dividing two direct sums can overflow even when their ratio is finite
+/// (for example, two observations near `f64::MAX`). Scaling the numerator by
+/// its largest supported observation computes the same ratio without that
+/// intermediate overflow.
+fn amplitude_upper_bound(observed: &[f64], template: &[f64]) -> Result<f64, FittingError> {
+    let maximum_observed = observed
+        .iter()
+        .zip(template)
+        .filter_map(|(&count, &weight)| (weight > 0.0).then_some(count))
+        .fold(0.0_f64, f64::max);
+    if maximum_observed == 0.0 {
+        return Ok(0.0);
+    }
+    let scaled_observed_sum: f64 = observed
+        .iter()
+        .zip(template)
+        .filter_map(|(&count, &weight)| (weight > 0.0).then_some(count / maximum_observed))
+        .sum();
+    let template_sum: f64 = template.iter().sum();
+    let upper = maximum_observed * (scaled_observed_sum / template_sum);
+    if upper.is_finite() {
+        Ok(upper)
+    } else {
+        Err(FittingError::EvaluationFailed(
+            "could not form a finite upper bound for a background amplitude".into(),
+        ))
+    }
+}
+
+fn linear_prediction_without_component(
+    neutron_signal: &[f64],
+    basis: &[Vec<f64>],
+    amplitudes: &[f64],
+    excluded: usize,
+) -> Result<Vec<f64>, FittingError> {
+    let mut prediction = neutron_signal.to_vec();
+    for (component, (&amplitude, template)) in amplitudes.iter().zip(basis).enumerate() {
+        if component != excluded {
+            add_scaled(&mut prediction, template, amplitude);
+        }
+    }
+    validate_linear_prediction(&prediction)?;
+    Ok(prediction)
+}
+
+fn linear_prediction(
+    neutron_signal: &[f64],
+    basis: &[Vec<f64>],
+    amplitudes: &[f64],
+) -> Result<Vec<f64>, FittingError> {
+    let mut prediction = neutron_signal.to_vec();
+    for (&amplitude, template) in amplitudes.iter().zip(basis) {
+        add_scaled(&mut prediction, template, amplitude);
+    }
+    validate_linear_prediction(&prediction)?;
+    Ok(prediction)
+}
+
+fn validate_linear_prediction(prediction: &[f64]) -> Result<(), FittingError> {
+    if prediction.iter().any(|value| !value.is_finite()) {
+        return Err(FittingError::EvaluationFailed(
+            "background fit produced non-finite expected counts".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn poisson_coordinate_gradient(observed: &[f64], prediction: &[f64], template: &[f64]) -> f64 {
+    observed
+        .iter()
+        .zip(prediction)
+        .zip(template)
+        .filter(|&((_, _), &weight)| weight > 0.0)
+        .map(|((&count, &expected), &weight)| {
+            weight - weighted_count_ratio(weight, count, expected)
+        })
+        .sum()
+}
+
+fn poisson_coordinate_gradient_at(
+    observed: &[f64],
+    base: &[f64],
+    template: &[f64],
+    amplitude: f64,
+) -> f64 {
+    poisson_coordinate_gradient_and_curvature_at(observed, base, template, amplitude).0
+}
+
+fn poisson_coordinate_gradient_and_curvature_at(
+    observed: &[f64],
+    base: &[f64],
+    template: &[f64],
+    amplitude: f64,
+) -> (f64, f64) {
+    observed.iter().zip(base).zip(template).fold(
+        (0.0, 0.0),
+        |(gradient, curvature), ((&count, &base_count), &weight)| {
+            if weight == 0.0 {
+                return (gradient, curvature);
+            }
+            let expected = base_count + amplitude * weight;
+            let weighted_ratio = weighted_count_ratio(weight, count, expected);
+            let curvature_term = if count == 0.0 {
+                0.0
+            } else {
+                (weight / expected) * weighted_ratio
+            };
+            (
+                gradient + weight - weighted_ratio,
+                curvature + curvature_term,
+            )
+        },
+    )
+}
+
+/// Compute `weight * count / expected` without avoidable intermediate
+/// overflow. Exact zero observations contribute zero; a positive observation
+/// with zero expectation contributes infinity, as required by Poisson counts.
+fn weighted_count_ratio(weight: f64, count: f64, expected: f64) -> f64 {
+    if weight == 0.0 || count == 0.0 {
+        0.0
+    } else if weight <= expected {
+        count * (weight / expected)
+    } else {
+        weight * (count / expected)
+    }
+}
+
+fn poisson_linear_uncertainties(
+    observed: &[f64],
+    prediction: &[f64],
+    basis: &[Vec<f64>],
+) -> Option<Vec<f64>> {
+    let mut fisher = FlatMatrix::zeros(basis.len(), basis.len());
+    for row in 0..basis.len() {
+        for column in 0..basis.len() {
+            *fisher.get_mut(row, column) = observed
+                .iter()
+                .zip(prediction)
+                .enumerate()
+                .map(|(bin, (&count, &expected))| {
+                    let left = basis[row][bin];
+                    let right = basis[column][bin];
+                    if left == 0.0 || right == 0.0 || count == 0.0 {
+                        0.0
+                    } else {
+                        (left / expected) * weighted_count_ratio(right, count, expected)
+                    }
+                })
+                .sum();
+        }
+    }
+    invert_matrix(&fisher).map(|covariance| {
+        (0..basis.len())
+            .map(|index| {
+                let variance = covariance.get(index, index);
+                if variance.is_finite() && variance > 0.0 {
+                    variance.sqrt()
+                } else {
+                    f64::NAN
+                }
+            })
+            .collect()
+    })
+}
+
+fn normalize_templates(
+    templates: &[TwoArmBackgroundTemplate],
+) -> (Vec<TwoArmBackgroundTemplate>, Vec<f64>) {
+    let scales: Vec<f64> = templates
+        .iter()
+        .map(|template| {
+            template
+                .open_beam
+                .iter()
+                .chain(&template.sample)
+                .copied()
+                .fold(0.0_f64, f64::max)
+        })
+        .collect();
+    let normalized = templates
+        .iter()
+        .zip(&scales)
+        .map(|(template, &scale)| TwoArmBackgroundTemplate {
+            name: template.name.clone(),
+            open_beam: template
+                .open_beam
+                .iter()
+                .map(|value| value / scale)
+                .collect(),
+            sample: template.sample.iter().map(|value| value / scale).collect(),
+        })
+        .collect();
+    (normalized, scales)
+}
+
+/// Number of linearly independent concatenated open/sample shapes.
+///
+/// Templates are first normalized to a maximum entry of one, so this test is
+/// independent of the caller's amplitude units. The tolerance identifies only
+/// dependence at floating-point resolution; it does not claim that two nearly
+/// similar shapes can be separated in noisy data. That practical question is
+/// handled by the later parameter-separation analysis.
+fn background_template_rank(basis: &[Vec<f64>]) -> usize {
+    let n_rows = basis.first().map_or(0, Vec::len);
+    let dimension = n_rows.max(basis.len()) as f64;
+    let tolerance = f64::EPSILON * dimension * (n_rows as f64).sqrt();
+    let mut orthonormal: Vec<Vec<f64>> = Vec::with_capacity(basis.len());
+
+    for column in basis {
+        let mut residual = column.clone();
+        // A second pass makes the result stable when several earlier columns
+        // are close to one another.
+        for _ in 0..2 {
+            for direction in &orthonormal {
+                let projection: f64 = residual.iter().zip(direction).map(|(a, b)| a * b).sum();
+                for (value, &unit_value) in residual.iter_mut().zip(direction) {
+                    *value -= projection * unit_value;
+                }
+            }
+        }
+        let norm = residual
+            .iter()
+            .map(|value| value * value)
+            .sum::<f64>()
+            .sqrt();
+        if norm > tolerance {
+            for value in &mut residual {
+                *value /= norm;
+            }
+            orthonormal.push(residual);
+        }
+    }
+    orthonormal.len()
+}
+
+fn add_scaled(output: &mut [f64], template: &[f64], amplitude: f64) {
+    for (value, &basis) in output.iter_mut().zip(template) {
+        *value += amplitude * basis;
+    }
+}
+
+fn validate_fit_inputs(
+    observed: &TwoArmCounts,
+    neutron_signal: &TwoArmCounts,
+    open_exposure_scale: f64,
+    sample_exposure_scale: f64,
+    templates: &[TwoArmBackgroundTemplate],
+    initial_amplitudes: &[f64],
+) -> Result<(), FittingError> {
+    let n_bins = observed.open_beam.len();
+    if n_bins == 0 {
+        return Err(FittingError::EmptyData);
+    }
+    for (field, actual) in [
+        ("observed_sample_counts", observed.sample.len()),
+        ("open_neutron_signal", neutron_signal.open_beam.len()),
+        ("sample_neutron_signal", neutron_signal.sample.len()),
+    ] {
+        if actual != n_bins {
+            return Err(FittingError::LengthMismatch {
+                expected: n_bins,
+                actual,
+                field,
+            });
+        }
+    }
+    if templates.is_empty() {
+        return Err(FittingError::InvalidConfig(
+            "at least one independently supplied background template is required".into(),
+        ));
+    }
+    if initial_amplitudes.len() != templates.len() {
+        return Err(FittingError::LengthMismatch {
+            expected: templates.len(),
+            actual: initial_amplitudes.len(),
+            field: "initial_amplitudes",
+        });
+    }
+    if 2 * n_bins <= templates.len() {
+        return Err(FittingError::InvalidConfig(format!(
+            "{} background amplitudes cannot be fitted from {} count values with positive degrees of freedom",
+            templates.len(),
+            2 * n_bins
+        )));
+    }
+
+    validate_non_negative("observed_open_counts", &observed.open_beam)?;
+    validate_non_negative("observed_sample_counts", &observed.sample)?;
+    validate_non_negative("open_neutron_signal", &neutron_signal.open_beam)?;
+    validate_non_negative("sample_neutron_signal", &neutron_signal.sample)?;
+    for (name, scale) in [
+        ("open_exposure_scale", open_exposure_scale),
+        ("sample_exposure_scale", sample_exposure_scale),
+    ] {
+        if !scale.is_finite() || scale <= 0.0 {
+            return Err(FittingError::InvalidConfig(format!(
+                "{name} must be finite and > 0, got {scale}"
+            )));
+        }
+    }
+
+    let mut names = HashSet::with_capacity(templates.len());
+    for (index, (template, &initial)) in templates.iter().zip(initial_amplitudes).enumerate() {
+        if template.name.trim().is_empty() {
+            return Err(FittingError::InvalidConfig(format!(
+                "background template {index} has an empty name"
+            )));
+        }
+        if !names.insert(template.name.as_str()) {
+            return Err(FittingError::InvalidConfig(format!(
+                "background template name '{}' is duplicated",
+                template.name
+            )));
+        }
+        for (field, actual) in [
+            ("open_background_template", template.open_beam.len()),
+            ("sample_background_template", template.sample.len()),
+        ] {
+            if actual != n_bins {
+                return Err(FittingError::LengthMismatch {
+                    expected: n_bins,
+                    actual,
+                    field,
+                });
+            }
+        }
+        validate_non_negative("open_background_template", &template.open_beam)?;
+        validate_non_negative("sample_background_template", &template.sample)?;
+        if !template
+            .open_beam
+            .iter()
+            .chain(&template.sample)
+            .any(|&value| value > 0.0)
+        {
+            return Err(FittingError::InvalidConfig(format!(
+                "background template '{}' is zero in both arms",
+                template.name
+            )));
+        }
+        if !initial.is_finite() || initial < 0.0 {
+            return Err(FittingError::InvalidConfig(format!(
+                "initial_amplitudes[{index}] must be finite and >= 0, got {initial}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_non_negative(field: &'static str, values: &[f64]) -> Result<(), FittingError> {
+    for (index, &value) in values.iter().enumerate() {
+        if !value.is_finite() || value < 0.0 {
+            return Err(FittingError::InvalidConfig(format!(
+                "{field}[{index}] must be finite and >= 0 expected counts, got {value}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn poisson_deviance(observed: &[f64], predicted: &[f64]) -> f64 {
+    observed
+        .iter()
+        .zip(predicted)
+        .map(|(&obs, &model)| {
+            if obs > 0.0 {
+                if model == 0.0 {
+                    return f64::INFINITY;
+                }
+                // h(r) = (1+r) ln(1+r) - r, where r=(obs-model)/model.
+                // A short series avoids subtracting nearly equal, very large
+                // numbers when the fitted and observed counts almost match.
+                let r = (obs - model) / model;
+                let deviance = if r.abs() < 1.0e-3 {
+                    let h = r
+                        * r
+                        * (0.5
+                            + r * (-1.0 / 6.0
+                                + r * (1.0 / 12.0 + r * (-1.0 / 20.0 + r * (1.0 / 30.0)))));
+                    2.0 * model * h
+                } else {
+                    // Away from equality the direct form does not suffer
+                    // cancellation.  Subtracting logarithms also avoids an
+                    // intermediate obs/model overflow or underflow.
+                    2.0 * (obs * (obs.ln() - model.ln()) - (obs - model))
+                };
+                // Each exact deviance term is non-negative.  Guard only
+                // against a final sub-ulp negative caused by floating point.
+                deviance.max(0.0)
+            } else {
+                2.0 * model
+            }
+        })
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::poisson_deviance;
+
+    #[test]
+    fn exact_zero_observation_and_prediction_have_zero_deviance() {
+        assert_eq!(poisson_deviance(&[0.0], &[0.0]), 0.0);
+        assert!(poisson_deviance(&[1.0], &[0.0]).is_infinite());
+    }
+
+    #[test]
+    fn nearly_equal_large_counts_have_non_negative_deviance() {
+        let observed = [31_415_926_535_897.0, 27_182_818_284_590.0];
+        let predicted = [31_415_926_535_896.0, 27_182_818_284_592.0];
+        let deviance = poisson_deviance(&observed, &predicted);
+        assert!(deviance.is_finite());
+        assert!(deviance >= 0.0, "deviance = {deviance}");
+    }
+
+    #[test]
+    fn extreme_finite_count_ratios_keep_finite_deviance() {
+        let low_observation = poisson_deviance(&[1.0e-200], &[1.0e200]);
+        let high_observation = poisson_deviance(&[1.0e200], &[1.0e-200]);
+        assert!(low_observation.is_finite() && low_observation >= 0.0);
+        assert!(high_observation.is_finite() && high_observation >= 0.0);
+    }
+}

--- a/crates/nereids-fitting/src/exact_count_model.rs
+++ b/crates/nereids-fitting/src/exact_count_model.rs
@@ -1,0 +1,263 @@
+//! Exact fixed-instrument model for a joint open/sample count likelihood.
+
+use nereids_core::constants::PIVOT_FLOOR;
+use nereids_physics::counts_response::DetectorBinResponseMatrix;
+
+use crate::error::FittingError;
+use crate::lm::{FitModel, FlatMatrix};
+
+/// Maps a true-energy transmission model into measured detector-bin ratios.
+///
+/// For a fixed response matrix `R` and fixed incident fluence weights `F`, the
+/// model supplied to the joint-Poisson objective is evaluated as
+///
+/// ```text
+/// T_eff,i = sum_j F_j T_j R_ij / sum_j F_j R_ij.
+/// ```
+///
+/// The open and sample arms are therefore broadened separately. This is not
+/// the invalid post-hoc shortcut `R[T]`.
+pub struct ExactTwoArmRatioModel {
+    inner: Box<dyn FitModel>,
+    weighted_response: Vec<f64>,
+    open_expectation: Vec<f64>,
+    n_true_energies: usize,
+    n_detector_bins: usize,
+}
+
+impl ExactTwoArmRatioModel {
+    /// Build the reusable fixed-response model.
+    pub fn new(
+        inner: Box<dyn FitModel>,
+        response: &DetectorBinResponseMatrix,
+        incident_fluence_weights: &[f64],
+    ) -> Result<Self, FittingError> {
+        if incident_fluence_weights.len() != response.n_true_energies() {
+            return Err(FittingError::LengthMismatch {
+                expected: response.n_true_energies(),
+                actual: incident_fluence_weights.len(),
+                field: "incident_fluence_weights",
+            });
+        }
+        for (index, &fluence) in incident_fluence_weights.iter().enumerate() {
+            if !fluence.is_finite() || fluence < 0.0 {
+                return Err(FittingError::InvalidConfig(format!(
+                    "incident_fluence_weights[{index}] must be finite and >= 0, got {fluence}"
+                )));
+            }
+        }
+        let fluence_scale = incident_fluence_weights
+            .iter()
+            .copied()
+            .fold(0.0_f64, f64::max);
+        if fluence_scale <= 0.0 {
+            return Err(FittingError::InvalidConfig(
+                "incident_fluence_weights must contain at least one positive value".into(),
+            ));
+        }
+
+        let n_true_energies = response.n_true_energies();
+        let n_detector_bins = response.n_detector_bins();
+        let mut weighted_response = vec![0.0; n_true_energies * n_detector_bins];
+        let mut open_expectation = vec![0.0; n_detector_bins];
+        let mut open_compensation = vec![0.0; n_detector_bins];
+        for (true_index, &fluence) in incident_fluence_weights.iter().enumerate() {
+            let fluence = fluence / fluence_scale;
+            for detector_bin in 0..n_detector_bins {
+                let value = fluence * response.probability(true_index, detector_bin);
+                weighted_response[true_index * n_detector_bins + detector_bin] = value;
+                compensated_add(
+                    &mut open_expectation[detector_bin],
+                    &mut open_compensation[detector_bin],
+                    value,
+                );
+            }
+        }
+        for detector_bin in 0..n_detector_bins {
+            open_expectation[detector_bin] += open_compensation[detector_bin];
+        }
+
+        Ok(Self {
+            inner,
+            weighted_response,
+            open_expectation,
+            n_true_energies,
+            n_detector_bins,
+        })
+    }
+
+    /// Expected open-arm source shape in detector-bin order.
+    pub fn open_expectation(&self) -> &[f64] {
+        &self.open_expectation
+    }
+
+    fn map_true_energy_values(&self, values: &[f64]) -> Result<Vec<f64>, FittingError> {
+        if values.len() != self.n_true_energies {
+            return Err(FittingError::LengthMismatch {
+                expected: self.n_true_energies,
+                actual: values.len(),
+                field: "true_energy_model",
+            });
+        }
+        let mut sample = vec![0.0; self.n_detector_bins];
+        let mut compensation = vec![0.0; self.n_detector_bins];
+        for (true_index, &value) in values.iter().enumerate() {
+            if !value.is_finite() {
+                return Err(FittingError::EvaluationFailed(format!(
+                    "true-energy model output[{true_index}] is not finite: {value}"
+                )));
+            }
+            for detector_bin in 0..self.n_detector_bins {
+                compensated_add(
+                    &mut sample[detector_bin],
+                    &mut compensation[detector_bin],
+                    value
+                        * self.weighted_response[true_index * self.n_detector_bins + detector_bin],
+                );
+            }
+        }
+
+        Ok(sample
+            .into_iter()
+            .zip(compensation)
+            .zip(&self.open_expectation)
+            .map(|((sum, correction), &open)| {
+                if open > PIVOT_FLOOR {
+                    (sum + correction) / open
+                } else {
+                    1.0
+                }
+            })
+            .collect())
+    }
+}
+
+impl FitModel for ExactTwoArmRatioModel {
+    fn evaluate(&self, params: &[f64]) -> Result<Vec<f64>, FittingError> {
+        let true_transmission = self.inner.evaluate(params)?;
+        self.map_true_energy_values(&true_transmission)
+    }
+
+    fn analytical_jacobian(
+        &self,
+        params: &[f64],
+        free_param_indices: &[usize],
+        _y_current: &[f64],
+    ) -> Option<FlatMatrix> {
+        let true_transmission = self.inner.evaluate(params).ok()?;
+        if true_transmission.len() != self.n_true_energies {
+            return None;
+        }
+        let inner_jacobian =
+            self.inner
+                .analytical_jacobian(params, free_param_indices, &true_transmission)?;
+        if inner_jacobian.nrows != self.n_true_energies
+            || inner_jacobian.ncols != free_param_indices.len()
+        {
+            return None;
+        }
+
+        let mut output = FlatMatrix::zeros(self.n_detector_bins, free_param_indices.len());
+        for true_index in 0..self.n_true_energies {
+            for detector_bin in 0..self.n_detector_bins {
+                let open = self.open_expectation[detector_bin];
+                if open <= PIVOT_FLOOR {
+                    continue;
+                }
+                let weight =
+                    self.weighted_response[true_index * self.n_detector_bins + detector_bin] / open;
+                for column in 0..free_param_indices.len() {
+                    *output.get_mut(detector_bin, column) +=
+                        weight * inner_jacobian.get(true_index, column);
+                }
+            }
+        }
+        Some(output)
+    }
+}
+
+#[inline]
+fn compensated_add(sum: &mut f64, compensation: &mut f64, value: f64) {
+    let next = *sum + value;
+    if sum.abs() >= value.abs() {
+        *compensation += (*sum - next) + value;
+    } else {
+        *compensation += (value - next) + *sum;
+    }
+    *sum = next;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use nereids_physics::resolution::{ResolutionFunction, TOF_FACTOR, TabulatedResolution};
+
+    use super::*;
+
+    struct LinearTrueEnergyModel;
+
+    impl FitModel for LinearTrueEnergyModel {
+        fn evaluate(&self, params: &[f64]) -> Result<Vec<f64>, FittingError> {
+            Ok(vec![params[0], 1.0 - 0.5 * params[0]])
+        }
+
+        fn analytical_jacobian(
+            &self,
+            _params: &[f64],
+            free_param_indices: &[usize],
+            _y_current: &[f64],
+        ) -> Option<FlatMatrix> {
+            if free_param_indices != [0] {
+                return None;
+            }
+            Some(FlatMatrix {
+                data: vec![1.0, -0.5],
+                nrows: 2,
+                ncols: 1,
+            })
+        }
+    }
+
+    fn triangle_response() -> ResolutionFunction {
+        ResolutionFunction::Tabulated(Arc::new(
+            TabulatedResolution::from_kernels(
+                vec![25.0],
+                vec![(vec![-1.0, 0.0, 1.0], vec![0.0, 1.0, 0.0])],
+                25.0,
+            )
+            .expect("valid triangle response"),
+        ))
+    }
+
+    #[test]
+    fn maps_values_and_analytical_jacobian_through_separate_arms() {
+        let arrival_0 = TOF_FACTOR * 25.0 / 25.0_f64.sqrt();
+        let arrival_1 = arrival_0 + 1.0;
+        let energy_1 = (TOF_FACTOR * 25.0 / arrival_1).powi(2);
+        let response = DetectorBinResponseMatrix::new(
+            &[25.0, energy_1],
+            &[arrival_0 - 1.0, arrival_0, arrival_0 + 1.0, arrival_0 + 2.0],
+            0.0,
+            &triangle_response(),
+        )
+        .expect("valid exact response");
+        let model =
+            ExactTwoArmRatioModel::new(Box::new(LinearTrueEnergyModel), &response, &[100.0, 200.0])
+                .expect("valid exact ratio model");
+
+        let values = model.evaluate(&[0.2]).expect("model evaluation");
+        let expected = [0.2, 2.0 / 3.0, 0.9];
+        for (got, want) in values.iter().zip(expected) {
+            assert!((got - want).abs() < 2.0e-12, "{got} != {want}");
+        }
+
+        let jacobian = model
+            .analytical_jacobian(&[0.2], &[0], &values)
+            .expect("analytical Jacobian");
+        let expected_jacobian = [1.0, 0.0, -0.5];
+        for (row, want) in expected_jacobian.into_iter().enumerate() {
+            assert!((jacobian.get(row, 0) - want).abs() < 2.0e-12);
+        }
+    }
+}

--- a/crates/nereids-fitting/src/exact_count_model.rs
+++ b/crates/nereids-fitting/src/exact_count_model.rs
@@ -19,7 +19,8 @@ use crate::lm::{FitModel, FlatMatrix};
 /// the invalid post-hoc shortcut `R[T]`.
 pub struct ExactTwoArmRatioModel {
     inner: Box<dyn FitModel>,
-    weighted_response: Vec<f64>,
+    response: DetectorBinResponseMatrix,
+    scaled_fluence_weights: Vec<f64>,
     open_expectation: Vec<f64>,
     n_true_energies: usize,
     n_detector_bins: usize,
@@ -29,7 +30,7 @@ impl ExactTwoArmRatioModel {
     /// Build the reusable fixed-response model.
     pub fn new(
         inner: Box<dyn FitModel>,
-        response: &DetectorBinResponseMatrix,
+        response: DetectorBinResponseMatrix,
         incident_fluence_weights: &[f64],
     ) -> Result<Self, FittingError> {
         if incident_fluence_weights.len() != response.n_true_energies() {
@@ -58,14 +59,15 @@ impl ExactTwoArmRatioModel {
 
         let n_true_energies = response.n_true_energies();
         let n_detector_bins = response.n_detector_bins();
-        let mut weighted_response = vec![0.0; n_true_energies * n_detector_bins];
+        let scaled_fluence_weights: Vec<f64> = incident_fluence_weights
+            .iter()
+            .map(|fluence| fluence / fluence_scale)
+            .collect();
         let mut open_expectation = vec![0.0; n_detector_bins];
         let mut open_compensation = vec![0.0; n_detector_bins];
-        for (true_index, &fluence) in incident_fluence_weights.iter().enumerate() {
-            let fluence = fluence / fluence_scale;
-            for detector_bin in 0..n_detector_bins {
-                let value = fluence * response.probability(true_index, detector_bin);
-                weighted_response[true_index * n_detector_bins + detector_bin] = value;
+        for (true_index, &fluence) in scaled_fluence_weights.iter().enumerate() {
+            for (detector_bin, probability) in response.row_entries(true_index) {
+                let value = fluence * probability;
                 compensated_add(
                     &mut open_expectation[detector_bin],
                     &mut open_compensation[detector_bin],
@@ -79,7 +81,8 @@ impl ExactTwoArmRatioModel {
 
         Ok(Self {
             inner,
-            weighted_response,
+            response,
+            scaled_fluence_weights,
             open_expectation,
             n_true_energies,
             n_detector_bins,
@@ -107,12 +110,12 @@ impl ExactTwoArmRatioModel {
                     "true-energy model output[{true_index}] is not finite: {value}"
                 )));
             }
-            for detector_bin in 0..self.n_detector_bins {
+            let fluence = self.scaled_fluence_weights[true_index];
+            for (detector_bin, probability) in self.response.row_entries(true_index) {
                 compensated_add(
                     &mut sample[detector_bin],
                     &mut compensation[detector_bin],
-                    value
-                        * self.weighted_response[true_index * self.n_detector_bins + detector_bin],
+                    value * fluence * probability,
                 );
             }
         }
@@ -159,13 +162,13 @@ impl FitModel for ExactTwoArmRatioModel {
 
         let mut output = FlatMatrix::zeros(self.n_detector_bins, free_param_indices.len());
         for true_index in 0..self.n_true_energies {
-            for detector_bin in 0..self.n_detector_bins {
+            let fluence = self.scaled_fluence_weights[true_index];
+            for (detector_bin, probability) in self.response.row_entries(true_index) {
                 let open = self.open_expectation[detector_bin];
                 if open <= PIVOT_FLOOR {
                     continue;
                 }
-                let weight =
-                    self.weighted_response[true_index * self.n_detector_bins + detector_bin] / open;
+                let weight = fluence * probability / open;
                 for column in 0..free_param_indices.len() {
                     *output.get_mut(detector_bin, column) +=
                         weight * inner_jacobian.get(true_index, column);
@@ -243,7 +246,7 @@ mod tests {
         )
         .expect("valid exact response");
         let model =
-            ExactTwoArmRatioModel::new(Box::new(LinearTrueEnergyModel), &response, &[100.0, 200.0])
+            ExactTwoArmRatioModel::new(Box::new(LinearTrueEnergyModel), response, &[100.0, 200.0])
                 .expect("valid exact ratio model");
 
         let values = model.evaluate(&[0.2]).expect("model evaluation");

--- a/crates/nereids-fitting/src/joint_poisson.rs
+++ b/crates/nereids-fitting/src/joint_poisson.rs
@@ -48,14 +48,40 @@ use crate::parameters::ParameterSet;
 
 /// Joint-Poisson objective.
 ///
-/// Wraps a transmission `FitModel` (which produces `T_i = model.evaluate(θ)`)
-/// together with the observed open-beam counts `O_i`, sample counts `S_i`,
-/// and proton-charge ratio `c = Q_s / Q_ob`.
+/// Wraps an effective count-ratio `FitModel` (which produces
+/// `T_eff,i = model.evaluate(θ)`) together with the observed open-beam counts
+/// `O_i`, sample counts `S_i`, and proton-charge ratio `c = Q_s / Q_ob`.
+///
+/// ## Physical count-response contract
+///
+/// This is a low-level API: it cannot inspect a `dyn FitModel` to determine
+/// how instrument resolution was applied.  The supplied model must already
+/// return the physically valid effective sample/open count response on the
+/// observed bins.  With an instrument response operator `R` and incident
+/// spectrum `Φ`, that response is
+///
+/// ```text
+/// T_eff = R[Φ · T] / R[Φ].
+/// ```
+///
+/// A post-hoc broadened transmission `R[T]` is not this response and must
+/// never be supplied as though it were.  In particular, do not directly wrap
+/// a resolution-bearing
+/// [`TransmissionFitModel`](crate::transmission_model::TransmissionFitModel),
+/// because that model returns `R[T]`.  A no-resolution transmission model
+/// remains valid because `R` is then the identity; a custom model that already
+/// returns the exact effective ratio is also valid.  Otherwise, callers must
+/// model the open and sample response arms separately or use the guarded
+/// pipeline entry point, which rejects unsupported counts-plus-resolution
+/// combinations.
 ///
 /// The caller is responsible for ensuring `o`, `s`, and `model.evaluate()`
 /// output all have the same length.
 pub struct JointPoissonObjective<'a> {
-    /// Transmission model: `evaluate(θ) → T(E)`.
+    /// Effective count-ratio model: `evaluate(θ) → T_eff(E)`.
+    ///
+    /// See the struct-level physical count-response contract.  In particular,
+    /// this must not be a post-hoc broadened transmission `R[T]`.
     pub model: &'a dyn FitModel,
     /// Open-beam counts per bin.
     pub o: &'a [f64],

--- a/crates/nereids-fitting/src/lib.rs
+++ b/crates/nereids-fitting/src/lib.rs
@@ -20,6 +20,7 @@
 //! - `trinidi/reconstruct.py` for Poisson-likelihood and APGM approach
 
 pub mod active_mask;
+pub mod count_background;
 pub mod error;
 pub mod forward_model;
 pub mod joint_poisson;

--- a/crates/nereids-fitting/src/lib.rs
+++ b/crates/nereids-fitting/src/lib.rs
@@ -5,6 +5,7 @@
 //! ## Modules
 //! - [`active_mask`] — Active-bin masking for fit-energy-range restriction
 //! - [`error`] — Error types for the fitting crate
+//! - [`exact_count_model`] — Exact two-arm detector-bin model for count fitting
 //! - [`forward_model`] — Solver-agnostic forward model trait
 //! - [`joint_poisson`] — Joint-Poisson profile binomial deviance (counts path)
 //! - [`lm`] — Levenberg-Marquardt least-squares optimizer
@@ -22,6 +23,7 @@
 pub mod active_mask;
 pub mod count_background;
 pub mod error;
+pub mod exact_count_model;
 pub mod forward_model;
 pub mod joint_poisson;
 pub mod lm;

--- a/crates/nereids-fitting/src/poisson.rs
+++ b/crates/nereids-fitting/src/poisson.rs
@@ -1,5 +1,4 @@
-//! Poisson-likelihood optimizer for low-count neutron data (transmission
-//! path).
+//! Low-level single-arm Poisson-likelihood optimizer for nonnegative data.
 //!
 //! Minimizes the single-arm Poisson negative log-likelihood
 //!
@@ -10,16 +9,12 @@
 //! using a projected damped Gauss-Newton / Fisher optimizer with
 //! backtracking line search and finite-difference fallback.
 //!
-//! **Scope note.**  In the current pipeline this solver is only reached
-//! for the **transmission + PoissonKL** path (via
-//! `crate::transmission_model::TransmissionKLBackgroundModel`).  The
-//! **counts** path uses the joint-Poisson conditional-binomial-deviance
-//! solver in [`crate::joint_poisson`], which replaced the older
-//! fixed-flux counts NLL that lived here.  The helpers [`CountsModel`]
-//! and [`CountsBackgroundScaleModel`] exposed from this module are
-//! retained for the [`crate::lm`]-side `evaluate_jacobian_and_fisher`
-//! Fisher-information helper and for spatial-regularization research
-//! drivers; they are not part of the production fit path.
+//! **Scope note.** The production pipeline does not apply this single-arm
+//! objective to normalized transmission. Raw open/sample counts use the
+//! joint-Poisson conditional-binomial-deviance solver in
+//! [`crate::joint_poisson`]. This module remains available to the standalone
+//! count-background fitter and research diagnostics; it is not a public
+//! transmission fitting route.
 //!
 //! ## TRINIDI Reference
 //! - `trinidi/reconstruct.py` — Poisson NLL and APGM optimizer

--- a/crates/nereids-fitting/src/poisson.rs
+++ b/crates/nereids-fitting/src/poisson.rs
@@ -1158,13 +1158,38 @@ pub fn poisson_fit(
 /// end users, which is precisely why the production path no longer
 /// uses this struct).
 ///
+/// ## Physical count-response contract
+///
+/// This low-level wrapper cannot inspect `transmission_model` to determine how
+/// instrument resolution was applied.  Its output must already be the
+/// physically valid effective sample/open count response.  With response
+/// operator `R` and incident spectrum `Φ`, the required ratio is
+///
+/// ```text
+/// T_eff = R[Φ · T] / R[Φ].
+/// ```
+///
+/// A post-hoc broadened transmission `R[T]` is not a valid substitute and
+/// must never be wrapped here as though it were.  In particular, do not
+/// directly wrap a resolution-bearing
+/// [`TransmissionFitModel`](crate::transmission_model::TransmissionFitModel),
+/// because that model returns `R[T]`.  An ordinary transmission is valid when
+/// resolution is disabled, and a custom inner model that already returns the
+/// exact effective ratio is also valid.  Otherwise, model the open and sample
+/// response arms separately or call the guarded pipeline, which rejects
+/// unsupported counts-plus-resolution combinations.  When resolution is
+/// active, `flux` must be the matching resolved open-arm response `R[Φ]`.
+///
 /// The `flux` and `background` slices must have the same length as the
 /// transmission vector returned by the inner model.  In debug builds,
 /// `evaluate()` asserts this invariant.
 pub struct CountsModel<'a> {
-    /// Underlying transmission model.
+    /// Underlying effective count-ratio model.
+    ///
+    /// See the struct-level physical count-response contract.  In particular,
+    /// this must not be a post-hoc broadened transmission `R[T]`.
     pub transmission_model: &'a dyn FitModel,
-    /// Incident flux (counts per bin in open beam, after normalization).
+    /// Open-arm flux response (counts per bin, after normalization).
     pub flux: &'a [f64],
     /// Background counts per bin.
     pub background: &'a [f64],
@@ -1255,11 +1280,27 @@ impl<'a> crate::forward_model::ForwardModel for CountsModel<'a> {
 /// `evaluate_jacobian_and_fisher` (Epic #394 spatial-regularization
 /// prototype) and from this module's `#[cfg(test)]` tests.
 ///
-/// Given a transmission model `T(θ)`, predicts:
+/// Given an effective count-ratio model `T_eff(θ)`, predicts:
 ///
-///   Y(E) = α₁ · [Φ(E) · T(θ)] + α₂ · B(E)
+///   Y(E) = α₁ · [F_open(E) · T_eff(θ)] + α₂ · B(E)
 ///
-/// where `α₁` and `α₂` are parameter-vector entries.
+/// where `F_open` is the observed open-arm count response and `α₁` and
+/// `α₂` are parameter-vector entries.
+///
+/// ## Physical count-response contract
+///
+/// This low-level wrapper cannot inspect `transmission_model` to determine how
+/// instrument resolution was applied.  The inner model must already return
+/// the physically valid effective sample/open count response
+/// `R[Φ · T] / R[Φ]`.  It must never return a post-hoc broadened
+/// transmission `R[T]` as a substitute.  In particular, do not directly wrap
+/// a resolution-bearing
+/// [`TransmissionFitModel`](crate::transmission_model::TransmissionFitModel),
+/// because that model returns `R[T]`.  No-resolution models and custom models
+/// that already compute the exact effective ratio remain valid.  Otherwise,
+/// model the two response arms separately or call the guarded pipeline, which
+/// rejects unsupported counts-plus-resolution combinations.  When resolution
+/// is active, `flux` must be the matching resolved open-arm response `R[Φ]`.
 ///
 /// ## Index invariant
 ///
@@ -1272,9 +1313,12 @@ impl<'a> crate::forward_model::ForwardModel for CountsModel<'a> {
 /// `alpha1_index == alpha2_index`, IS supported: the columns
 /// accumulate.)
 pub struct CountsBackgroundScaleModel<'a> {
-    /// Underlying transmission model.
+    /// Underlying effective count-ratio model.
+    ///
+    /// See the struct-level physical count-response contract.  In particular,
+    /// this must not be a post-hoc broadened transmission `R[T]`.
     pub transmission_model: &'a dyn FitModel,
-    /// Incident flux spectrum.
+    /// Open-arm flux response.
     pub flux: &'a [f64],
     /// Detector background spectrum.
     pub background: &'a [f64],

--- a/crates/nereids-fitting/src/resolution_calib.rs
+++ b/crates/nereids-fitting/src/resolution_calib.rs
@@ -611,7 +611,7 @@ fn build_resolution(
                     a0: theta[0].exp(),
                     a1: theta[1].exp(),
                 },
-                beta: theta[2].exp(),
+                beta: EnergyLaw::Const(theta[2].exp()),
                 // Scalar R: a free κ in ExpMilliEv is unidentifiable in the eV
                 // regime (R ≡ 0 across 1–200 eV for ANY plausible κ); a scalar
                 // lets the calibrant decide whether a storage tail is present.
@@ -1252,7 +1252,10 @@ mod tests {
         let EnergyLaw::Const(rr) = p.r else {
             panic!("expected a Const R law");
         };
-        (a0, a1, p.beta, rr, p.channel_fwhm_us.unwrap_or(0.0))
+        let EnergyLaw::Const(beta) = p.beta else {
+            panic!("expected a Const beta law");
+        };
+        (a0, a1, beta, rr, p.channel_fwhm_us.unwrap_or(0.0))
     }
 
     fn synthetic_base_udr() -> TabulatedResolution {
@@ -1606,7 +1609,7 @@ mod tests {
         let ic = IkedaCarpenter::new(
             IkedaCarpenterParams {
                 alpha: EnergyLaw::SqrtE { a0: 0.30, a1: 0.0 },
-                beta: 0.1,
+                beta: EnergyLaw::Const(0.1),
                 r: EnergyLaw::ExpMilliEv { kappa: 25.0 },
                 burst_sigma_us: None,
                 channel_fwhm_us: None,
@@ -1810,7 +1813,7 @@ mod tests {
         let ic = IkedaCarpenter::new(
             IkedaCarpenterParams {
                 alpha: EnergyLaw::SqrtE { a0: 0.30, a1: 0.0 },
-                beta: 0.1,
+                beta: EnergyLaw::Const(0.1),
                 r: EnergyLaw::ExpMilliEv { kappa: 25.0 },
                 burst_sigma_us: None,
                 channel_fwhm_us: None,
@@ -2119,7 +2122,7 @@ mod tests {
         let ic_truth = IkedaCarpenter::new(
             IkedaCarpenterParams {
                 alpha: EnergyLaw::SqrtE { a0: 0.35, a1: 0.05 },
-                beta: 0.1,
+                beta: EnergyLaw::Const(0.1),
                 r: EnergyLaw::Const(0.1),
                 burst_sigma_us: None,
                 channel_fwhm_us: Some(0.35),
@@ -2201,7 +2204,7 @@ mod tests {
         let ic_truth = IkedaCarpenter::new(
             IkedaCarpenterParams {
                 alpha: EnergyLaw::SqrtE { a0: 0.35, a1: 0.05 },
-                beta: 0.1,
+                beta: EnergyLaw::Const(0.1),
                 r: EnergyLaw::Const(0.1),
                 burst_sigma_us: None,
                 channel_fwhm_us: Some(psr_true),
@@ -2258,7 +2261,7 @@ mod tests {
         let ic_truth = IkedaCarpenter::new(
             IkedaCarpenterParams {
                 alpha: EnergyLaw::SqrtE { a0: 0.35, a1: 0.05 },
-                beta: 0.1,
+                beta: EnergyLaw::Const(0.1),
                 r: EnergyLaw::Const(0.1),
                 burst_sigma_us: None,
                 channel_fwhm_us: None, // unfolded truth
@@ -2321,7 +2324,7 @@ mod tests {
         let ic_truth = IkedaCarpenter::new(
             IkedaCarpenterParams {
                 alpha: EnergyLaw::SqrtE { a0: 0.35, a1: 0.05 },
-                beta: 0.1, // irrelevant at R = 0 (no storage term)
+                beta: EnergyLaw::Const(0.1), // irrelevant at R = 0 (no storage term)
                 r: EnergyLaw::Const(0.0),
                 burst_sigma_us: None,
                 channel_fwhm_us: Some(0.35),
@@ -2627,7 +2630,7 @@ mod tests {
                     a0: 0.5,
                     a1: IC_A1_MAX,
                 },
-                beta: IC_BETA_MIN,
+                beta: EnergyLaw::Const(IC_BETA_MIN),
                 r: EnergyLaw::Const(IC_R_MAX),
                 burst_sigma_us: None,
                 channel_fwhm_us: Some(fwhm_us),

--- a/crates/nereids-fitting/src/resolution_calib.rs
+++ b/crates/nereids-fitting/src/resolution_calib.rs
@@ -38,7 +38,7 @@ use nereids_physics::ikeda_carpenter::{
     EnergyLaw, IkedaCarpenter, IkedaCarpenterParams, SynthesisGrid,
 };
 use nereids_physics::resolution::{
-    ResolutionFunction, ResolutionParams, TOF_FACTOR, TabulatedResolution,
+    ResolutionFunction, ResolutionParams, TOF_FACTOR, TabulatedResolution, apply_resolution,
 };
 use nereids_physics::transmission::{InstrumentParams, SampleParams, forward_model};
 
@@ -1071,6 +1071,30 @@ pub fn calibrate_resolution(
         (t0, l_scale)
     };
 
+    // For tabulated UDR and IC kernels, the working grid is the data grid.
+    // When the energy scale is pinned, the Doppler-broadened Beer-Lambert
+    // transmission is therefore identical at every optimizer evaluation;
+    // only the resolution kernel changes.  Compute that fixed nuclear result
+    // once and reuse it.  Gaussian resolution is deliberately excluded because
+    // its auxiliary working grid depends on the trial width.  A fitted t0 or
+    // L_scale is also excluded because it changes the nuclear evaluation grid.
+    let fixed_unresolved = if !config.fit_t0
+        && !config.fit_l_scale
+        && !matches!(&family, ResolutionFamily::Gaussian)
+    {
+        let grid = corrected_energy_grid(
+            energies,
+            config.position_t0_center_us,
+            config.position_l_scale_center,
+            config.flight_path_m,
+        )?;
+        let transmission = forward_model(&grid, sample, None)
+            .map_err(|e| FittingError::EvaluationFailed(format!("forward: {e:?}")))?;
+        Some((grid, transmission))
+    } else {
+        None
+    };
+
     let mut best: Option<NelderMeadResult> = None;
     for r in 0..config.restarts.max(1) {
         // Additive perturbation (a fraction of each parameter's bound range) so
@@ -1096,13 +1120,18 @@ pub fn calibrate_resolution(
             };
             let inst = InstrumentParams { resolution: res };
             let (t0, l_scale) = unpack_position(theta);
-            // Infeasible energy scale (corrected TOF ≤ 0) → step away.
-            let Ok(grid) = corrected_energy_grid(energies, t0, l_scale, config.flight_path_m)
-            else {
-                return Ok(f64::INFINITY);
+            let model = if let Some((grid, unresolved)) = &fixed_unresolved {
+                apply_resolution(grid, unresolved, &inst.resolution)
+                    .map_err(|e| FittingError::EvaluationFailed(format!("resolution: {e:?}")))?
+            } else {
+                // Infeasible energy scale (corrected TOF ≤ 0) → step away.
+                let Ok(grid) = corrected_energy_grid(energies, t0, l_scale, config.flight_path_m)
+                else {
+                    return Ok(f64::INFINITY);
+                };
+                forward_model(&grid, sample, Some(&inst))
+                    .map_err(|e| FittingError::EvaluationFailed(format!("forward: {e:?}")))?
             };
-            let model = forward_model(&grid, sample, Some(&inst))
-                .map_err(|e| FittingError::EvaluationFailed(format!("forward: {e:?}")))?;
             if !model.iter().all(|v| v.is_finite()) {
                 return Err(FittingError::EvaluationFailed("non-finite model".into()));
             }
@@ -1182,8 +1211,13 @@ pub fn calibrate_resolution(
         config.flight_path_m,
     )?;
     let inst = InstrumentParams { resolution };
-    let model = forward_model(&grid, sample, Some(&inst))
-        .map_err(|e| FittingError::EvaluationFailed(format!("forward: {e:?}")))?;
+    let model = if let Some((fixed_grid, unresolved)) = &fixed_unresolved {
+        apply_resolution(fixed_grid, unresolved, &inst.resolution)
+            .map_err(|e| FittingError::EvaluationFailed(format!("resolution: {e:?}")))?
+    } else {
+        forward_model(&grid, sample, Some(&inst))
+            .map_err(|e| FittingError::EvaluationFailed(format!("forward: {e:?}")))?
+    };
     let (ssr, k) = inner_ssr(data, unc, &model, config.fit_background).ok_or_else(|| {
         FittingError::EvaluationFailed("singular anorm/baseline at the solution".into())
     })?;

--- a/crates/nereids-fitting/src/transmission_model.rs
+++ b/crates/nereids-fitting/src/transmission_model.rs
@@ -772,12 +772,21 @@ pub struct TransmissionFitModel {
     /// and included as a free parameter in the fit. The Doppler broadening
     /// kernel is recomputed at each `evaluate()` call.
     temperature_index: Option<usize>,
-    /// Cached unbroadened (Reich-Moore) cross-sections, computed once in
-    /// `new()` when `temperature_index` is `Some`. Eliminates redundant
-    /// O(N_energy × N_resonances) computation on every `evaluate()` call.
-    /// Wrapped in `Arc` so `spatial_map` can share a single allocation across
-    /// all per-pixel `TransmissionFitModel` instances without deep cloning.
+    /// Optional caller-supplied sampled zero-temperature cross sections.
+    ///
+    /// This preserves the explicit legacy API for callers whose source is a
+    /// table. When absent, temperature fitting retains `resonance_data` and
+    /// uses the source-equation free-gas integral; it never manufactures this
+    /// table internally from a resolved resonance source.
     base_xs: Option<Arc<Vec<Vec<f64>>>>,
+    /// Cached zero-temperature resonance-equation values used only when the
+    /// continuous source evaluator cannot cover a complete isotope.
+    ///
+    /// This is not an alternate public source. Supported SLBW/MLBW isotopes
+    /// continue to use the source equation; unsupported formalisms use their
+    /// matching cached row so repeated temperature trials do not reevaluate
+    /// the full resonance calculation.
+    fallback_base_xs: Option<Arc<Vec<Vec<f64>>>>,
     /// Cached broadened cross-sections from the last `evaluate()` call, on the
     /// **working grid** (auxiliary extended grid when Gaussian resolution is
     /// active, else the data grid).  Used by `analytical_jacobian()` to provide
@@ -826,9 +835,9 @@ pub struct TransmissionFitModel {
 impl TransmissionFitModel {
     /// Create a validated `TransmissionFitModel`.
     ///
-    /// When `external_base_xs` is `Some`, uses those precomputed unbroadened
-    /// cross-sections instead of computing them (expensive Reich-Moore).
-    /// `spatial_map` precomputes once for all pixels and passes them here.
+    /// When `external_base_xs` is `Some`, uses that explicit sampled source.
+    /// Otherwise a temperature fit retains the resonance source and evaluates
+    /// the error-controlled source-equation free-gas integral.
     ///
     /// # Errors
     /// Returns `FittingError::InvalidConfig` if `temperature_index` overlaps
@@ -841,6 +850,52 @@ impl TransmissionFitModel {
         density_mapping: (Vec<usize>, Vec<f64>),
         temperature_index: Option<usize>,
         external_base_xs: Option<Arc<Vec<Vec<f64>>>>,
+    ) -> Result<Self, FittingError> {
+        let needs_fallback = temperature_index.is_some() && external_base_xs.is_none();
+        let mut model = Self::new_with_cached_fallback(
+            energies,
+            resonance_data,
+            temperature_k,
+            instrument,
+            density_mapping,
+            temperature_index,
+            external_base_xs,
+            None,
+        )?;
+        if needs_fallback {
+            model.fallback_base_xs = Some(Arc::new(
+                transmission::unbroadened_cross_sections(
+                    &model.energies,
+                    &model.resonance_data,
+                    None,
+                )
+                .map_err(|error| {
+                    FittingError::InvalidConfig(format!(
+                        "failed to cache sampled Doppler fallback: {error}"
+                    ))
+                })?,
+            ));
+        }
+        Ok(model)
+    }
+
+    /// Construct a temperature model with a shared sampled-fallback cache.
+    ///
+    /// This exists for the spatial pipeline, which computes the immutable
+    /// fallback once and shares it across pixel models. `external_base_xs`
+    /// remains the caller-selected table source; `fallback_base_xs` is used
+    /// only for an unsupported resonance formalism.
+    #[doc(hidden)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_cached_fallback(
+        energies: Vec<f64>,
+        resonance_data: Vec<ResonanceData>,
+        temperature_k: f64,
+        instrument: Option<Arc<InstrumentParams>>,
+        density_mapping: (Vec<usize>, Vec<f64>),
+        temperature_index: Option<usize>,
+        external_base_xs: Option<Arc<Vec<Vec<f64>>>>,
+        fallback_base_xs: Option<Arc<Vec<Vec<f64>>>>,
     ) -> Result<Self, FittingError> {
         let (density_indices, density_ratios) = density_mapping;
         if density_indices.len() != resonance_data.len() {
@@ -864,11 +919,17 @@ impl TransmissionFitModel {
                 "temperature_index must not overlap with density_indices".into(),
             ));
         }
-        // Validate external base XS shape before accepting.
-        if let Some(ref xs) = external_base_xs {
+        // Validate every cached source shape before accepting it.
+        for (name, cached) in [
+            ("external_base_xs", external_base_xs.as_ref()),
+            ("fallback_base_xs", fallback_base_xs.as_ref()),
+        ] {
+            let Some(xs) = cached else {
+                continue;
+            };
             if xs.len() != resonance_data.len() {
                 return Err(FittingError::InvalidConfig(format!(
-                    "external_base_xs has {} isotopes but resonance_data has {}",
+                    "{name} has {} isotopes but resonance_data has {}",
                     xs.len(),
                     resonance_data.len(),
                 )));
@@ -876,25 +937,14 @@ impl TransmissionFitModel {
             for (i, row) in xs.iter().enumerate() {
                 if row.len() != energies.len() {
                     return Err(FittingError::InvalidConfig(format!(
-                        "external_base_xs[{i}] has {} energies but expected {}",
+                        "{name}[{i}] has {} energies but expected {}",
                         row.len(),
                         energies.len(),
                     )));
                 }
             }
         }
-        let base_xs = match external_base_xs {
-            Some(xs) => Some(xs),
-            None if temperature_index.is_some() => Some(Arc::new(
-                transmission::unbroadened_cross_sections(&energies, &resonance_data, None)
-                    .map_err(|e| {
-                        FittingError::InvalidConfig(format!(
-                            "failed to compute unbroadened cross-sections: {e}"
-                        ))
-                    })?,
-            )),
-            None => None,
-        };
+        let base_xs = external_base_xs;
         Ok(Self {
             energies,
             resonance_data,
@@ -904,6 +954,7 @@ impl TransmissionFitModel {
             density_ratios,
             temperature_index,
             base_xs,
+            fallback_base_xs,
             cached_broadened_xs: RefCell::new(None),
             cached_dxs_dt: RefCell::new(None),
             cached_work_layout: RefCell::new(None),
@@ -1009,8 +1060,9 @@ impl FitModel for TransmissionFitModel {
             None => self.temperature_k,
         };
 
-        if let Some(ref base_xs) = self.base_xs {
-            // Fast path: reuse cached unbroadened XS, only redo Doppler + Beer-Lambert.
+        if self.temperature_index.is_some() || self.base_xs.is_some() {
+            // Temperature-fit path: retain the resonance source unless the
+            // caller explicitly supplied a sampled zero-temperature table.
             // Validate temperature (same rules as SampleParams::new in the slow path)
             // so the optimizer can't silently evaluate an unphysical model.
             if !temperature_k.is_finite() || temperature_k < 0.0 {
@@ -1044,13 +1096,31 @@ impl FitModel for TransmissionFitModel {
                     Rc::clone(self.cached_work_layout.borrow().as_ref().unwrap()),
                 )
             } else {
-                let working = transmission::broadened_cross_sections_from_base_on_working_grid(
-                    &self.energies,
-                    base_xs,
-                    &self.resonance_data,
-                    temperature_k,
-                    self.instrument.as_deref(),
-                )
+                let working = if let Some(table_xs) = self.base_xs.as_deref() {
+                    transmission::broadened_cross_sections_from_table_on_working_grid(
+                        &self.energies,
+                        table_xs,
+                        &self.resonance_data,
+                        temperature_k,
+                        self.instrument.as_deref(),
+                    )
+                } else if let Some(fallback_base_xs) = self.fallback_base_xs.as_deref() {
+                    transmission::broadened_cross_sections_on_working_grid_with_cached_fallback(
+                        &self.energies,
+                        fallback_base_xs,
+                        &self.resonance_data,
+                        temperature_k,
+                        self.instrument.as_deref(),
+                    )
+                } else {
+                    transmission::broadened_cross_sections_on_working_grid(
+                        &self.energies,
+                        &self.resonance_data,
+                        temperature_k,
+                        self.instrument.as_deref(),
+                        None,
+                    )
+                }
                 .map_err(|e| FittingError::EvaluationFailed(e.to_string()))?;
                 let xs = Rc::new(working.sigma);
                 let layout = Rc::new(working.layout);
@@ -1120,20 +1190,15 @@ impl FitModel for TransmissionFitModel {
 
     /// Analytical Jacobian for the transmission model with temperature fitting.
     ///
-    /// When `base_xs` is available (temperature fitting path):
+    /// When the temperature path has populated its cross-section cache:
     /// - **Density columns**: `∂T/∂nᵢ = -σᵢ(E)·T(E)` using cached broadened XS
     ///   from the most recent `evaluate()` call.  Same formula as
     ///   `PrecomputedTransmissionModel`, zero extra broadening calls.
     /// - **Temperature column**: analytical chain rule via on-demand `∂σ/∂T`.
     ///   `∂T/∂T_temp = -T(E) · Σᵢ nᵢ·rᵢ·∂σᵢ/∂T`.  The derivative is
-    ///   computed once per temperature via
-    ///   `broadened_cross_sections_with_analytical_derivative_from_base()`
-    ///   and cached until temperature changes.  Costs one broadening call
-    ///   per Jacobian (same as the old FD approach, but exact).
-    ///
-    /// Returns `None` for the no-base_xs path (full forward model), which
-    /// falls back to finite-difference in the LM solver.
-    /// Analytical Jacobian for density and temperature fitting.
+    ///   computed once per temperature from either the retained resonance
+    ///   source or an explicitly supplied sampled source, then cached until
+    ///   temperature changes.
     ///
     /// Without resolution:
     ///   ∂T/∂N_g = -(Σ_{i∈g} rᵢ σᵢ) · T
@@ -1143,8 +1208,8 @@ impl FitModel for TransmissionFitModel {
     ///   ∂T_obs/∂N_g = R\[-(Σ_{i∈g} rᵢ σᵢ) · T\]
     ///   ∂T_obs/∂Temp = R\[-T · Σᵢ nᵢ rᵢ ∂σᵢ/∂T\]
     ///
-    /// Returns `None` only when `base_xs` is not available (full forward
-    /// model path falls back to FD) or when the temperature cache is stale.
+    /// Returns `None` only for a fixed-temperature full-forward path without a
+    /// populated cache, or when the temperature cache is stale.
     fn analytical_jacobian(
         &self,
         params: &[f64],
@@ -1193,9 +1258,12 @@ impl FitModel for TransmissionFitModel {
         // see the docstring at the corresponding
         // site in `TransmissionFitModel::evaluate()` above.
 
-        // Only provide analytical Jacobian when base_xs is available
-        // (temperature-fitting fast path with cached broadened XS).
-        let _base_xs_guard = self.base_xs.as_ref()?;
+        // Density derivatives require a populated broadened-XS cache. The
+        // temperature-fit path can populate it from either the retained
+        // resonance source or an explicitly supplied sampled table.
+        if self.temperature_index.is_none() && self.base_xs.is_none() {
+            return None;
+        }
         let cached_xs = self.cached_broadened_xs.borrow();
         let broadened_xs = cached_xs.as_ref()?;
         // Working-grid layout matching the cached σ (issue #608).  Inner
@@ -1297,17 +1365,32 @@ impl FitModel for TransmissionFitModel {
             {
                 let needs_compute = self.cached_dxs_dt.borrow().as_ref().is_none();
                 if needs_compute {
-                    let base_xs = self.base_xs.as_ref()?;
                     let temperature_k = self.cached_temperature.get();
-                    let working =
-                        transmission::broadened_cross_sections_with_analytical_derivative_from_base_on_working_grid(
+                    let working = if let Some(table_xs) = self.base_xs.as_deref() {
+                        transmission::broadened_cross_sections_with_analytical_derivative_from_table_on_working_grid(
                             &self.energies,
-                            base_xs,
+                            table_xs,
                             &self.resonance_data,
                             temperature_k,
                             self.instrument.as_deref(),
                         )
-                        .ok()?;
+                    } else if let Some(fallback_base_xs) = self.fallback_base_xs.as_deref() {
+                        transmission::broadened_cross_sections_with_analytical_derivative_on_working_grid_with_cached_fallback(
+                            &self.energies,
+                            fallback_base_xs,
+                            &self.resonance_data,
+                            temperature_k,
+                            self.instrument.as_deref(),
+                        )
+                    } else {
+                        transmission::broadened_cross_sections_with_analytical_derivative_on_working_grid(
+                            &self.energies,
+                            &self.resonance_data,
+                            temperature_k,
+                            self.instrument.as_deref(),
+                        )
+                    }
+                    .ok()?;
                     *self.cached_dxs_dt.borrow_mut() = Some(Rc::new(working.dsigma_dt));
                 }
             }
@@ -3115,7 +3198,7 @@ mod tests {
     use crate::lm::{self, FitModel, LmConfig};
     use crate::parameters::{FitParameter, ParameterSet};
     use nereids_core::types::Isotope;
-    use nereids_endf::resonance::test_support::u238_single_resonance;
+    use nereids_endf::resonance::test_support::{u238_single_resonance, u238_with_formalism};
     use nereids_endf::resonance::{LGroup, Resonance, ResonanceFormalism, ResonanceRange};
 
     /// ∞-norm of the residual between two equal-length spectra.
@@ -3421,6 +3504,93 @@ mod tests {
                 b
             );
         }
+    }
+
+    #[test]
+    fn temperature_fit_retains_resonance_source_unless_table_is_explicit() {
+        let data = u238_with_formalism(ResonanceFormalism::MLBW);
+        let energies = vec![6.0, 6.674, 7.5];
+        let density = 0.01;
+        let temperature = 300.0;
+        let source_model = TransmissionFitModel::new(
+            energies.clone(),
+            vec![data.clone()],
+            temperature,
+            None,
+            (vec![0], vec![1.0]),
+            Some(1),
+            None,
+        )
+        .unwrap();
+        let base = Arc::new(
+            transmission::unbroadened_cross_sections(&energies, std::slice::from_ref(&data), None)
+                .unwrap(),
+        );
+        let explicit_table_model = TransmissionFitModel::new(
+            energies.clone(),
+            vec![data.clone()],
+            temperature,
+            None,
+            (vec![0], vec![1.0]),
+            Some(1),
+            Some(base),
+        )
+        .unwrap();
+        let sample = SampleParams::new(temperature, vec![(data, density)]).unwrap();
+        let expected = transmission::forward_model(&energies, &sample, None).unwrap();
+        let source = source_model.evaluate(&[density, temperature]).unwrap();
+        let sampled = explicit_table_model
+            .evaluate(&[density, temperature])
+            .unwrap();
+
+        assert_eq!(source, expected);
+        let sampled_error = max_abs_diff(&sampled, &expected);
+        assert!(
+            sampled_error > 1.0e-6,
+            "the explicit sparse table control must reproduce the lost-source defect; error={sampled_error}"
+        );
+    }
+
+    #[test]
+    fn explicit_table_remains_the_only_source_on_gaussian_auxiliary_grid() {
+        let data = u238_single_resonance();
+        let energies: Vec<f64> = (0..101).map(|index| 4.0 + index as f64 * 0.05).collect();
+        let zero_table = Arc::new(vec![vec![0.0; energies.len()]]);
+        let instrument = Arc::new(InstrumentParams {
+            resolution: ResolutionFunction::Gaussian(
+                nereids_physics::resolution::ResolutionParams::new(25.0, 0.5, 0.005, 0.0).unwrap(),
+            ),
+        });
+        let model = TransmissionFitModel::new(
+            energies,
+            vec![data],
+            300.0,
+            Some(instrument),
+            (vec![0], vec![1.0]),
+            Some(1),
+            Some(zero_table),
+        )
+        .unwrap();
+
+        let predicted = model.evaluate(&[0.01, 300.0]).unwrap();
+        let maximum_deviation = predicted
+            .iter()
+            .map(|value| (value - 1.0).abs())
+            .fold(0.0_f64, f64::max);
+        assert!(
+            maximum_deviation < 1.0e-12,
+            "an explicit zero table must stay zero at auxiliary points; max transmission deviation={maximum_deviation}"
+        );
+        let jacobian = model
+            .analytical_jacobian(&[0.01, 300.0], &[1], &predicted)
+            .expect("explicit-table temperature derivative");
+        let maximum_derivative = (0..predicted.len())
+            .map(|row| jacobian.get(row, 0).abs())
+            .fold(0.0_f64, f64::max);
+        assert!(
+            maximum_derivative < 1.0e-12,
+            "an explicit zero table must have zero temperature derivative; max={maximum_derivative}"
+        );
     }
 
     /// Recover temperature from Doppler-broadened synthetic data.

--- a/crates/nereids-fitting/tests/count_background.rs
+++ b/crates/nereids-fitting/tests/count_background.rs
@@ -1,0 +1,464 @@
+use nereids_fitting::count_background::{
+    TwoArmBackgroundTemplate, fit_two_arm_background_templates,
+};
+use nereids_fitting::poisson::PoissonConfig;
+use nereids_physics::counts_response::{TwoArmCounts, add_count_backgrounds};
+
+fn signals() -> TwoArmCounts {
+    TwoArmCounts {
+        open_beam: vec![1000.0, 900.0, 800.0, 700.0, 600.0],
+        sample: vec![600.0, 540.0, 480.0, 420.0, 360.0],
+    }
+}
+
+fn shaped_template(name: &str) -> TwoArmBackgroundTemplate {
+    TwoArmBackgroundTemplate {
+        name: name.into(),
+        open_beam: vec![0.2, 0.5, 1.0, 2.0, 4.0],
+        sample: vec![4.0, 2.0, 1.0, 0.5, 0.2],
+    }
+}
+
+fn synthetic_observation(
+    signal: TwoArmCounts,
+    template: &TwoArmBackgroundTemplate,
+    amplitude: f64,
+) -> TwoArmCounts {
+    let open: Vec<f64> = template
+        .open_beam
+        .iter()
+        .map(|value| amplitude * value)
+        .collect();
+    let sample: Vec<f64> = template
+        .sample
+        .iter()
+        .map(|value| amplitude * value)
+        .collect();
+    let prediction =
+        add_count_backgrounds(signal, &open, &sample).expect("valid synthetic observation");
+    TwoArmCounts {
+        open_beam: prediction.open_beam.total,
+        sample: prediction.sample.total,
+    }
+}
+
+#[test]
+fn recovers_fixed_independent_background_template() {
+    let template = shaped_template("blocked_beam_reference");
+    let true_amplitude = 25.0;
+    let signal = signals();
+    let observed = synthetic_observation(signal.clone(), &template, true_amplitude);
+
+    let result = fit_two_arm_background_templates(
+        &observed,
+        signal,
+        1.0,
+        1.0,
+        std::slice::from_ref(&template),
+        &[1.0],
+        &PoissonConfig::default(),
+    )
+    .expect("correct template fit");
+
+    assert!(result.converged);
+    assert!(result.amplitudes_identifiable);
+    assert!((result.amplitudes[0] - true_amplitude).abs() < 1.0e-6);
+    assert!(result.poisson_deviance < 1.0e-10);
+    assert!((result.prediction.open_beam.background[4] - 100.0).abs() < 1.0e-6);
+    assert!((result.prediction.sample.background[0] - 100.0).abs() < 1.0e-6);
+}
+
+#[test]
+fn wrong_background_shape_cannot_silently_match_synthetic_counts() {
+    let true_template = shaped_template("true_blocked_beam_reference");
+    let signal = signals();
+    let observed = synthetic_observation(signal.clone(), &true_template, 100.0);
+    let wrong_template = TwoArmBackgroundTemplate {
+        name: "wrong_flat_reference".into(),
+        open_beam: vec![1.0; 5],
+        sample: vec![1.0; 5],
+    };
+
+    let wrong = fit_two_arm_background_templates(
+        &observed,
+        signal,
+        1.0,
+        1.0,
+        &[wrong_template],
+        &[1.0],
+        &PoissonConfig::default(),
+    )
+    .expect("wrong shape still has a defined best fit");
+
+    assert!(wrong.converged);
+    assert!(
+        wrong.deviance_per_dof > 5.0,
+        "wrong template unexpectedly passed: D/dof = {}",
+        wrong.deviance_per_dof
+    );
+}
+
+#[test]
+fn invalid_templates_fail_before_optimization() {
+    let observed = signals();
+    let signal = signals();
+    let invalid = TwoArmBackgroundTemplate {
+        name: "negative".into(),
+        open_beam: vec![1.0, 1.0, -1.0, 1.0, 1.0],
+        sample: vec![1.0; 5],
+    };
+    let error = fit_two_arm_background_templates(
+        &observed,
+        signal,
+        1.0,
+        1.0,
+        &[invalid],
+        &[1.0],
+        &PoissonConfig::default(),
+    )
+    .expect_err("negative expected counts must fail");
+    assert!(error.to_string().contains("must be finite and >= 0"));
+}
+
+#[test]
+fn template_units_do_not_change_the_physical_fit() {
+    let signal = TwoArmCounts {
+        open_beam: vec![100.0, 200.0, 300.0],
+        sample: vec![80.0, 160.0, 240.0],
+    };
+    let tiny_units = TwoArmBackgroundTemplate {
+        name: "same_reference_in_tiny_units".into(),
+        open_beam: vec![1.0e-8; 3],
+        sample: vec![1.0e-8; 3],
+    };
+    let true_amplitude = 1.0e9;
+    let observed = synthetic_observation(signal.clone(), &tiny_units, true_amplitude);
+
+    let result = fit_two_arm_background_templates(
+        &observed,
+        signal,
+        1.0,
+        1.0,
+        &[tiny_units],
+        &[0.0],
+        &PoissonConfig::default(),
+    )
+    .expect("template unit rescaling must not stall the optimizer");
+
+    assert!(result.converged);
+    assert!((result.amplitudes[0] / true_amplitude - 1.0).abs() < 1.0e-6);
+    assert!(result.deviance_per_dof >= 0.0);
+    assert!(result.deviance_per_dof < 1.0e-10);
+}
+
+#[test]
+fn recovers_several_overlapping_components_from_distant_initial_values() {
+    let signal = signals();
+    let templates = vec![
+        shaped_template("blocked_beam"),
+        TwoArmBackgroundTemplate {
+            name: "detector_dark".into(),
+            open_beam: vec![1.0; 5],
+            sample: vec![1.0; 5],
+        },
+        TwoArmBackgroundTemplate {
+            name: "sample_scatter_reference".into(),
+            open_beam: vec![4.0, 0.2, 2.0, 0.5, 1.0],
+            sample: vec![0.5, 4.0, 0.2, 2.0, 1.0],
+        },
+    ];
+    let truth = [25.0, 10.0, 3.0];
+    let mut observed = signal.clone();
+    for (&amplitude, template) in truth.iter().zip(&templates) {
+        for (count, &basis) in observed.open_beam.iter_mut().zip(&template.open_beam) {
+            *count += amplitude * basis;
+        }
+        for (count, &basis) in observed.sample.iter_mut().zip(&template.sample) {
+            *count += amplitude * basis;
+        }
+    }
+
+    let result = fit_two_arm_background_templates(
+        &observed,
+        signal,
+        1.0,
+        1.0,
+        &templates,
+        &[1000.0, 0.0, 200.0],
+        &PoissonConfig::default(),
+    )
+    .expect("convex multi-component fit");
+
+    assert!(result.converged);
+    for (&actual, &expected) in result.amplitudes.iter().zip(&truth) {
+        assert!((actual / expected - 1.0).abs() < 1.0e-5);
+    }
+    assert!(result.deviance_per_dof < 1.0e-10);
+    for (&actual, &expected) in result
+        .prediction
+        .open_beam
+        .total
+        .iter()
+        .chain(&result.prediction.sample.total)
+        .zip(observed.open_beam.iter().chain(&observed.sample))
+    {
+        assert!((actual - expected).abs() < 2.0e-5);
+    }
+}
+
+#[test]
+fn exact_poisson_fit_recovers_counts_below_the_general_solver_floor() {
+    let signal = TwoArmCounts {
+        open_beam: vec![0.0],
+        sample: vec![0.0],
+    };
+    let template = TwoArmBackgroundTemplate {
+        name: "tiny_count_reference".into(),
+        open_beam: vec![1.0],
+        sample: vec![1.0],
+    };
+    let observed = TwoArmCounts {
+        open_beam: vec![1.0e-12],
+        sample: vec![1.0e-12],
+    };
+
+    let result = fit_two_arm_background_templates(
+        &observed,
+        signal,
+        1.0,
+        1.0,
+        &[template],
+        &[0.0],
+        &PoissonConfig::default(),
+    )
+    .expect("exact count likelihood remains valid below 1e-10 count");
+
+    assert!(result.converged);
+    assert!((result.amplitudes[0] / 1.0e-12 - 1.0).abs() < 1.0e-8);
+    assert!(result.poisson_deviance < 1.0e-24);
+}
+
+#[test]
+fn zero_template_bins_do_not_contaminate_other_arm_gradient() {
+    let signal = TwoArmCounts {
+        open_beam: vec![0.0],
+        sample: vec![0.0],
+    };
+    let template = TwoArmBackgroundTemplate {
+        name: "open_only".into(),
+        open_beam: vec![1.0],
+        sample: vec![0.0],
+    };
+    let observed = TwoArmCounts {
+        open_beam: vec![1.0],
+        // This arm cannot be represented by the open-only template. Its
+        // large finite value must not create 0 * infinity in the derivative.
+        sample: vec![1.0e300],
+    };
+
+    let result = fit_two_arm_background_templates(
+        &observed,
+        signal,
+        1.0,
+        1.0,
+        &[template],
+        &[0.0],
+        &PoissonConfig::default(),
+    )
+    .expect("zero template weights are excluded from that coordinate");
+
+    assert!(result.converged);
+    assert!((result.amplitudes[0] - 1.0).abs() < 1.0e-8);
+    assert!(result.poisson_deviance.is_infinite());
+}
+
+#[test]
+fn unrepresentable_caller_amplitude_fails_instead_of_returning_infinity() {
+    let signal = TwoArmCounts {
+        open_beam: vec![0.0],
+        sample: vec![0.0],
+    };
+    let template = TwoArmBackgroundTemplate {
+        name: "unusable_units".into(),
+        open_beam: vec![1.0e-320],
+        sample: vec![1.0e-320],
+    };
+    let observed = TwoArmCounts {
+        open_beam: vec![1.0],
+        sample: vec![1.0],
+    };
+
+    let error = fit_two_arm_background_templates(
+        &observed,
+        signal,
+        1.0,
+        1.0,
+        &[template],
+        &[0.0],
+        &PoissonConfig::default(),
+    )
+    .expect_err("an infinite caller-unit amplitude must not escape the API");
+
+    assert!(error.to_string().contains("rescale the template counts"));
+}
+
+#[test]
+fn finite_ratio_of_large_count_sums_does_not_overflow() {
+    let signal = TwoArmCounts {
+        open_beam: vec![0.0],
+        sample: vec![0.0],
+    };
+    let template = TwoArmBackgroundTemplate {
+        name: "large_counts".into(),
+        open_beam: vec![1.0],
+        sample: vec![1.0],
+    };
+    let observed = TwoArmCounts {
+        open_beam: vec![1.0e308],
+        sample: vec![1.0e308],
+    };
+
+    let result = fit_two_arm_background_templates(
+        &observed,
+        signal,
+        1.0,
+        1.0,
+        &[template],
+        &[1.0e308],
+        &PoissonConfig::default(),
+    )
+    .expect("finite count ratio must not overflow through its direct sums");
+
+    assert!(result.converged);
+    assert_eq!(result.amplitudes[0], 1.0e308);
+    assert_eq!(result.poisson_deviance, 0.0);
+}
+
+#[test]
+fn unresolved_background_separation_never_reports_zero_uncertainty() {
+    let n_bins = 3;
+    let signal = TwoArmCounts {
+        open_beam: vec![100.0; n_bins],
+        sample: vec![100.0; n_bins],
+    };
+    let nearly_same = 1.0e-11;
+    let first = TwoArmBackgroundTemplate {
+        name: "first".into(),
+        open_beam: vec![1.0; n_bins],
+        sample: vec![1.0; n_bins],
+    };
+    let second = TwoArmBackgroundTemplate {
+        name: "nearly_the_same".into(),
+        open_beam: vec![1.0 - nearly_same, 1.0, 1.0 + nearly_same],
+        sample: vec![1.0 + nearly_same, 1.0, 1.0 - nearly_same],
+    };
+    let templates = vec![first, second];
+    let mut observed = signal.clone();
+    for (count, (&a, &b)) in observed
+        .open_beam
+        .iter_mut()
+        .zip(templates[0].open_beam.iter().zip(&templates[1].open_beam))
+    {
+        *count += 10.0 * a + 20.0 * b;
+    }
+    for (count, (&a, &b)) in observed
+        .sample
+        .iter_mut()
+        .zip(templates[0].sample.iter().zip(&templates[1].sample))
+    {
+        *count += 10.0 * a + 20.0 * b;
+    }
+
+    let result = fit_two_arm_background_templates(
+        &observed,
+        signal,
+        1.0,
+        1.0,
+        &templates,
+        &[10.0, 20.0],
+        &PoissonConfig::default(),
+    )
+    .expect("nearly dependent templates still have a prediction");
+
+    assert!(result.converged);
+    assert!(result.amplitudes_identifiable);
+    if let Some(uncertainties) = result.amplitude_uncertainties {
+        assert!(uncertainties.iter().all(|value| *value != 0.0));
+    }
+}
+
+#[test]
+fn exposure_scales_prevent_run_normalization_from_becoming_background() {
+    let reference_signal = TwoArmCounts {
+        open_beam: vec![100.0, 100.0],
+        sample: vec![50.0, 50.0],
+    };
+    let observed = TwoArmCounts {
+        open_beam: vec![100.0, 100.0],
+        sample: vec![100.0, 100.0],
+    };
+    let sample_only = TwoArmBackgroundTemplate {
+        name: "sample_only".into(),
+        open_beam: vec![0.0, 0.0],
+        sample: vec![1.0, 1.0],
+    };
+
+    let result = fit_two_arm_background_templates(
+        &observed,
+        reference_signal,
+        1.0,
+        2.0,
+        &[sample_only],
+        &[10.0],
+        &PoissonConfig::default(),
+    )
+    .expect("known exposure factors are part of the count prediction");
+
+    assert!(result.converged);
+    assert!(result.amplitudes[0] < 1.0e-10);
+    assert_eq!(result.prediction.sample.neutron_signal, vec![100.0, 100.0]);
+    assert_eq!(result.poisson_deviance, 0.0);
+}
+
+#[test]
+fn dependent_templates_are_explicitly_marked_unidentifiable() {
+    let signal = TwoArmCounts {
+        open_beam: vec![100.0; 3],
+        sample: vec![100.0; 3],
+    };
+    let observed = TwoArmCounts {
+        open_beam: vec![120.0; 3],
+        sample: vec![120.0; 3],
+    };
+    let templates = vec![
+        TwoArmBackgroundTemplate {
+            name: "dark".into(),
+            open_beam: vec![1.0; 3],
+            sample: vec![1.0; 3],
+        },
+        TwoArmBackgroundTemplate {
+            name: "gamma".into(),
+            open_beam: vec![2.0; 3],
+            sample: vec![2.0; 3],
+        },
+    ];
+
+    let result = fit_two_arm_background_templates(
+        &observed,
+        signal,
+        1.0,
+        1.0,
+        &templates,
+        &[0.0, 5.0],
+        &PoissonConfig::default(),
+    )
+    .expect("the total prediction remains defined");
+
+    assert!(result.converged);
+    assert!(!result.amplitudes_identifiable);
+    assert!(result.amplitude_uncertainties.is_none());
+    assert_eq!(result.poisson_deviance, 0.0);
+    for value in result.prediction.open_beam.background {
+        assert!((value - 20.0).abs() < 1.0e-12);
+    }
+}

--- a/crates/nereids-fitting/tests/ic_closed_loop.rs
+++ b/crates/nereids-fitting/tests/ic_closed_loop.rs
@@ -102,7 +102,7 @@ fn closed_loop(t_true_k: f64) {
                 a0: A0_TRUE,
                 a1: A1_TRUE,
             },
-            beta: BETA_TRUE,
+            beta: EnergyLaw::Const(BETA_TRUE),
             r: EnergyLaw::Const(R_TRUE),
             burst_sigma_us: None,
             channel_fwhm_us: Some(PSR_TRUE_US),
@@ -180,15 +180,18 @@ fn closed_loop(t_true_k: f64) {
     let EnergyLaw::Const(r_cal) = p.r else {
         panic!("expected a Const R law");
     };
+    let EnergyLaw::Const(beta_cal) = p.beta else {
+        panic!("expected a Const beta law");
+    };
     assert!(a1 > 0.0, "α(E) positive by construction (a1 = {a1})");
     assert!(
         (a0 - A0_TRUE).abs() < 0.10,
         "a0 = {a0}, truth {A0_TRUE} (T = {t_true_k} K)"
     );
     assert!(
-        (p.beta - BETA_TRUE).abs() < 0.20,
+        (beta_cal - BETA_TRUE).abs() < 0.20,
         "β = {}, truth {BETA_TRUE} (T = {t_true_k} K)",
-        p.beta
+        beta_cal
     );
     assert!(
         (r_cal - R_TRUE).abs() < 0.12,
@@ -266,7 +269,7 @@ fn closed_loop(t_true_k: f64) {
     eprintln!(
         "closed_loop(T={t_true_k} K): χ²/dof={:.3}, a0={a0:.3}, a1={a1:.4}, β={:.3}, R={:.3}, \
          T_fit={t_fit:.1} ± {sigma_t:.1} K",
-        cal.chi2_dof, p.beta, r_cal
+        cal.chi2_dof, beta_cal, r_cal
     );
 }
 

--- a/crates/nereids-physics/src/continuous_doppler.rs
+++ b/crates/nereids-physics/src/continuous_doppler.rs
@@ -12,6 +12,7 @@ use std::collections::BinaryHeap;
 use std::fmt;
 
 use nereids_endf::resonance::{ResonanceData, ResonanceFormalism, ResonanceRange};
+use rayon::prelude::*;
 
 use crate::doppler::DopplerParams;
 use crate::reich_moore::CrossSectionPlan;
@@ -490,9 +491,16 @@ fn try_broaden_integrals(
         return Ok(None);
     };
 
+    // Each target energy is a mathematically independent free-gas integral.
+    // Parallelize those independent integrals directly. The surrounding
+    // transmission code also parallelizes across isotopes, but the common
+    // thermometry case contains one isotope; isotope-only parallelism left
+    // almost the entire calculation serial. `IndexedParallelIterator::collect`
+    // preserves the input energy order, and no tolerance or quadrature rule is
+    // changed here.
     energies
-        .iter()
-        .zip(ranges)
+        .par_iter()
+        .zip(ranges.into_par_iter())
         .map(|(&energy, range)| {
             broaden_target(
                 &plan,

--- a/crates/nereids-physics/src/continuous_doppler.rs
+++ b/crates/nereids-physics/src/continuous_doppler.rs
@@ -560,6 +560,7 @@ pub(crate) fn try_broaden_with_derivative(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nereids_endf::parser::parse_endf_file2;
     use nereids_endf::resonance::test_support::u238_with_formalism;
 
     #[test]
@@ -660,6 +661,67 @@ mod tests {
             five_point,
             difference,
             allowance,
+        );
+    }
+
+    /// Independent full-kernel check for the Hf-177 regression used by the
+    /// public Python test. The oracle uses a fixed 400,001-point trapezoidal
+    /// integral in thermal-speed coordinates, not this module's adaptive
+    /// Gauss-Legendre panels, breakpoints, or error estimator.
+    #[test]
+    fn hf177_matches_uniform_speed_trapezoid_oracle() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("tests/data/endf/Hf-177.endf");
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("required Hf-177 fixture missing at {path:?}: {error}"));
+        let data = parse_endf_file2(&text).expect("tracked Hf-177 fixture must parse");
+
+        let target_energy = 8.876_917_538_350_767_f64;
+        let temperature_k = 300.0_f64;
+        let n_points = 400_001_usize;
+        let left_x = -8.0_f64;
+        let right_x = 8.0_f64;
+        let dx = (right_x - left_x) / (n_points - 1) as f64;
+        let thermal_speed = (8.617_333_262e-5 * temperature_k / data.awr).sqrt();
+        let target_speed = target_energy.sqrt();
+        let source_energies: Vec<f64> = (0..n_points)
+            .map(|index| {
+                let x = left_x + index as f64 * dx;
+                (target_speed + thermal_speed * x).powi(2)
+            })
+            .collect();
+        let source_cross_sections = CrossSectionPlan::new(&data).evaluate(&source_energies);
+        let normalization = std::f64::consts::PI.sqrt() * target_energy;
+        let mut trapezoid_sum = 0.0;
+        for (index, (&source_energy, cross_section)) in source_energies
+            .iter()
+            .zip(source_cross_sections.iter())
+            .enumerate()
+        {
+            let x = left_x + index as f64 * dx;
+            let endpoint_weight = if index == 0 || index + 1 == n_points {
+                0.5
+            } else {
+                1.0
+            };
+            trapezoid_sum += endpoint_weight * (-x * x).exp() * source_energy * cross_section.total
+                / normalization;
+        }
+        let oracle = trapezoid_sum * dx;
+
+        let params = DopplerParams::new(temperature_k, data.awr).unwrap();
+        let actual = try_broaden(&[target_energy], &data, &params)
+            .unwrap()
+            .expect("Hf-177 MLBW source is supported")[0];
+        let relative_difference = (actual - oracle).abs() / oracle.abs();
+
+        assert!(
+            relative_difference <= 1.0e-10,
+            "adaptive={actual:.16e} trapezoid={oracle:.16e} relative_difference={relative_difference:.3e}",
         );
     }
 }

--- a/crates/nereids-physics/src/continuous_doppler.rs
+++ b/crates/nereids-physics/src/continuous_doppler.rs
@@ -19,6 +19,7 @@ use crate::reich_moore::CrossSectionPlan;
 const SUPPORT_X: f64 = 8.0;
 const RELATIVE_TOLERANCE: f64 = 1.0e-8;
 const ABSOLUTE_TOLERANCE_BARN: f64 = 1.0e-8;
+const ABSOLUTE_DERIVATIVE_TOLERANCE_BARN_PER_K: f64 = 1.0e-10;
 const MAX_DEPTH: usize = 20;
 const MAX_ACTIVE_PANELS: usize = 4_096;
 const SQRT_PI: f64 = 1.772_453_850_905_516;
@@ -93,6 +94,10 @@ pub enum ContinuousDopplerError {
         energy_ev: f64,
         value: f64,
     },
+    InvalidDerivative {
+        energy_ev: f64,
+        value: f64,
+    },
     PanelLimit {
         energy_ev: f64,
         limit: usize,
@@ -128,6 +133,10 @@ impl fmt::Display for ContinuousDopplerError {
                 formatter,
                 "continuous Doppler integral at {energy_ev} eV is invalid: {value}"
             ),
+            Self::InvalidDerivative { energy_ev, value } => write!(
+                formatter,
+                "continuous Doppler temperature derivative at {energy_ev} eV is invalid: {value}"
+            ),
             Self::PanelLimit { energy_ev, limit } => write!(
                 formatter,
                 "continuous Doppler integral at {energy_ev} eV exceeded {limit} active panels"
@@ -156,13 +165,16 @@ struct Panel {
     right: f64,
     depth: usize,
     value: f64,
-    error: f64,
+    derivative: f64,
+    value_error: f64,
+    derivative_error: f64,
+    priority: f64,
     sequence: usize,
 }
 
 impl PartialEq for Panel {
     fn eq(&self, other: &Self) -> bool {
-        self.error.to_bits() == other.error.to_bits() && self.sequence == other.sequence
+        self.priority.to_bits() == other.priority.to_bits() && self.sequence == other.sequence
     }
 }
 
@@ -176,10 +188,26 @@ impl PartialOrd for Panel {
 
 impl Ord for Panel {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.error
-            .total_cmp(&other.error)
+        self.priority
+            .total_cmp(&other.priority)
             .then_with(|| self.sequence.cmp(&other.sequence))
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Integral {
+    value: f64,
+    derivative: f64,
+}
+
+type BroadenedWithDerivative = (Vec<f64>, Vec<f64>);
+
+struct TargetContext<'plan, 'data> {
+    plan: &'plan CrossSectionPlan<'data>,
+    target_energy: f64,
+    thermal_u: f64,
+    temperature_k: f64,
+    require_derivative: bool,
 }
 
 fn supported_range(
@@ -243,10 +271,11 @@ fn rule(
     plan: &CrossSectionPlan<'_>,
     target_energy: f64,
     thermal_u: f64,
+    temperature_k: f64,
     left: f64,
     right: f64,
     nodes: &[(f64, f64)],
-) -> f64 {
+) -> Integral {
     let middle = 0.5 * (left + right);
     let radius = 0.5 * (right - left);
     let target_speed = target_energy.sqrt();
@@ -258,36 +287,65 @@ fn rule(
         })
         .collect();
     let cross_sections = plan.evaluate(&source_energies);
-    radius
-        * nodes
-            .iter()
-            .zip(source_energies.iter().zip(cross_sections))
-            .map(|((node, weight), (source_energy, cross_section))| {
-                let coordinate = middle + radius * node;
+    let (value, derivative) = nodes
+        .iter()
+        .zip(source_energies.iter().zip(cross_sections))
+        .map(|((node, weight), (source_energy, cross_section))| {
+            let coordinate = middle + radius * node;
+            let contribution =
                 weight * (-coordinate * coordinate).exp() * source_energy * cross_section.total
-                    / (SQRT_PI * target_energy)
-            })
-            .sum::<f64>()
+                    / (SQRT_PI * target_energy);
+            (
+                contribution,
+                contribution * (coordinate * coordinate - 0.5) / temperature_k,
+            )
+        })
+        .fold((0.0, 0.0), |(value, derivative), contribution| {
+            (value + contribution.0, derivative + contribution.1)
+        });
+    Integral {
+        value: radius * value,
+        derivative: radius * derivative,
+    }
 }
 
-fn evaluate_panel(
-    plan: &CrossSectionPlan<'_>,
-    target_energy: f64,
-    thermal_u: f64,
-    left: f64,
-    right: f64,
-    depth: usize,
-    sequence: usize,
-) -> Panel {
-    let coarse = rule(plan, target_energy, thermal_u, left, right, &GL16);
-    let fine = rule(plan, target_energy, thermal_u, left, right, &GL32);
-    Panel {
-        left,
-        right,
-        depth,
-        value: fine,
-        error: (fine - coarse).abs(),
-        sequence,
+impl TargetContext<'_, '_> {
+    fn evaluate_panel(&self, left: f64, right: f64, depth: usize, sequence: usize) -> Panel {
+        let coarse = rule(
+            self.plan,
+            self.target_energy,
+            self.thermal_u,
+            self.temperature_k,
+            left,
+            right,
+            &GL16,
+        );
+        let fine = rule(
+            self.plan,
+            self.target_energy,
+            self.thermal_u,
+            self.temperature_k,
+            left,
+            right,
+            &GL32,
+        );
+        let value_error = (fine.value - coarse.value).abs();
+        let derivative_error = (fine.derivative - coarse.derivative).abs();
+        Panel {
+            left,
+            right,
+            depth,
+            value: fine.value,
+            derivative: fine.derivative,
+            value_error,
+            derivative_error,
+            priority: if self.require_derivative {
+                value_error.max(self.temperature_k * derivative_error)
+            } else {
+                value_error
+            },
+            sequence,
+        }
     }
 }
 
@@ -296,29 +354,38 @@ fn broaden_target(
     range: &ResonanceRange,
     target_energy: f64,
     thermal_u: f64,
-) -> Result<f64, ContinuousDopplerError> {
+    temperature_k: f64,
+    require_derivative: bool,
+) -> Result<Integral, ContinuousDopplerError> {
+    let context = TargetContext {
+        plan,
+        target_energy,
+        thermal_u,
+        temperature_k,
+        require_derivative,
+    };
     let points = breakpoints(range, target_energy, thermal_u);
     let mut heap = BinaryHeap::with_capacity(points.len());
     let mut value = 0.0;
-    let mut error = 0.0;
+    let mut derivative = 0.0;
+    let mut value_error = 0.0;
+    let mut derivative_error = 0.0;
     let mut sequence = 0usize;
     for pair in points.windows(2) {
-        let panel = evaluate_panel(
-            plan,
-            target_energy,
-            thermal_u,
-            pair[0],
-            pair[1],
-            0,
-            sequence,
-        );
+        let panel = context.evaluate_panel(pair[0], pair[1], 0, sequence);
         sequence += 1;
         value += panel.value;
-        error += panel.error;
+        derivative += panel.derivative;
+        value_error += panel.value_error;
+        derivative_error += panel.derivative_error;
         heap.push(panel);
     }
 
-    while error > ABSOLUTE_TOLERANCE_BARN + RELATIVE_TOLERANCE * value.abs() {
+    while value_error > ABSOLUTE_TOLERANCE_BARN + RELATIVE_TOLERANCE * value.abs()
+        || (require_derivative
+            && derivative_error
+                > ABSOLUTE_DERIVATIVE_TOLERANCE_BARN_PER_K + RELATIVE_TOLERANCE * derivative.abs())
+    {
         if heap.len() >= MAX_ACTIVE_PANELS {
             return Err(ContinuousDopplerError::PanelLimit {
                 energy_ev: target_energy,
@@ -341,28 +408,19 @@ fn broaden_target(
             });
         }
         let children = [
-            evaluate_panel(
-                plan,
-                target_energy,
-                thermal_u,
-                panel.left,
-                middle,
-                panel.depth + 1,
-                sequence,
-            ),
-            evaluate_panel(
-                plan,
-                target_energy,
-                thermal_u,
-                middle,
-                panel.right,
-                panel.depth + 1,
-                sequence + 1,
-            ),
+            context.evaluate_panel(panel.left, middle, panel.depth + 1, sequence),
+            context.evaluate_panel(middle, panel.right, panel.depth + 1, sequence + 1),
         ];
         sequence += 2;
         value += children[0].value + children[1].value - panel.value;
-        error = (error + children[0].error + children[1].error - panel.error).max(0.0);
+        derivative += children[0].derivative + children[1].derivative - panel.derivative;
+        value_error = (value_error + children[0].value_error + children[1].value_error
+            - panel.value_error)
+            .max(0.0);
+        derivative_error =
+            (derivative_error + children[0].derivative_error + children[1].derivative_error
+                - panel.derivative_error)
+                .max(0.0);
         heap.extend(children);
     }
 
@@ -372,20 +430,16 @@ fn broaden_target(
             value,
         });
     }
-    Ok(value)
+    if require_derivative && !derivative.is_finite() {
+        return Err(ContinuousDopplerError::InvalidDerivative {
+            energy_ev: target_energy,
+            value: derivative,
+        });
+    }
+    Ok(Integral { value, derivative })
 }
 
-/// Try the continuous source-aware free-gas transform.
-///
-/// `Ok(None)` means that at least one requested thermal support window is not
-/// wholly inside a resolved SLBW/MLBW range.  Callers must then use their
-/// explicitly named legacy route; unsupported data are never partially mixed
-/// with the continuous result.
-pub(crate) fn try_broaden(
-    energies: &[f64],
-    data: &ResonanceData,
-    params: &DopplerParams,
-) -> Result<Option<Vec<f64>>, ContinuousDopplerError> {
+fn validate_energies(energies: &[f64]) -> Result<(), ContinuousDopplerError> {
     for (index, &energy) in energies.iter().enumerate() {
         if !energy.is_finite() || energy <= 0.0 {
             return Err(ContinuousDopplerError::InvalidEnergy {
@@ -401,28 +455,33 @@ pub(crate) fn try_broaden(
             });
         }
     }
+    Ok(())
+}
+
+fn try_broaden_integrals(
+    energies: &[f64],
+    data: &ResonanceData,
+    params: &DopplerParams,
+    require_derivative: bool,
+) -> Result<Option<Vec<Integral>>, ContinuousDopplerError> {
+    validate_energies(energies)?;
     if energies.is_empty() {
         return Ok(Some(Vec::new()));
     }
 
     let plan = CrossSectionPlan::new(data);
-    if params.temperature_k() <= 0.0 {
+    if params.temperature_k() <= 0.0 || params.u() == 0.0 {
         return Ok(Some(
             plan.evaluate(energies)
                 .into_iter()
-                .map(|cross_section| cross_section.total)
+                .map(|cross_section| Integral {
+                    value: cross_section.total,
+                    derivative: 0.0,
+                })
                 .collect(),
         ));
     }
     let thermal_u = params.u();
-    if thermal_u == 0.0 {
-        return Ok(Some(
-            plan.evaluate(energies)
-                .into_iter()
-                .map(|cross_section| cross_section.total)
-                .collect(),
-        ));
-    }
     let ranges: Option<Vec<&ResonanceRange>> = energies
         .iter()
         .map(|&energy| supported_range(data, energy, thermal_u))
@@ -434,9 +493,60 @@ pub(crate) fn try_broaden(
     energies
         .iter()
         .zip(ranges)
-        .map(|(&energy, range)| broaden_target(&plan, range, energy, thermal_u))
+        .map(|(&energy, range)| {
+            broaden_target(
+                &plan,
+                range,
+                energy,
+                thermal_u,
+                params.temperature_k(),
+                require_derivative,
+            )
+        })
         .collect::<Result<Vec<_>, _>>()
         .map(Some)
+}
+
+/// Try the continuous source-aware free-gas transform.
+///
+/// `Ok(None)` means that at least one requested thermal support window is not
+/// wholly inside a resolved SLBW/MLBW range.  Callers must then use their
+/// explicitly named legacy route; unsupported data are never partially mixed
+/// with the continuous result.
+pub(crate) fn try_broaden(
+    energies: &[f64],
+    data: &ResonanceData,
+    params: &DopplerParams,
+) -> Result<Option<Vec<f64>>, ContinuousDopplerError> {
+    try_broaden_integrals(energies, data, params, false).map(|result| {
+        result.map(|integrals| {
+            integrals
+                .into_iter()
+                .map(|integral| integral.value)
+                .collect()
+        })
+    })
+}
+
+/// Try the continuous free-gas transform and its exact temperature derivative.
+///
+/// At fixed source speed, differentiating the Maxwellian kernel contributes
+/// `(x^2 - 1/2) / T` inside the same integral, where
+/// `x = (sqrt(E_source) - sqrt(E_target)) / u`.  Value and derivative are
+/// integrated together and must both pass error estimates before returning.
+pub(crate) fn try_broaden_with_derivative(
+    energies: &[f64],
+    data: &ResonanceData,
+    params: &DopplerParams,
+) -> Result<Option<BroadenedWithDerivative>, ContinuousDopplerError> {
+    try_broaden_integrals(energies, data, params, true).map(|result| {
+        result.map(|integrals| {
+            integrals
+                .into_iter()
+                .map(|integral| (integral.value, integral.derivative))
+                .unzip()
+        })
+    })
 }
 
 #[cfg(test)]
@@ -511,5 +621,37 @@ mod tests {
             .collect();
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn analytical_temperature_derivative_matches_five_point_difference() {
+        let data = u238_with_formalism(ResonanceFormalism::MLBW);
+        let energy = [6.674];
+        let temperature = 300.0;
+        let step = 0.5;
+        let params = DopplerParams::new(temperature, data.awr).unwrap();
+        let (_, derivative) = try_broaden_with_derivative(&energy, &data, &params)
+            .unwrap()
+            .expect("supported MLBW source");
+        let value_at = |offset: f64| {
+            let shifted = DopplerParams::new(temperature + offset, data.awr).unwrap();
+            try_broaden(&energy, &data, &shifted)
+                .unwrap()
+                .expect("supported MLBW source")[0]
+        };
+        let five_point = (value_at(-2.0 * step) - 8.0 * value_at(-step) + 8.0 * value_at(step)
+            - value_at(2.0 * step))
+            / (12.0 * step);
+        let difference = (derivative[0] - five_point).abs();
+        let allowance = 1.0e-8 + 1.0e-6 * five_point.abs();
+
+        assert!(
+            difference <= allowance,
+            "analytical={} five_point={} difference={} allowance={}",
+            derivative[0],
+            five_point,
+            difference,
+            allowance,
+        );
     }
 }

--- a/crates/nereids-physics/src/continuous_doppler.rs
+++ b/crates/nereids-physics/src/continuous_doppler.rs
@@ -1,0 +1,515 @@
+//! Error-controlled free-gas Doppler integration of the resonance equation.
+//!
+//! The legacy broadener interpolates a caller-supplied zero-temperature
+//! table.  That is appropriate only when the table already resolves every
+//! resonance inside each thermal kernel.  This module instead evaluates the
+//! immutable ENDF resonance equation at quadrature points selected from the
+//! physical resonance locations and widths.  It never creates or refines a
+//! stored source grid.
+
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+use std::fmt;
+
+use nereids_endf::resonance::{ResonanceData, ResonanceFormalism, ResonanceRange};
+
+use crate::doppler::DopplerParams;
+use crate::reich_moore::CrossSectionPlan;
+
+const SUPPORT_X: f64 = 8.0;
+const RELATIVE_TOLERANCE: f64 = 1.0e-8;
+const ABSOLUTE_TOLERANCE_BARN: f64 = 1.0e-8;
+const MAX_DEPTH: usize = 20;
+const MAX_ACTIVE_PANELS: usize = 4_096;
+const SQRT_PI: f64 = 1.772_453_850_905_516;
+const BREAKPOINT_WIDTHS: [f64; 5] = [-4.0, -1.0, 0.0, 1.0, 4.0];
+
+const GL16: [(f64, f64); 16] = [
+    (-9.894_009_349_916_499e-1, 2.715_245_941_175_405_5e-2),
+    (-9.445_750_230_732_326e-1, 6.225_352_393_864_761e-2),
+    (-8.656_312_023_878_316e-1, 9.515_851_168_249_3e-2),
+    (-7.554_044_083_550_031e-1, 1.246_289_712_555_339_5e-1),
+    (-6.178_762_444_026_438e-1, 1.495_959_888_165_766_5e-1),
+    (-4.580_167_776_572_273_7e-1, 1.691_565_193_950_026_2e-1),
+    (-2.816_035_507_792_589e-1, 1.826_034_150_449_236e-1),
+    (-9.501_250_983_763_744e-2, 1.894_506_104_550_685_9e-1),
+    (9.501_250_983_763_744e-2, 1.894_506_104_550_685_9e-1),
+    (2.816_035_507_792_589e-1, 1.826_034_150_449_236e-1),
+    (4.580_167_776_572_273_7e-1, 1.691_565_193_950_026_2e-1),
+    (6.178_762_444_026_438e-1, 1.495_959_888_165_766_5e-1),
+    (7.554_044_083_550_031e-1, 1.246_289_712_555_339_5e-1),
+    (8.656_312_023_878_316e-1, 9.515_851_168_249_3e-2),
+    (9.445_750_230_732_326e-1, 6.225_352_393_864_761e-2),
+    (9.894_009_349_916_499e-1, 2.715_245_941_175_405_5e-2),
+];
+
+const GL32: [(f64, f64); 32] = [
+    (-9.972_638_618_494_816e-1, 7.018_610_009_470_362e-3),
+    (-9.856_115_115_452_683e-1, 1.627_439_473_090_648_6e-2),
+    (-9.647_622_555_875_064e-1, 2.539_206_530_926_273e-2),
+    (-9.349_060_759_377_397e-1, 3.427_386_291_302_163e-2),
+    (-8.963_211_557_660_521e-1, 4.283_589_802_222_692_6e-2),
+    (-8.493_676_137_325_7e-1, 5.099_805_926_237_596e-2),
+    (-7.944_837_959_679_424e-1, 5.868_409_347_853_546e-2),
+    (-7.321_821_187_402_897e-1, 6.582_222_277_636_16e-2),
+    (-6.630_442_669_302_152e-1, 7.234_579_410_884_82e-2),
+    (-5.877_157_572_407_623e-1, 7.819_389_578_707_012e-2),
+    (-5.068_999_089_322_294e-1, 8.331_192_422_694_662e-2),
+    (-4.213_512_761_306_353_3e-1, 8.765_209_300_440_369e-2),
+    (-3.318_686_022_821_276_7e-1, 9.117_387_869_576_371e-2),
+    (-2.392_873_622_521_370_6e-1, 9.384_439_908_080_439e-2),
+    (-1.444_719_615_827_965e-1, 9.563_872_007_927_46e-2),
+    (-4.830_766_568_773_832e-2, 9.654_008_851_472_758e-2),
+    (4.830_766_568_773_832e-2, 9.654_008_851_472_758e-2),
+    (1.444_719_615_827_965e-1, 9.563_872_007_927_46e-2),
+    (2.392_873_622_521_370_6e-1, 9.384_439_908_080_439e-2),
+    (3.318_686_022_821_276_7e-1, 9.117_387_869_576_371e-2),
+    (4.213_512_761_306_353_3e-1, 8.765_209_300_440_369e-2),
+    (5.068_999_089_322_294e-1, 8.331_192_422_694_662e-2),
+    (5.877_157_572_407_623e-1, 7.819_389_578_707_012e-2),
+    (6.630_442_669_302_152e-1, 7.234_579_410_884_82e-2),
+    (7.321_821_187_402_897e-1, 6.582_222_277_636_16e-2),
+    (7.944_837_959_679_424e-1, 5.868_409_347_853_546e-2),
+    (8.493_676_137_325_7e-1, 5.099_805_926_237_596e-2),
+    (8.963_211_557_660_521e-1, 4.283_589_802_222_692_6e-2),
+    (9.349_060_759_377_397e-1, 3.427_386_291_302_163e-2),
+    (9.647_622_555_875_064e-1, 2.539_206_530_926_273e-2),
+    (9.856_115_115_452_683e-1, 1.627_439_473_090_648_6e-2),
+    (9.972_638_618_494_816e-1, 7.018_610_009_470_362e-3),
+];
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ContinuousDopplerError {
+    InvalidEnergy {
+        index: usize,
+        value: f64,
+    },
+    UnsortedEnergy {
+        index: usize,
+        previous: f64,
+        current: f64,
+    },
+    InvalidIntegral {
+        energy_ev: f64,
+        value: f64,
+    },
+    PanelLimit {
+        energy_ev: f64,
+        limit: usize,
+    },
+    DepthLimit {
+        energy_ev: f64,
+        depth: usize,
+    },
+    MidpointStagnation {
+        energy_ev: f64,
+        left: f64,
+        right: f64,
+    },
+}
+
+impl fmt::Display for ContinuousDopplerError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidEnergy { index, value } => write!(
+                formatter,
+                "continuous Doppler energy {index} must be finite and positive, got {value}"
+            ),
+            Self::UnsortedEnergy {
+                index,
+                previous,
+                current,
+            } => write!(
+                formatter,
+                "continuous Doppler energies must increase strictly; values at {} and {index} are {previous} and {current}",
+                index - 1
+            ),
+            Self::InvalidIntegral { energy_ev, value } => write!(
+                formatter,
+                "continuous Doppler integral at {energy_ev} eV is invalid: {value}"
+            ),
+            Self::PanelLimit { energy_ev, limit } => write!(
+                formatter,
+                "continuous Doppler integral at {energy_ev} eV exceeded {limit} active panels"
+            ),
+            Self::DepthLimit { energy_ev, depth } => write!(
+                formatter,
+                "continuous Doppler integral at {energy_ev} eV exceeded depth {depth}"
+            ),
+            Self::MidpointStagnation {
+                energy_ev,
+                left,
+                right,
+            } => write!(
+                formatter,
+                "continuous Doppler integral at {energy_ev} eV stagnated on [{left}, {right}]"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ContinuousDopplerError {}
+
+#[derive(Debug, Clone)]
+struct Panel {
+    left: f64,
+    right: f64,
+    depth: usize,
+    value: f64,
+    error: f64,
+    sequence: usize,
+}
+
+impl PartialEq for Panel {
+    fn eq(&self, other: &Self) -> bool {
+        self.error.to_bits() == other.error.to_bits() && self.sequence == other.sequence
+    }
+}
+
+impl Eq for Panel {}
+
+impl PartialOrd for Panel {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Panel {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.error
+            .total_cmp(&other.error)
+            .then_with(|| self.sequence.cmp(&other.sequence))
+    }
+}
+
+fn supported_range(
+    data: &ResonanceData,
+    target_energy: f64,
+    thermal_u: f64,
+) -> Option<&ResonanceRange> {
+    let speed = target_energy.sqrt();
+    let low_speed = speed - SUPPORT_X * thermal_u;
+    if low_speed <= 0.0 {
+        return None;
+    }
+    let low_energy = low_speed * low_speed;
+    let high_energy = (speed + SUPPORT_X * thermal_u).powi(2);
+    data.ranges.iter().find(|range| {
+        range.resolved
+            && matches!(
+                range.formalism,
+                ResonanceFormalism::SLBW | ResonanceFormalism::MLBW
+            )
+            && range.rml.is_none()
+            && range.urr.is_none()
+            && low_energy >= range.energy_low
+            && high_energy <= range.energy_high
+    })
+}
+
+fn breakpoints(range: &ResonanceRange, target_energy: f64, thermal_u: f64) -> Vec<f64> {
+    let speed = target_energy.sqrt();
+    let low_energy = (speed - SUPPORT_X * thermal_u).powi(2);
+    let high_energy = (speed + SUPPORT_X * thermal_u).powi(2);
+    let mut points = vec![-SUPPORT_X, SUPPORT_X];
+    for group in &range.l_groups {
+        for resonance in &group.resonances {
+            let total_width =
+                resonance.gn.abs() + resonance.gg.abs() + resonance.gfa.abs() + resonance.gfb.abs();
+            if total_width <= 0.0
+                || resonance.energy + 4.0 * total_width < low_energy
+                || resonance.energy - 4.0 * total_width > high_energy
+            {
+                continue;
+            }
+            for multiplier in BREAKPOINT_WIDTHS {
+                let source_energy = resonance.energy + multiplier * total_width;
+                if source_energy <= 0.0 {
+                    continue;
+                }
+                let coordinate = (source_energy.sqrt() - speed) / thermal_u;
+                if coordinate > -SUPPORT_X && coordinate < SUPPORT_X {
+                    points.push(coordinate);
+                }
+            }
+        }
+    }
+    points.sort_by(f64::total_cmp);
+    points.dedup_by(|left, right| left.to_bits() == right.to_bits());
+    points
+}
+
+fn rule(
+    plan: &CrossSectionPlan<'_>,
+    target_energy: f64,
+    thermal_u: f64,
+    left: f64,
+    right: f64,
+    nodes: &[(f64, f64)],
+) -> f64 {
+    let middle = 0.5 * (left + right);
+    let radius = 0.5 * (right - left);
+    let target_speed = target_energy.sqrt();
+    let source_energies: Vec<f64> = nodes
+        .iter()
+        .map(|(node, _)| {
+            let coordinate = middle + radius * node;
+            (target_speed + thermal_u * coordinate).powi(2)
+        })
+        .collect();
+    let cross_sections = plan.evaluate(&source_energies);
+    radius
+        * nodes
+            .iter()
+            .zip(source_energies.iter().zip(cross_sections))
+            .map(|((node, weight), (source_energy, cross_section))| {
+                let coordinate = middle + radius * node;
+                weight * (-coordinate * coordinate).exp() * source_energy * cross_section.total
+                    / (SQRT_PI * target_energy)
+            })
+            .sum::<f64>()
+}
+
+fn evaluate_panel(
+    plan: &CrossSectionPlan<'_>,
+    target_energy: f64,
+    thermal_u: f64,
+    left: f64,
+    right: f64,
+    depth: usize,
+    sequence: usize,
+) -> Panel {
+    let coarse = rule(plan, target_energy, thermal_u, left, right, &GL16);
+    let fine = rule(plan, target_energy, thermal_u, left, right, &GL32);
+    Panel {
+        left,
+        right,
+        depth,
+        value: fine,
+        error: (fine - coarse).abs(),
+        sequence,
+    }
+}
+
+fn broaden_target(
+    plan: &CrossSectionPlan<'_>,
+    range: &ResonanceRange,
+    target_energy: f64,
+    thermal_u: f64,
+) -> Result<f64, ContinuousDopplerError> {
+    let points = breakpoints(range, target_energy, thermal_u);
+    let mut heap = BinaryHeap::with_capacity(points.len());
+    let mut value = 0.0;
+    let mut error = 0.0;
+    let mut sequence = 0usize;
+    for pair in points.windows(2) {
+        let panel = evaluate_panel(
+            plan,
+            target_energy,
+            thermal_u,
+            pair[0],
+            pair[1],
+            0,
+            sequence,
+        );
+        sequence += 1;
+        value += panel.value;
+        error += panel.error;
+        heap.push(panel);
+    }
+
+    while error > ABSOLUTE_TOLERANCE_BARN + RELATIVE_TOLERANCE * value.abs() {
+        if heap.len() >= MAX_ACTIVE_PANELS {
+            return Err(ContinuousDopplerError::PanelLimit {
+                energy_ev: target_energy,
+                limit: MAX_ACTIVE_PANELS,
+            });
+        }
+        let panel = heap.pop().expect("an active panel while error is nonzero");
+        if panel.depth >= MAX_DEPTH {
+            return Err(ContinuousDopplerError::DepthLimit {
+                energy_ev: target_energy,
+                depth: MAX_DEPTH,
+            });
+        }
+        let middle = 0.5 * (panel.left + panel.right);
+        if !(panel.left < middle && middle < panel.right) {
+            return Err(ContinuousDopplerError::MidpointStagnation {
+                energy_ev: target_energy,
+                left: panel.left,
+                right: panel.right,
+            });
+        }
+        let children = [
+            evaluate_panel(
+                plan,
+                target_energy,
+                thermal_u,
+                panel.left,
+                middle,
+                panel.depth + 1,
+                sequence,
+            ),
+            evaluate_panel(
+                plan,
+                target_energy,
+                thermal_u,
+                middle,
+                panel.right,
+                panel.depth + 1,
+                sequence + 1,
+            ),
+        ];
+        sequence += 2;
+        value += children[0].value + children[1].value - panel.value;
+        error = (error + children[0].error + children[1].error - panel.error).max(0.0);
+        heap.extend(children);
+    }
+
+    if !value.is_finite() || value < 0.0 {
+        return Err(ContinuousDopplerError::InvalidIntegral {
+            energy_ev: target_energy,
+            value,
+        });
+    }
+    Ok(value)
+}
+
+/// Try the continuous source-aware free-gas transform.
+///
+/// `Ok(None)` means that at least one requested thermal support window is not
+/// wholly inside a resolved SLBW/MLBW range.  Callers must then use their
+/// explicitly named legacy route; unsupported data are never partially mixed
+/// with the continuous result.
+pub(crate) fn try_broaden(
+    energies: &[f64],
+    data: &ResonanceData,
+    params: &DopplerParams,
+) -> Result<Option<Vec<f64>>, ContinuousDopplerError> {
+    for (index, &energy) in energies.iter().enumerate() {
+        if !energy.is_finite() || energy <= 0.0 {
+            return Err(ContinuousDopplerError::InvalidEnergy {
+                index,
+                value: energy,
+            });
+        }
+        if index > 0 && energy <= energies[index - 1] {
+            return Err(ContinuousDopplerError::UnsortedEnergy {
+                index,
+                previous: energies[index - 1],
+                current: energy,
+            });
+        }
+    }
+    if energies.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+
+    let plan = CrossSectionPlan::new(data);
+    if params.temperature_k() <= 0.0 {
+        return Ok(Some(
+            plan.evaluate(energies)
+                .into_iter()
+                .map(|cross_section| cross_section.total)
+                .collect(),
+        ));
+    }
+    let thermal_u = params.u();
+    if thermal_u == 0.0 {
+        return Ok(Some(
+            plan.evaluate(energies)
+                .into_iter()
+                .map(|cross_section| cross_section.total)
+                .collect(),
+        ));
+    }
+    let ranges: Option<Vec<&ResonanceRange>> = energies
+        .iter()
+        .map(|&energy| supported_range(data, energy, thermal_u))
+        .collect();
+    let Some(ranges) = ranges else {
+        return Ok(None);
+    };
+
+    energies
+        .iter()
+        .zip(ranges)
+        .map(|(&energy, range)| broaden_target(&plan, range, energy, thermal_u))
+        .collect::<Result<Vec<_>, _>>()
+        .map(Some)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nereids_endf::resonance::test_support::u238_with_formalism;
+
+    #[test]
+    fn zero_temperature_matches_the_resonance_equation() {
+        let data = u238_with_formalism(ResonanceFormalism::MLBW);
+        let energies = [6.5, 6.674, 6.9];
+        let params = DopplerParams::new(0.0, data.awr).unwrap();
+        let actual = try_broaden(&energies, &data, &params)
+            .unwrap()
+            .expect("supported MLBW source");
+        let expected: Vec<f64> = CrossSectionPlan::new(&data)
+            .evaluate(&energies)
+            .into_iter()
+            .map(|cross_section| cross_section.total)
+            .collect();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn unsupported_reich_moore_is_one_named_fallback_not_partial_output() {
+        let data = u238_with_formalism(ResonanceFormalism::ReichMoore);
+        let params = DopplerParams::new(300.0, data.awr).unwrap();
+        assert_eq!(try_broaden(&[6.674], &data, &params).unwrap(), None);
+    }
+
+    #[test]
+    fn resolved_mlbw_result_is_finite_positive_and_reproducible() {
+        let data = u238_with_formalism(ResonanceFormalism::MLBW);
+        let params = DopplerParams::new(300.0, data.awr).unwrap();
+        let first = try_broaden(&[6.674], &data, &params)
+            .unwrap()
+            .expect("supported MLBW source");
+        let second = try_broaden(&[6.674], &data, &params)
+            .unwrap()
+            .expect("supported MLBW source");
+        assert!(first[0].is_finite() && first[0] > 0.0);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn result_at_a_target_does_not_depend_on_unrelated_output_points() {
+        let data = u238_with_formalism(ResonanceFormalism::MLBW);
+        let params = DopplerParams::new(300.0, data.awr).unwrap();
+        let isolated = try_broaden(&[6.674], &data, &params)
+            .unwrap()
+            .expect("supported MLBW source");
+        let surrounding = try_broaden(&[6.5, 6.674, 6.9], &data, &params)
+            .unwrap()
+            .expect("supported MLBW source");
+
+        assert_eq!(isolated[0], surrounding[1]);
+    }
+
+    #[test]
+    fn underflowed_thermal_width_is_exactly_unbroadened() {
+        let data = u238_with_formalism(ResonanceFormalism::MLBW);
+        let energies = [6.5, 6.674, 6.9];
+        let params = DopplerParams::new(f64::from_bits(1), data.awr).unwrap();
+        assert_eq!(params.u(), 0.0);
+        let actual = try_broaden(&energies, &data, &params)
+            .unwrap()
+            .expect("supported MLBW source");
+        let expected: Vec<f64> = CrossSectionPlan::new(&data)
+            .evaluate(&energies)
+            .into_iter()
+            .map(|cross_section| cross_section.total)
+            .collect();
+
+        assert_eq!(actual, expected);
+    }
+}

--- a/crates/nereids-physics/src/counts_response.rs
+++ b/crates/nereids-physics/src/counts_response.rs
@@ -1,0 +1,207 @@
+//! Separate open-beam and sample count response in detector time.
+//!
+//! A detector does not observe a blurred transmission ratio. For discrete
+//! true-energy quadrature points `E_j`, the two physical arms are
+//!
+//! ```text
+//! O_i = sum_j F_j       R_i(E_j)
+//! S_i = sum_j F_j T_j  R_i(E_j)
+//! ```
+//!
+//! `F_j` is the incident fluence weight at true energy `E_j` (the incident
+//! flux density multiplied by the caller's energy-integration weight), `T_j`
+//! is the sample transmission before instrument response, and `R_i(E_j)` is
+//! the probability that a neutron at `E_j` lands between the actual detector
+//! time edges of bin `i`.
+//!
+//! Keeping `F_j` as an already-integrated weight is deliberate: this operator
+//! never guesses energy-bin widths from centers. A caller using a continuous
+//! source spectrum must choose and disclose its energy quadrature, then pass
+//! `F_j = w_j Phi(E_j)`. The detector-time integration itself is performed by
+//! the response model over the supplied measured bin edges.
+
+use std::fmt;
+
+use crate::resolution::{ResolutionFunction, ResolutionParseError};
+
+/// Expected detector-bin counts for the open-beam and sample measurements.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TwoArmCounts {
+    /// Open-beam expectation `sum_j F_j R_i(E_j)`.
+    pub open_beam: Vec<f64>,
+    /// Sample expectation `sum_j F_j T_j R_i(E_j)`.
+    pub sample: Vec<f64>,
+}
+
+/// Invalid inputs or unsupported response models for [`two_arm_count_response`].
+#[derive(Debug)]
+pub enum CountsResponseError {
+    /// At least one true-energy point is required.
+    EmptyTrueEnergyGrid,
+    /// True-energy, fluence, and transmission arrays must have equal lengths.
+    LengthMismatch {
+        energies: usize,
+        incident_fluence: usize,
+        transmission: usize,
+    },
+    /// A true energy was non-positive or non-finite.
+    InvalidTrueEnergy { index: usize, value: f64 },
+    /// An incident fluence weight was negative or non-finite.
+    InvalidIncidentFluence { index: usize, value: f64 },
+    /// A physical sample transmission was outside `[0, 1]` or non-finite.
+    InvalidTransmission { index: usize, value: f64 },
+    /// The response could not evaluate detector-bin probabilities.
+    Resolution(ResolutionParseError),
+}
+
+impl fmt::Display for CountsResponseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyTrueEnergyGrid => write!(f, "true_energies_ev must not be empty"),
+            Self::LengthMismatch {
+                energies,
+                incident_fluence,
+                transmission,
+            } => write!(
+                f,
+                "true_energies_ev ({energies}), incident_fluence_weights ({incident_fluence}), and transmission ({transmission}) must have equal lengths"
+            ),
+            Self::InvalidTrueEnergy { index, value } => write!(
+                f,
+                "true_energies_ev[{index}] must be positive and finite, got {value}"
+            ),
+            Self::InvalidIncidentFluence { index, value } => write!(
+                f,
+                "incident_fluence_weights[{index}] must be finite and >= 0, got {value}"
+            ),
+            Self::InvalidTransmission { index, value } => write!(
+                f,
+                "transmission[{index}] must be finite and in [0, 1], got {value}"
+            ),
+            Self::Resolution(error) => write!(f, "detector-time response failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for CountsResponseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Resolution(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<ResolutionParseError> for CountsResponseError {
+    fn from(value: ResolutionParseError) -> Self {
+        Self::Resolution(value)
+    }
+}
+
+/// Apply one instrument response to the open-beam and sample arms separately.
+///
+/// `incident_fluence_weights[j]` is an expected neutron count integrated over
+/// the true-energy quadrature element represented by `true_energies_ev[j]`.
+/// Probability outside `detector_time_edges_us` is intentionally not
+/// renormalized into the acquisition window.
+///
+/// This function models only source fluence, sample attenuation, and the
+/// instrument response. Detector/gamma/scattering backgrounds and exposure
+/// normalization are separate physical terms and must be added by a higher
+/// layer that states their measurement location.
+pub fn two_arm_count_response(
+    true_energies_ev: &[f64],
+    incident_fluence_weights: &[f64],
+    transmission: &[f64],
+    detector_time_edges_us: &[f64],
+    timing_offset_us: f64,
+    response: &ResolutionFunction,
+) -> Result<TwoArmCounts, CountsResponseError> {
+    if true_energies_ev.is_empty() {
+        return Err(CountsResponseError::EmptyTrueEnergyGrid);
+    }
+    if incident_fluence_weights.len() != true_energies_ev.len()
+        || transmission.len() != true_energies_ev.len()
+    {
+        return Err(CountsResponseError::LengthMismatch {
+            energies: true_energies_ev.len(),
+            incident_fluence: incident_fluence_weights.len(),
+            transmission: transmission.len(),
+        });
+    }
+    for (index, &energy) in true_energies_ev.iter().enumerate() {
+        if !energy.is_finite() || energy <= 0.0 {
+            return Err(CountsResponseError::InvalidTrueEnergy {
+                index,
+                value: energy,
+            });
+        }
+    }
+    for (index, &fluence) in incident_fluence_weights.iter().enumerate() {
+        if !fluence.is_finite() || fluence < 0.0 {
+            return Err(CountsResponseError::InvalidIncidentFluence {
+                index,
+                value: fluence,
+            });
+        }
+    }
+    for (index, &value) in transmission.iter().enumerate() {
+        if !value.is_finite() || !(0.0..=1.0).contains(&value) {
+            return Err(CountsResponseError::InvalidTransmission { index, value });
+        }
+    }
+
+    // Calling the response once even when every fluence weight is zero is
+    // important: malformed detector edges and unsupported Gaussian responses
+    // must still fail clearly instead of appearing to succeed with all zeros.
+    let n_bins = detector_time_edges_us.len().saturating_sub(1);
+    let mut open_beam = vec![0.0; n_bins];
+    let mut sample = vec![0.0; n_bins];
+    let mut open_compensation = vec![0.0; n_bins];
+    let mut sample_compensation = vec![0.0; n_bins];
+
+    for ((&energy, &fluence), &sample_transmission) in true_energies_ev
+        .iter()
+        .zip(incident_fluence_weights)
+        .zip(transmission)
+    {
+        let probabilities = response.detector_bin_probabilities(
+            energy,
+            detector_time_edges_us,
+            timing_offset_us,
+        )?;
+        debug_assert_eq!(probabilities.len(), n_bins);
+
+        // Neumaier-compensated accumulation keeps a weak high-energy tail from
+        // being lost when the same bin also contains a much larger prompt term.
+        for (bin, probability) in probabilities.into_iter().enumerate() {
+            compensated_add(
+                &mut open_beam[bin],
+                &mut open_compensation[bin],
+                fluence * probability,
+            );
+            compensated_add(
+                &mut sample[bin],
+                &mut sample_compensation[bin],
+                fluence * sample_transmission * probability,
+            );
+        }
+    }
+    for bin in 0..n_bins {
+        open_beam[bin] += open_compensation[bin];
+        sample[bin] += sample_compensation[bin];
+    }
+
+    Ok(TwoArmCounts { open_beam, sample })
+}
+
+#[inline]
+fn compensated_add(sum: &mut f64, compensation: &mut f64, value: f64) {
+    let next = *sum + value;
+    if sum.abs() >= value.abs() {
+        *compensation += (*sum - next) + value;
+    } else {
+        *compensation += (value - next) + *sum;
+    }
+    *sum = next;
+}

--- a/crates/nereids-physics/src/counts_response.rs
+++ b/crates/nereids-physics/src/counts_response.rs
@@ -33,6 +33,31 @@ pub struct TwoArmCounts {
     pub sample: Vec<f64>,
 }
 
+/// Signal, additive background, and total expected counts for one measured arm.
+///
+/// Background is expressed directly in the detector bins of that measurement.
+/// It is added after source attenuation and instrument response.  This is not
+/// the SAMMY additive transmission curve, and it is not convolved a second
+/// time by the instrument response.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ArmCountPrediction {
+    /// Neutron counts produced by source, sample, and instrument response.
+    pub neutron_signal: Vec<f64>,
+    /// Independently supplied additive expected counts in the measured bins.
+    pub background: Vec<f64>,
+    /// Complete expectation, `neutron_signal + background`.
+    pub total: Vec<f64>,
+}
+
+/// Complete expected counts for the open-beam and sample measurements.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TwoArmCountPrediction {
+    /// Open-beam measurement components.
+    pub open_beam: ArmCountPrediction,
+    /// Sample measurement components.
+    pub sample: ArmCountPrediction,
+}
+
 /// Invalid inputs or unsupported response models for [`two_arm_count_response`].
 #[derive(Debug)]
 pub enum CountsResponseError {
@@ -50,6 +75,19 @@ pub enum CountsResponseError {
     InvalidIncidentFluence { index: usize, value: f64 },
     /// A physical sample transmission was outside `[0, 1]` or non-finite.
     InvalidTransmission { index: usize, value: f64 },
+    /// A signal or background expected count was negative or non-finite.
+    InvalidExpectedCount {
+        field: &'static str,
+        index: usize,
+        value: f64,
+    },
+    /// Signal and background arrays did not describe the same detector bins.
+    DetectorBinCountMismatch {
+        open_signal: usize,
+        sample_signal: usize,
+        open_background: usize,
+        sample_background: usize,
+    },
     /// The response could not evaluate detector-bin probabilities.
     Resolution(ResolutionParseError),
 }
@@ -78,9 +116,127 @@ impl fmt::Display for CountsResponseError {
                 f,
                 "transmission[{index}] must be finite and in [0, 1], got {value}"
             ),
+            Self::InvalidExpectedCount {
+                field,
+                index,
+                value,
+            } => write!(
+                f,
+                "{field}[{index}] must be finite and >= 0 expected counts, got {value}"
+            ),
+            Self::DetectorBinCountMismatch {
+                open_signal,
+                sample_signal,
+                open_background,
+                sample_background,
+            } => write!(
+                f,
+                "open neutron signal ({open_signal} bins), sample neutron signal ({sample_signal}), open_background_counts ({open_background}), and sample_background_counts ({sample_background}) must have equal lengths"
+            ),
             Self::Resolution(error) => write!(f, "detector-time response failed: {error}"),
         }
     }
+}
+
+/// Add detector-bin backgrounds to an already evaluated two-arm neutron signal.
+///
+/// Both background arrays are expected counts for the corresponding complete
+/// acquisition, already mapped into the same detector-time bins as `signal`.
+/// A measured dark/blocked-beam reference may therefore be supplied directly
+/// after applying its independently justified run normalization.  The function
+/// does not guess an exposure, fit a smooth curve, or reinterpret a SAMMY
+/// transmission-level background as detector counts.
+///
+/// A sample-scattering calculation that starts from a true-energy spectrum is
+/// not an input to this function: it must first be propagated through the
+/// instrument response.  Only a scattering reference already measured in the
+/// detector bins can enter here directly.
+pub fn add_count_backgrounds(
+    signal: TwoArmCounts,
+    open_background_counts: &[f64],
+    sample_background_counts: &[f64],
+) -> Result<TwoArmCountPrediction, CountsResponseError> {
+    let n_bins = signal.open_beam.len();
+    if signal.sample.len() != n_bins
+        || open_background_counts.len() != n_bins
+        || sample_background_counts.len() != n_bins
+    {
+        return Err(CountsResponseError::DetectorBinCountMismatch {
+            open_signal: n_bins,
+            sample_signal: signal.sample.len(),
+            open_background: open_background_counts.len(),
+            sample_background: sample_background_counts.len(),
+        });
+    }
+
+    validate_expected_counts("open_neutron_signal", &signal.open_beam)?;
+    validate_expected_counts("sample_neutron_signal", &signal.sample)?;
+    validate_expected_counts("open_background_counts", open_background_counts)?;
+    validate_expected_counts("sample_background_counts", sample_background_counts)?;
+
+    let open_total = sum_expected_counts(
+        "open_total_expected_counts",
+        &signal.open_beam,
+        open_background_counts,
+    )?;
+    let sample_total = sum_expected_counts(
+        "sample_total_expected_counts",
+        &signal.sample,
+        sample_background_counts,
+    )?;
+
+    Ok(TwoArmCountPrediction {
+        open_beam: ArmCountPrediction {
+            neutron_signal: signal.open_beam,
+            background: open_background_counts.to_vec(),
+            total: open_total,
+        },
+        sample: ArmCountPrediction {
+            neutron_signal: signal.sample,
+            background: sample_background_counts.to_vec(),
+            total: sample_total,
+        },
+    })
+}
+
+fn validate_expected_counts(
+    field: &'static str,
+    values: &[f64],
+) -> Result<(), CountsResponseError> {
+    for (index, &value) in values.iter().enumerate() {
+        if !value.is_finite() || value < 0.0 {
+            return Err(CountsResponseError::InvalidExpectedCount {
+                field,
+                index,
+                value,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn sum_expected_counts(
+    field: &'static str,
+    neutron_signal: &[f64],
+    background: &[f64],
+) -> Result<Vec<f64>, CountsResponseError> {
+    neutron_signal
+        .iter()
+        .zip(background)
+        .enumerate()
+        .map(|(index, (&neutron, &background))| {
+            let total = neutron + background;
+            if total.is_finite() {
+                Ok(total)
+            } else {
+                Err(CountsResponseError::InvalidExpectedCount {
+                    field,
+                    index,
+                    value: total,
+                })
+            }
+        })
+        .collect()
 }
 
 impl std::error::Error for CountsResponseError {

--- a/crates/nereids-physics/src/counts_response.rs
+++ b/crates/nereids-physics/src/counts_response.rs
@@ -33,6 +33,141 @@ pub struct TwoArmCounts {
     pub sample: Vec<f64>,
 }
 
+/// Exact detector-bin probabilities for a fixed instrument response.
+///
+/// Rows correspond to `true_energies_ev`; columns correspond to consecutive
+/// intervals in `detector_time_edges_us`. Building the matrix evaluates the
+/// analytical IC/tabulated bin integrals once. Reusing it during optimization
+/// changes only the true-energy sample transmission, not the detector physics.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DetectorBinResponseMatrix {
+    probabilities: Vec<f64>,
+    n_true_energies: usize,
+    n_detector_bins: usize,
+}
+
+impl DetectorBinResponseMatrix {
+    /// Build an exact fixed-response matrix.
+    pub fn new(
+        true_energies_ev: &[f64],
+        detector_time_edges_us: &[f64],
+        timing_offset_us: f64,
+        response: &ResolutionFunction,
+    ) -> Result<Self, CountsResponseError> {
+        if true_energies_ev.is_empty() {
+            return Err(CountsResponseError::EmptyTrueEnergyGrid);
+        }
+        for (index, &energy) in true_energies_ev.iter().enumerate() {
+            if !energy.is_finite() || energy <= 0.0 {
+                return Err(CountsResponseError::InvalidTrueEnergy {
+                    index,
+                    value: energy,
+                });
+            }
+        }
+
+        let n_detector_bins = detector_time_edges_us.len().saturating_sub(1);
+        let mut probabilities = Vec::with_capacity(
+            true_energies_ev
+                .len()
+                .checked_mul(n_detector_bins)
+                .ok_or_else(|| {
+                    CountsResponseError::Resolution(ResolutionParseError::InvalidFormat(
+                        "detector response matrix dimensions overflow usize".into(),
+                    ))
+                })?,
+        );
+        for &energy in true_energies_ev {
+            let row = response.detector_bin_probabilities(
+                energy,
+                detector_time_edges_us,
+                timing_offset_us,
+            )?;
+            debug_assert_eq!(row.len(), n_detector_bins);
+            probabilities.extend(row);
+        }
+
+        Ok(Self {
+            probabilities,
+            n_true_energies: true_energies_ev.len(),
+            n_detector_bins,
+        })
+    }
+
+    /// Number of true-energy quadrature points.
+    pub fn n_true_energies(&self) -> usize {
+        self.n_true_energies
+    }
+
+    /// Number of measured detector-time bins.
+    pub fn n_detector_bins(&self) -> usize {
+        self.n_detector_bins
+    }
+
+    /// Probability that true-energy row `true_index` lands in detector bin
+    /// `detector_bin`.
+    pub fn probability(&self, true_index: usize, detector_bin: usize) -> f64 {
+        self.probabilities[true_index * self.n_detector_bins + detector_bin]
+    }
+
+    /// Apply the fixed response separately to open and sample arms.
+    pub fn apply(
+        &self,
+        incident_fluence_weights: &[f64],
+        transmission: &[f64],
+    ) -> Result<TwoArmCounts, CountsResponseError> {
+        if incident_fluence_weights.len() != self.n_true_energies
+            || transmission.len() != self.n_true_energies
+        {
+            return Err(CountsResponseError::LengthMismatch {
+                energies: self.n_true_energies,
+                incident_fluence: incident_fluence_weights.len(),
+                transmission: transmission.len(),
+            });
+        }
+        for (index, &fluence) in incident_fluence_weights.iter().enumerate() {
+            if !fluence.is_finite() || fluence < 0.0 {
+                return Err(CountsResponseError::InvalidIncidentFluence {
+                    index,
+                    value: fluence,
+                });
+            }
+        }
+        for (index, &value) in transmission.iter().enumerate() {
+            if !value.is_finite() || !(0.0..=1.0).contains(&value) {
+                return Err(CountsResponseError::InvalidTransmission { index, value });
+            }
+        }
+
+        let mut open_beam = vec![0.0; self.n_detector_bins];
+        let mut sample = vec![0.0; self.n_detector_bins];
+        let mut open_compensation = vec![0.0; self.n_detector_bins];
+        let mut sample_compensation = vec![0.0; self.n_detector_bins];
+        for true_index in 0..self.n_true_energies {
+            let fluence = incident_fluence_weights[true_index];
+            let sample_weight = fluence * transmission[true_index];
+            for detector_bin in 0..self.n_detector_bins {
+                let probability = self.probability(true_index, detector_bin);
+                compensated_add(
+                    &mut open_beam[detector_bin],
+                    &mut open_compensation[detector_bin],
+                    fluence * probability,
+                );
+                compensated_add(
+                    &mut sample[detector_bin],
+                    &mut sample_compensation[detector_bin],
+                    sample_weight * probability,
+                );
+            }
+        }
+        for detector_bin in 0..self.n_detector_bins {
+            open_beam[detector_bin] += open_compensation[detector_bin];
+            sample[detector_bin] += sample_compensation[detector_bin];
+        }
+        Ok(TwoArmCounts { open_beam, sample })
+    }
+}
+
 /// Signal, additive background, and total expected counts for one measured arm.
 ///
 /// Background is expressed directly in the detector bins of that measurement.
@@ -273,9 +408,6 @@ pub fn two_arm_count_response(
     timing_offset_us: f64,
     response: &ResolutionFunction,
 ) -> Result<TwoArmCounts, CountsResponseError> {
-    if true_energies_ev.is_empty() {
-        return Err(CountsResponseError::EmptyTrueEnergyGrid);
-    }
     if incident_fluence_weights.len() != true_energies_ev.len()
         || transmission.len() != true_energies_ev.len()
     {
@@ -285,70 +417,13 @@ pub fn two_arm_count_response(
             transmission: transmission.len(),
         });
     }
-    for (index, &energy) in true_energies_ev.iter().enumerate() {
-        if !energy.is_finite() || energy <= 0.0 {
-            return Err(CountsResponseError::InvalidTrueEnergy {
-                index,
-                value: energy,
-            });
-        }
-    }
-    for (index, &fluence) in incident_fluence_weights.iter().enumerate() {
-        if !fluence.is_finite() || fluence < 0.0 {
-            return Err(CountsResponseError::InvalidIncidentFluence {
-                index,
-                value: fluence,
-            });
-        }
-    }
-    for (index, &value) in transmission.iter().enumerate() {
-        if !value.is_finite() || !(0.0..=1.0).contains(&value) {
-            return Err(CountsResponseError::InvalidTransmission { index, value });
-        }
-    }
-
-    // Calling the response once even when every fluence weight is zero is
-    // important: malformed detector edges and unsupported Gaussian responses
-    // must still fail clearly instead of appearing to succeed with all zeros.
-    let n_bins = detector_time_edges_us.len().saturating_sub(1);
-    let mut open_beam = vec![0.0; n_bins];
-    let mut sample = vec![0.0; n_bins];
-    let mut open_compensation = vec![0.0; n_bins];
-    let mut sample_compensation = vec![0.0; n_bins];
-
-    for ((&energy, &fluence), &sample_transmission) in true_energies_ev
-        .iter()
-        .zip(incident_fluence_weights)
-        .zip(transmission)
-    {
-        let probabilities = response.detector_bin_probabilities(
-            energy,
-            detector_time_edges_us,
-            timing_offset_us,
-        )?;
-        debug_assert_eq!(probabilities.len(), n_bins);
-
-        // Neumaier-compensated accumulation keeps a weak high-energy tail from
-        // being lost when the same bin also contains a much larger prompt term.
-        for (bin, probability) in probabilities.into_iter().enumerate() {
-            compensated_add(
-                &mut open_beam[bin],
-                &mut open_compensation[bin],
-                fluence * probability,
-            );
-            compensated_add(
-                &mut sample[bin],
-                &mut sample_compensation[bin],
-                fluence * sample_transmission * probability,
-            );
-        }
-    }
-    for bin in 0..n_bins {
-        open_beam[bin] += open_compensation[bin];
-        sample[bin] += sample_compensation[bin];
-    }
-
-    Ok(TwoArmCounts { open_beam, sample })
+    DetectorBinResponseMatrix::new(
+        true_energies_ev,
+        detector_time_edges_us,
+        timing_offset_us,
+        response,
+    )?
+    .apply(incident_fluence_weights, transmission)
 }
 
 #[inline]

--- a/crates/nereids-physics/src/counts_response.rs
+++ b/crates/nereids-physics/src/counts_response.rs
@@ -22,7 +22,11 @@
 
 use std::fmt;
 
+use rayon::prelude::*;
+
 use crate::resolution::{ResolutionFunction, ResolutionParseError};
+
+type CompactResponseRow = (Vec<u32>, Vec<f64>);
 
 /// Expected detector-bin counts for the open-beam and sample measurements.
 #[derive(Debug, Clone, PartialEq)]
@@ -33,21 +37,27 @@ pub struct TwoArmCounts {
     pub sample: Vec<f64>,
 }
 
-/// Exact detector-bin probabilities for a fixed instrument response.
+/// Detector-bin probabilities for a fixed instrument response.
 ///
 /// Rows correspond to `true_energies_ev`; columns correspond to consecutive
 /// intervals in `detector_time_edges_us`. Building the matrix evaluates the
 /// analytical IC/tabulated bin integrals once. Reusing it during optimization
 /// changes only the true-energy sample transmission, not the detector physics.
+///
+/// Only entries whose evaluated probability is strictly greater than zero are
+/// stored. This is lossless: there is no numerical cutoff, and every nonzero
+/// value returned by the response model is retained.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DetectorBinResponseMatrix {
+    row_offsets: Vec<usize>,
+    detector_bins: Vec<u32>,
     probabilities: Vec<f64>,
     n_true_energies: usize,
     n_detector_bins: usize,
 }
 
 impl DetectorBinResponseMatrix {
-    /// Build an exact fixed-response matrix.
+    /// Build a fixed detector-bin response matrix.
     pub fn new(
         true_energies_ev: &[f64],
         detector_time_edges_us: &[f64],
@@ -67,27 +77,65 @@ impl DetectorBinResponseMatrix {
         }
 
         let n_detector_bins = detector_time_edges_us.len().saturating_sub(1);
-        let mut probabilities = Vec::with_capacity(
-            true_energies_ev
-                .len()
-                .checked_mul(n_detector_bins)
-                .ok_or_else(|| {
-                    CountsResponseError::Resolution(ResolutionParseError::InvalidFormat(
-                        "detector response matrix dimensions overflow usize".into(),
-                    ))
-                })?,
-        );
-        for &energy in true_energies_ev {
-            let row = response.detector_bin_probabilities(
-                energy,
-                detector_time_edges_us,
-                timing_offset_us,
-            )?;
-            debug_assert_eq!(row.len(), n_detector_bins);
-            probabilities.extend(row);
+        if n_detector_bins > u32::MAX as usize {
+            return Err(CountsResponseError::Resolution(
+                ResolutionParseError::InvalidFormat(format!(
+                    "detector response has {n_detector_bins} bins, exceeding the u32 storage limit"
+                )),
+            ));
+        }
+        // Each true-energy response is independent. Rayon preserves the input
+        // order of this indexed parallel collect, so rows and all subsequent
+        // accumulation orders remain deterministic.
+        let row_results: Vec<Result<CompactResponseRow, ResolutionParseError>> = true_energies_ev
+            .par_iter()
+            .map(|&energy| {
+                let row = response.detector_bin_probabilities(
+                    energy,
+                    detector_time_edges_us,
+                    timing_offset_us,
+                )?;
+                debug_assert_eq!(row.len(), n_detector_bins);
+                let mut bins = Vec::new();
+                let mut values = Vec::new();
+                for (detector_bin, probability) in row.into_iter().enumerate() {
+                    if !probability.is_finite() || probability < 0.0 {
+                        return Err(ResolutionParseError::InvalidFormat(format!(
+                            "detector response probability at E = {energy} eV, bin {detector_bin} must be finite and >= 0, got {probability}"
+                        )));
+                    }
+                    if probability > 0.0 {
+                        bins.push(detector_bin as u32);
+                        values.push(probability);
+                    }
+                }
+                Ok::<_, ResolutionParseError>((bins, values))
+            })
+            .collect();
+        // Resolve errors after the ordered collect so the first failing input
+        // row is reported deterministically regardless of thread scheduling.
+        let rows: Vec<CompactResponseRow> = row_results.into_iter().collect::<Result<_, _>>()?;
+        let nonzero_count = rows.iter().try_fold(0_usize, |total, (_, values)| {
+            total.checked_add(values.len()).ok_or_else(|| {
+                CountsResponseError::Resolution(ResolutionParseError::InvalidFormat(
+                    "detector response nonzero count overflows usize".into(),
+                ))
+            })
+        })?;
+
+        let mut row_offsets = Vec::with_capacity(true_energies_ev.len() + 1);
+        let mut detector_bins = Vec::with_capacity(nonzero_count);
+        let mut probabilities = Vec::with_capacity(nonzero_count);
+        row_offsets.push(0);
+        for (mut bins, mut values) in rows {
+            detector_bins.append(&mut bins);
+            probabilities.append(&mut values);
+            row_offsets.push(probabilities.len());
         }
 
         Ok(Self {
+            row_offsets,
+            detector_bins,
             probabilities,
             n_true_energies: true_energies_ev.len(),
             n_detector_bins,
@@ -104,10 +152,43 @@ impl DetectorBinResponseMatrix {
         self.n_detector_bins
     }
 
+    /// Number of stored nonzero probabilities.
+    pub fn nnz(&self) -> usize {
+        self.probabilities.len()
+    }
+
+    /// Heap bytes used by the compact probability storage.
+    ///
+    /// This excludes the small fixed-size `Self` value and allocator overhead.
+    pub fn storage_bytes(&self) -> usize {
+        self.row_offsets.capacity() * std::mem::size_of::<usize>()
+            + self.detector_bins.capacity() * std::mem::size_of::<u32>()
+            + self.probabilities.capacity() * std::mem::size_of::<f64>()
+    }
+
+    /// Stored `(detector_bin, probability)` pairs for one true-energy row.
+    pub fn row_entries(&self, true_index: usize) -> impl Iterator<Item = (usize, f64)> + '_ {
+        let start = self.row_offsets[true_index];
+        let end = self.row_offsets[true_index + 1];
+        self.detector_bins[start..end]
+            .iter()
+            .map(|&bin| bin as usize)
+            .zip(self.probabilities[start..end].iter().copied())
+    }
+
     /// Probability that true-energy row `true_index` lands in detector bin
     /// `detector_bin`.
     pub fn probability(&self, true_index: usize, detector_bin: usize) -> f64 {
-        self.probabilities[true_index * self.n_detector_bins + detector_bin]
+        assert!(
+            detector_bin < self.n_detector_bins,
+            "detector bin out of range"
+        );
+        let start = self.row_offsets[true_index];
+        let end = self.row_offsets[true_index + 1];
+        match self.detector_bins[start..end].binary_search(&(detector_bin as u32)) {
+            Ok(offset) => self.probabilities[start + offset],
+            Err(_) => 0.0,
+        }
     }
 
     /// Apply the fixed response separately to open and sample arms.
@@ -146,8 +227,7 @@ impl DetectorBinResponseMatrix {
         for true_index in 0..self.n_true_energies {
             let fluence = incident_fluence_weights[true_index];
             let sample_weight = fluence * transmission[true_index];
-            for detector_bin in 0..self.n_detector_bins {
-                let probability = self.probability(true_index, detector_bin);
+            for (detector_bin, probability) in self.row_entries(true_index) {
                 compensated_add(
                     &mut open_beam[detector_bin],
                     &mut open_compensation[detector_bin],

--- a/crates/nereids-physics/src/counts_response.rs
+++ b/crates/nereids-physics/src/counts_response.rs
@@ -191,6 +191,79 @@ impl DetectorBinResponseMatrix {
         }
     }
 
+    /// Combine consecutive true-energy rows with quadrature weights.
+    ///
+    /// The returned matrix has one row per true-energy cell. Every positive
+    /// weighted probability is retained; no numerical cutoff is applied.
+    pub fn collapse_true_energy_groups(
+        &self,
+        quadrature_weights: &[f64],
+        group_size: usize,
+    ) -> Result<Self, CountsResponseError> {
+        if group_size == 0 || !self.n_true_energies.is_multiple_of(group_size) {
+            return Err(CountsResponseError::InvalidResponseGroupSize {
+                true_energies: self.n_true_energies,
+                group_size,
+            });
+        }
+        if quadrature_weights.len() != self.n_true_energies {
+            return Err(CountsResponseError::QuadratureWeightLengthMismatch {
+                true_energies: self.n_true_energies,
+                weights: quadrature_weights.len(),
+            });
+        }
+        for (index, &weight) in quadrature_weights.iter().enumerate() {
+            if !weight.is_finite() || weight < 0.0 {
+                return Err(CountsResponseError::InvalidQuadratureWeight {
+                    index,
+                    value: weight,
+                });
+            }
+        }
+
+        let n_groups = self.n_true_energies / group_size;
+        let mut row_offsets = Vec::with_capacity(n_groups + 1);
+        let mut detector_bins = Vec::new();
+        let mut probabilities = Vec::new();
+        let mut accumulated = vec![0.0; self.n_detector_bins];
+        let mut touched = Vec::new();
+        row_offsets.push(0);
+        for group in 0..n_groups {
+            touched.clear();
+            for offset in 0..group_size {
+                let true_index = group * group_size + offset;
+                let weight = quadrature_weights[true_index];
+                if weight == 0.0 {
+                    continue;
+                }
+                for (detector_bin, probability) in self.row_entries(true_index) {
+                    if accumulated[detector_bin] == 0.0 {
+                        touched.push(detector_bin);
+                    }
+                    accumulated[detector_bin] += weight * probability;
+                }
+            }
+            touched.sort_unstable();
+            touched.dedup();
+            for &detector_bin in &touched {
+                let probability = accumulated[detector_bin];
+                if probability > 0.0 {
+                    detector_bins.push(detector_bin as u32);
+                    probabilities.push(probability);
+                }
+                accumulated[detector_bin] = 0.0;
+            }
+            row_offsets.push(probabilities.len());
+        }
+        Ok(Self {
+            row_offsets,
+            detector_bins,
+            probabilities,
+            n_true_energies: n_groups,
+            n_detector_bins: self.n_detector_bins,
+        })
+    }
+
     /// Apply the fixed response separately to open and sample arms.
     pub fn apply(
         &self,
@@ -290,6 +363,18 @@ pub enum CountsResponseError {
     InvalidIncidentFluence { index: usize, value: f64 },
     /// A physical sample transmission was outside `[0, 1]` or non-finite.
     InvalidTransmission { index: usize, value: f64 },
+    /// Consecutive response rows could not be divided into equal cells.
+    InvalidResponseGroupSize {
+        true_energies: usize,
+        group_size: usize,
+    },
+    /// Quadrature weights must match the true-energy response rows.
+    QuadratureWeightLengthMismatch {
+        true_energies: usize,
+        weights: usize,
+    },
+    /// A quadrature weight was negative or non-finite.
+    InvalidQuadratureWeight { index: usize, value: f64 },
     /// A signal or background expected count was negative or non-finite.
     InvalidExpectedCount {
         field: &'static str,
@@ -330,6 +415,24 @@ impl fmt::Display for CountsResponseError {
             Self::InvalidTransmission { index, value } => write!(
                 f,
                 "transmission[{index}] must be finite and in [0, 1], got {value}"
+            ),
+            Self::InvalidResponseGroupSize {
+                true_energies,
+                group_size,
+            } => write!(
+                f,
+                "group_size must be positive and evenly divide {true_energies} true-energy rows, got {group_size}"
+            ),
+            Self::QuadratureWeightLengthMismatch {
+                true_energies,
+                weights,
+            } => write!(
+                f,
+                "quadrature weight length ({weights}) must match true-energy rows ({true_energies})"
+            ),
+            Self::InvalidQuadratureWeight { index, value } => write!(
+                f,
+                "quadrature_weights[{index}] must be finite and nonnegative, got {value}"
             ),
             Self::InvalidExpectedCount {
                 field,

--- a/crates/nereids-physics/src/doppler.rs
+++ b/crates/nereids-physics/src/doppler.rs
@@ -799,7 +799,11 @@ pub fn doppler_broaden_with_derivative(
 /// consolidation could unify both behind a shared trait or closure-based
 /// extrapolation strategy; for now they remain separate to avoid coupling
 /// the two broadening modules.
-fn interpolate_cross_section(energies: &[f64], cross_sections: &[f64], energy: f64) -> f64 {
+pub(crate) fn interpolate_cross_section(
+    energies: &[f64],
+    cross_sections: &[f64],
+    energy: f64,
+) -> f64 {
     if energies.is_empty() {
         return 0.0;
     }

--- a/crates/nereids-physics/src/ikeda_carpenter.rs
+++ b/crates/nereids-physics/src/ikeda_carpenter.rs
@@ -129,7 +129,7 @@
 //! applies its `psr_fwhm_ns` fold to the IC family only, never to
 //! tabulated/UDR kernels).
 
-use crate::resolution::{ResolutionParseError, TabulatedResolution};
+use crate::resolution::{ResolutionParseError, TOF_FACTOR, TabulatedResolution};
 
 /// de Broglie wavelength factor: λ (Å) = `LAMBDA_ANGSTROM_FACTOR` / √(E in eV).
 ///
@@ -263,6 +263,73 @@ pub fn ic_pulse(alpha: f64, beta: f64, r: f64, tau: f64) -> f64 {
         coeff * bracket / (u * u * u)
     };
     (1.0 - r) * fast + r * slow
+}
+
+/// Cumulative probability of the Ikeda–Carpenter moderator pulse.
+///
+/// Returns `P(U <= tau)` for moderator delay `U`. `tau` is in µs and rates
+/// are in 1/µs. The prompt term is the Gamma(3, α) cumulative distribution;
+/// the storage term is the cumulative distribution of Gamma(3, α) plus an
+/// independent exponential delay with rate β.
+///
+/// The expression is evaluated without subtracting nearly equal exponentials
+/// when `α ≈ β`. This is the bin-integral companion to [`ic_pulse`].
+#[must_use]
+pub fn ic_cdf(alpha: f64, beta: f64, r: f64, tau: f64) -> f64 {
+    if tau.is_nan() || tau <= 0.0 {
+        return 0.0;
+    }
+    if tau == f64::INFINITY {
+        return 1.0;
+    }
+    if !tau.is_finite() {
+        return 0.0;
+    }
+
+    let alpha = alpha.max(MIN_RATE);
+    let beta = beta.max(MIN_RATE);
+    let at = alpha * tau;
+    let fast = gamma3_cdf(at);
+    if r <= 0.0 {
+        return fast;
+    }
+
+    // The storage CDF is the prompt CDF minus the positive survival
+    // correction below. Written this way, the α=β limit is Gamma(4, α).
+    let u = (alpha - beta) * tau;
+    let correction = if u.abs() < 0.05 {
+        at.powi(3) * (-beta * tau).exp() * h_over_cube_taylor(u)
+    } else {
+        // Bounded form: neither exponential can overflow even when β >> α.
+        let bracket = (-beta * tau).exp() - (-alpha * tau).exp() * (1.0 + u + 0.5 * u * u);
+        at.powi(3) * bracket / u.powi(3)
+    };
+    (fast - r * correction).clamp(0.0, 1.0)
+}
+
+/// Gamma(3, rate=1) cumulative distribution at dimensionless time `x`.
+fn gamma3_cdf(x: f64) -> f64 {
+    if x <= 0.0 {
+        return 0.0;
+    }
+    if x < 0.5 {
+        // Integral of x² exp(-x) / 2 as an alternating series. The direct
+        // `1 - exp(-x)(1+x+x²/2)` loses most digits for small x.
+        let mut n = 0_u32;
+        let mut term = x.powi(3) / 6.0;
+        let mut sum = term;
+        loop {
+            let n_f = f64::from(n);
+            term *= -x * (n_f + 3.0) / ((n_f + 1.0) * (n_f + 4.0));
+            let next = sum + term;
+            n += 1;
+            if next == sum || n >= 128 {
+                return next.clamp(0.0, 1.0);
+            }
+            sum = next;
+        }
+    }
+    (1.0 - (-x).exp() * (1.0 + x + 0.5 * x * x)).clamp(0.0, 1.0)
 }
 
 /// Energy-dependence law for an Ikeda–Carpenter parameter.
@@ -555,6 +622,117 @@ impl IkedaCarpenter {
     pub fn kernel_at(&self, energy_ev: f64) -> Result<(Vec<f64>, Vec<f64>), ResolutionParseError> {
         synth_kernel(&self.params, self.n_tau, energy_ev)
     }
+
+    /// Evaluate the physical source pulse at one true neutron energy.
+    ///
+    /// Returns sampled moderator-delay coordinates in µs and peak-normalized
+    /// densities. Unlike [`Self::kernel_at`], this method does not move the
+    /// pulse mode to zero. With no symmetric proton/channel fold, the delay is
+    /// causal and starts at zero. A symmetric fold may extend the sampled
+    /// support below zero relative to its stated time origin.
+    ///
+    /// # Errors
+    /// Returns [`ResolutionParseError::InvalidFormat`] if `energy_ev` is not a
+    /// positive finite true energy, if an energy law is unphysical at that
+    /// energy, or if the requested pulse cannot be resolved by the configured
+    /// sampling limits.
+    pub fn source_pulse_at(
+        &self,
+        energy_ev: f64,
+    ) -> Result<(Vec<f64>, Vec<f64>), ResolutionParseError> {
+        self.validate_probe_energy(energy_ev)?;
+        synth_source_pulse(&self.params, self.n_tau, energy_ev)
+    }
+
+    /// Probability that a neutron of known true energy is recorded in each
+    /// supplied detector-time bin.
+    ///
+    /// `detector_time_edges_us` are the actual measured bin edges. The nominal
+    /// arrival time is
+    /// `timing_offset_us + TOF_FACTOR * flight_path_m / sqrt(true_energy_ev)`.
+    /// `timing_offset_us` represents the shared clock/detector offset; it does
+    /// not absorb or remove the moderator pulse's physical mode.
+    ///
+    /// The returned vector has one entry per adjacent edge pair and is not
+    /// renormalized to the supplied window: bins that do not cover the full
+    /// pulse correctly sum to less than one.
+    ///
+    /// # Errors
+    /// Returns [`ResolutionParseError::InvalidFormat`] unless the true energy
+    /// is physical, the timing offset is finite, and at least two finite bin
+    /// edges are supplied in strictly increasing order.
+    pub fn detector_bin_probabilities(
+        &self,
+        true_energy_ev: f64,
+        detector_time_edges_us: &[f64],
+        timing_offset_us: f64,
+    ) -> Result<Vec<f64>, ResolutionParseError> {
+        self.validate_probe_energy(true_energy_ev)?;
+        if !timing_offset_us.is_finite() {
+            return Err(ResolutionParseError::InvalidFormat(format!(
+                "timing_offset_us must be finite, got {timing_offset_us}"
+            )));
+        }
+        if detector_time_edges_us.len() < 2
+            || detector_time_edges_us.iter().any(|x| !x.is_finite())
+            || detector_time_edges_us.windows(2).any(|w| w[0] >= w[1])
+        {
+            return Err(ResolutionParseError::InvalidFormat(
+                "detector time edges must contain at least two finite, strictly increasing values"
+                    .to_string(),
+            ));
+        }
+
+        let nominal_arrival =
+            timing_offset_us + TOF_FACTOR * self.flight_path_m / true_energy_ev.sqrt();
+        let relative_edges: Vec<f64> = detector_time_edges_us
+            .iter()
+            .map(|edge| edge - nominal_arrival)
+            .collect();
+
+        if self.params.burst_sigma_us.unwrap_or(0.0) == 0.0
+            && self.params.channel_fwhm_us.unwrap_or(0.0) == 0.0
+        {
+            let alpha = self.params.alpha.eval(true_energy_ev);
+            let r = self.params.r.eval(true_energy_ev);
+            return Ok(relative_edges
+                .windows(2)
+                .map(|edge| {
+                    (ic_cdf(alpha, self.params.beta, r, edge[1])
+                        - ic_cdf(alpha, self.params.beta, r, edge[0]))
+                    .max(0.0)
+                })
+                .collect());
+        }
+
+        let (times, weights) = self.source_pulse_at(true_energy_ev)?;
+        sampled_bin_probabilities(&times, &weights, &relative_edges).ok_or_else(|| {
+            ResolutionParseError::InvalidFormat(format!(
+                "Ikeda–Carpenter pulse at E = {true_energy_ev} eV has zero sampled area"
+            ))
+        })
+    }
+
+    fn validate_probe_energy(&self, energy_ev: f64) -> Result<(), ResolutionParseError> {
+        if !energy_ev.is_finite() || energy_ev <= 0.0 {
+            return Err(ResolutionParseError::InvalidFormat(format!(
+                "true energy must be positive and finite, got {energy_ev}"
+            )));
+        }
+        let alpha = self.params.alpha.eval(energy_ev);
+        let r = self.params.r.eval(energy_ev);
+        if !alpha.is_finite() || alpha <= 0.0 {
+            return Err(ResolutionParseError::InvalidFormat(format!(
+                "Ikeda–Carpenter alpha({energy_ev}) must be positive and finite, got {alpha}"
+            )));
+        }
+        if !r.is_finite() || !(0.0..=1.0).contains(&r) {
+            return Err(ResolutionParseError::InvalidFormat(format!(
+                "Ikeda–Carpenter R({energy_ev}) must be in [0, 1], got {r}"
+            )));
+        }
+        Ok(())
+    }
 }
 
 /// τ-grid geometry for one kernel: `(dtau, tau_max, margin)`, or a
@@ -653,6 +831,20 @@ fn synth_kernel(
     n_tau: usize,
     energy_ev: f64,
 ) -> Result<(Vec<f64>, Vec<f64>), ResolutionParseError> {
+    let (mut offsets, weights) = synth_source_pulse(params, n_tau, energy_ev)?;
+    let peak_time = offsets[argmax(&weights)];
+    for offset in &mut offsets {
+        *offset -= peak_time;
+    }
+    Ok((offsets, weights))
+}
+
+/// Synthesize one physical-time source pulse without moving its mode.
+fn synth_source_pulse(
+    params: &IkedaCarpenterParams,
+    n_tau: usize,
+    energy_ev: f64,
+) -> Result<(Vec<f64>, Vec<f64>), ResolutionParseError> {
     let alpha = params.alpha.eval(energy_ev).max(MIN_RATE);
     let beta = params.beta.max(MIN_RATE);
     let r = params.r.eval(energy_ev).clamp(0.0, 1.0);
@@ -684,10 +876,8 @@ fn synth_kernel(
         weights = convolve_same(&weights, &triangle_kernel(dtau, fwhm));
     }
 
-    // Anchor the mode at offset 0.
     let peak_idx = argmax(&weights);
     let peak_val = weights[peak_idx].max(f64::MIN_POSITIVE);
-    let tau_peak = taus[peak_idx];
 
     // Trim tails below TRIM_REL of peak, keeping one guard sample each side so
     // the convolution's neighbor-difference trapezoid widths stay defined.
@@ -701,9 +891,51 @@ fn synth_kernel(
         .rposition(|&w| w > thresh)
         .map_or(weights.len() - 1, |i| (i + 1).min(weights.len() - 1));
 
-    let offsets: Vec<f64> = (lo..=hi).map(|j| taus[j] - tau_peak).collect();
+    let offsets: Vec<f64> = (lo..=hi).map(|j| taus[j]).collect();
     let w: Vec<f64> = (lo..=hi).map(|j| weights[j] / peak_val).collect();
     Ok((offsets, w))
+}
+
+/// Integrate a sampled piecewise-linear density into the requested edges.
+fn sampled_bin_probabilities(times: &[f64], weights: &[f64], edges: &[f64]) -> Option<Vec<f64>> {
+    if times.len() < 2 || times.len() != weights.len() {
+        return None;
+    }
+
+    let mut cumulative = Vec::with_capacity(times.len());
+    cumulative.push(0.0);
+    for i in 0..times.len() - 1 {
+        let width = times[i + 1] - times[i];
+        let area = 0.5 * (weights[i] + weights[i + 1]) * width;
+        cumulative.push(cumulative[i] + area.max(0.0));
+    }
+    let total = *cumulative.last()?;
+    if !total.is_finite() || total <= 0.0 {
+        return None;
+    }
+
+    let cdf = |x: f64| -> f64 {
+        if x <= times[0] {
+            return 0.0;
+        }
+        if x >= times[times.len() - 1] {
+            return 1.0;
+        }
+        let hi = times.partition_point(|&time| time <= x);
+        let lo = hi - 1;
+        let width = times[hi] - times[lo];
+        let dx = x - times[lo];
+        let slope = (weights[hi] - weights[lo]) / width;
+        let partial = weights[lo] * dx + 0.5 * slope * dx * dx;
+        ((cumulative[lo] + partial) / total).clamp(0.0, 1.0)
+    };
+
+    Some(
+        edges
+            .windows(2)
+            .map(|edge| (cdf(edge[1]) - cdf(edge[0])).max(0.0))
+            .collect(),
+    )
 }
 
 /// Index of the maximum element (first on ties). Slice is non-empty by

--- a/crates/nereids-physics/src/ikeda_carpenter.rs
+++ b/crates/nereids-physics/src/ikeda_carpenter.rs
@@ -130,7 +130,7 @@
 //! tabulated/UDR kernels).
 
 use crate::resolution::{
-    ResolutionParseError, TOF_FACTOR, TabulatedResolution, piecewise_linear_bin_probabilities,
+    ResolutionParseError, TOF_FACTOR, TabulatedResolution, piecewise_linear_bin_masses,
 };
 
 /// de Broglie wavelength factor: λ (Å) = `LAMBDA_ANGSTROM_FACTOR` / √(E in eV).
@@ -665,6 +665,12 @@ impl IkedaCarpenter {
     /// renormalized to the supplied window: bins that do not cover the full
     /// pulse correctly sum to less than one.
     ///
+    /// With no burst or channel fold, probabilities come directly from the
+    /// analytical IC CDF. With either optional fold, the continuous pulse is
+    /// represented on the configured synthesis grid and integrated as a
+    /// piecewise-linear density. The finite numerical support is not silently
+    /// renormalized; omitted physical tail probability remains omitted.
+    ///
     /// # Errors
     /// Returns [`ResolutionParseError::InvalidFormat`] unless the true energy
     /// is physical, the timing offset is finite, and at least two finite bin
@@ -712,8 +718,9 @@ impl IkedaCarpenter {
                 .collect());
         }
 
-        let (times, weights) = self.source_pulse_at(true_energy_ev)?;
-        piecewise_linear_bin_probabilities(&times, &weights, &relative_edges).ok_or_else(|| {
+        let (times, densities) =
+            synth_source_pulse_density(&self.params, self.n_tau, true_energy_ev)?;
+        piecewise_linear_bin_masses(&times, &densities, &relative_edges).ok_or_else(|| {
             ResolutionParseError::InvalidFormat(format!(
                 "Ikeda–Carpenter pulse at E = {true_energy_ev} eV has zero sampled area"
             ))
@@ -853,7 +860,7 @@ fn synth_kernel(
 }
 
 /// Synthesize one physical-time source pulse without moving its mode.
-fn synth_source_pulse(
+fn synth_source_pulse_density(
     params: &IkedaCarpenterParams,
     n_tau: usize,
     energy_ev: f64,
@@ -878,10 +885,34 @@ fn synth_source_pulse(
     let taus: Vec<f64> = (j_lo..=j_hi).map(|j| j as f64 * dtau).collect();
     let mut weights: Vec<f64> = taus.iter().map(|&t| ic_pulse(alpha, beta, r, t)).collect();
 
+    // Correct only the sampled quadrature error of the analytical moderator
+    // density. The target is its exact CDF at the finite grid endpoint, not
+    // one, so physical moderator probability beyond the grid is not moved
+    // back into the sampled support. This matters for the coarsest admitted
+    // n_tau values, where peak-normalization used to hide a large area error.
+    let sampled_area = dtau
+        * (0.5 * weights[0]
+            + weights[1..weights.len() - 1].iter().sum::<f64>()
+            + 0.5 * weights[weights.len() - 1]);
+    let moderator_mass = ic_cdf(alpha, beta, r, *taus.last().expect("non-empty tau grid"));
+    if !sampled_area.is_finite() || sampled_area <= 0.0 {
+        return Err(ResolutionParseError::InvalidFormat(format!(
+            "Ikeda–Carpenter pulse at E = {energy_ev} eV has zero sampled area"
+        )));
+    }
+    let area_correction = moderator_mass / sampled_area;
+    for weight in &mut weights {
+        *weight *= area_correction;
+    }
+
     if let Some(sigma) = params.burst_sigma_us
         && sigma > 0.0
     {
-        weights = convolve_same(&weights, &gaussian_kernel(dtau, sigma));
+        let (kernel, retained_mass) = gaussian_kernel(dtau, sigma);
+        weights = convolve_same(&weights, &kernel);
+        for weight in &mut weights {
+            *weight *= retained_mass;
+        }
     }
     if let Some(fwhm) = params.channel_fwhm_us
         && fwhm > 0.0
@@ -905,8 +936,24 @@ fn synth_source_pulse(
         .map_or(weights.len() - 1, |i| (i + 1).min(weights.len() - 1));
 
     let offsets: Vec<f64> = (lo..=hi).map(|j| taus[j]).collect();
-    let w: Vec<f64> = (lo..=hi).map(|j| weights[j] / peak_val).collect();
-    Ok((offsets, w))
+    let densities: Vec<f64> = (lo..=hi).map(|j| weights[j]).collect();
+    Ok((offsets, densities))
+}
+
+/// Synthesize the public peak-normalized source-pulse representation.
+fn synth_source_pulse(
+    params: &IkedaCarpenterParams,
+    n_tau: usize,
+    energy_ev: f64,
+) -> Result<(Vec<f64>, Vec<f64>), ResolutionParseError> {
+    let (offsets, densities) = synth_source_pulse_density(params, n_tau, energy_ev)?;
+    let peak = densities
+        .iter()
+        .copied()
+        .fold(0.0_f64, f64::max)
+        .max(f64::MIN_POSITIVE);
+    let weights = densities.into_iter().map(|value| value / peak).collect();
+    Ok((offsets, weights))
 }
 
 /// Index of the maximum element (first on ties). Slice is non-empty by
@@ -925,7 +972,7 @@ fn argmax(xs: &[f64]) -> usize {
 
 /// Symmetric, unit-sum Gaussian kernel sampled on a `dtau`-spaced grid out to
 /// ±[`GAUSS_REACH_SIGMAS`]·σ.
-fn gaussian_kernel(dtau: f64, sigma: f64) -> Vec<f64> {
+fn gaussian_kernel(dtau: f64, sigma: f64) -> (Vec<f64>, f64) {
     let half = ((GAUSS_REACH_SIGMAS * sigma / dtau).ceil() as isize).max(1);
     let mut k: Vec<f64> = (-half..=half)
         .map(|j| {
@@ -933,8 +980,10 @@ fn gaussian_kernel(dtau: f64, sigma: f64) -> Vec<f64> {
             (-0.5 * t * t).exp()
         })
         .collect();
+    let raw_sum: f64 = k.iter().sum();
+    let retained_mass = (raw_sum * dtau / (sigma * std::f64::consts::TAU.sqrt())).clamp(0.0, 1.0);
     normalize_sum(&mut k);
-    k
+    (k, retained_mass)
 }
 
 /// Symmetric, unit-sum triangle kernel of FWHM `fwhm` (half-base = FWHM;

--- a/crates/nereids-physics/src/ikeda_carpenter.rs
+++ b/crates/nereids-physics/src/ikeda_carpenter.rs
@@ -388,8 +388,8 @@ impl EnergyLaw {
 pub struct IkedaCarpenterParams {
     /// Fast (slowing-down) rate `α(E)`, 1/µs. Must evaluate to > 0.
     pub alpha: EnergyLaw,
-    /// Slow (storage) rate `β`, 1/µs. Energy-independent, must be > 0.
-    pub beta: f64,
+    /// Slow (storage) rate `β(E)`, 1/µs. Must evaluate to > 0.
+    pub beta: EnergyLaw,
     /// Storage mixing fraction `R(E)`, 0 ≤ R ≤ 1.
     pub r: EnergyLaw,
     /// Optional proton-burst Gaussian standard deviation (µs).
@@ -405,7 +405,7 @@ impl IkedaCarpenterParams {
     pub fn constant(alpha: f64, beta: f64, r: f64) -> Self {
         Self {
             alpha: EnergyLaw::Const(alpha),
-            beta,
+            beta: EnergyLaw::Const(beta),
             r: EnergyLaw::Const(r),
             burst_sigma_us: None,
             channel_fwhm_us: None,
@@ -471,7 +471,7 @@ impl IkedaCarpenter {
     /// # Errors
     /// Returns [`ResolutionParseError::InvalidFormat`] for a non-positive
     /// flight path, a degenerate grid (`n_energies < 2`, `n_tau < 8`,
-    /// `e_min ≤ 0`, `e_max ≤ e_min`), a non-positive `β`, a parameter/grid
+    /// `e_min ≤ 0`, `e_max ≤ e_min`), a non-positive `β(E)`, a parameter/grid
     /// combination whose τ-grid cannot resolve the prompt core and requested
     /// folds within the `MAX_TAU_SAMPLES` cap at some reference energy (see
     /// `tau_geometry` — remedy: larger `β`, `R = 0`, or a wider/disabled
@@ -509,13 +509,6 @@ impl IkedaCarpenter {
                 grid.e_min_ev, grid.e_max_ev
             )));
         }
-        if !params.beta.is_finite() || params.beta <= 0.0 {
-            return Err(ResolutionParseError::InvalidFormat(format!(
-                "beta must be a positive finite number, got {}",
-                params.beta
-            )));
-        }
-
         let ln_lo = grid.e_min_ev.ln();
         let ln_hi = grid.e_max_ev.ln();
         let denom = (grid.n_energies - 1) as f64;
@@ -533,6 +526,18 @@ impl IkedaCarpenter {
             return Err(ResolutionParseError::InvalidFormat(format!(
                 "Ikeda–Carpenter α(E) must be > 0, but α({bad}) = {} is not",
                 params.alpha.eval(bad)
+            )));
+        }
+        // β is a rate, so every synthesized reference energy must give a
+        // positive finite value. Reject invalid laws instead of clamping them
+        // into a different pulse.
+        if let Some(&bad) = ref_energies.iter().find(|&&e| {
+            let beta = params.beta.eval(e);
+            !beta.is_finite() || beta <= 0.0
+        }) {
+            return Err(ResolutionParseError::InvalidFormat(format!(
+                "Ikeda–Carpenter β(E) must be > 0, but β({bad}) = {} is not",
+                params.beta.eval(bad)
             )));
         }
         // Reject storage-fraction laws that fall outside [0, 1] (synthesis clamps
@@ -613,13 +618,14 @@ impl IkedaCarpenter {
     /// convention.
     ///
     /// # Errors
-    /// Returns [`ResolutionParseError::InvalidFormat`] when the τ-grid cannot
-    /// resolve the prompt core and requested folds within `MAX_TAU_SAMPLES`
-    /// at this energy. Construction validates every *reference* energy, but a
-    /// probe energy outside `[e_min, e_max]` — for the √E law, above `e_max`,
-    /// where the larger α(E) imposes a finer prompt resolution floor against
-    /// the same storage-tail span — can still leave the resolvable region.
+    /// Returns [`ResolutionParseError::InvalidFormat`] when the requested
+    /// energy or an energy-dependent rate/fraction is non-physical, or when
+    /// the τ-grid cannot resolve the prompt core and requested folds within
+    /// `MAX_TAU_SAMPLES` at this energy. Construction validates every
+    /// *reference* energy, but a probe outside `[e_min, e_max]` can still leave
+    /// the physical or resolvable region.
     pub fn kernel_at(&self, energy_ev: f64) -> Result<(Vec<f64>, Vec<f64>), ResolutionParseError> {
+        self.validate_probe_energy(energy_ev)?;
         synth_kernel(&self.params, self.n_tau, energy_ev)
     }
 
@@ -694,13 +700,12 @@ impl IkedaCarpenter {
             && self.params.channel_fwhm_us.unwrap_or(0.0) == 0.0
         {
             let alpha = self.params.alpha.eval(true_energy_ev);
+            let beta = self.params.beta.eval(true_energy_ev);
             let r = self.params.r.eval(true_energy_ev);
             return Ok(relative_edges
                 .windows(2)
                 .map(|edge| {
-                    (ic_cdf(alpha, self.params.beta, r, edge[1])
-                        - ic_cdf(alpha, self.params.beta, r, edge[0]))
-                    .max(0.0)
+                    (ic_cdf(alpha, beta, r, edge[1]) - ic_cdf(alpha, beta, r, edge[0])).max(0.0)
                 })
                 .collect());
         }
@@ -720,10 +725,16 @@ impl IkedaCarpenter {
             )));
         }
         let alpha = self.params.alpha.eval(energy_ev);
+        let beta = self.params.beta.eval(energy_ev);
         let r = self.params.r.eval(energy_ev);
         if !alpha.is_finite() || alpha <= 0.0 {
             return Err(ResolutionParseError::InvalidFormat(format!(
                 "Ikeda–Carpenter alpha({energy_ev}) must be positive and finite, got {alpha}"
+            )));
+        }
+        if !beta.is_finite() || beta <= 0.0 {
+            return Err(ResolutionParseError::InvalidFormat(format!(
+                "Ikeda–Carpenter beta({energy_ev}) must be positive and finite, got {beta}"
             )));
         }
         if !r.is_finite() || !(0.0..=1.0).contains(&r) {
@@ -846,7 +857,7 @@ fn synth_source_pulse(
     energy_ev: f64,
 ) -> Result<(Vec<f64>, Vec<f64>), ResolutionParseError> {
     let alpha = params.alpha.eval(energy_ev).max(MIN_RATE);
-    let beta = params.beta.max(MIN_RATE);
+    let beta = params.beta.eval(energy_ev).max(MIN_RATE);
     let r = params.r.eval(energy_ev).clamp(0.0, 1.0);
 
     let (dtau, tau_max, margin) = tau_geometry(params, n_tau, alpha, beta, r).map_err(|msg| {
@@ -1111,7 +1122,7 @@ mod tests {
         // The synthesized kernel must contain no non-finite entries.
         let p = IkedaCarpenterParams {
             alpha: EnergyLaw::Const(0.05),
-            beta: 4.0,
+            beta: EnergyLaw::Const(4.0),
             r: EnergyLaw::Const(0.5),
             burst_sigma_us: None,
             channel_fwhm_us: None,
@@ -1188,7 +1199,7 @@ mod tests {
         // α(E) ∝ √E ⇒ prompt width 1/α shrinks with E ⇒ smaller TOF support.
         let p = IkedaCarpenterParams {
             alpha: EnergyLaw::SqrtE { a0: 0.3, a1: 0.0 },
-            beta: 0.1,
+            beta: EnergyLaw::Const(0.1),
             r: EnergyLaw::Const(0.0),
             burst_sigma_us: None,
             channel_fwhm_us: None,

--- a/crates/nereids-physics/src/ikeda_carpenter.rs
+++ b/crates/nereids-physics/src/ikeda_carpenter.rs
@@ -129,7 +129,9 @@
 //! applies its `psr_fwhm_ns` fold to the IC family only, never to
 //! tabulated/UDR kernels).
 
-use crate::resolution::{ResolutionParseError, TOF_FACTOR, TabulatedResolution};
+use crate::resolution::{
+    ResolutionParseError, TOF_FACTOR, TabulatedResolution, piecewise_linear_bin_probabilities,
+};
 
 /// de Broglie wavelength factor: λ (Å) = `LAMBDA_ANGSTROM_FACTOR` / √(E in eV).
 ///
@@ -711,7 +713,7 @@ impl IkedaCarpenter {
         }
 
         let (times, weights) = self.source_pulse_at(true_energy_ev)?;
-        sampled_bin_probabilities(&times, &weights, &relative_edges).ok_or_else(|| {
+        piecewise_linear_bin_probabilities(&times, &weights, &relative_edges).ok_or_else(|| {
             ResolutionParseError::InvalidFormat(format!(
                 "Ikeda–Carpenter pulse at E = {true_energy_ev} eV has zero sampled area"
             ))
@@ -905,48 +907,6 @@ fn synth_source_pulse(
     let offsets: Vec<f64> = (lo..=hi).map(|j| taus[j]).collect();
     let w: Vec<f64> = (lo..=hi).map(|j| weights[j] / peak_val).collect();
     Ok((offsets, w))
-}
-
-/// Integrate a sampled piecewise-linear density into the requested edges.
-fn sampled_bin_probabilities(times: &[f64], weights: &[f64], edges: &[f64]) -> Option<Vec<f64>> {
-    if times.len() < 2 || times.len() != weights.len() {
-        return None;
-    }
-
-    let mut cumulative = Vec::with_capacity(times.len());
-    cumulative.push(0.0);
-    for i in 0..times.len() - 1 {
-        let width = times[i + 1] - times[i];
-        let area = 0.5 * (weights[i] + weights[i + 1]) * width;
-        cumulative.push(cumulative[i] + area.max(0.0));
-    }
-    let total = *cumulative.last()?;
-    if !total.is_finite() || total <= 0.0 {
-        return None;
-    }
-
-    let cdf = |x: f64| -> f64 {
-        if x <= times[0] {
-            return 0.0;
-        }
-        if x >= times[times.len() - 1] {
-            return 1.0;
-        }
-        let hi = times.partition_point(|&time| time <= x);
-        let lo = hi - 1;
-        let width = times[hi] - times[lo];
-        let dx = x - times[lo];
-        let slope = (weights[hi] - weights[lo]) / width;
-        let partial = weights[lo] * dx + 0.5 * slope * dx * dx;
-        ((cumulative[lo] + partial) / total).clamp(0.0, 1.0)
-    };
-
-    Some(
-        edges
-            .windows(2)
-            .map(|edge| (cdf(edge[1]) - cdf(edge[0])).max(0.0))
-            .collect(),
-    )
 }
 
 /// Index of the maximum element (first on ties). Slice is non-empty by

--- a/crates/nereids-physics/src/lib.rs
+++ b/crates/nereids-physics/src/lib.rs
@@ -31,6 +31,7 @@
 pub mod auxiliary_grid;
 pub mod channel;
 pub mod coulomb;
+pub mod counts_response;
 pub mod doppler;
 pub mod ikeda_carpenter;
 pub mod penetrability;

--- a/crates/nereids-physics/src/lib.rs
+++ b/crates/nereids-physics/src/lib.rs
@@ -30,6 +30,7 @@
 
 pub mod auxiliary_grid;
 pub mod channel;
+pub mod continuous_doppler;
 pub mod coulomb;
 pub mod counts_response;
 pub mod doppler;

--- a/crates/nereids-physics/src/reich_moore.rs
+++ b/crates/nereids-physics/src/reich_moore.rs
@@ -430,65 +430,74 @@ pub fn cross_sections_at_energy(data: &ResonanceData, energy_ev: f64) -> CrossSe
 /// the same release-mode silent-zero footgun that the SLBW / RML / URR
 /// leaf asserts guard against per-point.
 pub fn cross_sections_on_grid(data: &ResonanceData, energies: &[f64]) -> Vec<CrossSections> {
-    if energies.is_empty() {
-        return Vec::new();
+    CrossSectionPlan::new(data).evaluate(energies)
+}
+
+/// Reusable evaluation plan for one immutable resonance source.
+///
+/// Continuous Doppler integration evaluates the same ENDF equation on many
+/// adaptively selected energy batches.  Building the formalism-specific
+/// resonance caches for every quadrature panel would change only runtime, not
+/// physics, so this crate-private plan builds them once and reuses them.
+pub(crate) struct CrossSectionPlan<'a> {
+    awr: f64,
+    precomputed: Vec<PrecomputedRangeData<'a>>,
+}
+
+impl<'a> CrossSectionPlan<'a> {
+    pub(crate) fn new(data: &'a ResonanceData) -> Self {
+        let awr = data.awr;
+        let precomputed = data
+            .ranges
+            .iter()
+            .enumerate()
+            .map(|(range_idx, range)| precompute_range_data(range, range_idx, data, awr))
+            .collect();
+        Self { awr, precomputed }
     }
 
-    // Symmetric public-API guard.  See `cross_sections_at_energy` above.
-    // O(n) — negligible next to the per-range precompute and per-point
-    // resonance evaluation that follow.
-    for &energy_ev in energies {
-        assert!(
-            energy_ev.is_finite() && energy_ev > 0.0,
-            "expected positive finite energy_ev, got {energy_ev}"
-        );
-    }
+    pub(crate) fn evaluate(&self, energies: &[f64]) -> Vec<CrossSections> {
+        for &energy_ev in energies {
+            assert!(
+                energy_ev.is_finite() && energy_ev > 0.0,
+                "expected positive finite energy_ev, got {energy_ev}"
+            );
+        }
 
-    let awr = data.awr;
+        energies
+            .iter()
+            .map(|&energy_ev| {
+                let mut total = 0.0;
+                let mut elastic = 0.0;
+                let mut capture = 0.0;
+                let mut fission = 0.0;
 
-    // Phase 1: precompute per-range data (J-groups, reduced widths, etc.).
-    // This runs once for the entire grid, not per energy point.
-    let precomputed: Vec<PrecomputedRangeData> = data
-        .ranges
-        .iter()
-        .enumerate()
-        .map(|(range_idx, range)| precompute_range_data(range, range_idx, data, awr))
-        .collect();
+                for range in &self.precomputed {
+                    let in_range = if range.half_open_upper {
+                        energy_ev >= range.energy_low && energy_ev < range.energy_high
+                    } else {
+                        energy_ev >= range.energy_low && energy_ev <= range.energy_high
+                    };
+                    if !in_range {
+                        continue;
+                    }
 
-    // Phase 2: evaluate each energy point using precomputed data.
-    energies
-        .iter()
-        .map(|&energy_ev| {
-            let mut total = 0.0;
-            let mut elastic = 0.0;
-            let mut capture = 0.0;
-            let mut fission = 0.0;
-
-            for pc in &precomputed {
-                let in_range = if pc.half_open_upper {
-                    energy_ev >= pc.energy_low && energy_ev < pc.energy_high
-                } else {
-                    energy_ev >= pc.energy_low && energy_ev <= pc.energy_high
-                };
-                if !in_range {
-                    continue;
+                    let (t, e, c, f) = evaluate_precomputed_range(range, energy_ev, self.awr);
+                    total += t;
+                    elastic += e;
+                    capture += c;
+                    fission += f;
                 }
 
-                let (t, e, c, f) = evaluate_precomputed_range(pc, energy_ev, awr);
-                total += t;
-                elastic += e;
-                capture += c;
-                fission += f;
-            }
-
-            CrossSections {
-                total,
-                elastic,
-                capture,
-                fission,
-            }
-        })
-        .collect()
+                CrossSections {
+                    total,
+                    elastic,
+                    capture,
+                    fission,
+                }
+            })
+            .collect()
+    }
 }
 
 // ─── Precomputed range data for batch grid evaluation ────────────────────────

--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -1306,6 +1306,15 @@ pub enum ResolutionFunction {
 }
 
 impl ResolutionFunction {
+    /// Flight path used to map true neutron energy to detector time.
+    pub fn flight_path_m(&self) -> f64 {
+        match self {
+            Self::Gaussian(params) => params.flight_path_m(),
+            Self::Tabulated(tabulated) => tabulated.flight_path_m(),
+            Self::IkedaCarpenter(ic) => ic.flight_path_m(),
+        }
+    }
+
     /// Probability that one neutron of known true energy is recorded in each
     /// supplied detector-time bin.
     ///

--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -895,6 +895,75 @@ fn trapezoidal_moments(offsets: &[f64], weights: &[f64]) -> (f64, f64) {
     (centroid, sigma)
 }
 
+/// Integrate a sampled probability distribution into adjacent requested
+/// edges. A one-point kernel is treated as a delta mass at that point; longer
+/// kernels are piecewise-linear densities.
+///
+/// The density is normalized over its complete supplied support.  The result
+/// is deliberately not renormalized to `edges`: a requested detector window
+/// that covers only part of the pulse therefore sums to less than one.
+pub(crate) fn piecewise_linear_bin_probabilities(
+    times: &[f64],
+    weights: &[f64],
+    edges: &[f64],
+) -> Option<Vec<f64>> {
+    if times.is_empty() || times.len() != weights.len() {
+        return None;
+    }
+
+    if times.len() == 1 {
+        if !times[0].is_finite() || !weights[0].is_finite() || weights[0] <= 0.0 {
+            return None;
+        }
+        let mut probabilities = vec![0.0; edges.len().saturating_sub(1)];
+        for (index, edge) in edges.windows(2).enumerate() {
+            let in_bin = edge[0] <= times[0]
+                && (times[0] < edge[1]
+                    || (index + 1 == probabilities.len() && times[0] == edge[1]));
+            if in_bin {
+                probabilities[index] = 1.0;
+                break;
+            }
+        }
+        return Some(probabilities);
+    }
+
+    let mut cumulative = Vec::with_capacity(times.len());
+    cumulative.push(0.0);
+    for i in 0..times.len() - 1 {
+        let width = times[i + 1] - times[i];
+        let area = 0.5 * (weights[i] + weights[i + 1]) * width;
+        cumulative.push(cumulative[i] + area.max(0.0));
+    }
+    let total = *cumulative.last()?;
+    if !total.is_finite() || total <= 0.0 {
+        return None;
+    }
+
+    let cdf = |x: f64| -> f64 {
+        if x <= times[0] {
+            return 0.0;
+        }
+        if x >= times[times.len() - 1] {
+            return 1.0;
+        }
+        let hi = times.partition_point(|&time| time <= x);
+        let lo = hi - 1;
+        let width = times[hi] - times[lo];
+        let dx = x - times[lo];
+        let slope = (weights[hi] - weights[lo]) / width;
+        let partial = weights[lo] * dx + 0.5 * slope * dx * dx;
+        ((cumulative[lo] + partial) / total).clamp(0.0, 1.0)
+    };
+
+    Some(
+        edges
+            .windows(2)
+            .map(|edge| (cdf(edge[1]) - cdf(edge[0])).max(0.0))
+            .collect(),
+    )
+}
+
 impl TabulatedResolution {
     /// Reference energies (eV), sorted ascending.
     pub fn ref_energies(&self) -> &[f64] {
@@ -910,6 +979,67 @@ impl TabulatedResolution {
     /// Flight path length in meters (needed for TOF↔energy conversion).
     pub fn flight_path_m(&self) -> f64 {
         self.flight_path_m
+    }
+
+    /// Probability that a neutron of known true energy is recorded in each
+    /// supplied detector-time bin.
+    ///
+    /// The tabulated pulse is selected and interpolated at `true_energy_ev`.
+    /// Its offsets are relative to the reference pulse mode, so the nominal
+    /// arrival is `timing_offset_us + TOF_FACTOR * flight_path_m / sqrt(E)`.
+    /// `timing_offset_us` is the effective clock/energy-axis offset calibrated
+    /// for the measurement; this method does not invent an absolute moderator
+    /// emission time that is absent from a mode-centred UDR file.
+    ///
+    /// The returned vector has one entry per adjacent edge pair and is not
+    /// renormalized to the supplied window.  Probability outside the measured
+    /// window remains outside it.
+    ///
+    /// # Errors
+    /// Returns [`ResolutionParseError::InvalidFormat`] unless the true energy
+    /// is positive and finite, the timing offset is finite, and at least two
+    /// finite bin edges are supplied in strictly increasing order.  It also
+    /// fails if the interpolated tabulated pulse has zero area.
+    pub fn detector_bin_probabilities(
+        &self,
+        true_energy_ev: f64,
+        detector_time_edges_us: &[f64],
+        timing_offset_us: f64,
+    ) -> Result<Vec<f64>, ResolutionParseError> {
+        if !true_energy_ev.is_finite() || true_energy_ev <= 0.0 {
+            return Err(ResolutionParseError::InvalidFormat(format!(
+                "true energy must be positive and finite, got {true_energy_ev}"
+            )));
+        }
+        if !timing_offset_us.is_finite() {
+            return Err(ResolutionParseError::InvalidFormat(format!(
+                "timing_offset_us must be finite, got {timing_offset_us}"
+            )));
+        }
+        if detector_time_edges_us.len() < 2
+            || detector_time_edges_us.iter().any(|edge| !edge.is_finite())
+            || detector_time_edges_us
+                .windows(2)
+                .any(|edge| edge[0] >= edge[1])
+        {
+            return Err(ResolutionParseError::InvalidFormat(
+                "detector time edges must contain at least two finite, strictly increasing values"
+                    .to_string(),
+            ));
+        }
+
+        let nominal_arrival =
+            timing_offset_us + TOF_FACTOR * self.flight_path_m / true_energy_ev.sqrt();
+        let relative_edges: Vec<f64> = detector_time_edges_us
+            .iter()
+            .map(|edge| edge - nominal_arrival)
+            .collect();
+        let (times, weights) = self.interpolated_kernel(true_energy_ev);
+        piecewise_linear_bin_probabilities(&times, &weights, &relative_edges).ok_or_else(|| {
+            ResolutionParseError::InvalidFormat(format!(
+                "tabulated resolution at E = {true_energy_ev} eV has zero sampled area"
+            ))
+        })
     }
 
     /// Width-corrected copy of this tabulated kernel.
@@ -1698,6 +1828,11 @@ impl TabulatedResolution {
     /// * `text` — File contents as a string.
     /// * `flight_path_m` — Flight path length in meters.
     pub fn from_text(text: &str, flight_path_m: f64) -> Result<Self, ResolutionParseError> {
+        if !flight_path_m.is_finite() || flight_path_m <= 0.0 {
+            return Err(ResolutionParseError::InvalidFormat(format!(
+                "Flight path must be positive and finite, got {flight_path_m}"
+            )));
+        }
         let mut lines = text.lines();
 
         // Skip header and separator
@@ -1861,15 +1996,21 @@ impl TabulatedResolution {
     /// offsets/weights.
     ///
     /// # Errors
-    /// Returns [`ResolutionParseError::InvalidFormat`] if the reference
-    /// energies are empty / not strictly ascending, if the energy and kernel
-    /// counts differ, if any kernel is empty, if a kernel's offset and weight
-    /// vectors differ in length, or if any offset/weight is non-finite.
+    /// Returns [`ResolutionParseError::InvalidFormat`] if the flight path is
+    /// not positive and finite, if the reference energies are empty / not
+    /// strictly ascending, if the energy and kernel counts differ, if any
+    /// kernel is empty, if a kernel's offset and weight vectors differ in
+    /// length, or if any offset/weight is non-finite.
     pub fn from_kernels(
         ref_energies: Vec<f64>,
         kernels: Vec<(Vec<f64>, Vec<f64>)>,
         flight_path_m: f64,
     ) -> Result<Self, ResolutionParseError> {
+        if !flight_path_m.is_finite() || flight_path_m <= 0.0 {
+            return Err(ResolutionParseError::InvalidFormat(format!(
+                "Flight path must be positive and finite, got {flight_path_m}"
+            )));
+        }
         if ref_energies.is_empty() {
             return Err(ResolutionParseError::InvalidFormat(
                 "No reference energies provided".into(),

--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -1305,6 +1305,41 @@ pub enum ResolutionFunction {
     IkedaCarpenter(Arc<crate::ikeda_carpenter::IkedaCarpenter>),
 }
 
+impl ResolutionFunction {
+    /// Probability that one neutron of known true energy is recorded in each
+    /// supplied detector-time bin.
+    ///
+    /// The tabulated and Ikeda–Carpenter variants are evaluated directly in
+    /// detector time. In particular, the analytical IC variant does not pass
+    /// through its legacy synthesized [`TabulatedResolution`] broadening
+    /// table. The older Gaussian energy-broadening model has no physical
+    /// detector-time probability law and is therefore rejected rather than
+    /// silently treated as one.
+    pub fn detector_bin_probabilities(
+        &self,
+        true_energy_ev: f64,
+        detector_time_edges_us: &[f64],
+        timing_offset_us: f64,
+    ) -> Result<Vec<f64>, ResolutionParseError> {
+        match self {
+            Self::Tabulated(tabulated) => tabulated.detector_bin_probabilities(
+                true_energy_ev,
+                detector_time_edges_us,
+                timing_offset_us,
+            ),
+            Self::IkedaCarpenter(ic) => ic.detector_bin_probabilities(
+                true_energy_ev,
+                detector_time_edges_us,
+                timing_offset_us,
+            ),
+            Self::Gaussian(_) => Err(ResolutionParseError::InvalidFormat(
+                "Gaussian energy broadening cannot produce detector-time bin probabilities; use a validated tabulated or Ikeda–Carpenter time response"
+                    .to_string(),
+            )),
+        }
+    }
+}
+
 /// Pre-built resolution-broadening plan for a specific target energy grid.
 ///
 /// Encodes every quantity that depends only on the target grid, the

--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -895,23 +895,26 @@ fn trapezoidal_moments(offsets: &[f64], weights: &[f64]) -> (f64, f64) {
     (centroid, sigma)
 }
 
-/// Integrate a sampled probability distribution into adjacent requested
-/// edges. A one-point kernel is treated as a delta mass at that point; longer
-/// kernels are piecewise-linear densities.
+/// Integrate a sampled distribution into adjacent requested edges.
 ///
-/// The density is normalized over its complete supplied support.  The result
-/// is deliberately not renormalized to `edges`: a requested detector window
-/// that covers only part of the pulse therefore sums to less than one.
-pub(crate) fn piecewise_linear_bin_probabilities(
+/// With `normalize_support`, a one-point kernel is treated as a unit delta and
+/// a longer kernel is normalized over its supplied support. Without it, the
+/// supplied values retain their physical density scale and a one-point density
+/// is rejected because it has no defined integration width.
+fn piecewise_linear_bin_integrals(
     times: &[f64],
     weights: &[f64],
     edges: &[f64],
+    normalize_support: bool,
 ) -> Option<Vec<f64>> {
     if times.is_empty() || times.len() != weights.len() {
         return None;
     }
 
     if times.len() == 1 {
+        if !normalize_support {
+            return None;
+        }
         if !times[0].is_finite() || !weights[0].is_finite() || weights[0] <= 0.0 {
             return None;
         }
@@ -939,13 +942,14 @@ pub(crate) fn piecewise_linear_bin_probabilities(
     if !total.is_finite() || total <= 0.0 {
         return None;
     }
+    let scale = if normalize_support { total } else { 1.0 };
 
     let cdf = |x: f64| -> f64 {
         if x <= times[0] {
             return 0.0;
         }
         if x >= times[times.len() - 1] {
-            return 1.0;
+            return total / scale;
         }
         let hi = times.partition_point(|&time| time <= x);
         let lo = hi - 1;
@@ -953,7 +957,7 @@ pub(crate) fn piecewise_linear_bin_probabilities(
         let dx = x - times[lo];
         let slope = (weights[hi] - weights[lo]) / width;
         let partial = weights[lo] * dx + 0.5 * slope * dx * dx;
-        ((cumulative[lo] + partial) / total).clamp(0.0, 1.0)
+        ((cumulative[lo] + partial) / scale).clamp(0.0, total / scale)
     };
 
     Some(
@@ -962,6 +966,35 @@ pub(crate) fn piecewise_linear_bin_probabilities(
             .map(|edge| (cdf(edge[1]) - cdf(edge[0])).max(0.0))
             .collect(),
     )
+}
+
+/// Integrate a sampled probability distribution into adjacent requested
+/// edges. A one-point kernel is treated as a delta mass at that point; longer
+/// kernels are piecewise-linear densities.
+///
+/// The density is normalized over its complete supplied support. The result
+/// is deliberately not renormalized to `edges`: a requested detector window
+/// that covers only part of the supplied pulse therefore sums to less than
+/// one.
+pub(crate) fn piecewise_linear_bin_probabilities(
+    times: &[f64],
+    weights: &[f64],
+    edges: &[f64],
+) -> Option<Vec<f64>> {
+    piecewise_linear_bin_integrals(times, weights, edges, true)
+}
+
+/// Integrate a sampled density without changing its physical mass scale.
+///
+/// This is used by analytical responses whose source density is already in
+/// probability per unit time. Probability omitted by finite numerical support
+/// therefore remains omitted instead of being redistributed into that support.
+pub(crate) fn piecewise_linear_bin_masses(
+    times: &[f64],
+    densities: &[f64],
+    edges: &[f64],
+) -> Option<Vec<f64>> {
+    piecewise_linear_bin_integrals(times, densities, edges, false)
 }
 
 impl TabulatedResolution {

--- a/crates/nereids-physics/src/transmission.rs
+++ b/crates/nereids-physics/src/transmission.rs
@@ -201,6 +201,26 @@ fn build_extended_xs_from_base(
     xs_ext
 }
 
+/// Extend an explicitly supplied table without consulting resonance data.
+///
+/// This is deliberately separate from [`build_extended_xs_from_base`].  That
+/// helper is a cache of the same resonance equation and may therefore evaluate
+/// that equation at auxiliary points.  A genuine table is a different source:
+/// every auxiliary value must be interpolated or extrapolated from the table
+/// itself so a Gaussian working grid cannot silently mix two sources.
+fn build_extended_xs_from_table(
+    source_energies: &[f64],
+    source_cross_sections: &[f64],
+    work_energies: &[f64],
+) -> Vec<f64> {
+    work_energies
+        .iter()
+        .map(|&energy| {
+            doppler::interpolate_cross_section(source_energies, source_cross_sections, energy)
+        })
+        .collect()
+}
+
 /// Validate `base_xs` shape against `resonance_data` and `energies`.
 ///
 /// Shared by the base-XS broadening family so the same `InputMismatch`
@@ -392,6 +412,36 @@ fn source_aware_doppler(
 
     let sampled = unbroadened();
     doppler::doppler_broaden(energies, &sampled, &params).map_err(Into::into)
+}
+
+/// Source-aware Doppler broadening and exact temperature derivative.
+///
+/// Resolved SLBW/MLBW data use the resonance equation inside both integrals.
+/// Unsupported formalisms use the named sampled-table route for both value and
+/// derivative, so a single isotope never mixes representations.
+fn source_aware_doppler_with_derivative(
+    energies: &[f64],
+    data: &ResonanceData,
+    temperature_k: f64,
+) -> Result<(Vec<f64>, Vec<f64>), TransmissionError> {
+    let unbroadened = || {
+        reich_moore::cross_sections_on_grid(data, energies)
+            .into_iter()
+            .map(|cross_section| cross_section.total)
+            .collect::<Vec<_>>()
+    };
+    if temperature_k <= 0.0 {
+        return Ok((unbroadened(), vec![0.0; energies.len()]));
+    }
+
+    let params = DopplerParams::new(temperature_k, data.awr)?;
+    if let Some(result) = continuous_doppler::try_broaden_with_derivative(energies, data, &params)?
+    {
+        return Ok(result);
+    }
+
+    let sampled = unbroadened();
+    doppler::doppler_broaden_with_derivative(energies, &sampled, &params).map_err(Into::into)
 }
 
 /// Broadened cross-sections and their temperature derivative.
@@ -1201,6 +1251,264 @@ pub fn broadened_cross_sections_with_analytical_derivative_from_base_on_working_
     })
 }
 
+/// Doppler-broaden a genuine sampled source on the resolution working grid.
+///
+/// Unlike the `_from_base` cache API, auxiliary Gaussian-grid values are
+/// obtained only from the supplied table.  Resonance equations are not read,
+/// so the route cannot silently combine two different nuclear sources.
+pub fn broadened_cross_sections_from_table_on_working_grid(
+    energies: &[f64],
+    table_xs: &[Vec<f64>],
+    resonance_data: &[ResonanceData],
+    temperature_k: f64,
+    instrument: Option<&InstrumentParams>,
+) -> Result<WorkingGridXs, TransmissionError> {
+    validate_base_xs(energies, table_xs, resonance_data)?;
+    if instrument.is_some() && !energies.windows(2).all(|window| window[0] <= window[1]) {
+        return Err(ResolutionError::UnsortedEnergies.into());
+    }
+
+    let references: Vec<&ResonanceData> = resonance_data.iter().collect();
+    let extended_grid = build_aux_grid(energies, instrument, &references);
+    let (work_energies, layout) = working_grid_layout(energies, extended_grid.as_ref());
+    let sigma: Result<Vec<Vec<f64>>, TransmissionError> = table_xs
+        .par_iter()
+        .zip(resonance_data.par_iter())
+        .map(|(source, data)| {
+            let work_source = if extended_grid.is_some() {
+                build_extended_xs_from_table(energies, source, work_energies)
+            } else {
+                source.clone()
+            };
+            if temperature_k > 0.0 {
+                let params = DopplerParams::new(temperature_k, data.awr)?;
+                doppler::doppler_broaden(work_energies, &work_source, &params).map_err(Into::into)
+            } else {
+                Ok(work_source)
+            }
+        })
+        .collect();
+
+    Ok(WorkingGridXs {
+        sigma: sigma?,
+        layout,
+    })
+}
+
+/// Sampled-source counterpart of
+/// [`broadened_cross_sections_from_table_on_working_grid`] with the analytical
+/// temperature derivative.
+pub fn broadened_cross_sections_with_analytical_derivative_from_table_on_working_grid(
+    energies: &[f64],
+    table_xs: &[Vec<f64>],
+    resonance_data: &[ResonanceData],
+    temperature_k: f64,
+    instrument: Option<&InstrumentParams>,
+) -> Result<WorkingGridXsWithDerivative, TransmissionError> {
+    validate_base_xs(energies, table_xs, resonance_data)?;
+    if instrument.is_some() && !energies.windows(2).all(|window| window[0] <= window[1]) {
+        return Err(ResolutionError::UnsortedEnergies.into());
+    }
+
+    let references: Vec<&ResonanceData> = resonance_data.iter().collect();
+    let extended_grid = build_aux_grid(energies, instrument, &references);
+    let (work_energies, layout) = working_grid_layout(energies, extended_grid.as_ref());
+    type IsotopeXsDxs = Result<(Vec<f64>, Vec<f64>), TransmissionError>;
+    let results: Vec<IsotopeXsDxs> = table_xs
+        .par_iter()
+        .zip(resonance_data.par_iter())
+        .map(|(source, data)| {
+            let work_source = if extended_grid.is_some() {
+                build_extended_xs_from_table(energies, source, work_energies)
+            } else {
+                source.clone()
+            };
+            if temperature_k > 0.0 {
+                let params = DopplerParams::new(temperature_k, data.awr)?;
+                doppler::doppler_broaden_with_derivative(work_energies, &work_source, &params)
+                    .map_err(Into::into)
+            } else {
+                Ok((work_source, vec![0.0; work_energies.len()]))
+            }
+        })
+        .collect();
+
+    let mut sigma = Vec::with_capacity(results.len());
+    let mut dsigma_dt = Vec::with_capacity(results.len());
+    for result in results {
+        let (values, derivatives) = result?;
+        sigma.push(values);
+        dsigma_dt.push(derivatives);
+    }
+    Ok(WorkingGridXsWithDerivative {
+        sigma,
+        dsigma_dt,
+        layout,
+    })
+}
+
+/// Compute source-aware Doppler-broadened cross sections and their exact
+/// temperature derivatives on the resolution working grid.
+///
+/// Unlike the `_from_base` API, this function retains the immutable resonance
+/// source. Resolved SLBW/MLBW evaluations therefore integrate the resonance
+/// equation directly inside the free-gas kernel instead of interpolating a
+/// caller-grid table. Resolution is not applied here; callers apply it after
+/// Beer-Lambert attenuation.
+pub fn broadened_cross_sections_with_analytical_derivative_on_working_grid(
+    energies: &[f64],
+    resonance_data: &[ResonanceData],
+    temperature_k: f64,
+    instrument: Option<&InstrumentParams>,
+) -> Result<WorkingGridXsWithDerivative, TransmissionError> {
+    if instrument.is_some() && !energies.windows(2).all(|window| window[0] <= window[1]) {
+        return Err(ResolutionError::UnsortedEnergies.into());
+    }
+
+    let references: Vec<&ResonanceData> = resonance_data.iter().collect();
+    let extended_grid = build_aux_grid(energies, instrument, &references);
+    let (work_energies, layout) = working_grid_layout(energies, extended_grid.as_ref());
+    type IsotopeXsDxs = Result<(Vec<f64>, Vec<f64>), TransmissionError>;
+    let results: Vec<IsotopeXsDxs> = resonance_data
+        .par_iter()
+        .map(|data| source_aware_doppler_with_derivative(work_energies, data, temperature_k))
+        .collect();
+
+    let mut sigma = Vec::with_capacity(results.len());
+    let mut dsigma_dt = Vec::with_capacity(results.len());
+    for result in results {
+        let (values, derivatives) = result?;
+        sigma.push(values);
+        dsigma_dt.push(derivatives);
+    }
+    Ok(WorkingGridXsWithDerivative {
+        sigma,
+        dsigma_dt,
+        layout,
+    })
+}
+
+/// Source-aware Doppler broadening with a cached sampled fallback.
+///
+/// Resolved SLBW/MLBW sources still use the continuous resonance-equation
+/// integral.  Only an isotope that the continuous evaluator cannot cover uses
+/// its matching cached zero-temperature row.  The choice is all-or-nothing per
+/// isotope, and the cache avoids reevaluating unsupported resonance sources at
+/// every trial temperature.
+pub fn broadened_cross_sections_on_working_grid_with_cached_fallback(
+    energies: &[f64],
+    fallback_base_xs: &[Vec<f64>],
+    resonance_data: &[ResonanceData],
+    temperature_k: f64,
+    instrument: Option<&InstrumentParams>,
+) -> Result<WorkingGridXs, TransmissionError> {
+    validate_base_xs(energies, fallback_base_xs, resonance_data)?;
+    if instrument.is_some() && !energies.windows(2).all(|window| window[0] <= window[1]) {
+        return Err(ResolutionError::UnsortedEnergies.into());
+    }
+
+    let references: Vec<&ResonanceData> = resonance_data.iter().collect();
+    let extended_grid = build_aux_grid(energies, instrument, &references);
+    let is_data_point = data_point_mask(extended_grid.as_ref());
+    let (work_energies, layout) = working_grid_layout(energies, extended_grid.as_ref());
+    let sigma: Result<Vec<Vec<f64>>, TransmissionError> = fallback_base_xs
+        .par_iter()
+        .zip(resonance_data.par_iter())
+        .map(|(cached_source, data)| {
+            let params = DopplerParams::new(temperature_k, data.awr)?;
+            if let Some(values) = continuous_doppler::try_broaden(work_energies, data, &params)? {
+                return Ok(values);
+            }
+
+            let work_source = if let Some((ref work_grid, ref data_indices)) = extended_grid {
+                build_extended_xs_from_base(
+                    work_grid,
+                    data_indices,
+                    is_data_point.as_ref().expect("extended-grid mask"),
+                    cached_source,
+                    data,
+                )
+            } else {
+                cached_source.clone()
+            };
+            if temperature_k > 0.0 {
+                doppler::doppler_broaden(work_energies, &work_source, &params).map_err(Into::into)
+            } else {
+                Ok(work_source)
+            }
+        })
+        .collect();
+
+    Ok(WorkingGridXs {
+        sigma: sigma?,
+        layout,
+    })
+}
+
+/// Derivative counterpart of
+/// [`broadened_cross_sections_on_working_grid_with_cached_fallback`].
+pub fn broadened_cross_sections_with_analytical_derivative_on_working_grid_with_cached_fallback(
+    energies: &[f64],
+    fallback_base_xs: &[Vec<f64>],
+    resonance_data: &[ResonanceData],
+    temperature_k: f64,
+    instrument: Option<&InstrumentParams>,
+) -> Result<WorkingGridXsWithDerivative, TransmissionError> {
+    validate_base_xs(energies, fallback_base_xs, resonance_data)?;
+    if instrument.is_some() && !energies.windows(2).all(|window| window[0] <= window[1]) {
+        return Err(ResolutionError::UnsortedEnergies.into());
+    }
+
+    let references: Vec<&ResonanceData> = resonance_data.iter().collect();
+    let extended_grid = build_aux_grid(energies, instrument, &references);
+    let is_data_point = data_point_mask(extended_grid.as_ref());
+    let (work_energies, layout) = working_grid_layout(energies, extended_grid.as_ref());
+    type IsotopeXsDxs = Result<(Vec<f64>, Vec<f64>), TransmissionError>;
+    let results: Vec<IsotopeXsDxs> = fallback_base_xs
+        .par_iter()
+        .zip(resonance_data.par_iter())
+        .map(|(cached_source, data)| {
+            let params = DopplerParams::new(temperature_k, data.awr)?;
+            if let Some(result) =
+                continuous_doppler::try_broaden_with_derivative(work_energies, data, &params)?
+            {
+                return Ok(result);
+            }
+
+            let work_source = if let Some((ref work_grid, ref data_indices)) = extended_grid {
+                build_extended_xs_from_base(
+                    work_grid,
+                    data_indices,
+                    is_data_point.as_ref().expect("extended-grid mask"),
+                    cached_source,
+                    data,
+                )
+            } else {
+                cached_source.clone()
+            };
+            if temperature_k > 0.0 {
+                doppler::doppler_broaden_with_derivative(work_energies, &work_source, &params)
+                    .map_err(Into::into)
+            } else {
+                Ok((work_source, vec![0.0; work_energies.len()]))
+            }
+        })
+        .collect();
+
+    let mut sigma = Vec::with_capacity(results.len());
+    let mut dsigma_dt = Vec::with_capacity(results.len());
+    for result in results {
+        let (values, derivatives) = result?;
+        sigma.push(values);
+        dsigma_dt.push(derivatives);
+    }
+    Ok(WorkingGridXsWithDerivative {
+        sigma,
+        dsigma_dt,
+        layout,
+    })
+}
+
 /// Compute a transmission spectrum from precomputed unbroadened cross-sections.
 ///
 /// Applies Doppler broadening and Beer-Lambert using cached base XS, then
@@ -1334,7 +1642,7 @@ pub fn forward_model_from_base_xs(
 mod tests {
     use super::*;
     use nereids_core::types::Isotope;
-    use nereids_endf::resonance::test_support::u238_single_resonance;
+    use nereids_endf::resonance::test_support::{u238_single_resonance, u238_with_formalism};
     use nereids_endf::resonance::{LGroup, Resonance, ResonanceFormalism, ResonanceRange};
 
     /// Issue #608 R2: the spatial pipeline builds the working-grid σ
@@ -1382,6 +1690,85 @@ mod tests {
                 "working-grid energies must be bit-identical"
             );
         }
+    }
+
+    #[test]
+    fn cached_fallback_is_used_only_for_unsupported_formalism() {
+        let energies: Vec<f64> = (0..201).map(|index| 5.5 + index as f64 * 0.01).collect();
+        let temperature = 300.0;
+
+        let unsupported = u238_with_formalism(ResonanceFormalism::ReichMoore);
+        let unsupported_base =
+            unbroadened_cross_sections(&energies, std::slice::from_ref(&unsupported), None)
+                .unwrap();
+        let cached = broadened_cross_sections_on_working_grid_with_cached_fallback(
+            &energies,
+            &unsupported_base,
+            std::slice::from_ref(&unsupported),
+            temperature,
+            None,
+        )
+        .unwrap();
+        let legacy = broadened_cross_sections_from_base_on_working_grid(
+            &energies,
+            &unsupported_base,
+            std::slice::from_ref(&unsupported),
+            temperature,
+            None,
+        )
+        .unwrap();
+        assert_eq!(cached.sigma, legacy.sigma);
+        let cached_derivative =
+            broadened_cross_sections_with_analytical_derivative_on_working_grid_with_cached_fallback(
+                &energies,
+                &unsupported_base,
+                std::slice::from_ref(&unsupported),
+                temperature,
+                None,
+            )
+            .unwrap();
+        let legacy_derivative =
+            broadened_cross_sections_with_analytical_derivative_from_base_on_working_grid(
+                &energies,
+                &unsupported_base,
+                std::slice::from_ref(&unsupported),
+                temperature,
+                None,
+            )
+            .unwrap();
+        assert_eq!(cached_derivative.sigma, legacy_derivative.sigma);
+        assert_eq!(cached_derivative.dsigma_dt, legacy_derivative.dsigma_dt);
+
+        let zero_fallback = vec![vec![0.0; energies.len()]];
+        let zero_result = broadened_cross_sections_on_working_grid_with_cached_fallback(
+            &energies,
+            &zero_fallback,
+            std::slice::from_ref(&unsupported),
+            temperature,
+            None,
+        )
+        .unwrap();
+        assert!(zero_result.sigma[0].iter().all(|&value| value == 0.0));
+
+        let supported = u238_with_formalism(ResonanceFormalism::MLBW);
+        let deliberately_wrong_fallback = vec![vec![0.0; energies.len()]];
+        let cached = broadened_cross_sections_on_working_grid_with_cached_fallback(
+            &energies,
+            &deliberately_wrong_fallback,
+            std::slice::from_ref(&supported),
+            temperature,
+            None,
+        )
+        .unwrap();
+        let source = broadened_cross_sections_on_working_grid(
+            &energies,
+            std::slice::from_ref(&supported),
+            temperature,
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(cached.sigma, source.sigma);
     }
 
     #[test]

--- a/crates/nereids-physics/src/transmission.rs
+++ b/crates/nereids-physics/src/transmission.rs
@@ -30,6 +30,7 @@ use rayon::prelude::*;
 
 use nereids_endf::resonance::ResonanceData;
 
+use crate::continuous_doppler::{self, ContinuousDopplerError};
 use crate::doppler::{self, DopplerParams, DopplerParamsError};
 use crate::reich_moore;
 use crate::resolution::{self, ResolutionError, ResolutionFunction};
@@ -302,6 +303,8 @@ pub enum TransmissionError {
     Doppler(DopplerParamsError),
     /// Doppler broadening input validation failed (e.g. length mismatch).
     DopplerBroadening(crate::doppler::DopplerError),
+    /// Error-controlled source-equation Doppler integration failed.
+    ContinuousDoppler(ContinuousDopplerError),
     /// Computation was cancelled via the cancel token.
     Cancelled,
     /// Input array mismatch (e.g. cross-sections vs thicknesses length).
@@ -314,6 +317,9 @@ impl fmt::Display for TransmissionError {
             Self::Resolution(e) => write!(f, "resolution broadening error: {}", e),
             Self::Doppler(e) => write!(f, "Doppler parameter error: {}", e),
             Self::DopplerBroadening(e) => write!(f, "Doppler broadening error: {}", e),
+            Self::ContinuousDoppler(e) => {
+                write!(f, "continuous Doppler broadening error: {e}")
+            }
             Self::Cancelled => write!(f, "computation cancelled"),
             Self::InputMismatch(msg) => write!(f, "input mismatch: {}", msg),
         }
@@ -326,6 +332,7 @@ impl std::error::Error for TransmissionError {
             Self::Resolution(e) => Some(e),
             Self::Doppler(e) => Some(e),
             Self::DopplerBroadening(e) => Some(e),
+            Self::ContinuousDoppler(e) => Some(e),
             Self::Cancelled => None,
             Self::InputMismatch(_) => None,
         }
@@ -348,6 +355,43 @@ impl From<crate::doppler::DopplerError> for TransmissionError {
     fn from(e: crate::doppler::DopplerError) -> Self {
         Self::DopplerBroadening(e)
     }
+}
+
+impl From<ContinuousDopplerError> for TransmissionError {
+    fn from(e: ContinuousDopplerError) -> Self {
+        Self::ContinuousDoppler(e)
+    }
+}
+
+/// Doppler-broaden an immutable resonance source without first sampling it
+/// onto the output grid.
+///
+/// Resolved SLBW/MLBW sources use the error-controlled free-gas integral of
+/// the resonance equation.  Other ENDF formalisms take the explicitly named
+/// legacy sampled-table route until a source-aware evaluator exists for that
+/// formalism.  The two routes are never mixed within one isotope result.
+fn source_aware_doppler(
+    energies: &[f64],
+    data: &ResonanceData,
+    temperature_k: f64,
+) -> Result<Vec<f64>, TransmissionError> {
+    let unbroadened = || {
+        reich_moore::cross_sections_on_grid(data, energies)
+            .into_iter()
+            .map(|cross_section| cross_section.total)
+            .collect::<Vec<_>>()
+    };
+    if temperature_k <= 0.0 {
+        return Ok(unbroadened());
+    }
+
+    let params = DopplerParams::new(temperature_k, data.awr)?;
+    if let Some(cross_sections) = continuous_doppler::try_broaden(energies, data, &params)? {
+        return Ok(cross_sections);
+    }
+
+    let sampled = unbroadened();
+    doppler::doppler_broaden(energies, &sampled, &params).map_err(Into::into)
 }
 
 /// Broadened cross-sections and their temperature derivative.
@@ -663,16 +707,8 @@ pub fn forward_model(
         .par_iter()
         .filter(|(_, thickness)| *thickness > 0.0)
         .map(|(res_data, thickness)| {
-            let unbroadened: Vec<f64> = work_energies
-                .iter()
-                .map(|&e| reich_moore::cross_sections_at_energy(res_data, e).total)
-                .collect();
-            let after_doppler = if sample.temperature_k() > 0.0 {
-                let params = DopplerParams::new(sample.temperature_k(), res_data.awr)?;
-                doppler::doppler_broaden(work_energies, &unbroadened, &params)?
-            } else {
-                unbroadened
-            };
+            let after_doppler =
+                source_aware_doppler(work_energies, res_data, sample.temperature_k())?;
             Ok((after_doppler, *thickness))
         })
         .collect();
@@ -801,16 +837,7 @@ pub fn broadened_cross_sections_on_working_grid(
                 return Err(TransmissionError::Cancelled);
             }
 
-            let unbroadened: Vec<f64> = work_energies
-                .iter()
-                .map(|&e| reich_moore::cross_sections_at_energy(rd, e).total)
-                .collect();
-            if temperature_k > 0.0 {
-                let params = DopplerParams::new(temperature_k, rd.awr)?;
-                doppler::doppler_broaden(work_energies, &unbroadened, &params).map_err(Into::into)
-            } else {
-                Ok(unbroadened)
-            }
+            source_aware_doppler(work_energies, rd, temperature_k)
         })
         .collect();
 
@@ -890,19 +917,8 @@ pub fn broadened_cross_sections_for_transmission(
                 // Extended grid available: evaluate the full pipeline on the
                 // extended grid and extract at data positions.
 
-                // 1. Unbroadened cross sections on extended grid.
-                let unbroadened: Vec<f64> = ext_energies
-                    .iter()
-                    .map(|&e| reich_moore::cross_sections_at_energy(rd, e).total)
-                    .collect();
-
-                // 2. Doppler broadening.
-                let after_doppler = if temperature_k > 0.0 {
-                    let params = DopplerParams::new(temperature_k, rd.awr)?;
-                    doppler::doppler_broaden(ext_energies, &unbroadened, &params)?
-                } else {
-                    unbroadened
-                };
+                // 1–2. Evaluate and Doppler-broaden the immutable source.
+                let after_doppler = source_aware_doppler(ext_energies, rd, temperature_k)?;
 
                 // 3. Convert to transmission: T = exp(-nd × σ_D).
                 let transmission: Vec<f64> = after_doppler
@@ -928,17 +944,7 @@ pub fn broadened_cross_sections_for_transmission(
             } else {
                 // No extended grid (e.g. tabulated resolution with no aux grid):
                 // Doppler on data grid, Beer-Lambert, resolution on data grid.
-                let unbroadened: Vec<f64> = energies
-                    .iter()
-                    .map(|&e| reich_moore::cross_sections_at_energy(rd, e).total)
-                    .collect();
-
-                let after_doppler = if temperature_k > 0.0 {
-                    let params = DopplerParams::new(temperature_k, rd.awr)?;
-                    doppler::doppler_broaden(energies, &unbroadened, &params)?
-                } else {
-                    unbroadened
-                };
+                let after_doppler = source_aware_doppler(energies, rd, temperature_k)?;
 
                 let transmission: Vec<f64> = after_doppler
                     .iter()

--- a/crates/nereids-physics/tests/ic_causal_response.rs
+++ b/crates/nereids-physics/tests/ic_causal_response.rs
@@ -1,0 +1,210 @@
+use nereids_physics::ikeda_carpenter::{
+    EnergyLaw, IkedaCarpenter, IkedaCarpenterParams, SynthesisGrid,
+};
+use nereids_physics::resolution::TOF_FACTOR;
+
+fn gamma3_cdf(x: f64) -> f64 {
+    if x <= 0.0 {
+        0.0
+    } else {
+        1.0 - (-x).exp() * (1.0 + x + 0.5 * x * x)
+    }
+}
+
+#[test]
+fn prompt_only_bins_match_closed_form_and_keep_physical_time() {
+    let alpha = 2.0;
+    let flight_path_m = 25.0_f64;
+    let true_energy_ev = 25.0_f64;
+    let timing_offset_us = 3.25_f64;
+    let model = IkedaCarpenter::new(
+        IkedaCarpenterParams::constant(alpha, 0.1, 0.0),
+        flight_path_m,
+        &SynthesisGrid::new(1.0, 100.0),
+    )
+    .expect("valid prompt-only IC model");
+
+    let nominal_arrival = timing_offset_us + TOF_FACTOR * flight_path_m / true_energy_ev.sqrt();
+    let delay_edges = [0.0, 0.5, 1.0, 2.0, 10.0];
+    let detector_edges: Vec<f64> = delay_edges
+        .iter()
+        .map(|delay| nominal_arrival + delay)
+        .collect();
+
+    let actual = model
+        .detector_bin_probabilities(true_energy_ev, &detector_edges, timing_offset_us)
+        .expect("valid detector bins");
+    let expected: Vec<f64> = delay_edges
+        .windows(2)
+        .map(|edge| gamma3_cdf(alpha * edge[1]) - gamma3_cdf(alpha * edge[0]))
+        .collect();
+
+    assert_eq!(actual.len(), expected.len());
+    for (bin, (&got, &want)) in actual.iter().zip(&expected).enumerate() {
+        assert!(
+            (got - want).abs() < 2e-12,
+            "bin {bin}: causal IC probability {got:.16e} != closed form {want:.16e}"
+        );
+    }
+
+    let (delays, weights) = model
+        .source_pulse_at(true_energy_ev)
+        .expect("valid physical source pulse");
+    let peak = weights
+        .iter()
+        .enumerate()
+        .max_by(|(_, a), (_, b)| a.total_cmp(b))
+        .map(|(index, _)| index)
+        .expect("non-empty pulse");
+    let step = delays[1] - delays[0];
+    assert!(
+        (delays[peak] - 2.0 / alpha).abs() <= step,
+        "source pulse peak was moved from physical delay 2/alpha={} us to {} us",
+        2.0 / alpha,
+        delays[peak]
+    );
+}
+
+#[test]
+fn energy_law_is_evaluated_at_true_energy() {
+    let flight_path_m = 25.0;
+    let params = IkedaCarpenterParams {
+        alpha: EnergyLaw::SqrtE { a0: 1.0, a1: 0.0 },
+        beta: 0.1,
+        r: EnergyLaw::Const(0.0),
+        burst_sigma_us: None,
+        channel_fwhm_us: None,
+    };
+    let model = IkedaCarpenter::new(params, flight_path_m, &SynthesisGrid::new(1.0, 100.0))
+        .expect("valid energy-dependent IC model");
+
+    for true_energy_ev in [1.0_f64, 4.0] {
+        let nominal_arrival = TOF_FACTOR * flight_path_m / true_energy_ev.sqrt();
+        let edges = [nominal_arrival, nominal_arrival + 1.0];
+        let got = model
+            .detector_bin_probabilities(true_energy_ev, &edges, 0.0)
+            .expect("valid detector bin")[0];
+        let alpha = true_energy_ev.sqrt();
+        let want = gamma3_cdf(alpha);
+        assert!(
+            (got - want).abs() < 2e-12,
+            "E={true_energy_ev} eV used the wrong pulse: {got:.16e} != {want:.16e}"
+        );
+    }
+}
+
+#[test]
+fn invalid_detector_edges_fail_instead_of_being_reordered() {
+    let model = IkedaCarpenter::new(
+        IkedaCarpenterParams::constant(1.0, 0.1, 0.0),
+        25.0,
+        &SynthesisGrid::new(1.0, 100.0),
+    )
+    .expect("valid IC model");
+
+    assert!(
+        model
+            .detector_bin_probabilities(10.0, &[100.0, 99.0], 0.0)
+            .is_err()
+    );
+    assert!(
+        model
+            .detector_bin_probabilities(10.0, &[100.0, f64::NAN], 0.0)
+            .is_err()
+    );
+    assert!(
+        model
+            .detector_bin_probabilities(0.0, &[100.0, 101.0], 0.0)
+            .is_err()
+    );
+}
+
+#[test]
+fn equal_rate_storage_limit_matches_gamma4_closed_form() {
+    let rate = 1.25_f64;
+    let flight_path_m = 25.0_f64;
+    let true_energy_ev = 16.0_f64;
+    let model = IkedaCarpenter::new(
+        IkedaCarpenterParams::constant(rate, rate, 1.0),
+        flight_path_m,
+        &SynthesisGrid::new(1.0, 100.0),
+    )
+    .expect("valid equal-rate storage model");
+    let nominal_arrival = TOF_FACTOR * flight_path_m / true_energy_ev.sqrt();
+    let delay_edges = [0.0, 0.2, 0.8, 2.0, 20.0];
+    let detector_edges: Vec<f64> = delay_edges
+        .iter()
+        .map(|delay| nominal_arrival + delay)
+        .collect();
+
+    let got = model
+        .detector_bin_probabilities(true_energy_ev, &detector_edges, 0.0)
+        .expect("valid detector bins");
+    let gamma4_cdf = |delay: f64| {
+        let x = rate * delay;
+        if x <= 0.0 {
+            0.0
+        } else {
+            1.0 - (-x).exp() * (1.0 + x + x * x / 2.0 + x.powi(3) / 6.0)
+        }
+    };
+    for (index, edge) in delay_edges.windows(2).enumerate() {
+        let want = gamma4_cdf(edge[1]) - gamma4_cdf(edge[0]);
+        assert!(
+            (got[index] - want).abs() < 3e-12,
+            "equal-rate storage bin {index}: {} != {want}",
+            got[index]
+        );
+    }
+}
+
+#[test]
+fn symmetric_sns_pulse_fold_keeps_source_clock_and_conserves_probability() {
+    let alpha = 2.0_f64;
+    let flight_path_m = 25.0_f64;
+    let true_energy_ev = 25.0_f64;
+    let params = IkedaCarpenterParams {
+        channel_fwhm_us: Some(0.35),
+        ..IkedaCarpenterParams::constant(alpha, 0.1, 0.0)
+    };
+    let model = IkedaCarpenter::new(params, flight_path_m, &SynthesisGrid::new(1.0, 100.0))
+        .expect("valid folded IC model");
+    let (delays, weights) = model
+        .source_pulse_at(true_energy_ev)
+        .expect("valid folded source pulse");
+
+    let mut area = 0.0;
+    let mut first_moment = 0.0;
+    for i in 0..delays.len() - 1 {
+        let width = delays[i + 1] - delays[i];
+        area += 0.5 * (weights[i] + weights[i + 1]) * width;
+        first_moment += width
+            * (delays[i] * (2.0 * weights[i] + weights[i + 1])
+                + delays[i + 1] * (weights[i] + 2.0 * weights[i + 1]))
+            / 6.0;
+    }
+    let mean = first_moment / area;
+    assert!(
+        (mean - 3.0 / alpha).abs() < 3e-3,
+        "symmetric fold moved the physical source mean from {} us to {mean} us",
+        3.0 / alpha
+    );
+
+    let nominal_arrival = TOF_FACTOR * flight_path_m / true_energy_ev.sqrt();
+    let detector_edges: Vec<f64> = (0..=20)
+        .map(|index| {
+            nominal_arrival
+                + delays[0]
+                + (delays[delays.len() - 1] - delays[0]) * index as f64 / 20.0
+        })
+        .collect();
+    let probabilities = model
+        .detector_bin_probabilities(true_energy_ev, &detector_edges, 0.0)
+        .expect("valid folded detector bins");
+    let total: f64 = probabilities.iter().sum();
+    assert!(
+        (total - 1.0).abs() < 2e-12,
+        "full sampled pulse has probability {total}, expected 1"
+    );
+    assert!(probabilities.iter().all(|p| p.is_finite() && *p >= 0.0));
+}

--- a/crates/nereids-physics/tests/ic_causal_response.rs
+++ b/crates/nereids-physics/tests/ic_causal_response.rs
@@ -216,7 +216,7 @@ fn equal_rate_storage_limit_matches_gamma4_closed_form() {
 }
 
 #[test]
-fn symmetric_sns_pulse_fold_keeps_source_clock_and_conserves_probability() {
+fn symmetric_sns_pulse_fold_keeps_source_clock_and_preserves_missing_tail_mass() {
     let alpha = 2.0_f64;
     let flight_path_m = 25.0_f64;
     let true_energy_ev = 25.0_f64;
@@ -259,9 +259,111 @@ fn symmetric_sns_pulse_fold_keeps_source_clock_and_conserves_probability() {
         .detector_bin_probabilities(true_energy_ev, &detector_edges, 0.0)
         .expect("valid folded detector bins");
     let total: f64 = probabilities.iter().sum();
+
+    // Independent oracle for X + C, where X is the prompt-only Gamma(3,
+    // alpha) moderator delay and C is the symmetric triangular channel-time
+    // density. Integrating the analytical moderator CDF over C predicts the
+    // probability inside these finite detector edges without using the
+    // implementation's sampled convolution or bin integration.
+    let gamma3_cdf = |delay: f64| {
+        let x = alpha * delay;
+        if x <= 0.0 {
+            0.0
+        } else {
+            1.0 - (-x).exp() * (1.0 + x + x * x / 2.0)
+        }
+    };
+    let half_base = 0.35_f64;
+    let lower = delays[0];
+    let upper = delays[delays.len() - 1];
+    let integrand = |channel_delay: f64| {
+        let channel_density = (1.0 - channel_delay.abs() / half_base) / half_base;
+        channel_density * (gamma3_cdf(upper - channel_delay) - gamma3_cdf(lower - channel_delay))
+    };
+    let intervals = 20_000_usize;
+    let step = 2.0 * half_base / intervals as f64;
+    let mut oracle = integrand(-half_base) + integrand(half_base);
+    for index in 1..intervals {
+        let delay = -half_base + index as f64 * step;
+        oracle += if index % 2 == 0 { 2.0 } else { 4.0 } * integrand(delay);
+    }
+    oracle *= step / 3.0;
     assert!(
-        (total - 1.0).abs() < 2e-12,
-        "full sampled pulse has probability {total}, expected 1"
+        (total - oracle).abs() < 2.0e-7,
+        "sampled folded pulse has probability {total}, independent analytical integral gives {oracle}"
+    );
+    assert!(
+        oracle < 1.0,
+        "finite detector edges must omit a physical tail"
     );
     assert!(probabilities.iter().all(|p| p.is_finite() && *p >= 0.0));
+}
+
+#[test]
+fn gaussian_fold_preserves_finite_window_tail_mass() {
+    let alpha = 100.0_f64;
+    let sigma = 1.0_f64;
+    let flight_path_m = 25.0_f64;
+    let true_energy_ev = 25.0_f64;
+    let params = IkedaCarpenterParams {
+        burst_sigma_us: Some(sigma),
+        ..IkedaCarpenterParams::constant(alpha, 1.0, 0.0)
+    };
+    let model = IkedaCarpenter::new(
+        params,
+        flight_path_m,
+        &SynthesisGrid {
+            e_min_ev: 24.0,
+            e_max_ev: 26.0,
+            n_energies: 2,
+            n_tau: 8,
+        },
+    )
+    .expect("valid Gaussian-folded IC model");
+    let (delays, _) = model
+        .source_pulse_at(true_energy_ev)
+        .expect("valid folded source pulse");
+    let lower = delays[0];
+    let upper = delays[delays.len() - 1];
+    let nominal_arrival = TOF_FACTOR * flight_path_m / true_energy_ev.sqrt();
+    let got: f64 = model
+        .detector_bin_probabilities(
+            true_energy_ev,
+            &[nominal_arrival + lower, nominal_arrival + upper],
+            0.0,
+        )
+        .expect("valid folded detector window")
+        .iter()
+        .sum();
+
+    // Independent oracle: integrate the exact Gamma(3) moderator CDF over a
+    // standard normal variable. This does not use the sampled convolution or
+    // detector-bin integrator under test.
+    let normal_density = |delay: f64| {
+        (-0.5 * (delay / sigma).powi(2)).exp() / (sigma * std::f64::consts::TAU.sqrt())
+    };
+    let moderator_cdf = |delay: f64| gamma3_cdf(alpha * delay);
+    let integrand = |gaussian_delay: f64| {
+        normal_density(gaussian_delay)
+            * (moderator_cdf(upper - gaussian_delay) - moderator_cdf(lower - gaussian_delay))
+    };
+    let integration_limit = 10.0 * sigma;
+    let intervals = 200_000_usize;
+    let step = 2.0 * integration_limit / intervals as f64;
+    let mut oracle = integrand(-integration_limit) + integrand(integration_limit);
+    for index in 1..intervals {
+        let delay = -integration_limit + index as f64 * step;
+        oracle += if index % 2 == 0 { 2.0 } else { 4.0 } * integrand(delay);
+    }
+    oracle *= step / 3.0;
+
+    assert!(
+        1.0 - oracle > 4.0e-5,
+        "oracle window must expose enough missing tail to reject silent renormalization"
+    );
+    assert!(
+        (got - oracle).abs() < 2.0e-5,
+        "sampled Gaussian-folded probability {got} disagrees with independent integral {oracle}"
+    );
+    assert!(got < 1.0, "finite window was silently renormalized to one");
 }

--- a/crates/nereids-physics/tests/ic_causal_response.rs
+++ b/crates/nereids-physics/tests/ic_causal_response.rs
@@ -70,7 +70,7 @@ fn energy_law_is_evaluated_at_true_energy() {
     let flight_path_m = 25.0;
     let params = IkedaCarpenterParams {
         alpha: EnergyLaw::SqrtE { a0: 1.0, a1: 0.0 },
-        beta: 0.1,
+        beta: EnergyLaw::Const(0.1),
         r: EnergyLaw::Const(0.0),
         burst_sigma_us: None,
         channel_fwhm_us: None,
@@ -91,6 +91,63 @@ fn energy_law_is_evaluated_at_true_energy() {
             "E={true_energy_ev} eV used the wrong pulse: {got:.16e} != {want:.16e}"
         );
     }
+}
+
+#[test]
+fn moderator_rates_that_follow_neutron_speed_preserve_scaled_pulse_time() {
+    let flight_path_m = 25.0;
+    let params = IkedaCarpenterParams {
+        alpha: EnergyLaw::SqrtE { a0: 2.0, a1: 0.0 },
+        beta: EnergyLaw::SqrtE { a0: 0.5, a1: 0.0 },
+        r: EnergyLaw::Const(0.3),
+        burst_sigma_us: None,
+        channel_fwhm_us: None,
+    };
+    let model = IkedaCarpenter::new(params, flight_path_m, &SynthesisGrid::new(1.0, 4.0))
+        .expect("valid speed-scaled IC model");
+
+    let probability_to_scaled_delay = |energy_ev: f64, delay_us: f64| {
+        let arrival = TOF_FACTOR * flight_path_m / energy_ev.sqrt();
+        model
+            .detector_bin_probabilities(energy_ev, &[arrival, arrival + delay_us], 0.0)
+            .expect("valid detector bin")[0]
+    };
+
+    let at_one_ev = probability_to_scaled_delay(1.0, 2.0);
+    let at_four_ev = probability_to_scaled_delay(4.0, 1.0);
+    assert!(
+        (at_one_ev - at_four_ev).abs() < 2e-12,
+        "speed-scaled moderator pulse changed shape: {at_one_ev:.16e} != {at_four_ev:.16e}"
+    );
+}
+
+#[test]
+fn probe_outside_synthesis_range_rejects_nonphysical_beta_law() {
+    let model = IkedaCarpenter::new(
+        IkedaCarpenterParams {
+            alpha: EnergyLaw::Const(1.0),
+            beta: EnergyLaw::SqrtE { a0: -1.0, a1: 2.0 },
+            r: EnergyLaw::Const(0.3),
+            burst_sigma_us: None,
+            channel_fwhm_us: None,
+        },
+        25.0,
+        &SynthesisGrid::new(1.0, 2.0),
+    )
+    .expect("beta law is physical inside the synthesis range");
+
+    let legacy_error = model
+        .kernel_at(9.0)
+        .expect_err("legacy kernel probe must reject a negative beta law")
+        .to_string();
+    assert!(
+        legacy_error.contains("beta(9)"),
+        "legacy kernel probe hid the invalid beta law behind: {legacy_error}"
+    );
+    assert!(
+        model.source_pulse_at(9.0).is_err(),
+        "physical source probe must reject a negative beta law"
+    );
 }
 
 #[test]

--- a/crates/nereids-physics/tests/tabulated_detector_bins.rs
+++ b/crates/nereids-physics/tests/tabulated_detector_bins.rs
@@ -1,0 +1,113 @@
+use nereids_physics::resolution::{TOF_FACTOR, TabulatedResolution};
+
+fn one_asymmetric_pulse() -> TabulatedResolution {
+    TabulatedResolution::from_kernels(
+        vec![25.0],
+        vec![(vec![-1.0, 0.0, 2.0], vec![0.0, 1.0, 0.0])],
+        25.0,
+    )
+    .expect("valid one-energy tabulated response")
+}
+
+#[test]
+fn tabulated_bins_integrate_piecewise_linear_density_without_window_renormalization() {
+    let response = one_asymmetric_pulse();
+    let nominal_arrival = TOF_FACTOR * 25.0 / 25.0_f64.sqrt();
+    let relative_edges = [-2.0, -1.0, 0.0, 1.0, 2.0, 3.0];
+    let detector_edges: Vec<f64> = relative_edges
+        .iter()
+        .map(|offset| nominal_arrival + offset)
+        .collect();
+    let got = response
+        .detector_bin_probabilities(25.0, &detector_edges, 0.0)
+        .expect("valid detector bins");
+    let want = [0.0, 1.0 / 3.0, 1.0 / 2.0, 1.0 / 6.0, 0.0];
+    for (index, (&actual, expected)) in got.iter().zip(want).enumerate() {
+        assert!(
+            (actual - expected).abs() < 2.0e-14,
+            "bin {index}: {actual:.16e} != {expected:.16e}"
+        );
+    }
+    assert!((got.iter().sum::<f64>() - 1.0).abs() < 2.0e-14);
+
+    let truncated = response
+        .detector_bin_probabilities(25.0, &[nominal_arrival, nominal_arrival + 1.0], 0.0)
+        .expect("valid truncated detector window");
+    assert_eq!(truncated.len(), 1);
+    assert!(
+        (truncated[0] - 0.5).abs() < 2.0e-14,
+        "partial pulse was renormalized: {}",
+        truncated[0]
+    );
+}
+
+#[test]
+fn tabulated_bins_select_the_pulse_by_true_energy() {
+    let response = TabulatedResolution::from_kernels(
+        vec![4.0, 16.0],
+        vec![
+            (vec![-2.0, 0.0, 2.0], vec![0.0, 1.0, 0.0]),
+            (vec![-1.0, 0.0, 1.0], vec![0.0, 1.0, 0.0]),
+        ],
+        25.0,
+    )
+    .expect("valid two-energy tabulated response");
+
+    let probability = |energy_ev: f64| {
+        let arrival = TOF_FACTOR * 25.0 / energy_ev.sqrt();
+        response
+            .detector_bin_probabilities(energy_ev, &[arrival - 1.0, arrival + 1.0], 0.0)
+            .expect("valid detector bin")[0]
+    };
+    assert!((probability(4.0) - 0.75).abs() < 2.0e-14);
+    assert!((probability(16.0) - 1.0).abs() < 2.0e-14);
+}
+
+#[test]
+fn tabulated_bins_reject_invalid_physical_inputs() {
+    let response = one_asymmetric_pulse();
+    assert!(
+        response
+            .detector_bin_probabilities(0.0, &[1.0, 2.0], 0.0)
+            .is_err()
+    );
+    assert!(
+        response
+            .detector_bin_probabilities(25.0, &[2.0, 1.0], 0.0)
+            .is_err()
+    );
+    assert!(
+        response
+            .detector_bin_probabilities(25.0, &[1.0, f64::NAN], 0.0)
+            .is_err()
+    );
+    assert!(
+        response
+            .detector_bin_probabilities(25.0, &[1.0, 2.0], f64::INFINITY)
+            .is_err()
+    );
+}
+
+#[test]
+fn tabulated_bins_support_delta_kernel_and_reject_invalid_flight_path() {
+    let response =
+        TabulatedResolution::from_kernels(vec![25.0], vec![(vec![0.0], vec![1.0])], 25.0)
+            .expect("valid one-point delta response");
+    let arrival = TOF_FACTOR * 25.0 / 25.0_f64.sqrt();
+    let got = response
+        .detector_bin_probabilities(25.0, &[arrival - 1.0, arrival, arrival + 1.0], 0.0)
+        .expect("delta response must be integrable");
+    assert_eq!(got, vec![0.0, 1.0]);
+
+    for bad_path in [0.0, -25.0, f64::NAN, f64::INFINITY] {
+        assert!(
+            TabulatedResolution::from_kernels(
+                vec![25.0],
+                vec![(vec![-1.0, 0.0, 1.0], vec![0.0, 1.0, 0.0])],
+                bad_path,
+            )
+            .is_err(),
+            "invalid flight path {bad_path} was accepted"
+        );
+    }
+}

--- a/crates/nereids-physics/tests/two_arm_counts.rs
+++ b/crates/nereids-physics/tests/two_arm_counts.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 use nereids_physics::counts_response::{
-    CountsResponseError, TwoArmCounts, add_count_backgrounds, two_arm_count_response,
+    CountsResponseError, DetectorBinResponseMatrix, TwoArmCounts, add_count_backgrounds,
+    two_arm_count_response,
 };
 use nereids_physics::ikeda_carpenter::{
     EnergyLaw, IkedaCarpenter, IkedaCarpenterParams, SynthesisGrid,
@@ -19,6 +20,46 @@ fn triangle_response() -> ResolutionFunction {
         )
         .expect("valid triangle response"),
     ))
+}
+
+#[test]
+fn compact_response_keeps_every_nonzero_and_reconstructs_interior_zeros() {
+    let response = triangle_response();
+    let arrival_0 = TOF_FACTOR * 25.0 / 25.0_f64.sqrt();
+    let arrival_1 = arrival_0 + 1.0;
+    let energy_1 = (TOF_FACTOR * 25.0 / arrival_1).powi(2);
+    let matrix = DetectorBinResponseMatrix::new(
+        &[25.0, energy_1],
+        &[arrival_0 - 1.0, arrival_0, arrival_0 + 1.0, arrival_0 + 2.0],
+        0.0,
+        &response,
+    )
+    .expect("valid compact response");
+
+    assert_eq!(matrix.nnz(), 4);
+    assert_eq!(
+        matrix.storage_bytes(),
+        3 * std::mem::size_of::<usize>()
+            + 4 * std::mem::size_of::<u32>()
+            + 4 * std::mem::size_of::<f64>()
+    );
+    assert_eq!(
+        matrix.row_entries(0).collect::<Vec<_>>(),
+        [(0, 0.5), (1, 0.5)]
+    );
+    assert_eq!(
+        matrix.row_entries(1).collect::<Vec<_>>(),
+        [(1, 0.5), (2, 0.5)]
+    );
+    assert_eq!(matrix.probability(0, 2), 0.0);
+    assert_eq!(matrix.probability(1, 0), 0.0);
+    assert_eq!(matrix.probability(0, 0), 0.5);
+
+    let got = matrix
+        .apply(&[100.0, 200.0], &[0.2, 0.8])
+        .expect("valid compact response application");
+    assert_eq!(got.open_beam, [50.0, 150.0, 100.0]);
+    assert_eq!(got.sample, [10.0, 90.0, 80.0]);
 }
 
 #[test]

--- a/crates/nereids-physics/tests/two_arm_counts.rs
+++ b/crates/nereids-physics/tests/two_arm_counts.rs
@@ -1,0 +1,145 @@
+use std::sync::Arc;
+
+use nereids_physics::counts_response::{CountsResponseError, two_arm_count_response};
+use nereids_physics::ikeda_carpenter::{
+    EnergyLaw, IkedaCarpenter, IkedaCarpenterParams, SynthesisGrid,
+};
+use nereids_physics::resolution::{
+    ResolutionFunction, ResolutionParams, TOF_FACTOR, TabulatedResolution,
+};
+
+fn triangle_response() -> ResolutionFunction {
+    ResolutionFunction::Tabulated(Arc::new(
+        TabulatedResolution::from_kernels(
+            vec![25.0],
+            vec![(vec![-1.0, 0.0, 1.0], vec![0.0, 1.0, 0.0])],
+            25.0,
+        )
+        .expect("valid triangle response"),
+    ))
+}
+
+#[test]
+fn two_arm_response_integrates_fluence_and_transmission_before_detector_binning() {
+    let response = triangle_response();
+    let arrival_0 = TOF_FACTOR * 25.0 / 25.0_f64.sqrt();
+    let arrival_1 = arrival_0 + 1.0;
+    let energy_1 = (TOF_FACTOR * 25.0 / arrival_1).powi(2);
+    let edges = [arrival_0 - 1.0, arrival_0, arrival_0 + 1.0, arrival_0 + 2.0];
+
+    let got = two_arm_count_response(
+        &[25.0, energy_1],
+        &[100.0, 200.0],
+        &[0.2, 0.8],
+        &edges,
+        0.0,
+        &response,
+    )
+    .expect("valid two-arm response");
+
+    // E0 contributes [0.5, 0.5, 0.0]; E1 contributes [0.0, 0.5, 0.5].
+    // The open and attenuated sample arms are summed separately.
+    let want_open = [50.0, 150.0, 100.0];
+    let want_sample = [10.0, 90.0, 80.0];
+    for (index, ((&open, &sample), (&expected_open, &expected_sample))) in got
+        .open_beam
+        .iter()
+        .zip(&got.sample)
+        .zip(want_open.iter().zip(&want_sample))
+        .enumerate()
+    {
+        assert!((open - expected_open).abs() < 2.0e-11, "open bin {index}");
+        assert!(
+            (sample - expected_sample).abs() < 2.0e-11,
+            "sample bin {index}"
+        );
+    }
+}
+
+#[test]
+fn acquisition_window_loss_is_not_renormalized() {
+    let response = triangle_response();
+    let arrival = TOF_FACTOR * 25.0 / 25.0_f64.sqrt();
+    let got = two_arm_count_response(
+        &[25.0],
+        &[100.0],
+        &[0.4],
+        &[arrival, arrival + 1.0],
+        0.0,
+        &response,
+    )
+    .expect("valid truncated response");
+    assert!((got.open_beam[0] - 50.0).abs() < 1.0e-12);
+    assert!((got.sample[0] - 20.0).abs() < 1.0e-12);
+}
+
+#[test]
+fn analytical_ic_is_evaluated_directly_in_detector_time() {
+    let ic = Arc::new(
+        IkedaCarpenter::new(
+            IkedaCarpenterParams {
+                alpha: EnergyLaw::Const(1.2),
+                beta: EnergyLaw::Const(0.2),
+                r: EnergyLaw::Const(0.25),
+                burst_sigma_us: None,
+                channel_fwhm_us: None,
+            },
+            25.0,
+            &SynthesisGrid {
+                e_min_ev: 20.0,
+                e_max_ev: 30.0,
+                n_energies: 8,
+                n_tau: 600,
+            },
+        )
+        .expect("valid IC response"),
+    );
+    let arrival = TOF_FACTOR * 25.0 / 25.0_f64.sqrt();
+    let edges = [arrival, arrival + 1.0, arrival + 5.0, arrival + 20.0];
+    let expected_probability = ic
+        .detector_bin_probabilities(25.0, &edges, 0.0)
+        .expect("direct IC probabilities");
+    let got = two_arm_count_response(
+        &[25.0],
+        &[80.0],
+        &[0.5],
+        &edges,
+        0.0,
+        &ResolutionFunction::IkedaCarpenter(ic),
+    )
+    .expect("direct IC two-arm response");
+
+    for (index, (&probability, (&open, &sample))) in expected_probability
+        .iter()
+        .zip(got.open_beam.iter().zip(&got.sample))
+        .enumerate()
+    {
+        assert!((open - 80.0 * probability).abs() < 2.0e-12, "open {index}");
+        assert!(
+            (sample - 40.0 * probability).abs() < 2.0e-12,
+            "sample {index}"
+        );
+    }
+}
+
+#[test]
+fn unsupported_or_unphysical_inputs_fail_clearly() {
+    let gaussian = ResolutionFunction::Gaussian(
+        ResolutionParams::new(25.0, 1.0, 0.0, 0.0).expect("valid Gaussian parameters"),
+    );
+    let error = two_arm_count_response(&[25.0], &[100.0], &[0.5], &[100.0, 101.0], 0.0, &gaussian)
+        .expect_err("Gaussian detector-time response must fail");
+    assert!(error.to_string().contains("Gaussian energy broadening"));
+
+    assert!(matches!(
+        two_arm_count_response(
+            &[25.0],
+            &[100.0],
+            &[1.01],
+            &[100.0, 101.0],
+            0.0,
+            &triangle_response(),
+        ),
+        Err(CountsResponseError::InvalidTransmission { .. })
+    ));
+}

--- a/crates/nereids-physics/tests/two_arm_counts.rs
+++ b/crates/nereids-physics/tests/two_arm_counts.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use nereids_physics::counts_response::{CountsResponseError, two_arm_count_response};
+use nereids_physics::counts_response::{
+    CountsResponseError, TwoArmCounts, add_count_backgrounds, two_arm_count_response,
+};
 use nereids_physics::ikeda_carpenter::{
     EnergyLaw, IkedaCarpenter, IkedaCarpenterParams, SynthesisGrid,
 };
@@ -141,5 +143,45 @@ fn unsupported_or_unphysical_inputs_fail_clearly() {
             &triangle_response(),
         ),
         Err(CountsResponseError::InvalidTransmission { .. })
+    ));
+}
+
+#[test]
+fn count_background_is_added_after_response_and_returned_separately() {
+    let prediction = add_count_backgrounds(
+        TwoArmCounts {
+            open_beam: vec![50.0, 150.0, 100.0],
+            sample: vec![10.0, 90.0, 80.0],
+        },
+        &[2.0, 3.0, 4.0],
+        &[5.0, 7.0, 11.0],
+    )
+    .expect("valid detector-bin backgrounds");
+
+    assert_eq!(prediction.open_beam.neutron_signal, [50.0, 150.0, 100.0]);
+    assert_eq!(prediction.open_beam.background, [2.0, 3.0, 4.0]);
+    assert_eq!(prediction.open_beam.total, [52.0, 153.0, 104.0]);
+    assert_eq!(prediction.sample.neutron_signal, [10.0, 90.0, 80.0]);
+    assert_eq!(prediction.sample.background, [5.0, 7.0, 11.0]);
+    assert_eq!(prediction.sample.total, [15.0, 97.0, 91.0]);
+}
+
+#[test]
+fn count_background_rejects_shape_mismatch_and_negative_counts() {
+    let signal = TwoArmCounts {
+        open_beam: vec![10.0, 20.0],
+        sample: vec![5.0, 8.0],
+    };
+    assert!(matches!(
+        add_count_backgrounds(signal.clone(), &[1.0], &[2.0, 3.0]),
+        Err(CountsResponseError::DetectorBinCountMismatch { .. })
+    ));
+    assert!(matches!(
+        add_count_backgrounds(signal, &[1.0, 2.0], &[0.0, -1.0]),
+        Err(CountsResponseError::InvalidExpectedCount {
+            field: "sample_background_counts",
+            index: 1,
+            ..
+        })
     ));
 }

--- a/crates/nereids-physics/tests/two_arm_counts.rs
+++ b/crates/nereids-physics/tests/two_arm_counts.rs
@@ -63,6 +63,50 @@ fn compact_response_keeps_every_nonzero_and_reconstructs_interior_zeros() {
 }
 
 #[test]
+fn quadrature_rows_collapse_to_the_same_open_beam_operator() {
+    let response = triangle_response();
+    let arrival_0 = TOF_FACTOR * 25.0 / 25.0_f64.sqrt();
+    let energy_1 = (TOF_FACTOR * 25.0 / (arrival_0 + 1.0)).powi(2);
+    let full = DetectorBinResponseMatrix::new(
+        &[25.0, energy_1, 25.0, energy_1],
+        &[arrival_0 - 1.0, arrival_0, arrival_0 + 1.0, arrival_0 + 2.0],
+        0.0,
+        &response,
+    )
+    .expect("valid quadrature response");
+    let weights = [0.25, 0.75, 0.6, 0.4];
+    let collapsed = full
+        .collapse_true_energy_groups(&weights, 2)
+        .expect("valid two-point cells");
+    let source = [120.0, 80.0];
+    let expanded_source = [
+        source[0] * weights[0],
+        source[0] * weights[1],
+        source[1] * weights[2],
+        source[1] * weights[3],
+    ];
+    let full_open = full
+        .apply(&expanded_source, &[1.0; 4])
+        .expect("full response")
+        .open_beam;
+    let collapsed_open = collapsed
+        .apply(&source, &[1.0; 2])
+        .expect("collapsed response")
+        .open_beam;
+    for (full_value, collapsed_value) in full_open.iter().zip(&collapsed_open) {
+        assert!((full_value - collapsed_value).abs() < 2.0e-14);
+    }
+    assert!(matches!(
+        full.collapse_true_energy_groups(&weights, 3),
+        Err(CountsResponseError::InvalidResponseGroupSize { .. })
+    ));
+    assert!(matches!(
+        full.collapse_true_energy_groups(&[0.5; 3], 2),
+        Err(CountsResponseError::QuadratureWeightLengthMismatch { .. })
+    ));
+}
+
+#[test]
 fn two_arm_response_integrates_fluence_and_transmission_before_detector_binning() {
     let response = triangle_response();
     let arrival_0 = TOF_FACTOR * 25.0 / 25.0_f64.sqrt();

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -1134,6 +1134,34 @@ impl UnifiedFitConfig {
     }
 }
 
+/// Reject count-domain requests that attach instrument resolution until the
+/// pipeline can migrate the incident flux and sample arm separately.
+///
+/// The current counts fit wraps a transmission model and therefore evaluates
+/// a broadened transmission `R[T]`.  A detector observes separate broadened
+/// arms, so the physical normalized response is `R[Phi*T] / R[Phi]`.  These
+/// expressions agree only for special flat-flux cases.  Returning a fit from
+/// the former model would be numerically plausible but scientifically wrong.
+///
+/// Kept as one shared boundary check so single-spectrum fitting, spatial
+/// fitting, and the public Fisher helper cannot drift to different behavior.
+pub(crate) fn validate_counts_resolution_route(
+    is_counts: bool,
+    config: &UnifiedFitConfig,
+) -> Result<(), PipelineError> {
+    if is_counts && config.resolution().is_some() {
+        return Err(PipelineError::InvalidParameter(
+            "counts input with instrument resolution is unsupported: the current \
+             counts path broadens transmission as R[T], but the physical detector \
+             model requires separate open/sample response arms R[Phi] and \
+             R[Phi*T]. Supply pre-normalized transmission, or disable instrument \
+             resolution until an exact counts response is implemented."
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
 /// Fit a single spectrum using the typed input data API.
 ///
 /// Dispatches to the correct fitting engine based on the `InputData` variant
@@ -1230,6 +1258,11 @@ pub fn fit_spectrum_typed(
             }
         }
     }
+
+    // The count-domain objective currently sees only an already-broadened
+    // transmission model.  Fail before any cross-section/model construction
+    // rather than returning a good-looking fit for the wrong response.
+    validate_counts_resolution_route(input.is_counts(), config)?;
 
     // Reject a malformed caller-supplied precomputed cross-section stack here,
     // before it reaches the forward-model builders (which would otherwise panic
@@ -3361,6 +3394,11 @@ pub fn evaluate_jacobian_and_fisher(
     flux: &[f64],
     background: &[f64],
 ) -> Result<ModelJacobianResult, PipelineError> {
+    // This helper builds a counts-space Jacobian/Fisher from the same
+    // transmission-first chain as production fitting.  It is no more physical
+    // under instrument resolution than the optimizer route, so reject it too.
+    validate_counts_resolution_route(true, config)?;
+
     // Reject a malformed caller-supplied precomputed cross-section stack here,
     // before it reaches `build_transmission_model`.  Without this, an empty
     // stack is caught only deep in `PrecomputedTransmissionModel` (as an
@@ -6250,6 +6288,100 @@ mod tests {
         assert!(r.reduced_chi_squared.is_finite());
     }
 
+    /// Gate 1: the current counts likelihood profiles an already-broadened
+    /// transmission model. With instrument resolution this computes R[T], not
+    /// the physical separate-arm response R[Phi*T] / R[Phi]. Until the public
+    /// counts input carries the required true-energy incident flux and both
+    /// detector-response arms, every counts + resolution request must fail
+    /// before model construction instead of returning a plausible wrong fit.
+    #[test]
+    fn counts_resolution_requires_exact_count_response() {
+        use nereids_physics::resolution::{
+            ResolutionFunction, ResolutionParams, TabulatedResolution,
+        };
+
+        let data = u238_single_resonance();
+        let energies: Vec<f64> = (0..101).map(|i| 1.0 + (i as f64) * 0.1).collect();
+        let (sample_counts, open_beam_counts) = synthetic_counts(&data, 0.0005, &energies, 1000.0);
+        let tab_text = "header\n---\n\
+             5.0 0.0\n\
+             -0.01 0.0\n\
+             0.0 1.0\n\
+             0.01 0.0\n\
+             \n\
+             20.0 0.0\n\
+             -0.02 0.0\n\
+             0.0 1.0\n\
+             0.02 0.0\n";
+        let resolutions = [
+            (
+                "gaussian",
+                ResolutionFunction::Gaussian(ResolutionParams::new(25.0, 0.5, 0.005, 0.0).unwrap()),
+            ),
+            (
+                "tabulated",
+                ResolutionFunction::Tabulated(Arc::new(
+                    TabulatedResolution::from_text(tab_text, 25.0).unwrap(),
+                )),
+            ),
+        ];
+        let solvers = [
+            ("auto", SolverConfig::Auto),
+            ("kl", SolverConfig::PoissonKL(PoissonConfig::default())),
+            ("lm", SolverConfig::LevenbergMarquardt(LmConfig::default())),
+        ];
+
+        for (resolution_name, resolution) in resolutions {
+            for (solver_name, solver) in &solvers {
+                let config = UnifiedFitConfig::new(
+                    energies.clone(),
+                    vec![data.clone()],
+                    vec!["U-238".into()],
+                    293.6,
+                    Some(resolution.clone()),
+                    vec![0.001],
+                )
+                .unwrap()
+                .with_solver(solver.clone());
+                let inputs = [
+                    (
+                        "counts",
+                        InputData::Counts {
+                            sample_counts: sample_counts.clone(),
+                            open_beam_counts: open_beam_counts.clone(),
+                        },
+                    ),
+                    (
+                        "counts-with-nuisance",
+                        InputData::CountsWithNuisance {
+                            sample_counts: sample_counts.clone(),
+                            flux: open_beam_counts.clone(),
+                            background: vec![0.0; energies.len()],
+                        },
+                    ),
+                ];
+
+                for (input_name, input) in inputs {
+                    let err = match fit_spectrum_typed(&input, &config) {
+                        Ok(_) => panic!(
+                            "{input_name} + {solver_name} + {resolution_name} resolution \
+                             returned a scientifically invalid fit"
+                        ),
+                        Err(err) => err,
+                    };
+                    let msg = err.to_string();
+                    assert!(
+                        msg.contains("counts")
+                            && msg.contains("instrument resolution")
+                            && msg.contains("separate open/sample response arms"),
+                        "{input_name} + {solver_name} + {resolution_name}: expected \
+                         physical counts-response rejection, got: {msg}"
+                    );
+                }
+            }
+        }
+    }
+
     // ──────────────────────────────────────────────────────────────────
     // transmission_background through the joint-Poisson path.
     // ──────────────────────────────────────────────────────────────────
@@ -6843,15 +6975,12 @@ mod tests {
     // ── Issue #608: Rust coverage for paths previously exercised only
     //    via Python / the spatial-identity path (codecov/patch gap) ───────────
 
-    /// `evaluate_jacobian_and_fisher` (the research Fisher / `compute_model_jacobian`
-    /// entry point) was exercised only through the Python bindings, which the
-    /// Rust-only coverage run excludes — so its body, and the #608
-    /// compute-working-grid-σ branch, were uncovered.  Drive it with a
-    /// Gaussian-resolution config carrying NO precomputed σ: that exercises the
-    /// aux-grid σ build + the model construction + the analytical Jacobian /
-    /// Fisher assembly.
+    /// The research Fisher helper is a counts-space model.  It must reject
+    /// instrument resolution for the same separate-arm reason as the production
+    /// optimizer, rather than exposing a wrong-but-finite Jacobian/Fisher for
+    /// `R[T]`.
     #[test]
-    fn evaluate_jacobian_and_fisher_gaussian_aux_grid() {
+    fn evaluate_jacobian_and_fisher_rejects_resolution() {
         use nereids_physics::resolution::{ResolutionFunction, ResolutionParams};
         let data = u238_single_resonance();
         let energies: Vec<f64> = (0..101).map(|i| 1.0 + (i as f64) * 0.1).collect();
@@ -6869,16 +6998,16 @@ mod tests {
         .unwrap();
         let flux = vec![5000.0; n_e];
         let background = vec![10.0; n_e];
-        let result = evaluate_jacobian_and_fisher(&config, &flux, &background).unwrap();
-        assert_eq!(result.model_prediction.len(), n_e);
-        assert!(result.model_prediction.iter().all(|v| v.is_finite()));
-        assert_eq!(result.param_names.len(), 1, "one free density parameter");
-        // Density Fisher information must be finite + positive (well-posed
-        // measurement); the Jacobian endpoints must be finite.
-        let f00 = result.fisher.get(0, 0);
-        assert!(f00.is_finite() && f00 > 0.0, "Fisher[0,0] = {f00}");
-        assert!(result.jacobian.get(0, 0).is_finite());
-        assert!(result.jacobian.get(n_e - 1, 0).is_finite());
+        let err = match evaluate_jacobian_and_fisher(&config, &flux, &background) {
+            Ok(_) => panic!("counts-space Fisher helper accepted instrument resolution"),
+            Err(err) => err,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("instrument resolution")
+                && msg.contains("separate open/sample response arms"),
+            "expected physical counts-response rejection, got: {msg}"
+        );
     }
 
     /// Non-spatial energy-scale fit through `fit_spectrum_typed` (LM

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -771,7 +771,12 @@ impl UnifiedFitConfig {
         self
     }
 
-    /// Enable the exact separate-arm detector response for raw counts.
+    /// Enable the separate-arm detector-bin response for raw counts.
+    ///
+    /// The historical `exact_count_response` name means that open and sample
+    /// arms are integrated over the caller's actual detector-time edges before
+    /// forming a ratio. It does not change the numerical accuracy contract of
+    /// the selected response model.
     #[must_use]
     pub fn with_exact_count_response(mut self, response: ExactCountResponseConfig) -> Self {
         self.exact_count_response = Some(response);
@@ -1864,7 +1869,7 @@ fn fit_counts_joint_poisson(
             ))
         })?;
         let exact_model =
-            ExactTwoArmRatioModel::new(stacked, &matrix, &exact.incident_fluence_weights)
+            ExactTwoArmRatioModel::new(stacked, matrix, &exact.incident_fluence_weights)
                 .map_err(PipelineError::Fitting)?;
         for (bin, ((&observed_open, &observed_sample), &predicted_open)) in flux
             .iter()

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -10,8 +10,9 @@
 use std::fmt;
 use std::sync::Arc;
 
-use nereids_core::constants::{EV_TO_JOULES, NEUTRON_MASS_KG};
+use nereids_core::constants::{EV_TO_JOULES, NEUTRON_MASS_KG, PIVOT_FLOOR, tof_to_energy};
 use nereids_endf::resonance::ResonanceData;
+use nereids_fitting::exact_count_model::ExactTwoArmRatioModel;
 use nereids_fitting::joint_poisson::{self, JointPoissonFitConfig, JointPoissonObjective};
 use nereids_fitting::lm::{self, FitModel, LmConfig, LmResult};
 use nereids_fitting::parameters::{FitParameter, ParameterSet};
@@ -20,6 +21,7 @@ use nereids_fitting::transmission_model::{
     EnergyScaleTransmissionModel, MultiplicativeBaselineModel, NormalizedTransmissionModel,
     PrecomputedTransmissionModel, TransmissionFitModel,
 };
+use nereids_physics::counts_response::DetectorBinResponseMatrix;
 use nereids_physics::resolution::ResolutionFunction;
 use nereids_physics::transmission::InstrumentParams;
 
@@ -215,7 +217,8 @@ struct BaselineIndices {
 pub enum InputData {
     /// Pre-normalized transmission with Gaussian uncertainties.
     ///
-    /// Use with LM (default) or Poisson KL (opt-in for low-count T data).
+    /// Use with LM. A Poisson objective is rejected because normalized
+    /// fractional transmission is not count data.
     Transmission {
         /// Measured transmission T(E), values typically in [0, 2].
         transmission: Vec<f64>,
@@ -281,9 +284,9 @@ pub enum SolverConfig {
     /// GOF.  Stage-1 damped Fisher + optional Nelder-Mead polish (see
     /// [`nereids_fitting::joint_poisson::JointPoissonFitConfig`]).
     ///
-    /// For **transmission** inputs this dispatches to Poisson NLL on the
-    /// transmission values directly (legacy path, unchanged).  The payload
-    /// `PoissonConfig` carries `max_iter` common to both dispatches.
+    /// **Transmission inputs are rejected.** A Poisson objective requires the
+    /// separate open and sample counts; applying it to a fractional
+    /// transmission silently ignores the supplied uncertainty.
     PoissonKL(PoissonConfig),
     /// Automatic: Counts → PoissonKL (counts-domain joint-Poisson),
     /// Transmission → LM.
@@ -359,6 +362,23 @@ impl Default for CountsBackgroundConfig {
     }
 }
 
+/// Source and detector-bin information required for exact resolved-count fits.
+///
+/// `UnifiedFitConfig::energies` supplies the true-energy quadrature points.
+/// The observed open/sample count arrays must be in the same detector-time
+/// order as consecutive intervals in `detector_time_edges_us`.
+#[derive(Debug, Clone)]
+pub struct ExactCountResponseConfig {
+    /// Incident neutron fluence already integrated over each true-energy
+    /// quadrature element. The absolute scale cancels in the profiled count
+    /// likelihood; the energy dependence does not.
+    pub incident_fluence_weights: Vec<f64>,
+    /// Actual detector-time bin edges in ascending microseconds.
+    pub detector_time_edges_us: Vec<f64>,
+    /// Fixed time offset applied by the detector response, in microseconds.
+    pub timing_offset_us: f64,
+}
+
 // ── Phase 2: UnifiedFitConfig + fit_spectrum_typed ───────────────────────
 
 /// Unified fit configuration for all data types and solvers.
@@ -377,8 +397,8 @@ pub struct UnifiedFitConfig {
     fit_temperature: bool,
     compute_covariance: bool,
     /// Inflate covariance-only uncertainties by `sqrt(χ²/dof)` at convergence
-    /// (issue #638). Applies only to the raw-covariance solver paths (Poisson-KL,
-    /// joint-Poisson); the LM transmission path is already χ²-scaled, so the flag
+    /// (issue #638). Applies only to the raw-count joint-Poisson path; the LM
+    /// transmission path is already χ²-scaled, so the flag
     /// is a no-op there. Off by default — reported σ stays the inverse-Fisher
     /// lower bound.
     scale_by_chi2: bool,
@@ -393,6 +413,8 @@ pub struct UnifiedFitConfig {
     multiplicative_baseline: Option<MultiplicativeBaselineConfig>,
     /// Counts-domain background for the counts engine.
     counts_background: Option<CountsBackgroundConfig>,
+    /// Exact separate-arm response inputs for resolved counts.
+    exact_count_response: Option<ExactCountResponseConfig>,
 
     // ── Joint-Poisson solver knobs (counts path only) ──
     /// When `Some(false)`, the counts-KL dispatch disables Nelder-Mead polish
@@ -574,6 +596,7 @@ impl UnifiedFitConfig {
             transmission_background: None,
             multiplicative_baseline: None,
             counts_background: None,
+            exact_count_response: None,
             counts_enable_polish: None,
             precomputed_cross_sections: None,
             precomputed_work_cross_sections: None,
@@ -648,11 +671,8 @@ impl UnifiedFitConfig {
     /// inverse-Fisher lower bound into a goodness-of-fit-scaled estimate.
     /// Self-consistent on every path:
     ///
-    /// - **Transmission (LM and Poisson-KL)**: `σ → σ·√(χ²/ν)` using the
-    ///   Gaussian `reduced_chi_squared`. The LM path applies this
-    ///   unconditionally (Numerical Recipes §15.6), so the flag is a **no-op**
-    ///   there; the Poisson-KL path applies it on opt-in (the raw inverse-Fisher
-    ///   bound is the default).
+    /// - **Transmission (LM)**: the LM path applies its chi-squared scaling
+    ///   unconditionally (Numerical Recipes §15.6), so the flag is a **no-op**.
     /// - **Counts (joint-Poisson)**: `σ → σ·√(D/ν)` using the
     ///   conditional-binomial `deviance_per_dof` (a genuine count-statistics
     ///   GOF), on opt-in.
@@ -738,6 +758,13 @@ impl UnifiedFitConfig {
     #[must_use]
     pub fn with_counts_background(mut self, bg: CountsBackgroundConfig) -> Self {
         self.counts_background = Some(bg);
+        self
+    }
+
+    /// Enable the exact separate-arm detector response for raw counts.
+    #[must_use]
+    pub fn with_exact_count_response(mut self, response: ExactCountResponseConfig) -> Self {
+        self.exact_count_response = Some(response);
         self
     }
 
@@ -1001,6 +1028,10 @@ impl UnifiedFitConfig {
     pub fn counts_background(&self) -> Option<&CountsBackgroundConfig> {
         self.counts_background.as_ref()
     }
+
+    pub fn exact_count_response(&self) -> Option<&ExactCountResponseConfig> {
+        self.exact_count_response.as_ref()
+    }
     /// Counts-KL polish override (see [`Self::with_counts_enable_polish`]).
     pub fn counts_enable_polish(&self) -> Option<bool> {
         self.counts_enable_polish
@@ -1134,29 +1165,70 @@ impl UnifiedFitConfig {
     }
 }
 
-/// Reject count-domain requests that attach instrument resolution until the
-/// pipeline can migrate the incident flux and sample arm separately.
-///
-/// The current counts fit wraps a transmission model and therefore evaluates
-/// a broadened transmission `R[T]`.  A detector observes separate broadened
-/// arms, so the physical normalized response is `R[Phi*T] / R[Phi]`.  These
-/// expressions agree only for special flat-flux cases.  Returning a fit from
-/// the former model would be numerically plausible but scientifically wrong.
-///
-/// Kept as one shared boundary check so single-spectrum fitting, spatial
-/// fitting, and the public Fisher helper cannot drift to different behavior.
+/// Validate the exact separate-arm contract for count-domain resolution.
 pub(crate) fn validate_counts_resolution_route(
     is_counts: bool,
+    observed_bin_count: usize,
     config: &UnifiedFitConfig,
 ) -> Result<(), PipelineError> {
-    if is_counts && config.resolution().is_some() {
+    if !is_counts && config.exact_count_response().is_some() {
         return Err(PipelineError::InvalidParameter(
-            "counts input with instrument resolution is unsupported: the current \
-             counts path broadens transmission as R[T], but the physical detector \
-             model requires separate open/sample response arms R[Phi] and \
-             R[Phi*T]. Supply pre-normalized transmission, or disable instrument \
-             resolution until an exact counts response is implemented."
+            "exact_count_response is a raw-count model and cannot be attached to \
+             normalized transmission"
                 .into(),
+        ));
+    }
+    if is_counts && config.resolution().is_some() {
+        let exact = config.exact_count_response().ok_or_else(|| {
+            PipelineError::InvalidParameter(
+                "counts input with instrument resolution requires the exact \
+                 separate-arm model R[Phi] and R[Phi*T]: provide incident fluence \
+                 weights and detector-time bin edges through exact_count_response; \
+                 the R[T] shortcut is not used"
+                    .into(),
+            )
+        })?;
+        if exact.incident_fluence_weights.len() != config.energies().len() {
+            return Err(PipelineError::ShapeMismatch(format!(
+                "exact_count_response incident_fluence_weights length {} must match \
+                 the true-energy grid length {}",
+                exact.incident_fluence_weights.len(),
+                config.energies().len()
+            )));
+        }
+        if exact.detector_time_edges_us.len() != observed_bin_count + 1 {
+            return Err(PipelineError::ShapeMismatch(format!(
+                "exact_count_response detector_time_edges_us length {} must be one \
+                 greater than the observed count-bin length {}",
+                exact.detector_time_edges_us.len(),
+                observed_bin_count
+            )));
+        }
+        if !exact.timing_offset_us.is_finite() {
+            return Err(PipelineError::InvalidParameter(format!(
+                "exact_count_response timing_offset_us must be finite, got {}",
+                exact.timing_offset_us
+            )));
+        }
+        if config.fit_energy_scale() {
+            return Err(PipelineError::InvalidParameter(
+                "energy-scale fitting is not yet connected to the exact two-arm \
+                 detector response; fitting cross-section energy while holding the \
+                 response clock fixed would be physically inconsistent"
+                    .into(),
+            ));
+        }
+        if config.fit_energy_range().is_some() {
+            return Err(PipelineError::InvalidParameter(
+                "fit_energy_range is not yet supported by exact detector-time count \
+                 response because true-energy points and detector-time bins are \
+                 different axes"
+                    .into(),
+            ));
+        }
+    } else if is_counts && config.exact_count_response().is_some() {
+        return Err(PipelineError::InvalidParameter(
+            "exact_count_response requires an instrument resolution model".into(),
         ));
     }
     Ok(())
@@ -1170,10 +1242,10 @@ pub(crate) fn validate_counts_resolution_route(
 /// | Input | Solver | Path |
 /// |-------|--------|------|
 /// | Transmission | LM | LM chi-squared with optional SAMMY background |
-/// | Transmission | KL | Poisson NLL on transmission with optional background |
+/// | Transmission | KL | Rejected: fractional transmission is not Poisson count data |
 /// | Counts | KL | Poisson NLL on raw counts (statistically optimal) |
-/// | Counts | LM | Convert to T internally and route to LM |
-/// | CountsWithNuisance | KL | Direct Poisson with user-supplied nuisance |
+/// | Counts | LM | Rejected: silent ratio conversion loses count information |
+/// | CountsWithNuisance | KL | Compatibility-only; nonzero background rejected |
 pub fn fit_spectrum_typed(
     input: &InputData,
     config: &UnifiedFitConfig,
@@ -1202,8 +1274,11 @@ pub fn fit_spectrum_typed(
         ));
     }
 
-    // Validate input length matches energy grid
-    if input.n_energies() != n_e {
+    // Exact resolved counts have two distinct axes: the config grid is true
+    // neutron energy, while the input arrays are measured detector-time bins.
+    // All other routes still require one datum per configured energy.
+    let exact_resolved_counts = input.is_counts() && config.exact_count_response().is_some();
+    if input.n_energies() != n_e && !exact_resolved_counts {
         return Err(PipelineError::ShapeMismatch(format!(
             "input data has {} energy bins but config.energies has {}",
             input.n_energies(),
@@ -1259,10 +1334,17 @@ pub fn fit_spectrum_typed(
         }
     }
 
-    // The count-domain objective currently sees only an already-broadened
-    // transmission model.  Fail before any cross-section/model construction
-    // rather than returning a good-looking fit for the wrong response.
-    validate_counts_resolution_route(input.is_counts(), config)?;
+    if matches!(input, InputData::Transmission { .. }) && config.counts_background().is_some() {
+        return Err(PipelineError::InvalidParameter(
+            "counts background configuration cannot be used with transmission data; \
+             use SAMMY transmission_background or multiplicative_baseline for a \
+             transmission fit, or supply separate open/sample counts for a \
+             detector-count background"
+                .into(),
+        ));
+    }
+
+    validate_counts_resolution_route(input.is_counts(), input.n_energies(), config)?;
 
     // Reject a malformed caller-supplied precomputed cross-section stack here,
     // before it reaches the forward-model builders (which would otherwise panic
@@ -1281,14 +1363,17 @@ pub fn fit_spectrum_typed(
             SolverConfig::LevenbergMarquardt(lm_cfg),
         ) => fit_transmission_lm(transmission, uncertainty, config, lm_cfg),
 
-        // ── Transmission + KL: Poisson NLL on transmission values ──
+        // ── Transmission + KL: statistically invalid cross-domain route ──
         (
-            InputData::Transmission {
-                transmission,
-                uncertainty,
-            },
-            SolverConfig::PoissonKL(poisson_cfg),
-        ) => fit_transmission_poisson(transmission, uncertainty, config, poisson_cfg),
+            InputData::Transmission { .. },
+            SolverConfig::PoissonKL(_),
+        ) => Err(PipelineError::InvalidParameter(
+            "normalized transmission cannot use the Poisson/KL count objective: \
+             fractional transmission is not Poisson count data and the supplied \
+             uncertainty would be ignored; use the LM least-squares transmission \
+             engine, or supply separate open/sample counts"
+                .into(),
+        )),
 
         // ── Counts + KL: joint-Poisson profile-binomial-deviance path ──
         //
@@ -1306,7 +1391,7 @@ pub fn fit_spectrum_typed(
             },
             SolverConfig::PoissonKL(poisson_cfg),
         ) => {
-            let bg = vec![0.0f64; n_e];
+            let bg = vec![0.0f64; sample_counts.len()];
             fit_counts_joint_poisson(
                 sample_counts,
                 open_beam_counts,
@@ -1332,25 +1417,16 @@ pub fn fit_spectrum_typed(
             &poisson_to_joint_poisson_config(poisson_cfg, config),
         ),
 
-        // ── Counts + LM: convert to transmission (approximate path) ──
-        //
-        // This is NOT a native counts-domain LM engine.  Counts are divided
-        // (sample/OB) to produce transmission, with σ ≈ √max(sample,1)/OB
-        // as a simplified Poisson-to-Gaussian conversion.  Poisson structure
-        // is lost.  For statistically correct low-count fitting, use the
-        // Poisson KL solver (`solver="kl"` or `SolverConfig::Auto`), which
-        // now routes to the joint-Poisson path.
+        // ── Counts + LM: information-losing cross-domain route ──
         (
-            InputData::Counts {
-                sample_counts,
-                open_beam_counts,
-            },
-            SolverConfig::LevenbergMarquardt(lm_cfg),
-        ) => {
-            let (transmission, uncertainty) =
-                counts_to_transmission(sample_counts, open_beam_counts);
-            fit_transmission_lm(&transmission, &uncertainty, config, lm_cfg)
-        }
+            InputData::Counts { .. },
+            SolverConfig::LevenbergMarquardt(_),
+        ) => Err(PipelineError::InvalidParameter(
+            "separate open/sample counts cannot use the LM least-squares \
+             transmission engine: silently dividing the arms loses open-beam \
+             uncertainty and count statistics; use the Poisson/KL count engine"
+                .into(),
+        )),
 
         // ── CountsWithNuisance + LM: not meaningful ──
         (InputData::CountsWithNuisance { .. }, SolverConfig::LevenbergMarquardt(_)) => {
@@ -1383,43 +1459,6 @@ fn poisson_to_joint_poisson_config(
         jp_cfg.enable_polish = override_val;
     }
     jp_cfg
-}
-
-/// Convert counts to transmission: T = sample/open_beam, σ = √(max(sample,1))/open_beam.
-///
-/// Zero-count bins (sample == 0) get σ = 1e10 so the fitter effectively ignores them.
-/// Near-zero open beam bins use a floor of 1e-10 to avoid division by zero.
-/// Convert raw counts to transmission with approximate Poisson uncertainty.
-///
-/// This is a simplified conversion for the Counts+LM fallback path.
-/// The uncertainty σ ≈ √max(sample,1)/OB is a Gaussian approximation of
-/// Poisson statistics, valid when counts are high (≥ ~20).  At low counts,
-/// this overestimates confidence relative to the Poisson KL solver.
-///
-/// Zero-count and zero-OB bins are marked with sentinel uncertainties
-/// (1e10 and 1e30 respectively) so the LM solver effectively ignores them.
-fn counts_to_transmission(sample: &[f64], open_beam: &[f64]) -> (Vec<f64>, Vec<f64>) {
-    let transmission: Vec<f64> = sample
-        .iter()
-        .zip(open_beam.iter())
-        .map(|(&s, &ob)| if ob > 0.0 { s / ob } else { 0.0 })
-        .collect();
-    let uncertainty: Vec<f64> = sample
-        .iter()
-        .zip(open_beam.iter())
-        .map(|(&s, &ob)| {
-            if ob <= 0.0 {
-                // No open beam signal — treat as dead bin
-                1e30
-            } else if s <= 0.0 {
-                // Zero sample counts — large σ so the fitter ignores this bin
-                1e10
-            } else {
-                s.max(1.0).sqrt() / ob.max(1e-10)
-            }
-        })
-        .collect();
-    (transmission, uncertainty)
 }
 
 /// Transmission + LM path.
@@ -1581,150 +1620,6 @@ fn fit_transmission_lm(
     Ok(sr)
 }
 
-/// Transmission + Poisson KL path.
-///
-/// Uses the same model architecture as the LM path:
-/// - `EnergyScaleTransmissionModel` when energy-scale fitting is enabled
-/// - `NormalizedTransmissionModel` for SAMMY-style background (Anorm + BackA/B/C)
-/// - Poisson NLL handles negative model predictions via smooth extrapolation
-fn fit_transmission_poisson(
-    measured_t: &[f64],
-    sigma: &[f64],
-    config: &UnifiedFitConfig,
-    poisson_cfg: &PoissonConfig,
-) -> Result<SpectrumFitResult, PipelineError> {
-    // SAMMY EMIN/EMAX-equivalent fit-energy-range (#514): the legacy
-    // transmission-domain `poisson_fit` does not honour an active mask,
-    // so silently routing the data here when the user set a fit range
-    // would bias the fit by including out-of-range bins (margin region)
-    // in the cost function.  Hard-reject up-front rather than producing
-    // a misleading "successful" fit.  Joint-Poisson (counts) and LM
-    // transmission both honour the mask correctly.
-    if config.fit_energy_range().is_some() {
-        return Err(PipelineError::InvalidParameter(
-            "fit_energy_range is not supported for the transmission + \
-             Poisson-KL solver path. Use joint-Poisson (provide sample + \
-             open-beam counts) or switch to the LM transmission solver."
-                .into(),
-        ));
-    }
-
-    let mut poisson_cfg = poisson_cfg.clone();
-    poisson_cfg.compute_covariance = config.compute_covariance;
-    let poisson_cfg = &poisson_cfg;
-
-    let n_density_params = config.n_density_params();
-    let mut param_vec = build_density_params(config);
-
-    let temperature_index = append_temperature_param(&mut param_vec, config);
-    let energy_scale_indices = append_energy_scale_params(&mut param_vec, config);
-
-    // Issue #608: peak-match seed for (t0, L_scale) — see fit_transmission_lm.
-    seed_energy_scale_in_params(&mut param_vec, energy_scale_indices, measured_t, config);
-
-    // Background parameters — use same SAMMY-style model as LM, with the
-    // same partial-BackD/BackF rejection.
-    if let Some(bg) = config.transmission_background.as_ref() {
-        validate_transmission_background(bg)?;
-    }
-    let bg_indices = config
-        .transmission_background
-        .as_ref()
-        .map(|bg| append_background_params(&mut param_vec, bg));
-
-    // Multiplicative-baseline parameters (issue #635) — appended LAST,
-    // same layout as the LM path.
-    validate_multiplicative_baseline(config)?;
-    let bl_indices = config
-        .multiplicative_baseline
-        .as_ref()
-        .map(|bl| append_multiplicative_baseline_params(&mut param_vec, bl));
-
-    let mut params = ParameterSet::new(param_vec);
-
-    // Build inner model (energy-scale or precomputed)
-    let model: Box<dyn FitModel> = if let Some((t0_idx, ls_idx)) = energy_scale_indices {
-        build_energy_scale_transmission_model(config, t0_idx, ls_idx, temperature_index)?
-    } else {
-        build_transmission_model(config, n_density_params, temperature_index)?
-    };
-
-    // Wrap with NormalizedTransmissionModel for background (same as LM),
-    // then MultiplicativeBaselineModel OUTERMOST (issue #635) — the same
-    // Box-stacking as the LM path.
-    let mut stacked: Box<dyn FitModel> = model;
-    if let Some(bi) = bg_indices {
-        stacked = if let (Some(di), Some(fi)) = (bi.back_d, bi.back_f) {
-            Box::new(NormalizedTransmissionModel::new_with_exponential(
-                stacked,
-                config.energies(),
-                bi.anorm,
-                bi.back_a,
-                bi.back_b,
-                bi.back_c,
-                di,
-                fi,
-            ))
-        } else {
-            Box::new(NormalizedTransmissionModel::new(
-                stacked,
-                config.energies(),
-                bi.anorm,
-                bi.back_a,
-                bi.back_b,
-                bi.back_c,
-            ))
-        };
-    }
-    if let Some(bli) = bl_indices {
-        // No active mask here: this path hard-rejects fit_energy_range up
-        // front, so every bin participates and the full-grid positivity
-        // guard is the correct contract.
-        stacked = Box::new(MultiplicativeBaselineModel::new(
-            stacked,
-            config.energies(),
-            config.baseline_reference_energy(),
-            bli.b0,
-            bli.b1,
-            bli.b2,
-        ));
-    }
-    let pr = poisson::poisson_fit(&*stacked, measured_t, &mut params, poisson_cfg)?;
-    let result = poisson_to_lm_result(
-        &*stacked,
-        measured_t,
-        sigma,
-        &pr,
-        &params,
-        config.scale_by_chi2,
-    )?;
-
-    let free_indices = params.free_indices();
-    let mut sr = extract_result(
-        config,
-        &result,
-        n_density_params,
-        &free_indices,
-        bg_indices,
-        bl_indices,
-    )?;
-
-    // Temperature (value and 1-σ) is fully populated by `extract_result`,
-    // which maps the solver's FREE-only uncertainty vector through
-    // `free_indices` (issue #633). Do NOT re-derive it here: a prior
-    // full-layout `result.uncertainties.get(temperature_index)` overwrite
-    // clobbered the corrected σ with the wrong free slot (out of bounds →
-    // None in the all-frozen thermometry case). Mirror `fit_transmission_lm`
-    // and only overwrite the energy-scale outputs below.
-    if let Some((t0_idx, ls_idx)) = energy_scale_indices {
-        sr.t0_us = Some(result.params[t0_idx]);
-        sr.l_scale = Some(result.params[ls_idx]);
-        sr.energy_scale_flight_path_m = Some(config.flight_path_m);
-    }
-
-    Ok(sr)
-}
-
 /// Joint-Poisson counts-path fitter.
 ///
 /// Builds a pure transmission `FitModel` (density + optional temperature +
@@ -1846,11 +1741,27 @@ fn fit_counts_joint_poisson(
 
     let mut params = ParameterSet::new(param_vec);
 
-    // ── Build pure transmission model ──
+    // ── Build the true-energy transmission model ──
+    // The exact count wrapper applies detector response after this model. Clear
+    // the legacy transmission-broadening fields so R[T] cannot be evaluated
+    // inside the inner model and then broadened a second time.
+    let mut true_model_config = config.clone();
+    if config.exact_count_response().is_some() {
+        true_model_config.resolution = None;
+        true_model_config.precomputed_work_cross_sections = None;
+        true_model_config.precomputed_resolution_plan = None;
+        true_model_config.precomputed_sparse_cubature_plan = None;
+        true_model_config.precomputed_sparse_scalar_plan = None;
+    }
     let t_model: Box<dyn FitModel> = if let Some((t0_idx, ls_idx)) = energy_scale_indices {
-        build_energy_scale_transmission_model(config, t0_idx, ls_idx, temperature_index)?
+        build_energy_scale_transmission_model(
+            &true_model_config,
+            t0_idx,
+            ls_idx,
+            temperature_index,
+        )?
     } else {
-        build_transmission_model(config, n_density_params, temperature_index)?
+        build_transmission_model(&true_model_config, n_density_params, temperature_index)?
     };
 
     // ── Wrap with NormalizedTransmissionModel if bg is active ──
@@ -1893,36 +1804,114 @@ fn fit_counts_joint_poisson(
         }
     }
 
-    // Box-stack the wrappers (same as the LM / KL-transmission paths):
-    // inner physics → NormalizedTransmissionModel (if bg) →
-    // MultiplicativeBaselineModel (issue #635, OUTERMOST, if configured).
+    // Model placement is domain-specific. The multiplicative baseline changes
+    // the true-energy sample arm before detector response. The SAMMY
+    // normalization/ABC curve changes apparent transmission in the measured
+    // bins, so on the exact route it is applied only after the separate-arm
+    // detector ratio has been formed.
     let mut stacked: Box<dyn FitModel> = t_model;
-    if let Some(bi) = bg_indices {
-        stacked = Box::new(NormalizedTransmissionModel::new(
-            stacked,
-            config.energies(),
-            bi.anorm,
-            bi.back_a,
-            bi.back_b,
-            bi.back_c,
-        ));
-    }
-    if let Some(bli) = bl_indices {
-        stacked = Box::new(
-            MultiplicativeBaselineModel::new(
+    if let Some(exact) = config.exact_count_response() {
+        if let Some(bli) = bl_indices {
+            stacked = Box::new(MultiplicativeBaselineModel::new(
                 stacked,
                 config.energies(),
                 nereids_fitting::transmission_model::baseline_reference_energy_active(
                     config.energies(),
-                    active_mask_slice,
+                    None,
                 ),
                 bli.b0,
                 bli.b1,
                 bli.b2,
-            )
-            // Scope the runtime positivity guard to the fit window (#514).
-            .with_active_mask(active_mask_slice),
+            ));
+        }
+        let response = config.resolution().expect(
+            "validate_counts_resolution_route requires resolution with exact_count_response",
         );
+        let matrix = DetectorBinResponseMatrix::new(
+            config.energies(),
+            &exact.detector_time_edges_us,
+            exact.timing_offset_us,
+            response,
+        )
+        .map_err(|error| {
+            PipelineError::InvalidParameter(format!(
+                "failed to build exact detector-bin response: {error}"
+            ))
+        })?;
+        let exact_model =
+            ExactTwoArmRatioModel::new(stacked, &matrix, &exact.incident_fluence_weights)
+                .map_err(PipelineError::Fitting)?;
+        for (bin, ((&observed_open, &observed_sample), &predicted_open)) in flux
+            .iter()
+            .zip(sample_counts)
+            .zip(exact_model.open_expectation())
+            .enumerate()
+        {
+            if observed_open + observed_sample > 0.0 && predicted_open <= PIVOT_FLOOR {
+                return Err(PipelineError::InvalidParameter(format!(
+                    "exact incident source has zero detector response in occupied \
+                     detector bin {bin}; the supplied source/response cannot explain \
+                     the observed counts"
+                )));
+            }
+        }
+        stacked = Box::new(exact_model);
+
+        if let Some(bi) = bg_indices {
+            let detector_energies: Result<Vec<f64>, PipelineError> = exact
+                .detector_time_edges_us
+                .windows(2)
+                .enumerate()
+                .map(|(bin, edges)| {
+                    let corrected_tof_us = 0.5 * (edges[0] + edges[1]) - exact.timing_offset_us;
+                    let energy = tof_to_energy(corrected_tof_us, response.flight_path_m());
+                    if energy.is_finite() && energy > 0.0 {
+                        Ok(energy)
+                    } else {
+                        Err(PipelineError::InvalidParameter(format!(
+                            "detector-time bin {bin} has non-positive time after the fixed \
+                             timing offset; SAMMY apparent-transmission background cannot \
+                             be evaluated on that bin"
+                        )))
+                    }
+                })
+                .collect();
+            stacked = Box::new(NormalizedTransmissionModel::new(
+                stacked,
+                &detector_energies?,
+                bi.anorm,
+                bi.back_a,
+                bi.back_b,
+                bi.back_c,
+            ));
+        }
+    } else {
+        if let Some(bi) = bg_indices {
+            stacked = Box::new(NormalizedTransmissionModel::new(
+                stacked,
+                config.energies(),
+                bi.anorm,
+                bi.back_a,
+                bi.back_b,
+                bi.back_c,
+            ));
+        }
+        if let Some(bli) = bl_indices {
+            stacked = Box::new(
+                MultiplicativeBaselineModel::new(
+                    stacked,
+                    config.energies(),
+                    nereids_fitting::transmission_model::baseline_reference_energy_active(
+                        config.energies(),
+                        active_mask_slice,
+                    ),
+                    bli.b0,
+                    bli.b1,
+                    bli.b2,
+                )
+                .with_active_mask(active_mask_slice),
+            );
+        }
     }
     let objective = JointPoissonObjective {
         model: &*stacked,
@@ -3144,73 +3133,6 @@ fn build_transmission_model(
     ))
 }
 
-/// Convert PoissonResult to LmResult with Pearson chi-squared.
-fn poisson_to_lm_result(
-    model: &dyn FitModel,
-    measured_t: &[f64],
-    sigma: &[f64],
-    pr: &poisson::PoissonResult,
-    params: &ParameterSet,
-    scale_by_chi2: bool,
-) -> Result<LmResult, PipelineError> {
-    let n_free = params.n_free();
-    let dof = measured_t.len().saturating_sub(n_free).max(1);
-    let y_model = model.evaluate(&pr.params)?;
-    let chi_sq: f64 = measured_t
-        .iter()
-        .zip(y_model.iter())
-        .zip(sigma.iter())
-        .map(|((obs, mdl), s)| {
-            let residual = obs - mdl;
-            (residual * residual) / (s * s).max(1e-30)
-        })
-        .sum();
-    let reduced_chi_squared = chi_sq / dof as f64;
-
-    // Issue #638: `scale_by_chi2` makes the transmission Poisson-KL path's
-    // covariance-only σ self-consistent with the goodness-of-fit THIS result
-    // reports — exactly as the LM transmission path does unconditionally
-    // (`lm.rs` #108.1, Numerical Recipes §15.6): `Cov → (χ²/ν)·Cov`, so
-    // `σ → σ·√(χ²/ν)`. It scales by the SAME Gaussian reduced-χ² (`chi_sq/dof`)
-    // surfaced in `reduced_chi_squared` below — NOT a Poisson deviance on the
-    // transmission fractions. The Poisson deviance assumes count statistics
-    // (Var ≈ mean); on transmission (~0..1) it is a pseudo-Poisson statistic,
-    // not a valid reduced-χ², and a good fit gives `D ≪ dof`, which would
-    // SHRINK σ far below the Cramér-Rao bound (the opposite of the flag's
-    // intent). Opt-in: the raw inverse-Fisher bound is the default; scaling
-    // needs a finite, positive reduced-χ². A perfect transmission fit
-    // (`chi_sq == 0`, so `reduced_chi_squared == 0` since `dof` is floored to 1
-    // above) or a non-finite model output leaves the raw bound untouched.
-    let (covariance, uncertainties) =
-        if scale_by_chi2 && reduced_chi_squared.is_finite() && reduced_chi_squared > 0.0 {
-            let sigma_factor = reduced_chi_squared.sqrt();
-            let covariance = pr.covariance.as_ref().map(|cov| {
-                let mut scaled = cov.clone();
-                for v in scaled.data.iter_mut() {
-                    *v *= reduced_chi_squared;
-                }
-                scaled
-            });
-            let uncertainties = pr
-                .uncertainties
-                .as_ref()
-                .map(|unc| unc.iter().map(|s| s * sigma_factor).collect());
-            (covariance, uncertainties)
-        } else {
-            (pr.covariance.clone(), pr.uncertainties.clone())
-        };
-
-    Ok(LmResult {
-        chi_squared: chi_sq,
-        reduced_chi_squared,
-        iterations: pr.iterations,
-        converged: pr.converged,
-        params: pr.params.clone(),
-        covariance,
-        uncertainties,
-    })
-}
-
 /// Uncertainty of the full-layout parameter `full_index`, read from the
 /// solver's FREE-only `uncertainties` vector.
 ///
@@ -3394,10 +3316,18 @@ pub fn evaluate_jacobian_and_fisher(
     flux: &[f64],
     background: &[f64],
 ) -> Result<ModelJacobianResult, PipelineError> {
+    if config.exact_count_response().is_some() {
+        return Err(PipelineError::InvalidParameter(
+            "evaluate_jacobian_and_fisher does not implement the exact two-arm \
+             detector operator; use the single-spectrum count fitter for resolved \
+             counts rather than reporting a Jacobian for a different model"
+                .into(),
+        ));
+    }
     // This helper builds a counts-space Jacobian/Fisher from the same
     // transmission-first chain as production fitting.  It is no more physical
     // under instrument resolution than the optimizer route, so reject it too.
-    validate_counts_resolution_route(true, config)?;
+    validate_counts_resolution_route(true, flux.len(), config)?;
 
     // Reject a malformed caller-supplied precomputed cross-section stack here,
     // before it reaches `build_transmission_model`.  Without this, an empty
@@ -3786,14 +3716,14 @@ pub struct SpectrumFitResult {
     pub temperature_k: Option<f64>,
     /// 1-sigma uncertainty on the fitted temperature (from covariance matrix).
     ///
-    /// **Covariance-only lower bound** for the raw-covariance solver paths
-    /// (Poisson-KL, joint-Poisson): this is `sqrt` of the temperature diagonal
+    /// **Covariance-only lower bound** for the joint-Poisson path: this is
+    /// `sqrt` of the temperature diagonal
     /// of the inverse curvature (Fisher) matrix at convergence. It reflects only
     /// statistical curvature — baseline/model noise is not in the covariance —
     /// so on real data it can **underestimate the observed per-superpixel scatter
     /// by ~3–4×**. Set `UnifiedFitConfig::scale_by_chi2` to inflate it by `sqrt`
     /// of the goodness-of-fit this result reports (Gaussian `reduced_chi_squared`
-    /// on the transmission paths, `deviance_per_dof` on the counts joint-Poisson
+    /// on the transmission LM path, `deviance_per_dof` on the counts joint-Poisson
     /// path) for a goodness-of-fit-scaled estimate. The LM transmission path is
     /// already χ²-scaled (Numerical Recipes §15.6), so the flag is a no-op there.
     pub temperature_k_unc: Option<f64>,
@@ -3848,8 +3778,7 @@ pub struct SpectrumFitResult {
     /// `InputData::CountsWithNuisance`).
     ///
     /// `Some(D/dof)` when the counts-KL (joint-Poisson) path was used;
-    /// `None` for the LM path and for transmission + PoissonKL (those
-    /// populate `reduced_chi_squared` with Pearson χ² / (n−k) instead).
+    /// `None` for the LM transmission path.
     pub deviance_per_dof: Option<f64>,
     /// Fitted multiplicative-baseline coefficients `[b0, b1, b2]` (issue
     /// #635) for
@@ -4627,7 +4556,7 @@ mod tests {
     }
 
     #[test]
-    fn test_typed_transmission_kl_recovers_density() {
+    fn test_typed_transmission_kl_is_rejected() {
         let data = u238_single_resonance();
         let true_density = 0.0005;
         let energies: Vec<f64> = (0..201).map(|i| 1.0 + (i as f64) * 0.05).collect();
@@ -4649,18 +4578,19 @@ mod tests {
             uncertainty: sigma,
         };
 
-        let result = fit_spectrum_typed(&input, &config).unwrap();
-        assert!(result.converged, "KL on transmission should converge");
-        let fitted = result.densities[0];
+        let error = fit_spectrum_typed(&input, &config)
+            .expect_err("fractional transmission must not use a Poisson count objective");
+        let message = error.to_string();
         assert!(
-            (fitted - true_density).abs() / true_density < 0.05,
-            "density: fitted={fitted}, true={true_density}"
+            message.contains("transmission")
+                && message.contains("Poisson")
+                && message.contains("least-squares"),
+            "rejection must explain the valid transmission engine, got: {message}"
         );
     }
 
     #[test]
-    fn test_typed_counts_lm_auto_converts() {
-        // Counts + LM should auto-convert to transmission and fit
+    fn test_typed_counts_lm_is_rejected() {
         let data = u238_single_resonance();
         let true_density = 0.0005;
         let energies: Vec<f64> = (0..201).map(|i| 1.0 + (i as f64) * 0.05).collect();
@@ -4682,15 +4612,44 @@ mod tests {
             open_beam_counts: open_beam,
         };
 
-        let result = fit_spectrum_typed(&input, &config).unwrap();
+        let error = fit_spectrum_typed(&input, &config)
+            .expect_err("raw counts must not be silently converted to transmission");
+        let message = error.to_string();
         assert!(
-            result.converged,
-            "LM on auto-converted counts should converge"
+            message.contains("counts")
+                && message.contains("least-squares")
+                && message.contains("Poisson"),
+            "rejection must explain the valid counts engine, got: {message}"
         );
-        let fitted = result.densities[0];
+    }
+
+    #[test]
+    fn transmission_rejects_counts_background_config() {
+        let data = u238_single_resonance();
+        let energies: Vec<f64> = (0..51).map(|i| 1.0 + (i as f64) * 0.05).collect();
+        let (transmission, uncertainty) = synthetic_transmission(&data, 0.0005, &energies);
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![data],
+            vec!["U-238".into()],
+            0.0,
+            None,
+            vec![0.001],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig::default()))
+        .with_counts_background(CountsBackgroundConfig::default());
+        let input = InputData::Transmission {
+            transmission,
+            uncertainty,
+        };
+
+        let error = fit_spectrum_typed(&input, &config)
+            .expect_err("a counts-background request must not be ignored on transmission");
+        let message = error.to_string();
         assert!(
-            (fitted - true_density).abs() / true_density < 0.10,
-            "density: fitted={fitted}, true={true_density}"
+            message.contains("counts background") && message.contains("transmission"),
+            "rejection must name the domain mismatch, got: {message}"
         );
     }
 
@@ -4854,7 +4813,7 @@ mod tests {
     }
 
     #[test]
-    fn test_typed_poisson_kl_with_temperature() {
+    fn test_typed_lm_with_temperature() {
         let data = u238_single_resonance();
         let true_density = 0.0005;
         let true_temp = 350.0;
@@ -4870,9 +4829,9 @@ mod tests {
             vec![0.001],
         )
         .unwrap()
-        .with_solver(SolverConfig::PoissonKL(PoissonConfig {
+        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig {
             max_iter: 500,
-            ..PoissonConfig::default()
+            ..LmConfig::default()
         }))
         .with_fit_temperature(true);
 
@@ -4903,7 +4862,7 @@ mod tests {
     }
 
     #[test]
-    fn test_typed_poisson_kl_with_temperature_and_background() {
+    fn test_typed_lm_with_temperature_and_background() {
         let data = u238_single_resonance();
         let true_density = 0.0005;
         let true_temp = 350.0;
@@ -4926,10 +4885,9 @@ mod tests {
             vec![0.001],
         )
         .unwrap()
-        .with_solver(SolverConfig::PoissonKL(PoissonConfig {
+        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig {
             max_iter: 120,
-            gauss_newton_lambda: 1e-4,
-            ..PoissonConfig::default()
+            ..LmConfig::default()
         }))
         .with_fit_temperature(true)
         .with_transmission_background(BackgroundConfig::default());
@@ -4944,7 +4902,7 @@ mod tests {
         assert!(result.converged, "fit did not converge: {result:?}");
         assert!(
             result.iterations <= 80,
-            "expected KL background+temperature fit to converge well before max_iter; got {}",
+            "expected LM background+temperature fit to converge well before max_iter; got {}",
             result.iterations,
         );
 
@@ -5044,7 +5002,7 @@ mod tests {
     }
 
     #[test]
-    fn test_grouped_poisson_kl_with_temperature_and_background_noiseless() {
+    fn test_grouped_lm_with_temperature_and_background_noiseless() {
         use nereids_core::types::IsotopeGroup;
 
         let rd1 = synthetic_single_resonance(72, 176, 8.5, 5.0);
@@ -5095,10 +5053,9 @@ mod tests {
         .unwrap()
         .with_groups(&[(&group, &[rd1, rd2, rd3])], vec![0.0008])
         .unwrap()
-        .with_solver(SolverConfig::PoissonKL(PoissonConfig {
+        .with_solver(SolverConfig::LevenbergMarquardt(LmConfig {
             max_iter: 200,
-            gauss_newton_lambda: 1e-4,
-            ..PoissonConfig::default()
+            ..LmConfig::default()
         }))
         .with_fit_temperature(true)
         .with_transmission_background(BackgroundConfig::default());
@@ -5372,117 +5329,6 @@ mod tests {
         );
     }
 
-    /// Issue #638 (review R1): on the transmission Poisson-KL path,
-    /// `scale_by_chi2` scales σ by the SAME Gaussian `reduced_chi_squared` the
-    /// result reports — the identical prescription the LM path applies
-    /// unconditionally (`lm.rs` #108.1, Numerical Recipes §15.6) — NOT a Poisson
-    /// deviance on transmission fractions.
-    ///
-    /// Two regimes, both asserting `σ_scaled == σ_unscaled·√(reduced_chi_squared)`
-    /// (self-consistency with the reported GOF):
-    ///  - a good fit (`reduced_chi_squared < 1`) SHRINKS σ, and
-    ///  - a deliberately poor fit (`reduced_chi_squared > 1`, forced by a
-    ///    high-frequency zig-zag the smooth density model cannot absorb) GROWS σ.
-    ///
-    /// The direction guard is the key regression check: the original bug scaled
-    /// by the Poisson deviance of transmission fractions, which gives `D ≪ dof`
-    /// on a poor pseudo-Poisson fit and SHRANK σ (~30×), the opposite of intent.
-    #[test]
-    fn test_scale_by_chi2_transmission_kl_scales_by_reported_reduced_chi2() {
-        let data = u238_single_resonance();
-        let true_density = 0.002;
-        let energies: Vec<f64> = (0..201).map(|i| 1.0 + (i as f64) * 0.05).collect();
-
-        let make_config = |scale: bool| {
-            UnifiedFitConfig::new(
-                energies.clone(),
-                vec![data.clone()],
-                vec!["U-238".into()],
-                0.0,
-                None,
-                vec![0.001],
-            )
-            .unwrap()
-            .with_solver(SolverConfig::PoissonKL(PoissonConfig::default()))
-            .with_scale_by_chi2(scale)
-        };
-
-        // Fit `t` (with uncertainty `sigma`) twice — flag off/on — assert
-        // `σ_scaled == σ_unscaled·√(reduced_chi_squared)` and that the flag does
-        // not change the reported GOF. Returns (reduced_chi², σ_scaled/σ_unscaled).
-        let check = |t: Vec<f64>, sigma: Vec<f64>| -> (f64, f64) {
-            let input = InputData::Transmission {
-                transmission: t,
-                uncertainty: sigma,
-            };
-            let unscaled = fit_spectrum_typed(&input, &make_config(false)).unwrap();
-            let scaled = fit_spectrum_typed(&input, &make_config(true)).unwrap();
-            assert!(unscaled.converged && scaled.converged);
-            let rcs = scaled.reduced_chi_squared;
-            assert!(
-                (rcs - unscaled.reduced_chi_squared).abs() < 1e-9,
-                "scale flag must not change the reported reduced_chi_squared"
-            );
-            assert!(rcs.is_finite() && rcs > 0.0, "reduced_chi_squared = {rcs}");
-            let factor = rcs.sqrt();
-            let s_un = unscaled.uncertainties.as_ref().expect("σ unscaled")[0];
-            let s_sc = scaled.uncertainties.as_ref().expect("σ scaled")[0];
-            let rel = (s_sc - s_un * factor).abs() / (s_un * factor);
-            assert!(
-                rel < 1e-6,
-                "σ_scaled {s_sc} must equal σ_unscaled {s_un} × √(reduced_chi² {rcs})"
-            );
-            (rcs, s_sc / s_un)
-        };
-
-        // ±k (relative) zig-zag: a zero-mean high-frequency perturbation the
-        // smooth density model cannot absorb. Multiplicative (`t·(1±k)`) so the
-        // transmission stays strictly positive even at a deep resonance dip (an
-        // additive ±k·σ perturbation drives `t` negative there, violating the
-        // Poisson `obs ≥ 0` contract). Since `σ = 0.01·max(t, 0.01)`, the bulk
-        // bins give `(residual/σ)² ≈ (100·k)²`, so the reported Gaussian
-        // reduced-χ² ≈ (100·k)².
-        let zigzag = |k: f64| -> (Vec<f64>, Vec<f64>) {
-            let (t, sigma) = synthetic_transmission(&data, true_density, &energies);
-            let perturbed: Vec<f64> = t
-                .iter()
-                .enumerate()
-                .map(|(i, &ti)| {
-                    if i % 2 == 0 {
-                        ti * (1.0 + k)
-                    } else {
-                        ti * (1.0 - k)
-                    }
-                })
-                .collect();
-            (perturbed, sigma)
-        };
-
-        // Good fit (±0.3% → reduced-χ² ≈ 0.09 < 1): σ shrinks.
-        let (t_good, s_good) = zigzag(0.003);
-        let (rcs_good, ratio_good) = check(t_good, s_good);
-        assert!(
-            rcs_good < 1.0,
-            "clean-ish fit should give reduced-χ² < 1, got {rcs_good}"
-        );
-        assert!(
-            ratio_good < 1.0,
-            "good fit must shrink σ, ratio = {ratio_good}"
-        );
-
-        // Poor fit (±3% → reduced-χ² ≈ 9 > 1): σ grows (bug inverted this).
-        let (t_poor, s_poor) = zigzag(0.03);
-        let (rcs_poor, ratio_poor) = check(t_poor, s_poor);
-        assert!(
-            rcs_poor > 1.0,
-            "zig-zag fit should give reduced-χ² > 1, got {rcs_poor}"
-        );
-        assert!(
-            ratio_poor > 1.0,
-            "poor fit must GROW σ, ratio = {ratio_poor}"
-        );
-    }
-
     #[test]
     fn test_kl_counts_with_background_returns_uncertainty() {
         let data = u238_single_resonance();
@@ -5639,15 +5485,10 @@ mod tests {
         );
     }
 
-    /// Issue #634: the joint combination must also work on the
-    /// transmission-PoissonKL path — its guard was lifted too, and the KL
-    /// solver consumes the model Jacobian through a different route
-    /// (deviance gradient plus Fisher) than the LM normal equations,
-    /// exactly the seam where wrong-slot σ bugs have hidden before (#641).
-    /// Same closed loop as the LM test; also pins a finite positive
-    /// temperature σ.
+    /// Optional energy-scale and temperature settings do not make a
+    /// transmission Poisson/KL request statistically valid.
     #[test]
-    fn test_energy_scale_with_temperature_recovers_all_three_kl() {
+    fn test_energy_scale_with_temperature_does_not_enable_transmission_kl() {
         let data = u238_three_resonances();
         let flight_path = 25.0_f64;
         let true_density = 0.002;
@@ -5678,37 +5519,15 @@ mod tests {
         .with_fit_temperature(true)
         .with_energy_scale(0.0, 1.0, flight_path);
 
-        let result = fit_spectrum_typed(
+        let error = fit_spectrum_typed(
             &InputData::Transmission {
                 transmission: t_obs,
                 uncertainty: sigma,
             },
             &config,
         )
-        .expect("KL joint fit runs");
-        assert!(result.converged, "KL joint fit should converge");
-        let t0 = result.t0_us.expect("t0_us populated");
-        let ls = result.l_scale.expect("l_scale populated");
-        let temp = result.temperature_k.expect("temperature_k populated");
-        assert!(
-            (t0 - true_t0).abs() < 0.1,
-            "KL t0: fitted={t0}, true={true_t0}"
-        );
-        assert!(
-            (ls - true_l_scale).abs() / true_l_scale < 2e-3,
-            "KL l_scale: fitted={ls}, true={true_l_scale}"
-        );
-        assert!(
-            (temp - true_temp).abs() < 5.0,
-            "KL temperature: fitted={temp}, true={true_temp}"
-        );
-        let t_unc = result
-            .temperature_k_unc
-            .expect("KL joint fit must report a temperature σ");
-        assert!(
-            t_unc.is_finite() && t_unc > 0.0,
-            "KL joint temperature σ must be finite positive, got {t_unc}"
-        );
+        .expect_err("transmission plus Poisson/KL must be rejected");
+        assert!(error.to_string().contains("normalized transmission"));
     }
 
     /// Issue #634: the joint combination on the COUNTS joint-Poisson path —
@@ -6256,11 +6075,10 @@ mod tests {
         );
     }
 
-    /// Transmission + PoissonKL is a valid combination (routes to
-    /// `fit_transmission_poisson`, unchanged by the counts-KL collapse).
-    /// This test asserts the transmission-KL path still works end-to-end.
+    /// A normalized transmission is not a Poisson count. The supplied
+    /// uncertainty must not be silently ignored by a Poisson objective.
     #[test]
-    fn test_transmission_poisson_kl_dispatches_to_transmission_path() {
+    fn test_transmission_poisson_kl_rejects_fractional_data() {
         let data = u238_single_resonance();
         let energies: Vec<f64> = (0..51).map(|i| 1.0 + (i as f64) * 0.05).collect();
         let (t, u) = synthetic_transmission(&data, 0.0005, &energies);
@@ -6280,20 +6098,14 @@ mod tests {
             transmission: t,
             uncertainty: u,
         };
-        let r = fit_spectrum_typed(&input, &config).unwrap();
-        // Transmission-KL path does NOT report deviance_per_dof (that's
-        // the counts-domain joint-Poisson GOF only); reduced_chi_squared
-        // is the transmission Poisson NLL measure.
-        assert!(r.deviance_per_dof.is_none());
-        assert!(r.reduced_chi_squared.is_finite());
+        let error = fit_spectrum_typed(&input, &config)
+            .expect_err("transmission plus Poisson/KL must be rejected");
+        assert!(error.to_string().contains("Poisson"));
     }
 
-    /// Gate 1: the current counts likelihood profiles an already-broadened
-    /// transmission model. With instrument resolution this computes R[T], not
-    /// the physical separate-arm response R[Phi*T] / R[Phi]. Until the public
-    /// counts input carries the required true-energy incident flux and both
-    /// detector-response arms, every counts + resolution request must fail
-    /// before model construction instead of returning a plausible wrong fit.
+    /// Resolved counts require the source weights and measured time-bin edges.
+    /// Omitting either must fail before model construction instead of falling
+    /// back to the invalid post-hoc shortcut R[T].
     #[test]
     fn counts_resolution_requires_exact_count_response() {
         use nereids_physics::resolution::{
@@ -6373,13 +6185,119 @@ mod tests {
                     assert!(
                         msg.contains("counts")
                             && msg.contains("instrument resolution")
-                            && msg.contains("separate open/sample response arms"),
+                            && msg.contains("separate-arm model"),
                         "{input_name} + {solver_name} + {resolution_name}: expected \
                          physical counts-response rejection, got: {msg}"
                     );
                 }
             }
         }
+    }
+
+    /// The supported resolved-count path must recover a known density from
+    /// counts generated by the separate-arm detector equation. The true-energy
+    /// quadrature and detector-time bin counts deliberately differ so a future
+    /// ratio-on-one-grid shortcut cannot satisfy this test.
+    #[test]
+    fn exact_resolved_counts_closed_loop_recovers_density() {
+        use nereids_physics::counts_response::two_arm_count_response;
+        use nereids_physics::resolution::{ResolutionFunction, TabulatedResolution};
+
+        let data = u238_single_resonance();
+        let true_density = 5.0e-4;
+        let energies: Vec<f64> = (0..80).map(|i| 5.0 + i as f64 * 3.0 / 79.0).collect();
+        let (true_transmission, _) = synthetic_transmission(&data, true_density, &energies);
+        let response = ResolutionFunction::Tabulated(Arc::new(
+            TabulatedResolution::from_kernels(
+                vec![6.5],
+                vec![(vec![-3.0, 0.0, 3.0], vec![0.0, 1.0, 0.0])],
+                25.0,
+            )
+            .expect("valid detector-time response"),
+        ));
+        let source: Vec<f64> = energies
+            .iter()
+            .enumerate()
+            .map(|(index, _)| 4.0e4 * (1.0 + 0.4 * index as f64 / 79.0))
+            .collect();
+        let detector_edges: Vec<f64> = (0..102).map(|i| 630.0 + i as f64 * 2.5).collect();
+        let expected = two_arm_count_response(
+            &energies,
+            &source,
+            &true_transmission,
+            &detector_edges,
+            0.0,
+            &response,
+        )
+        .expect("valid synthetic count response");
+        let fixed_anorm = 0.98;
+        let fixed_back_a = 0.01;
+        let fixed_back_b = 0.002;
+        let sample_counts: Vec<f64> = expected
+            .open_beam
+            .iter()
+            .zip(&expected.sample)
+            .zip(detector_edges.windows(2))
+            .map(|((&open, &sample), edges)| {
+                if open == 0.0 {
+                    0.0
+                } else {
+                    let measured_energy = tof_to_energy(0.5 * (edges[0] + edges[1]), 25.0);
+                    open * (fixed_anorm * sample / open
+                        + fixed_back_a
+                        + fixed_back_b / measured_energy.sqrt())
+                }
+            })
+            .collect();
+
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![data],
+            vec!["U-238".into()],
+            0.0,
+            Some(response),
+            vec![2.0e-4],
+        )
+        .unwrap()
+        .with_solver(SolverConfig::PoissonKL(PoissonConfig {
+            max_iter: 400,
+            ..Default::default()
+        }))
+        .with_exact_count_response(ExactCountResponseConfig {
+            incident_fluence_weights: source,
+            detector_time_edges_us: detector_edges,
+            timing_offset_us: 0.0,
+        })
+        .with_transmission_background(BackgroundConfig {
+            anorm_init: fixed_anorm,
+            back_a_init: fixed_back_a,
+            back_b_init: fixed_back_b,
+            back_c_init: 0.0,
+            back_d_init: 0.01,
+            back_f_init: 1.0,
+            fit_anorm: false,
+            fit_back_a: false,
+            fit_back_b: false,
+            fit_back_c: false,
+            fit_back_d: false,
+            fit_back_f: false,
+        });
+        let result = fit_spectrum_typed(
+            &InputData::Counts {
+                sample_counts,
+                open_beam_counts: expected.open_beam,
+            },
+            &config,
+        )
+        .expect("exact resolved count fit");
+
+        assert!(result.converged, "fit did not converge");
+        assert!(
+            (result.densities[0] - true_density).abs() < 2.0e-6,
+            "recovered density {} differs from truth {true_density}",
+            result.densities[0]
+        );
+        assert!(result.deviance_per_dof.unwrap_or(f64::INFINITY) < 1.0e-8);
     }
 
     // ──────────────────────────────────────────────────────────────────
@@ -6699,7 +6617,8 @@ mod tests {
         );
     }
 
-    /// Same rule on the transmission Poisson-KL path.
+    /// A transmission Poisson/KL request is rejected for the more fundamental
+    /// domain mismatch before background-specific validation.
     #[test]
     fn test_transmission_poisson_kl_rejects_partial_back_d_f() {
         let data = u238_single_resonance();
@@ -6729,9 +6648,10 @@ mod tests {
             uncertainty: u,
         };
         let err = fit_spectrum_typed(&input, &config).unwrap_err();
+        let message = err.to_string();
         assert!(
-            err.to_string().contains("fit_back_d"),
-            "expected partial-BackD/F rejection on transmission-PoissonKL path"
+            message.contains("normalized transmission") && message.contains("Poisson"),
+            "expected transmission/Poisson domain rejection, got: {message}"
         );
     }
 
@@ -6865,12 +6785,8 @@ mod tests {
         );
     }
 
-    /// Transmission + PoissonKL with `fit_energy_range` set must be
-    /// hard-rejected at dispatch.  The legacy `poisson_fit` does not
-    /// honour the active-bin mask, so silently fitting on the
-    /// (margin-extended) grid would bias the result.  Joint-Poisson
-    /// (counts) and LM transmission both honour the mask correctly.
-    /// Regression for #514.
+    /// Transmission + PoissonKL is rejected before route-specific options are
+    /// considered; `fit_energy_range` cannot revive the invalid domain pair.
     #[test]
     fn test_fit_energy_range_rejected_on_transmission_poisson_path() {
         let data = u238_single_resonance();
@@ -6898,10 +6814,8 @@ mod tests {
         let err = fit_spectrum_typed(&input, &cfg).unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("fit_energy_range")
-                && (msg.contains("Poisson") || msg.contains("poisson")),
-            "expected rejection message mentioning fit_energy_range and the \
-             Poisson-KL path; got: {msg}"
+            msg.contains("normalized transmission") && msg.contains("Poisson"),
+            "expected transmission/Poisson domain rejection; got: {msg}"
         );
     }
 
@@ -7004,8 +6918,7 @@ mod tests {
         };
         let msg = err.to_string();
         assert!(
-            msg.contains("instrument resolution")
-                && msg.contains("separate open/sample response arms"),
+            msg.contains("instrument resolution") && msg.contains("separate-arm model"),
             "expected physical counts-response rejection, got: {msg}"
         );
     }
@@ -7571,15 +7484,10 @@ mod tests {
         );
     }
 
-    /// #633 P0 (review round 2): the KL transmission path
-    /// (`SolverConfig::PoissonKL`) must also report the frozen-density
-    /// temperature σ from the correct free slot. A leftover post-extract
-    /// block indexed the FREE-only uncertainty vector by the FULL temperature
-    /// index, so with a density frozen it read out of bounds → `None`,
-    /// silently dropping the temperature 1-σ that `extract_result` had
-    /// computed correctly. LM was covered; this pins the parallel KL path.
+    /// Freezing density does not make fractional transmission valid Poisson
+    /// count data.
     #[test]
-    fn test_fix_densities_kl_reports_temperature_uncertainty() {
+    fn test_fix_densities_does_not_enable_transmission_kl() {
         let data = u238_single_resonance();
         let true_density = 0.0005;
         let true_temp = 350.0;
@@ -7603,25 +7511,9 @@ mod tests {
             transmission: t,
             uncertainty: sigma,
         };
-        let result = fit_spectrum_typed(&input, &config).unwrap();
-        assert!(result.converged, "KL T-only fit should converge");
-        assert_eq!(
-            result.densities[0], true_density,
-            "frozen density must not move"
-        );
-        let fitted_temp = result.temperature_k.expect("temperature_k should be Some");
-        assert!(
-            (fitted_temp - true_temp).abs() < 5.0,
-            "KL temperature: fitted={fitted_temp}, true={true_temp}"
-        );
-        // The regression: this was None pre-fix whenever a density was frozen.
-        let t_unc = result
-            .temperature_k_unc
-            .expect("KL frozen-density fit must report a temperature σ, not None");
-        assert!(
-            t_unc.is_finite() && t_unc > 0.0,
-            "KL frozen-density temperature σ must be finite positive, got {t_unc}"
-        );
+        let error = fit_spectrum_typed(&input, &config)
+            .expect_err("transmission plus Poisson/KL must be rejected");
+        assert!(error.to_string().contains("normalized transmission"));
     }
 
     /// Regression for the #633 P0: with a FROZEN leading density, result
@@ -7822,7 +7714,7 @@ mod tests {
     }
 
     #[test]
-    fn baseline_kl_transmission_closed_loop() {
+    fn baseline_does_not_enable_transmission_kl() {
         let data = u238_single_resonance();
         let true_density = 0.002;
         let energies: Vec<f64> = (0..201).map(|i| 1.0 + (i as f64) * 0.05).collect();
@@ -7849,20 +7741,9 @@ mod tests {
             transmission: measured,
             uncertainty: sigma,
         };
-        let result = fit_spectrum_typed(&input, &config).unwrap();
-        assert!(result.converged, "baseline KL closed loop should converge");
-        let fitted = result.densities[0];
-        assert!(
-            (fitted - true_density).abs() / true_density < 0.02,
-            "density: fitted={fitted}, true={true_density}"
-        );
-        let b = result.baseline.expect("baseline fitted");
-        for (i, (&fit_b, &truth)) in b.iter().zip(BL_TRUE.iter()).enumerate() {
-            assert!(
-                (fit_b - truth).abs() < 1e-2,
-                "b{i}: fitted={fit_b}, true={truth}"
-            );
-        }
+        let error = fit_spectrum_typed(&input, &config)
+            .expect_err("a baseline must not enable transmission plus Poisson/KL");
+        assert!(error.to_string().contains("normalized transmission"));
     }
 
     #[test]
@@ -7951,11 +7832,6 @@ mod tests {
                 "LM transmission",
                 &transmission_input,
                 SolverConfig::LevenbergMarquardt(LmConfig::default()),
-            ),
-            (
-                "KL transmission",
-                &transmission_input,
-                SolverConfig::PoissonKL(PoissonConfig::default()),
             ),
             (
                 "joint-Poisson counts",

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -1647,6 +1647,22 @@ fn fit_transmission_lm(
         sr.energy_scale_flight_path_m = Some(config.flight_path_m);
     }
 
+    let model_prediction = stacked.evaluate(&result.params)?;
+    let prediction_energies_ev = config.energies().to_vec();
+    let (signal_prediction, background_prediction) = split_prediction_components(
+        config,
+        &result.params,
+        &prediction_energies_ev,
+        &model_prediction,
+        bg_indices,
+        bl_indices,
+        true,
+    )?;
+    sr.prediction_energies_ev = prediction_energies_ev;
+    sr.signal_prediction = signal_prediction;
+    sr.background_prediction = background_prediction;
+    sr.model_prediction = model_prediction;
+
     Ok(sr)
 }
 
@@ -1840,6 +1856,8 @@ fn fit_counts_joint_poisson(
     // bins, so on the exact route it is applied only after the separate-arm
     // detector ratio has been formed.
     let mut stacked: Box<dyn FitModel> = t_model;
+    let prediction_energies_ev: Vec<f64>;
+    let baseline_wraps_background: bool;
     if let Some(exact) = config.exact_count_response() {
         if let Some(bli) = bl_indices {
             stacked = Box::new(MultiplicativeBaselineModel::new(
@@ -1857,6 +1875,26 @@ fn fit_counts_joint_poisson(
         let response = config.resolution().expect(
             "validate_counts_resolution_route requires resolution with exact_count_response",
         );
+        let detector_energies: Result<Vec<f64>, PipelineError> = exact
+            .detector_time_edges_us
+            .windows(2)
+            .enumerate()
+            .map(|(bin, edges)| {
+                let corrected_tof_us = 0.5 * (edges[0] + edges[1]) - exact.timing_offset_us;
+                let energy = tof_to_energy(corrected_tof_us, response.flight_path_m());
+                if energy.is_finite() && energy > 0.0 {
+                    Ok(energy)
+                } else {
+                    Err(PipelineError::InvalidParameter(format!(
+                        "detector-time bin {bin} has non-positive time after the fixed \
+                         timing offset; the fitted prediction energy is undefined"
+                    )))
+                }
+            })
+            .collect();
+        let detector_energies = detector_energies?;
+        prediction_energies_ev = detector_energies.clone();
+        baseline_wraps_background = false;
         let matrix = DetectorBinResponseMatrix::new(
             config.energies(),
             &exact.detector_time_edges_us,
@@ -1888,27 +1926,9 @@ fn fit_counts_joint_poisson(
         stacked = Box::new(exact_model);
 
         if let Some(bi) = bg_indices {
-            let detector_energies: Result<Vec<f64>, PipelineError> = exact
-                .detector_time_edges_us
-                .windows(2)
-                .enumerate()
-                .map(|(bin, edges)| {
-                    let corrected_tof_us = 0.5 * (edges[0] + edges[1]) - exact.timing_offset_us;
-                    let energy = tof_to_energy(corrected_tof_us, response.flight_path_m());
-                    if energy.is_finite() && energy > 0.0 {
-                        Ok(energy)
-                    } else {
-                        Err(PipelineError::InvalidParameter(format!(
-                            "detector-time bin {bin} has non-positive time after the fixed \
-                             timing offset; SAMMY apparent-transmission background cannot \
-                             be evaluated on that bin"
-                        )))
-                    }
-                })
-                .collect();
             stacked = Box::new(NormalizedTransmissionModel::new(
                 stacked,
-                &detector_energies?,
+                &detector_energies,
                 bi.anorm,
                 bi.back_a,
                 bi.back_b,
@@ -1916,6 +1936,8 @@ fn fit_counts_joint_poisson(
             ));
         }
     } else {
+        prediction_energies_ev = config.energies().to_vec();
+        baseline_wraps_background = true;
         if let Some(bi) = bg_indices {
             stacked = Box::new(NormalizedTransmissionModel::new(
                 stacked,
@@ -1962,6 +1984,16 @@ fn fit_counts_joint_poisson(
     // FittingError.
     let result = joint_poisson::joint_poisson_fit(&objective, &mut params, &cfg)
         .map_err(PipelineError::Fitting)?;
+    let model_prediction = stacked.evaluate(&result.params)?;
+    let (signal_prediction, background_prediction) = split_prediction_components(
+        config,
+        &result.params,
+        &prediction_energies_ev,
+        &model_prediction,
+        bg_indices,
+        bl_indices,
+        baseline_wraps_background,
+    )?;
 
     // ── Extract fitted quantities ──
     let densities: Vec<f64> = (0..n_density_params).map(|i| result.params[i]).collect();
@@ -2051,6 +2083,10 @@ fn fit_counts_joint_poisson(
         warnings: degenerate_normalization_warning(config)
             .into_iter()
             .collect(),
+        prediction_energies_ev,
+        signal_prediction,
+        background_prediction,
+        model_prediction,
     })
 }
 
@@ -3196,6 +3232,69 @@ fn free_uncertainty(free_indices: &[usize], unc_all: &[f64], full_index: usize) 
         .and_then(|pos| unc_all.get(pos).copied())
 }
 
+/// Split a complete fitted curve into the signal and additive-background
+/// contributions returned by [`SpectrumFitResult`].
+///
+/// The model itself remains the source of truth for the complete curve. This
+/// helper evaluates only the explicit SAMMY additive term and subtracts it
+/// from that complete curve. On ordinary transmission routes the optional
+/// multiplicative baseline wraps both signal and background, so it is applied
+/// to the background contribution here. On the exact two-arm count route the
+/// baseline belongs to the true-energy sample arm and is inside the detector
+/// response, while the SAMMY background is added afterwards in detector-bin
+/// space; `baseline_wraps_background` is therefore false for that route.
+fn split_prediction_components(
+    config: &UnifiedFitConfig,
+    params: &[f64],
+    prediction_energies_ev: &[f64],
+    model_prediction: &[f64],
+    bg_indices: Option<BackgroundIndices>,
+    bl_indices: Option<BaselineIndices>,
+    baseline_wraps_background: bool,
+) -> Result<(Vec<f64>, Vec<f64>), PipelineError> {
+    if prediction_energies_ev.len() != model_prediction.len() {
+        return Err(PipelineError::ShapeMismatch(format!(
+            "prediction energy length {} != fitted model length {}",
+            prediction_energies_ev.len(),
+            model_prediction.len(),
+        )));
+    }
+
+    let mut background = vec![0.0; model_prediction.len()];
+    if let Some(bi) = bg_indices {
+        for (index, &energy) in prediction_energies_ev.iter().enumerate() {
+            if !energy.is_finite() || energy <= 0.0 {
+                return Err(PipelineError::InvalidParameter(format!(
+                    "prediction_energies_ev[{index}] must be finite and positive, got {energy}",
+                )));
+            }
+            let sqrt_energy = energy.sqrt();
+            let mut value = params[bi.back_a]
+                + params[bi.back_b] / sqrt_energy
+                + params[bi.back_c] * sqrt_energy;
+            if let (Some(back_d), Some(back_f)) = (bi.back_d, bi.back_f) {
+                value += params[back_d] * (-params[back_f] / sqrt_energy).exp();
+            }
+            background[index] = value;
+        }
+    }
+
+    if baseline_wraps_background && let Some(bli) = bl_indices {
+        let e_ref = config.baseline_reference_energy();
+        for (value, &energy) in background.iter_mut().zip(prediction_energies_ev) {
+            let z = (energy / e_ref).ln();
+            *value *= params[bli.b0] + params[bli.b1] * z + params[bli.b2] * z * z;
+        }
+    }
+
+    let signal = model_prediction
+        .iter()
+        .zip(&background)
+        .map(|(&model, &background)| model - background)
+        .collect();
+    Ok((signal, background))
+}
+
 /// Extract SpectrumFitResult from solver output.
 fn extract_result(
     config: &UnifiedFitConfig,
@@ -3309,6 +3408,10 @@ fn extract_result(
         warnings: degenerate_normalization_warning(config)
             .into_iter()
             .collect(),
+        prediction_energies_ev: Vec::new(),
+        signal_prediction: Vec::new(),
+        background_prediction: Vec::new(),
+        model_prediction: Vec::new(),
     })
 }
 
@@ -3853,6 +3956,28 @@ pub struct SpectrumFitResult {
     /// tracing dependency, and structured warnings survive across the
     /// PyO3 / GUI boundaries.
     pub warnings: Vec<String>,
+    /// Energy coordinate for the returned fitted prediction.
+    ///
+    /// For ordinary transmission fits this is the caller's measured-energy
+    /// grid. For the exact two-arm count path it is derived from the measured
+    /// detector-time bin centres using the fixed response flight path and
+    /// timing offset. It therefore always has the same length and ordering as
+    /// [`Self::model_prediction`].
+    pub prediction_energies_ev: Vec<f64>,
+    /// Complete fitted signal contribution before the additive SAMMY
+    /// background, after all response, normalization, and multiplicative
+    /// baseline terms that belong to the signal have been applied.
+    pub signal_prediction: Vec<f64>,
+    /// Additive SAMMY background contribution in the returned prediction.
+    ///
+    /// This is an all-zero array when no additive transmission background was
+    /// configured. If a multiplicative baseline is outside the background on
+    /// the selected route, that baseline is already included here, so
+    /// `signal_prediction + background_prediction == model_prediction`
+    /// without caller-side reconstruction.
+    pub background_prediction: Vec<f64>,
+    /// Complete fitted curve in measured-bin order.
+    pub model_prediction: Vec<f64>,
 }
 
 impl SpectrumFitResult {
@@ -5860,6 +5985,10 @@ mod tests {
             baseline: None,
             baseline_e_ref_ev: None,
             warnings: Vec::new(),
+            prediction_energies_ev: Vec::new(),
+            signal_prediction: Vec::new(),
+            background_prediction: Vec::new(),
+            model_prediction: Vec::new(),
         };
 
         // Fitted energy scale → Some(corrected grid) == the canonical

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -1686,7 +1686,7 @@ fn fit_counts_joint_poisson(
                 .into(),
         ));
     }
-    if detector_background.iter().any(|&v| v.abs() > 1e-12) {
+    if detector_background.iter().any(|&v| v != 0.0) {
         return Err(PipelineError::InvalidParameter(
             "joint-Poisson solver with non-zero detector_background is not yet supported \
              (B_det wiring is deferred)."
@@ -6509,34 +6509,35 @@ mod tests {
         let (t, _) = synthetic_transmission(&data, 0.0005, &energies);
         let flux: Vec<f64> = vec![500.0; energies.len()];
         let s: Vec<f64> = t.iter().map(|&ti| 500.0 * ti).collect();
-        let background: Vec<f64> = vec![5.0; energies.len()];
+        for nonzero_background in [5.0, 5.0e-13] {
+            let background: Vec<f64> = vec![nonzero_background; energies.len()];
+            let config = UnifiedFitConfig::new(
+                energies.clone(),
+                vec![data.clone()],
+                vec!["U-238".into()],
+                0.0,
+                None,
+                vec![0.001],
+            )
+            .unwrap()
+            .with_solver(SolverConfig::PoissonKL(PoissonConfig::default()))
+            .with_counts_background(CountsBackgroundConfig {
+                c: 1.0,
+                ..Default::default()
+            });
 
-        let config = UnifiedFitConfig::new(
-            energies,
-            vec![data],
-            vec!["U-238".into()],
-            0.0,
-            None,
-            vec![0.001],
-        )
-        .unwrap()
-        .with_solver(SolverConfig::PoissonKL(PoissonConfig::default()))
-        .with_counts_background(CountsBackgroundConfig {
-            c: 1.0,
-            ..Default::default()
-        });
-
-        let input = InputData::CountsWithNuisance {
-            sample_counts: s,
-            flux,
-            background,
-        };
-        let err = fit_spectrum_typed(&input, &config).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("B_det"),
-            "expected deferred-B_det rejection message, got: {msg}"
-        );
+            let input = InputData::CountsWithNuisance {
+                sample_counts: s.clone(),
+                flux: flux.clone(),
+                background,
+            };
+            let err = fit_spectrum_typed(&input, &config).unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("B_det"),
+                "expected deferred-B_det rejection for {nonzero_background}, got: {msg}"
+            );
+        }
     }
 
     /// Joint-Poisson rejects BackD/BackF exponential tail (support is deferred).

--- a/crates/nereids-pipeline/src/pipeline.rs
+++ b/crates/nereids-pipeline/src/pipeline.rs
@@ -444,7 +444,16 @@ pub struct UnifiedFitConfig {
     /// working-grid copy consumed only by `build_transmission_model`'s
     /// precomputed branch.
     precomputed_work_cross_sections: Option<PrecomputedWorkXs>,
+    /// Explicit sampled zero-temperature source for the legacy table route.
+    /// Do not populate this from `resonance_data`: doing so loses unresolved
+    /// narrow structure between the caller's energy points before Doppler
+    /// broadening. The standard temperature-fit path leaves this `None` and
+    /// retains the resonance source.
     precomputed_base_xs: Option<Arc<Vec<Vec<f64>>>>,
+    /// Shared zero-temperature cache used only when the continuous source
+    /// evaluator cannot cover an isotope. Injected by the spatial route so
+    /// unsupported formalisms are not reevaluated once per pixel and trial.
+    precomputed_fallback_base_xs: Option<Arc<Vec<Vec<f64>>>>,
     /// Resolution broadening plan built once for `(energies, resolution)`.
     ///
     /// Populated by [`spatial_map_typed`] when the data grid is shared
@@ -601,6 +610,7 @@ impl UnifiedFitConfig {
             precomputed_cross_sections: None,
             precomputed_work_cross_sections: None,
             precomputed_base_xs: None,
+            precomputed_fallback_base_xs: None,
             precomputed_resolution_plan: None,
             precomputed_sparse_cubature_plan: None,
             precomputed_sparse_scalar_plan: None,
@@ -822,6 +832,10 @@ impl UnifiedFitConfig {
         self
     }
 
+    /// Select the explicit sampled-source temperature route.
+    ///
+    /// This is for a genuinely tabulated source. A resolved ENDF evaluation
+    /// should remain in `resonance_data` so the source-aware integral is used.
     #[must_use]
     pub fn with_precomputed_base_xs(mut self, xs: Arc<Vec<Vec<f64>>>) -> Self {
         self.precomputed_base_xs = Some(xs);
@@ -830,6 +844,16 @@ impl UnifiedFitConfig {
         // the same reason as `with_precomputed_cross_sections`.
         self.precomputed_sparse_cubature_plan = None;
         self.precomputed_sparse_scalar_plan = None;
+        self
+    }
+
+    pub(crate) fn has_precomputed_base_xs(&self) -> bool {
+        self.precomputed_base_xs.is_some()
+    }
+
+    /// Attach the spatial route's shared sampled-fallback cache.
+    pub(crate) fn with_precomputed_fallback_base_xs(mut self, xs: Arc<Vec<Vec<f64>>>) -> Self {
+        self.precomputed_fallback_base_xs = Some(xs);
         self
     }
 
@@ -965,6 +989,7 @@ impl UnifiedFitConfig {
         self.precomputed_cross_sections = None;
         self.precomputed_work_cross_sections = None;
         self.precomputed_base_xs = None;
+        self.precomputed_fallback_base_xs = None;
         // Clear the cubature plan too: atoms are σ-coordinates in
         // ℝ^k and `k` / σ-stack change when groups are reconfigured,
         // so a stale plan would silently produce wrong forward /
@@ -2924,8 +2949,8 @@ fn build_transmission_model(
     // uses) so this path also returns a `PrecomputedTransmissionModel`.
     //
     // Before issue #635 this case fell through to `TransmissionFitModel`,
-    // whose constructor only builds `base_xs` when a temperature index is
-    // present — so `analytical_jacobian` returned `None` and every
+    // whose constructor only enters its cached cross-section path when a
+    // temperature index is present — so `analytical_jacobian` returned `None` and every
     // downstream consumer silently degraded to finite differences.  For
     // the LM path that is a hidden slowdown; for the joint-Poisson
     // stage-1 the degradation is to an IDENTITY-Fisher fallback (plain
@@ -3094,6 +3119,7 @@ fn build_transmission_model(
         .map(|r| Arc::new(InstrumentParams { resolution: r }));
 
     let base_xs = config.precomputed_base_xs.clone();
+    let fallback_base_xs = config.precomputed_fallback_base_xs.clone();
     let density_ratios = config
         .density_ratios
         .clone()
@@ -3117,7 +3143,18 @@ fn build_transmission_model(
     } else {
         None
     };
-    Ok(Box::new(
+    let model = if let Some(fallback_base_xs) = fallback_base_xs {
+        TransmissionFitModel::new_with_cached_fallback(
+            config.energies.clone(),
+            config.resonance_data.clone(),
+            config.temperature_k,
+            instrument.clone(),
+            (density_indices, density_ratios),
+            temperature_index,
+            base_xs.clone(),
+            Some(fallback_base_xs),
+        )?
+    } else {
         TransmissionFitModel::new(
             config.energies.clone(),
             config.resonance_data.clone(),
@@ -3127,9 +3164,12 @@ fn build_transmission_model(
             temperature_index,
             base_xs,
         )?
-        .with_resolution_plan(resolution_plan)
-        .with_sparse_cubature_plan(sparse_cubature_plan)
-        .with_sparse_scalar_plan(sparse_scalar_plan),
+    };
+    Ok(Box::new(
+        model
+            .with_resolution_plan(resolution_plan)
+            .with_sparse_cubature_plan(sparse_cubature_plan)
+            .with_sparse_scalar_plan(sparse_scalar_plan),
     ))
 }
 
@@ -3445,17 +3485,17 @@ pub fn evaluate_jacobian_and_fisher(
     // ── Precompute cross-sections so that analytical Jacobian is available ──
     // For the density-only case (no temperature fitting), the model uses
     // PrecomputedTransmissionModel which requires precomputed XS.
-    // For the temperature case, TransmissionFitModel computes base_xs in
-    // its constructor.  Either way, precomputing here ensures the analytical
-    // Jacobian path is always available.
+    // For the temperature case, TransmissionFitModel retains the resonance
+    // source and caches the source-aware broadened result. Either way, the
+    // analytical Jacobian path is available.
     // Issue #608: the non-temperature path uses `PrecomputedTransmissionModel`,
     // which must apply resolution on the WORKING grid (auxiliary extended grid
     // under Gaussian resolution) and extract the data points last — the same
     // #608 path as production fitting + spatial mapping, not the old coarse
     // data-grid path.  Derive σ from `resonance_data` (the source of truth) on
     // the working grid here whenever it is not already set up:
-    //   * `fit_temperature` → skip: `TransmissionFitModel` builds its own
-    //     working-grid base σ internally.
+    //   * `fit_temperature` → skip: `TransmissionFitModel` evaluates the
+    //     retained resonance source on the working grid.
     //   * working-grid σ already attached (a caller did the #608 setup) → skip.
     //   * otherwise (caller passed no σ, OR only a data-grid σ) → (re)build the
     //     data-grid σ = `extract(work σ)` AND the working-grid σ + layout from
@@ -7117,7 +7157,7 @@ mod tests {
     /// Cover the OTHER branches of the #608 `evaluate_jacobian_and_fisher` σ
     /// restructure: the identity-layout path (no resolution ⇒ working grid ==
     /// data grid) and the early-return when `fit_temperature` is set (the
-    /// `TransmissionFitModel` builds its own working-grid base σ).
+    /// `TransmissionFitModel` retains its resonance source).
     #[test]
     fn evaluate_jacobian_and_fisher_identity_and_temperature_paths() {
         let data = u238_single_resonance();
@@ -7143,7 +7183,7 @@ mod tests {
             "identity-path Fisher[0,0]={f00}"
         );
         // (b) fit_temperature ⇒ the σ-branch early-returns `config`;
-        //     TransmissionFitModel builds its own working-grid base σ.
+        //     TransmissionFitModel retains its resonance source.
         let cfg_t = UnifiedFitConfig::new(
             energies,
             vec![data],

--- a/crates/nereids-pipeline/src/spatial.rs
+++ b/crates/nereids-pipeline/src/spatial.rs
@@ -47,8 +47,7 @@ pub struct SpatialResult {
     pub chi_squared_map: Array2<f64>,
     /// Per-pixel conditional binomial deviance `D/(n−k)` map.  `Some` when
     /// the effective per-pixel solver is the counts-KL dispatch
-    /// (joint-Poisson); `None` for LM-only runs and transmission+PoissonKL
-    /// where Pearson χ²/dof is the GOF.
+    /// (joint-Poisson); `None` for LM transmission runs.
     /// NaN at pixels where `converged_map` is `false`.
     pub deviance_per_dof_map: Option<Array2<f64>>,
     /// Convergence map (true = converged).
@@ -61,7 +60,7 @@ pub struct SpatialResult {
     /// Entries are NaN where uncertainty was unavailable for that pixel.
     ///
     /// **Covariance-only lower bound.** For the raw-covariance solver paths
-    /// (Poisson-KL, joint-Poisson) each σ_T is the square root of the
+    /// (joint-Poisson) each σ_T is the square root of the
     /// temperature entry of the inverse curvature (Fisher) matrix at the
     /// converged point. That is a *lower bound* on the true uncertainty: it
     /// captures only the statistical curvature and omits baseline/model
@@ -69,7 +68,7 @@ pub struct SpatialResult {
     /// observed per-superpixel scatter by ~3–4×**. Enable
     /// `UnifiedFitConfig::scale_by_chi2` to inflate σ_T by `sqrt` of the
     /// goodness-of-fit this result reports (Gaussian `reduced_chi_squared` on the
-    /// transmission paths, `deviance_per_dof` on the counts joint-Poisson path)
+    /// transmission LM path, `deviance_per_dof` on the counts joint-Poisson path)
     /// for a goodness-of-fit-scaled estimate. The LM transmission path is already
     /// χ²-scaled (Numerical Recipes §15.6), so the flag is a no-op there.
     pub temperature_uncertainty_map: Option<Array2<f64>>,
@@ -328,25 +327,38 @@ fn validate_spatial_fit_preflight(
     // `UnifiedFitConfig` but takes the 1D `InputData`; inline the
     // resolution here so we do not have to materialise a 1D stub.
     let is_counts = input.is_counts();
+    if config.exact_count_response().is_some() {
+        return Err(PipelineError::InvalidParameter(
+            "exact resolved counts are currently supported by the single-spectrum \
+             count fitter only; spatial mapping would rebuild the detector matrix \
+             for every pixel and is disabled until that fixed matrix is cached once"
+                .into(),
+        ));
+    }
     // Hoist the scientifically unsupported counts + resolution combination so
     // it becomes one actionable boundary error, not an all-NaN map after every
     // per-pixel error is swallowed by the rayon loop.
-    validate_counts_resolution_route(is_counts, config)?;
+    validate_counts_resolution_route(is_counts, input.shape().0, config)?;
     let is_kl = matches!(config.solver(), SolverConfig::PoissonKL(_))
         || (matches!(config.solver(), SolverConfig::Auto) && is_counts);
 
-    // Gate: transmission + Poisson-KL solver path does not honour
-    // `fit_energy_range` — `fit_transmission_poisson` rejects this
-    // combination per-pixel (`pipeline.rs::fit_transmission_poisson`).
-    // Without hoisting, every pixel errors and the spatial layer
-    // hides the dispatch-level incompatibility.  Counts-KL (joint-
-    // Poisson) and LM transmission both honour the mask correctly,
-    // so this gate is scoped to the transmission + KL combination.
-    if !is_counts && is_kl && config.fit_energy_range().is_some() {
+    // Fractional transmission is not Poisson count data. Hoist the
+    // single-spectrum rejection so the pixel loop cannot turn it into an
+    // all-NaN success-shaped result.
+    if !is_counts && is_kl {
         return Err(PipelineError::InvalidParameter(
-            "fit_energy_range is not supported for the transmission + \
-             Poisson-KL solver path. Use joint-Poisson (provide sample + \
-             open-beam counts) or switch to the LM transmission solver."
+            "spatial_map_typed: normalized transmission cannot use the Poisson/KL \
+             count objective because fractional transmission is not Poisson count \
+             data and the supplied uncertainty would be ignored; use the LM \
+             least-squares transmission engine, or supply separate open/sample counts"
+                .into(),
+        ));
+    }
+    if !is_counts && config.counts_background().is_some() {
+        return Err(PipelineError::InvalidParameter(
+            "spatial_map_typed: counts background configuration cannot be used with \
+             transmission data; use SAMMY transmission_background or \
+             multiplicative_baseline, or supply separate open/sample counts"
                 .into(),
         ));
     }
@@ -381,8 +393,7 @@ fn validate_spatial_fit_preflight(
         if n_active < required {
             // Mirror the per-pixel string from whichever path the
             // dispatcher would actually take.  LM and joint-Poisson
-            // both reach this branch; transmission + Poisson-KL is
-            // already rejected by the previous gate above.
+            // both supported routes reach this branch.
             let path_msg = if is_counts && is_kl {
                 "joint-Poisson"
             } else {
@@ -763,8 +774,9 @@ fn validate_spatial_data_values(
 /// `input` selects the per-pixel objective: pre-normalized
 /// [`InputData3D::Transmission`] (+ per-bin uncertainty),
 /// [`InputData3D::Counts`] (sample + open-beam), or
-/// [`InputData3D::CountsWithNuisance`] (sample + flux + background
-/// nuisance arms; counts-domain solvers only).
+/// [`InputData3D::CountsWithNuisance`] (legacy compatibility input; a nonzero
+/// background is rejected because it is not connected to the physical
+/// two-arm likelihood).
 ///
 /// # Validation (all up-front, before any pixel is fitted)
 ///
@@ -778,11 +790,9 @@ fn validate_spatial_data_values(
 ///   map.  For transmission inputs
 ///   with a `fit_energy_range`, the value checks are scoped to the
 ///   active bins — out-of-range bins may contain NaN by design.
-/// * Known-degenerate configurations are rejected with a diagnostic
-///   rather than letting every pixel fail into an all-NaN map:
-///   counts + LM + `fit_energy_scale` (numerically ill-conditioned
-///   per-pixel — issue #458 B3) and `CountsWithNuisance` with an LM
-///   solver (requires a counts-domain solver).
+/// * Invalid domain/engine configurations are rejected with a diagnostic
+///   rather than letting every pixel fail into an all-NaN map. Raw counts use
+///   the joint-Poisson engine; LM is reserved for normalized transmission.
 ///   `transmission_background` settings are validated here for the
 ///   same reason.  (`fit_energy_scale` together with `fit_temperature`
 ///   is SUPPORTED since issue #634 — the energy-scale model carries a
@@ -882,32 +892,15 @@ pub fn spatial_map_typed(
         )));
     }
 
-    // Reject known-broken configurations at entry.
-    //
-    // Issue #458 B3: per-pixel LM with `fit_energy_scale=True` on
-    // counts data is numerically ill-conditioned.  On real VENUS Hf
-    // 120 min, only ~8 % of pixels converged; `t0` drifts to the
-    // ±10 µs bounds while `density` absorbs the compensating shift
-    // (4-order-of-magnitude errors).  Reject upfront with a pointer
-    // to the global-calibration workaround.
-    //
-    // Note: the LM-on-transmission path with `fit_energy_scale=True`
-    // has the same structural issue, but is left unblocked here —
-    // per-pixel transmission has higher SNR per bin (pre-normalised
-    // by open-beam) and this combination is sometimes useful for
-    // calibration crosschecks.  The config still produces NaN maps
-    // for failed pixels thanks to B1 gating.
-    if input.is_counts()
-        && matches!(config.solver(), SolverConfig::LevenbergMarquardt(_))
-        && config.fit_energy_scale()
-    {
+    // Raw counts are not silently divided into transmission for LM. Hoist the
+    // single-spectrum rejection so a spatial call cannot degrade into an
+    // all-NaN success-shaped result after every pixel fails.
+    if input.is_counts() && matches!(config.solver(), SolverConfig::LevenbergMarquardt(_)) {
         return Err(PipelineError::InvalidParameter(
-            "spatial_map_typed: solver='lm' + fit_energy_scale=true on counts input is \
-             numerically unstable per-pixel (issue #458 B3). Recommended workaround: fit \
-             TZERO once on the aggregated spectrum via fit_counts_spectrum_typed, then \
-             build the corrected energy grid and pass it to spatial_map_typed with \
-             fit_energy_scale=false. For counts data, solver='kl' (or 'auto') is robust \
-             with per-pixel TZERO fitting."
+            "spatial_map_typed: separate open/sample counts cannot use the LM \
+             least-squares transmission engine because silent ratio conversion loses \
+             open-beam uncertainty and count statistics; use the Poisson/KL count \
+             engine or SolverConfig::Auto"
                 .into(),
         ));
     }
@@ -917,26 +910,6 @@ pub fn spatial_map_typed(
     // per-pixel `fit_spectrum_typed` handles the combination and no spatial
     // guard is needed. (The #458 B3 guard above — LM + fit_energy_scale on
     // counts — is a separate, still-active numerical-stability restriction.)
-
-    // `fit_spectrum_typed` rejects `CountsWithNuisance + LM` per-pixel
-    // (see `validate_input_solver` in `pipeline.rs` — "CountsWithNuisance
-    // requires a counts-domain solver"), but per-pixel errors here are
-    // swallowed as `n_failed` and `spatial_map_typed` returns
-    // `Ok(SpatialResult)` with all-NaN maps.  Hoist the rejection so
-    // callers get a clear diagnostic instead of a silently-failed
-    // spatial result.
-    if matches!(input, InputData3D::CountsWithNuisance { .. })
-        && matches!(config.solver(), SolverConfig::LevenbergMarquardt(_))
-    {
-        return Err(PipelineError::InvalidParameter(
-            "spatial_map_typed: InputData3D::CountsWithNuisance requires a counts-domain \
-             solver (joint-Poisson via SolverConfig::PoissonKL or SolverConfig::Auto); \
-             SolverConfig::LevenbergMarquardt cannot use the user-supplied nuisance \
-             parameters (alpha_1, alpha_2).  Choose a counts-domain solver, or drop the \
-             nuisance arm by passing `InputData3D::Counts` instead."
-                .into(),
-        ));
-    }
 
     // Validate `transmission_background` BackD/BackF here rather than
     // per-pixel.  Invalid configs (unpaired flags, non-finite or non-
@@ -1046,8 +1019,8 @@ pub fn spatial_map_typed(
     // Whether the per-pixel dispatch routes through the counts-KL
     // (joint-Poisson) solver.  True iff the input is counts AND the
     // effective solver is either explicit `PoissonKL` or `Auto`
-    // (Auto resolves to PoissonKL on counts input).  When false (LM
-    // dispatch on counts, or any transmission input), per-pixel
+    // (Auto resolves to PoissonKL on counts input). When false (a transmission
+    // LM input), per-pixel
     // SpectrumFitResult.deviance_per_dof is `None`, so the spatial
     // deviance_per_dof_map should also be `None` — otherwise GUI /
     // Python consumers using `is_some()` to label GOF as "D/dof"
@@ -3677,14 +3650,13 @@ mod tests {
                 .expect_err("spatial counts + resolution must fail at preflight");
             let msg = err.to_string();
             assert!(
-                msg.contains("instrument resolution")
-                    && msg.contains("separate open/sample response arms"),
+                msg.contains("instrument resolution") && msg.contains("separate-arm model"),
                 "expected physical counts-response rejection, got: {msg}"
             );
         }
     }
 
-    /// `CountsWithNuisance + LM` is rejected up-front so the caller
+    /// Every count variant plus LM is rejected up-front so the caller
     /// does not get an all-NaN spatial result from per-pixel `n_failed`
     /// swallowing.  `fit_spectrum_typed` rejects this combo per-pixel;
     /// the hoisted spatial-level rejection surfaces the same diagnostic
@@ -3719,8 +3691,8 @@ mod tests {
             .expect_err("CountsWithNuisance + LM must be rejected up-front");
         let msg = err.to_string();
         assert!(
-            msg.contains("CountsWithNuisance") && msg.contains("counts-domain"),
-            "error must mention CountsWithNuisance + counts-domain requirement, got: {msg}"
+            msg.contains("counts") && msg.contains("least-squares") && msg.contains("Poisson"),
+            "error must explain the count-domain engine requirement, got: {msg}"
         );
     }
 
@@ -3774,7 +3746,7 @@ mod tests {
             "expected InvalidParameter, got {err:?}"
         );
         assert!(
-            msg.contains("CountsWithNuisance") && msg.contains("counts-domain"),
+            msg.contains("counts") && msg.contains("least-squares") && msg.contains("Poisson"),
             "error must surface the solver mismatch (not the fit-range gate), got: {msg}"
         );
         assert!(
@@ -3946,10 +3918,8 @@ mod tests {
         assert!(dpd.iter().all(|v| v.is_finite()));
     }
 
-    /// `(Counts, LM)` spatial dispatch must NOT allocate a
-    /// `deviance_per_dof_map` — the per-pixel LM path doesn't populate
-    /// `deviance_per_dof`, so an `Some(all-NaN)` map would mislead GUI /
-    /// Python consumers that switch the GOF label on `is_some()`.
+    /// `(Counts, LM)` is rejected at the spatial boundary rather than
+    /// returning a success-shaped map from a lossy ratio conversion.
     #[test]
     fn test_spatial_map_typed_counts_lm_no_deviance_map() {
         let data = u238_single_resonance();
@@ -3975,21 +3945,21 @@ mod tests {
             vec![0.001],
         )
         .unwrap()
-        // Force LM (counts → transmission conversion under the hood); no
-        // deviance is computed by that dispatch.
         .with_solver(SolverConfig::LevenbergMarquardt(LmConfig::default()));
 
         let input = InputData3D::Counts {
             sample_counts: sample.view(),
             open_beam_counts: open_beam.view(),
         };
-        let r = spatial_map_typed(&input, &config, None, None, None).unwrap();
+        let error = spatial_map_typed(&input, &config, None, None, None)
+            .expect_err("counts plus LM must be rejected before the pixel loop");
+        let message = error.to_string();
         assert!(
-            r.deviance_per_dof_map.is_none(),
-            "(Counts, LM) must not allocate deviance_per_dof_map (would mislabel GOF in GUI)"
+            message.contains("counts")
+                && message.contains("least-squares")
+                && message.contains("Poisson"),
+            "rejection must explain the valid counts engine, got: {message}"
         );
-        // chi_squared_map (Pearson) is the GOF on the LM path.
-        assert!(r.chi_squared_map.iter().any(|v| v.is_finite()));
     }
 
     /// Transmission input must never produce a `deviance_per_dof_map`
@@ -4108,10 +4078,8 @@ mod tests {
         assert!(result.l_scale_map.is_none());
     }
 
-    /// `(Counts + LM + fit_energy_scale=true)` must be rejected at
-    /// `spatial_map_typed` entry (issue #458 B3).  The combination
-    /// passed silently before and produced 92 % non-convergence with
-    /// garbage parameter values on real VENUS data.
+    /// Counts plus LM is rejected before optional energy-scale settings are
+    /// considered; the invalid engine/domain pair is the primary cause.
     #[test]
     fn test_spatial_map_typed_rejects_counts_lm_with_energy_scale() {
         let rd = u238_single_resonance();
@@ -4137,12 +4105,8 @@ mod tests {
             .expect_err("LM + counts + fit_energy_scale must be rejected");
         let msg = err.to_string();
         assert!(
-            msg.contains("fit_energy_scale") && msg.contains("lm"),
-            "error message should name both culprits, got: {msg}"
-        );
-        assert!(
-            msg.contains("#458"),
-            "error message should reference the tracking issue, got: {msg}"
+            msg.contains("counts") && msg.contains("least-squares") && msg.contains("Poisson"),
+            "error message should explain the valid counts engine, got: {msg}"
         );
     }
 
@@ -4326,10 +4290,8 @@ mod tests {
             transmission: t_3d.view(),
             uncertainty: u_3d.view(),
         };
-        // Transmission + Poisson-KL + any `fit_energy_range` is
-        // unsupported because the transmission-domain `poisson_fit`
-        // does not honour the active mask.  The per-pixel rejection
-        // would otherwise silently produce an all-NaN map.
+        // Transmission + Poisson-KL is rejected regardless of optional
+        // `fit_energy_range`; the domain mismatch is the primary cause.
         let config = UnifiedFitConfig::new(
             energies,
             vec![rd],
@@ -4351,7 +4313,7 @@ mod tests {
             "expected InvalidParameter, got {err:?}"
         );
         assert!(
-            msg.contains("fit_energy_range") && msg.contains("Poisson-KL"),
+            msg.contains("normalized transmission") && msg.contains("Poisson"),
             "error must name the incompatibility, got: {msg}"
         );
     }

--- a/crates/nereids-pipeline/src/spatial.rs
+++ b/crates/nereids-pipeline/src/spatial.rs
@@ -166,7 +166,8 @@ pub struct SpatialResult {
 use crate::pipeline::{
     InputData, MultiplicativeBaselineConfig, SolverConfig, UnifiedFitConfig, count_free_params,
     degenerate_normalization_warning, fit_spectrum_typed, required_active_bins,
-    validate_multiplicative_baseline, validate_transmission_background,
+    validate_counts_resolution_route, validate_multiplicative_baseline,
+    validate_transmission_background,
 };
 
 /// 3D input data for spatial mapping.
@@ -327,6 +328,10 @@ fn validate_spatial_fit_preflight(
     // `UnifiedFitConfig` but takes the 1D `InputData`; inline the
     // resolution here so we do not have to materialise a 1D stub.
     let is_counts = input.is_counts();
+    // Hoist the scientifically unsupported counts + resolution combination so
+    // it becomes one actionable boundary error, not an all-NaN map after every
+    // per-pixel error is swallowed by the rayon loop.
+    validate_counts_resolution_route(is_counts, config)?;
     let is_kl = matches!(config.solver(), SolverConfig::PoissonKL(_))
         || (matches!(config.solver(), SolverConfig::Auto) && is_counts);
 
@@ -3629,6 +3634,54 @@ mod tests {
             msg.contains("counts-KL") || msg.contains("joint-Poisson"),
             "error must reference the counts-KL incompatibility, got: {msg}"
         );
+    }
+
+    /// Gate 1: spatial count fitting must surface the unsupported response
+    /// model once at the public boundary.  Returning an all-NaN map would hide
+    /// the fact that every pixel tried to use R[T] instead of the physical
+    /// separate-arm response R[Phi*T] / R[Phi].
+    #[test]
+    fn spatial_counts_resolution_requires_exact_count_response() {
+        use nereids_physics::resolution::{ResolutionFunction, ResolutionParams};
+
+        let rd = u238_single_resonance();
+        let energies: Vec<f64> = (0..51).map(|i| 1.0 + (i as f64) * 0.2).collect();
+        let (sample, ob) = synthetic_4x4_counts(&rd, 0.0005, &energies, 1000.0);
+        let flux = Array3::from_elem((energies.len(), 4, 4), 1000.0);
+        let background = Array3::zeros((energies.len(), 4, 4));
+        let config = UnifiedFitConfig::new(
+            energies,
+            vec![rd],
+            vec!["U-238".into()],
+            293.6,
+            Some(ResolutionFunction::Gaussian(
+                ResolutionParams::new(25.0, 0.5, 0.005, 0.0).unwrap(),
+            )),
+            vec![0.001],
+        )
+        .unwrap();
+
+        let inputs = [
+            InputData3D::Counts {
+                sample_counts: sample.view(),
+                open_beam_counts: ob.view(),
+            },
+            InputData3D::CountsWithNuisance {
+                sample_counts: sample.view(),
+                flux: flux.view(),
+                background: background.view(),
+            },
+        ];
+        for input in inputs {
+            let err = spatial_map_typed(&input, &config, None, None, None)
+                .expect_err("spatial counts + resolution must fail at preflight");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("instrument resolution")
+                    && msg.contains("separate open/sample response arms"),
+                "expected physical counts-response rejection, got: {msg}"
+            );
+        }
     }
 
     /// `CountsWithNuisance + LM` is rejected up-front so the caller

--- a/crates/nereids-pipeline/src/spatial.rs
+++ b/crates/nereids-pipeline/src/spatial.rs
@@ -680,7 +680,7 @@ fn check_cube(
 ///   quantities, where a bad value anywhere is an upstream bug (matching the
 ///   all-bins `validate_counts`).
 /// - **background** (CountsWithNuisance) is checked **finite, all bins**,
-///   closing the `NaN.abs() > 1e-12 == false` finiteness leak in the
+///   closing the `NaN != 0.0` comparison leak in the
 ///   per-pixel detector-background gate.
 fn validate_spatial_data_values(
     input: &InputData3D<'_>,
@@ -753,7 +753,7 @@ fn validate_spatial_data_values(
                 None,
             )?;
             if live_pixels.iter().any(|&(y, x)| {
-                (0..background.shape()[0]).any(|energy| background[[energy, y, x]].abs() > 1.0e-12)
+                (0..background.shape()[0]).any(|energy| background[[energy, y, x]] != 0.0)
             }) {
                 return Err(PipelineError::InvalidParameter(
                     "joint-Poisson solver with non-zero detector_background is not yet \
@@ -4751,7 +4751,7 @@ mod tests {
     #[test]
     fn test_spatial_counts_with_nuisance_rejects_nonfinite_background() {
         // Background is validated finite before the nonzero-background gate;
-        // this closes the `NaN.abs() > 1e-12 == false` comparison leak.
+        // this closes the `NaN != 0.0` comparison leak.
         let energies: Vec<f64> = (0..51).map(|i| 1.0 + (i as f64) * 0.2).collect();
         for bad in [f64::NAN, f64::INFINITY] {
             let data = u238_single_resonance();
@@ -4784,25 +4784,27 @@ mod tests {
         let energies: Vec<f64> = (0..51).map(|i| 1.0 + (i as f64) * 0.2).collect();
         let (sample, _ob) = synthetic_4x4_counts(&data, 0.0005, &energies, 1000.0);
         let flux = Array3::from_elem((energies.len(), 4, 4), 1000.0);
-        let mut background = Array3::from_elem((energies.len(), 4, 4), 0.0);
-        background[[2, 3, 3]] = 1.0;
-        let config = kl_counts_config(energies.clone(), data);
-        let input = InputData3D::CountsWithNuisance {
-            sample_counts: sample.view(),
-            flux: flux.view(),
-            background: background.view(),
-        };
+        for nonzero_background in [1.0, 5.0e-13] {
+            let mut background = Array3::from_elem((energies.len(), 4, 4), 0.0);
+            background[[2, 3, 3]] = nonzero_background;
+            let config = kl_counts_config(energies.clone(), data.clone());
+            let input = InputData3D::CountsWithNuisance {
+                sample_counts: sample.view(),
+                flux: flux.view(),
+                background: background.view(),
+            };
 
-        let err = spatial_map_typed(&input, &config, None, None, None)
-            .expect_err("unsupported detector background must fail before pixel fitting");
-        assert!(
-            matches!(err, PipelineError::InvalidParameter(_)),
-            "got {err:?}"
-        );
-        assert!(
-            err.to_string().contains("non-zero detector_background"),
-            "error must name the unsupported detector background, got: {err}"
-        );
+            let err = spatial_map_typed(&input, &config, None, None, None)
+                .expect_err("unsupported detector background must fail before pixel fitting");
+            assert!(
+                matches!(err, PipelineError::InvalidParameter(_)),
+                "got {err:?}"
+            );
+            assert!(
+                err.to_string().contains("non-zero detector_background"),
+                "error must name the unsupported detector background, got: {err}"
+            );
+        }
     }
 
     #[test]

--- a/crates/nereids-pipeline/src/spatial.rs
+++ b/crates/nereids-pipeline/src/spatial.rs
@@ -254,10 +254,10 @@ fn apply_spatial_polish_default(config: UnifiedFitConfig, n_pixels: usize) -> Un
 /// raised inside `fit_spectrum_typed` / `fit_transmission_poisson` /
 /// `fit_counts_joint_poisson` whose decision depends only on
 /// `(input variant, config)` — i.e. fires identically for every pixel.
-/// Per-pixel error variants (numerical fit failure, per-pixel detector
-/// background contamination on `CountsWithNuisance`) intentionally stay
-/// inside the closure where they correctly produce a NaN-only single
-/// pixel rather than a whole-map error.
+/// Per-pixel numerical fit failures intentionally stay inside the closure
+/// where they correctly produce a NaN-only single pixel rather than a
+/// whole-map error. Unsupported detector background is validated separately
+/// on every live pixel before the closure starts.
 ///
 /// The error messages here are kept byte-identical to the originating
 /// per-pixel sites so the user-facing diagnostic does not bifurcate
@@ -420,10 +420,9 @@ fn validate_spatial_fit_preflight(
     // Every gate below mirrors a per-pixel rejection in
     // `pipeline.rs::fit_counts_joint_poisson`.  All fire identically
     // across the map because they depend only on shared config flags
-    // (alpha fitting, B_A/B/C interlock, `c` value); per-pixel
-    // detector-background contamination is *not* hoisted because
-    // `CountsWithNuisance` carries per-pixel `background` slices and
-    // contamination is a legitimately per-pixel signal.
+    // (alpha fitting, B_A/B/C interlock, `c` value). Unsupported nonzero
+    // detector background is rejected across all live pixels by
+    // `validate_spatial_data_values` before any fit starts.
     if is_counts && is_kl {
         if let Some(bg) = config.counts_background() {
             if bg.fit_alpha_1 || bg.fit_alpha_2 {
@@ -753,6 +752,15 @@ fn validate_spatial_data_values(
                 live_pixels,
                 None,
             )?;
+            if live_pixels.iter().any(|&(y, x)| {
+                (0..background.shape()[0]).any(|energy| background[[energy, y, x]].abs() > 1.0e-12)
+            }) {
+                return Err(PipelineError::InvalidParameter(
+                    "joint-Poisson solver with non-zero detector_background is not yet \
+                     supported (B_det wiring is deferred)."
+                        .into(),
+                ));
+            }
         }
     }
     Ok(())
@@ -4742,9 +4750,8 @@ mod tests {
 
     #[test]
     fn test_spatial_counts_with_nuisance_rejects_nonfinite_background() {
-        // Background is validated finite (sign deferred to the per-pixel
-        // detector-background gate); this closes the `NaN.abs() > 1e-12 ==
-        // false` finiteness leak in that gate at the boundary.
+        // Background is validated finite before the nonzero-background gate;
+        // this closes the `NaN.abs() > 1e-12 == false` comparison leak.
         let energies: Vec<f64> = (0..51).map(|i| 1.0 + (i as f64) * 0.2).collect();
         for bad in [f64::NAN, f64::INFINITY] {
             let data = u238_single_resonance();
@@ -4769,6 +4776,33 @@ mod tests {
                 "error must name the background cube, got: {err}"
             );
         }
+    }
+
+    #[test]
+    fn test_spatial_counts_with_nuisance_rejects_nonzero_live_background() {
+        let data = u238_single_resonance();
+        let energies: Vec<f64> = (0..51).map(|i| 1.0 + (i as f64) * 0.2).collect();
+        let (sample, _ob) = synthetic_4x4_counts(&data, 0.0005, &energies, 1000.0);
+        let flux = Array3::from_elem((energies.len(), 4, 4), 1000.0);
+        let mut background = Array3::from_elem((energies.len(), 4, 4), 0.0);
+        background[[2, 3, 3]] = 1.0;
+        let config = kl_counts_config(energies.clone(), data);
+        let input = InputData3D::CountsWithNuisance {
+            sample_counts: sample.view(),
+            flux: flux.view(),
+            background: background.view(),
+        };
+
+        let err = spatial_map_typed(&input, &config, None, None, None)
+            .expect_err("unsupported detector background must fail before pixel fitting");
+        assert!(
+            matches!(err, PipelineError::InvalidParameter(_)),
+            "got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("non-zero detector_background"),
+            "error must name the unsupported detector background, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/nereids-pipeline/src/spatial.rs
+++ b/crates/nereids-pipeline/src/spatial.rs
@@ -1558,23 +1558,27 @@ pub fn spatial_map_typed(
         })
     });
 
-    // Precompute unbroadened (base) cross-sections for temperature fitting.
-    // This avoids 74× overhead from redundant Reich-Moore evaluation per
-    // KL iteration (112ms Reich-Moore vs 1.5ms Doppler rebroadening).
+    // A temperature fit retains the resonance source for supported SLBW/MLBW
+    // data. Cache the zero-temperature rows once only as the all-isotope
+    // fallback for unsupported formalisms; the fit model never selects these
+    // rows for an isotope covered by the continuous source evaluator.
+    let fallback_base_xs = if config.fit_temperature() && !config.has_precomputed_base_xs() {
+        Some(Arc::new(unbroadened_cross_sections(
+            config.energies(),
+            config.resonance_data(),
+            cancel,
+        )?))
+    } else {
+        None
+    };
     let fast_config = if config.fit_temperature() {
-        // Bare `?`: the `From<TransmissionError>` impl maps
-        // `TransmissionError::Cancelled` to `PipelineError::Cancelled`,
-        // keeping the documented uniform-Cancelled contract when the user
-        // cancels during this (expensive) Reich-Moore precompute.  A
-        // `.map_err(PipelineError::Transmission)` here would bypass that
-        // conversion and surface cancellation as an error.
-        let base_xs: Vec<Vec<f64>> =
-            unbroadened_cross_sections(config.energies(), config.resonance_data(), cancel)?;
         let mut cfg = config
             .clone()
             .with_precomputed_cross_sections(xs)
-            .with_precomputed_base_xs(Arc::new(base_xs))
             .with_compute_covariance(true);
+        if let Some(fallback_base_xs) = fallback_base_xs {
+            cfg = cfg.with_precomputed_fallback_base_xs(fallback_base_xs);
+        }
         if let Some(plan) = resolution_plan.clone() {
             cfg = cfg.with_precomputed_resolution_plan(plan);
         }

--- a/docs/guide/src/mcp-server.md
+++ b/docs/guide/src/mcp-server.md
@@ -104,6 +104,11 @@ delimiters. Pure JSON manifests must contain the frontmatter object directly.
 The workflow configuration may be placed under `analysis`, `workflow`, or
 `processing`; otherwise the root object is treated as the workflow.
 
+The fitting domain follows the stored data. Normalized transmission uses LM.
+Separate sample/open-beam counts use the Poisson/KL count engine. The workflow
+does not silently divide counts into transmission, and it rejects a
+Poisson/KL request for normalized transmission.
+
 Minimal single-spectrum manifest:
 
 ```markdown
@@ -208,15 +213,10 @@ Example NeXus density-map manifest:
       {"isotope": "U-238", "initial_density": 0.001}
     ],
     "fit": {
-      "solver": "lm",
+      "solver": "auto",
       "max_iter": 100
     },
-    "resolution": {
-      "kind": "gaussian",
-      "flight_path_m": 25.0,
-      "delta_t_us": 0.5,
-      "delta_l_m": 0.005
-    }
+    "resolution": {"kind": "none"}
   }
 }
 ---

--- a/docs/guide/src/physics.md
+++ b/docs/guide/src/physics.md
@@ -75,12 +75,9 @@ Standard nonlinear least-squares minimization for Gaussian-distributed data.
 
 Maximum-likelihood fitting for low-count data where Gaussian statistics break down.
 
-- Module: [`joint_poisson`](api/nereids_fitting/joint_poisson/) -- counts-domain
-  joint-Poisson fit (conditional binomial deviance); the production path for
-  counts data
-- Module: [`poisson`](api/nereids_fitting/poisson/) -- transmission-domain
-  Poisson likelihood (projected damped Gauss-Newton); used for the
-  transmission + PoissonKL combination
+- Module: [`joint_poisson`](api/nereids_fitting/joint_poisson/) -- count-domain
+  joint-Poisson fit (conditional binomial deviance) using the separate open and
+  sample count arms; the production path for counts data
 - Reference: TRINIDI approach (`trinidi/reconstruct.py`)
 
 ## ENDF Nuclear Data

--- a/docs/guide/src/python-api.md
+++ b/docs/guide/src/python-api.md
@@ -56,6 +56,10 @@ Returned by `fit_spectrum_typed(...)` and `fit_counts_spectrum_typed(...)`.
 | `iterations` | `int` | Iteration count. |
 | `temperature_k` | `float or None` | Fitted temperature when `fit_temperature=True`. |
 | `t0_us`, `l_scale` | `float or None` | Fitted energy-scale parameters when `fit_energy_scale=True`. |
+| `prediction_energies_ev` | `NDArray[float64]` | Energy coordinate for the returned fitted curve, in measured-bin order. |
+| `signal_prediction` | `NDArray[float64]` | Fitted signal after response and normalization, excluding the explicit additive background. |
+| `background_prediction` | `NDArray[float64]` | Explicit additive SAMMY background contribution. |
+| `model_prediction` | `NDArray[float64]` | Complete fitted curve; exactly `signal_prediction + background_prediction`. |
 
 ### `InputData`
 
@@ -160,6 +164,94 @@ falling outside the supplied acquisition window is not silently moved back
 into it. Both arrays are predictions for the same reference exposure. Scale
 them to the measured proton charge, live time, or other documented exposure of
 each complete acquisition before comparing them with observed counts.
+
+For repeated work, build `DetectorResponseMatrix(...)` once. Its `project(...)`
+and `apply(...)` methods reuse the compact native response, while
+`transpose_project(...)` supplies the reverse operation needed by source
+inference. `collapse_true_energy_groups(...)` pre-sums fixed quadrature points
+inside each source cell. It changes neither the quadrature nor any response
+probability; it avoids repeating the same sum during every source-optimizer
+step.
+
+## Aggregate 1D Room Calibration and Frozen Hot Fit
+
+Use `calibrate_aggregated_1d(...)` for the room run and pass its result directly
+to `fit_frozen_aggregated_1d(...)` for the hot run. The room function accepts no
+hot data, so the instrument cannot be adjusted to improve the hot result.
+
+```python
+calibration = nereids.calibrate_aggregated_1d(
+    detector_time_edges_us=detector_edges,
+    open_counts=open_counts,
+    room_counts=room_counts,
+    sample_over_open_exposure=room_charge / open_charge,
+    isotopes=[ta181],
+    room_temperature_k=room_temperature,
+    reference_flight_path_m=reference_path,
+    reference_timing_offset_us=reference_t0,
+    initial_physical_parameters=(t0_start, path_start, width_start, density_start),
+    fit_energy_range_ev=(energy_min, energy_max),
+    ic_profile=instrument_ic_profile,
+    physical_lower_bounds=(t0_min, path_min, width_min, density_min),
+    physical_upper_bounds=(t0_max, path_max, width_max, density_max),
+    debye_temperature_k=217.0,
+)
+
+hot = nereids.fit_frozen_aggregated_1d(
+    calibration,
+    hot_counts=hot_counts,
+    sample_over_open_exposure=hot_charge / open_charge,
+    initial_temperature_k=1000.0,
+    initial_density_atoms_per_barn=density_start,
+)
+```
+
+The supported calculation is:
+
+1. Integrate the analytical IC response over the actual detector-time edges
+   with a fixed 15-point rule inside every true-energy cell.
+2. Infer one nonnegative incident-source amount per cell from the open beam
+   only.
+3. Fit room timing offset, effective path, IC width scale, and material amount.
+   At each physical trial, fit the four SAMMY apparent-transmission background
+   coefficients inside that trial.
+4. Freeze the room response, source, energy interval, nuclear evaluation,
+   material model, and open-beam uncertainty.
+5. Fit only hot temperature, material amount, and the same four background
+   coefficients.
+
+`Aggregated1DFitResult` returns measured transmission, uncertainty, signal,
+background, complete model, residual, every fitted parameter, bound hits, and
+summary residual values. It returns both `poisson_uncertainty` /
+`poisson_residual` (independent count statistics) and `uncertainty` / `residual`
+(including any independently measured detector variance factors supplied by
+the caller). A notebook must not rebuild the background or fitted curve. The
+measured arrays and evaluated nuclear values are never modified. Variance
+factors must come from detector data independent of the spectrum fit; they must
+not be adjusted to improve a residual.
+
+The IC profile, fit-energy range, and physical bounds are required arguments.
+There are no hidden VENUS geometry or fit-window defaults in the generic API.
+The VENUS example uses a 4--120 eV true-energy response interval so neutrons
+outside the fit window can still migrate into measured bins, while its 8--45
+eV calibration interval is the pre-existing tantalum analysis region fixed
+before the IC comparison. Its JSON and figure report all supplied 4--120 eV
+bins as diagnostics as well as the bins that determine the fit.
+
+The public VENUS example is
+`examples/workflows/venus_aggregated_1d.py`. It uses scatter points for the
+measured spectra and lines for the fitted curves. The fixed
+`VENUS_UDR_MATCHED_IC_PROFILE` is an analytical approximation to the archived
+VENUS UDR shape; it is not a new nuclear evaluation and is not claimed to be
+more faithful than the high-fidelity UDR itself. The example's TPX1 variance
+factors were measured from the raw pixels for those exact acquisitions and are
+reported alongside the independent-Poisson residuals.
+
+Current boundary: this workflow is for one aggregated spectrum. Exact-response
+spatial fitting remains unsupported until one frozen detector response can be
+reused safely across pixels. The aggregate calibration is also not an
+interactive operation; source inference and repeated response construction are
+still the main runtime costs.
 
 ### Independently Measured Count Backgrounds
 

--- a/docs/guide/src/python-api.md
+++ b/docs/guide/src/python-api.md
@@ -82,7 +82,7 @@ Returned by `spatial_map_typed(...)`.
 | `converged_map` | `NDArray[bool_]` | Per-pixel convergence flags. |
 | `n_converged`, `n_failed`, `n_total` | `int` | Pixel fit counts. |
 | `temperature_map` | `NDArray[float64] or None` | Fitted temperature map when enabled. |
-| `temperature_uncertainty_map` | `NDArray[float64] or None` | Per-pixel 1σ temperature uncertainty (K) when `fit_temperature=True`. **Covariance-only lower bound** on the Poisson-KL / joint-Poisson paths: it captures only statistical curvature (inverse Fisher matrix), omits baseline/model noise, and on real data can underestimate the observed per-superpixel scatter by ~3–4×. Pass `scale_by_chi2=True` for a goodness-of-fit-scaled estimate: σ is multiplied by `sqrt` of the reduced χ² each pixel's result reports (Gaussian `reduced_chi_squared` on the transmission paths, `deviance_per_dof` on the counts joint-Poisson path). This inflates σ for an under-fit pixel (χ²/dof > 1) and, less commonly, shrinks it for an over-fit one (χ²/dof < 1). The flag is a no-op on the already-χ²-scaled LM transmission path. |
+| `temperature_uncertainty_map` | `NDArray[float64] or None` | Per-pixel 1σ temperature uncertainty (K) when `fit_temperature=True`. On the raw-count joint-Poisson path this is a **covariance-only lower bound**: it captures only statistical curvature (inverse Fisher matrix) and omits baseline/model noise. Pass `scale_by_chi2=True` to multiply it by the square root of `deviance_per_dof`. The flag is a no-op on the LM transmission path, which already scales covariance by reduced chi-squared. |
 | `anorm_map`, `background_maps` | `NDArray[float64] / list[...] or None` | SAMMY `Anorm` and the polynomial background `[BackA, BackB, BackC]` per pixel when `background=True`. |
 | `back_d_map`, `back_f_map` | `NDArray[float64] or None` | SAMMY exponential background `BackD` / `BackF` per pixel when `background=True` and `fit_back_d=True` / `fit_back_f=True`. Counts-KL spatial runs always return `None` for both (the joint-Poisson dispatch never fits the exponential tail). |
 | `t0_us_map`, `l_scale_map` | `NDArray[float64] or None` | Energy-scale maps when enabled. |
@@ -199,14 +199,16 @@ Background placement is part of the model, not a scripting choice:
 | Sample scattering measured directly in detector-time bins under independently documented conditions | Add after the neutron response as a detector-bin template. |
 | SAMMY-style transmission baseline/background | Use the separate transmission model; it is not accepted as a count template by this API. |
 
-The older fitting routes remain separate:
+The supported fit matrix is explicit:
 
-| Fitting route | Current background behavior |
-|---------------|-----------------------------|
-| Transmission with LM or KL | `background=True` fits the SAMMY-style transmission model. |
-| Counts with KL | `background=True` also fits a SAMMY-style change to transmission inside the count likelihood; this is not a detector-count background. |
-| Counts with a nonzero `detector_background` argument | The production fit currently rejects this input because its detector-background scale is not wired into the joint count likelihood. It is not silently substituted with the SAMMY model. |
-| Exact two-arm response shown above | `fit_two_arm_background_templates(...)` fits independently supplied detector-bin templates while holding the neutron signal fixed. Joint fitting with nuclear or calibration parameters is deliberately deferred until the parameter-separation checks are complete. |
+| Data | Engine | Decision and background behavior |
+|------|--------|----------------------------------|
+| Pre-normalized transmission | LM least squares | Supported. `background=True` fits the SAMMY apparent-transmission curve. Resolution on this route is a ratio-level approximation because the separate count arms are unavailable. |
+| Pre-normalized transmission | Poisson/KL | Rejected: a fractional ratio is not a Poisson count and its supplied uncertainty would be ignored. |
+| Separate open/sample counts | Poisson/KL | Supported. With a detector response, the exact source weights and detector-time edges are required. `background=True` applies the SAMMY curve to measured apparent transmission after the two-arm detector calculation. |
+| Separate open/sample counts | LM least squares | Rejected: silently dividing the arms loses the open-beam count uncertainty. |
+| Count data with detector/gamma templates | Fixed-signal count-template fit | Supported by `fit_two_arm_background_templates(...)`. The template fit is deliberately separate from nuclear/calibration fitting; a nonzero `detector_background` on the main fitter is rejected rather than misinterpreted. |
+| Spatial count cube with detector response | Any | Not yet supported: the spatial API does not carry the exact source/time inputs and does not yet cache one fixed detector matrix for all pixels. |
 
 `TwoArmBackgroundFitResult` reports `names`, `amplitudes`, optional local
 `amplitude_uncertainties`, `amplitudes_identifiable`, the
@@ -246,7 +248,7 @@ Keyword arguments:
 | `temperature_k=293.6` | Sample temperature in kelvin. |
 | `fit_temperature=False` | Fit sample temperature in addition to densities. |
 | `max_iter=200` | Maximum optimizer iterations. |
-| `solver="lm"` | `"lm"`, `"kl"`, `"auto"`, `"poisson"`, or `"joint_poisson"`. `"poisson"` and `"joint_poisson"` are aliases used by the counts dispatch and accepted here for symmetry. |
+| `solver="lm"` | `"lm"` or `"auto"` for normalized transmission. Poisson/KL names are rejected because transmission ratios are not Poisson counts. |
 | `background=False` | Enable SAMMY-style transmission background parameters. |
 | `fit_back_d=False`, `fit_back_f=False` | Fit optional exponential background terms. |
 | `back_d_init=0.01`, `back_f_init=1.0` | Initial exponential background values. |
@@ -279,12 +281,18 @@ counts have different proton charge or dwell-time normalization. The primary
 GOF for this path is `FitResult.deviance_per_dof`.
 
 Counts fitting accepts temperature, isotope groups, energy-scale calibration,
-and `fit_energy_range`. It does not currently accept every transmission option:
-the production counts route rejects a nonzero `detector_background`, fitted
-counts nuisance factors, and an instrument-resolution argument instead of
-silently routing them through a different model. The exact two-arm APIs above
-provide the validated response and detector-bin background operations while
-their joint calibration is being checked. Counts-specific options are:
+and `fit_energy_range` when no detector response is active. Resolved counts use
+the exact two-arm model by supplying `resolution`, `incident_fluence_weights`,
+and `detector_time_edges_us` together. `energies` is then the true-energy
+quadrature and may have a different length from the measured count arrays. The
+fit evaluates `response(flux * transmission) / response(flux)`; it never uses
+the post-hoc shortcut `response(transmission)`. Energy-scale fitting and an
+energy fit window are rejected on this two-axis route until the detector clock
+is fitted consistently.
+
+The production counts route still rejects a nonzero `detector_background` and
+fitted count nuisance factors. Use the independently measured template API
+above for those backgrounds. Counts-specific options are:
 
 | Option | Meaning |
 |--------|---------|
@@ -292,6 +300,10 @@ their joint calibration is being checked. Counts-specific options are:
 | `fit_alpha_1=False`, `fit_alpha_2=False` | Research-only flags. The production fit rejects enabling them. |
 | `alpha_1_init=1.0`, `alpha_2_init=1.0` | Research-only initial values; they do not enable nuisance fitting in the production route. |
 | `c=1.0` | Proton-charge ratio `Q_s / Q_ob`. |
+| `resolution=...` | Exact detector-time response (`TabulatedResolution` or `IkedaCarpenter`); requires the two arrays below. |
+| `incident_fluence_weights=...` | Incident fluence integrated over the true-energy quadrature. |
+| `detector_time_edges_us=...` | Measured detector-time edges; length is `len(sample_counts) + 1`. |
+| `timing_offset_us=0.0` | Fixed detector-clock offset used by the response. |
 | `enable_polish=True/False/None` | Override counts-KL polish behavior; `None` uses the dispatcher default. |
 
 ## Spatial Mapping
@@ -309,11 +321,10 @@ result = nereids.spatial_map_typed(
 )
 ```
 
-For `from_transmission(...)` inputs the default `solver="lm"` and `solver="auto"`
-both route to LM (this is the dispatcher contract in `__init__.pyi`:
-"`from_transmission + solver="lm"` (default for transmission) → LM"). The
-explicit `solver="kl"` opt-in for `from_transmission` runs the legacy
-Poisson-NLL-on-transmission path. `density_maps[0]` is the fitted U-238 map.
+For `from_transmission(...)` inputs, `solver="lm"` and `solver="auto"` both
+route to LM. Poisson/KL solver names are rejected because the normalized ratio
+no longer contains the separate open and sample count arms.
+`density_maps[0]` is the fitted U-238 map.
 
 ### Raw Count Cubes
 

--- a/docs/guide/src/python-api.md
+++ b/docs/guide/src/python-api.md
@@ -138,6 +138,85 @@ input energy grid. Pass either `isotopes=[(ResonanceData, density), ...]` or
 enabled by the `flight_path_m`, `delta_t_us`, and `delta_l_m` parameters.
 Tabulated resolution can be supplied with `resolution=load_resolution(...)`.
 
+### Exact Two-Arm Count Response
+
+```python
+open_signal, sample_signal = nereids.two_arm_count_response(
+    true_energies_ev,
+    incident_fluence_weights,
+    transmission,
+    detector_time_edges_us,
+    resolution,
+)
+```
+
+`two_arm_count_response(...)` applies the instrument response separately to
+the incident spectrum and to the attenuated sample spectrum. It returns the
+numerator and denominator needed to form the physical ratio
+`response(flux * transmission) / response(flux)` without broadening a
+transmission ratio directly. The fluence array must already include the
+energy-integration weights. The result uses detector-time bins; probability
+falling outside the supplied acquisition window is not silently moved back
+into it. Both arrays are predictions for the same reference exposure. Scale
+them to the measured proton charge, live time, or other documented exposure of
+each complete acquisition before comparing them with observed counts.
+
+### Independently Measured Count Backgrounds
+
+```python
+background_fit = nereids.fit_two_arm_background_templates(
+    observed_open_counts,
+    observed_sample_counts,
+    open_signal,
+    sample_signal,
+    open_exposure_scale,
+    sample_exposure_scale,
+    ["blocked_beam"],
+    open_background_templates,
+    sample_background_templates,
+    initial_amplitudes,
+)
+```
+
+Each row of the two template matrices is a fixed detector-bin shape from an
+independent measurement such as blocked-beam or detector-only data. NEREIDS
+fits only a non-negative amplitude and returns all three pieces for each arm:
+the fixed neutron signal, the fitted background, and their exact total. This
+count background is added after the neutron response and is not the SAMMY
+transmission background. The code does not generate a flexible residual curve
+or establish template provenance; callers must retain the independent source
+record. `open_exposure_scale` and `sample_exposure_scale` are required: they
+convert the common reference neutron signal to the proton charge, live time, or
+other documented exposure of each complete acquisition. A missing exposure
+correction can otherwise be falsely absorbed by an additive background.
+
+Background placement is part of the model, not a scripting choice:
+
+| Background source | Required input to this API |
+|-------------------|----------------------------|
+| Detector dark counts, gamma counts, or a blocked-beam reference measured in detector-time bins | Add after the neutron response as a detector-bin template. |
+| Sample scattering calculated as a function of true neutron energy | Pass through the instrument response first; only its resulting detector-bin template is fitted here. |
+| Sample scattering measured directly in detector-time bins under independently documented conditions | Add after the neutron response as a detector-bin template. |
+| SAMMY-style transmission baseline/background | Use the separate transmission model; it is not accepted as a count template by this API. |
+
+The older fitting routes remain separate:
+
+| Fitting route | Current background behavior |
+|---------------|-----------------------------|
+| Transmission with LM or KL | `background=True` fits the SAMMY-style transmission model. |
+| Counts with KL | `background=True` also fits a SAMMY-style change to transmission inside the count likelihood; this is not a detector-count background. |
+| Counts with a nonzero `detector_background` argument | The production fit currently rejects this input because its detector-background scale is not wired into the joint count likelihood. It is not silently substituted with the SAMMY model. |
+| Exact two-arm response shown above | `fit_two_arm_background_templates(...)` fits independently supplied detector-bin templates while holding the neutron signal fixed. Joint fitting with nuclear or calibration parameters is deliberately deferred until the parameter-separation checks are complete. |
+
+`TwoArmBackgroundFitResult` reports `names`, `amplitudes`, optional local
+`amplitude_uncertainties`, `amplitudes_identifiable`, the
+signal/background/total arrays for both arms, `poisson_deviance`,
+`deviance_per_dof`, `converged`, and `iterations`. If
+`amplitudes_identifiable` is false, two or more supplied shapes cannot be
+separated: the summed background and total prediction remain usable, but the
+individual named amounts are arbitrary and their uncertainties are returned as
+`NaN`.
+
 ## Single-Spectrum Fitting
 
 ### Transmission Data
@@ -199,15 +278,19 @@ data to the counts-KL dispatch. Use `c=Q_s / Q_ob` when sample and open-beam
 counts have different proton charge or dwell-time normalization. The primary
 GOF for this path is `FitResult.deviance_per_dof`.
 
-Counts fitting accepts the same temperature, background, group, resolution,
-energy-scale, and `fit_energy_range` options as transmission fitting. Counts
-specific options are:
+Counts fitting accepts temperature, isotope groups, energy-scale calibration,
+and `fit_energy_range`. It does not currently accept every transmission option:
+the production counts route rejects a nonzero `detector_background`, fitted
+counts nuisance factors, and an instrument-resolution argument instead of
+silently routing them through a different model. The exact two-arm APIs above
+provide the validated response and detector-bin background operations while
+their joint calibration is being checked. Counts-specific options are:
 
 | Option | Meaning |
 |--------|---------|
-| `detector_background=...` | Optional 1D detector background spectrum; required when `fit_alpha_2=True`. |
-| `fit_alpha_1=False`, `fit_alpha_2=False` | Fit counts-domain nuisance/background terms. |
-| `alpha_1_init=1.0`, `alpha_2_init=1.0` | Initial nuisance/background values. |
+| `detector_background=...` | Reserved compatibility input. The production fit rejects nonzero values; use `fit_two_arm_background_templates(...)` for independently supplied detector-bin shapes. |
+| `fit_alpha_1=False`, `fit_alpha_2=False` | Research-only flags. The production fit rejects enabling them. |
+| `alpha_1_init=1.0`, `alpha_2_init=1.0` | Research-only initial values; they do not enable nuisance fitting in the production route. |
 | `c=1.0` | Proton-charge ratio `Q_s / Q_ob`. |
 | `enable_polish=True/False/None` | Override counts-KL polish behavior; `None` uses the dispatcher default. |
 

--- a/docs/guide/src/resolution-calibration.md
+++ b/docs/guide/src/resolution-calibration.md
@@ -13,6 +13,15 @@ This page covers (1) the three resolution models NEREIDS provides and (2) the
 **calibrate → pin → fit** procedure that determines the resolution from a known
 standard.
 
+For separate open/sample counts from an aggregate detector ROI, use the
+supported `calibrate_aggregated_1d(...)` then
+`fit_frozen_aggregated_1d(...)` workflow described in the
+[Python API reference](python-api.md#aggregate-1d-room-calibration-and-frozen-hot-fit).
+It applies the response to the two count arms separately and returns the full
+signal/background/model curve. The older `calibrate_resolution(...)` API below
+fits a normalized transmission spectrum and remains the supported route when
+the separate count arms are unavailable.
+
 ## The three resolution models
 
 All three are passed to [`forward_model`](./python-api.md) and the fitters the

--- a/examples/workflows/venus_aggregated_1d.py
+++ b/examples/workflows/venus_aggregated_1d.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Run the supported VENUS room-calibration then frozen-hot workflow.
+
+The input NPZ follows the documented VENUS aggregate export keys.  This file
+contains input loading and plotting only; response construction, source
+inference, background fitting, room calibration, curve assembly, and the hot
+fit are all library calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import nereids
+
+
+REFERENCE_T0_US = 1.0212486261382638
+REFERENCE_PATH_M = 25.0 * 1.0008178597256119
+
+# The starting point came from the earlier VENUS UDR calibration.  It is only
+# an optimizer start; the room data determine the returned calibration.
+ROOM_PHYSICAL_START = (0.742117988, 25.0745433, 0.946344901, 0.000826583693)
+ROOM_BACKGROUND_START = (0.826764552, 0.157084784, -0.134339595, 0.00128658541)
+RESPONSE_ENERGY_RANGE_EV = (4.0, 120.0)
+FIT_ENERGY_RANGE_EV = (8.0, 45.0)
+
+# These three factors were measured from the raw TPX1 pixel covariance for
+# these exact open, room, and hot runs. They account for correlated detector
+# hits and were fixed before the spectrum fit; they are not residual-tuning
+# parameters. Use 1.0 for independent Poisson counts or supply factors measured
+# independently for a different ROI or acquisition.
+OPEN_VARIANCE_FACTOR = 3.819301921170809
+ROOM_VARIANCE_FACTOR = 3.5796759175
+HOT_VARIANCE_FACTOR = 3.7197893500316446
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--region-counts", type=Path, required=True)
+    parser.add_argument("--jendl-ta181", type=Path, required=True)
+    parser.add_argument("--output-json", type=Path, required=True)
+    parser.add_argument("--output-figure", type=Path, required=True)
+    factor_help = (
+        "independently measured variance factor for this acquisition; "
+        "use 1.0 for independent Poisson counts"
+    )
+    parser.add_argument(
+        "--open-variance-factor", type=float, default=OPEN_VARIANCE_FACTOR, help=factor_help
+    )
+    parser.add_argument(
+        "--room-variance-factor", type=float, default=ROOM_VARIANCE_FACTOR, help=factor_help
+    )
+    parser.add_argument(
+        "--hot-variance-factor", type=float, default=HOT_VARIANCE_FACTOR, help=factor_help
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    def report(stage: str, values: dict[str, float]) -> None:
+        summary = " ".join(f"{name}={value:.7g}" for name, value in values.items())
+        print(f"[{stage}] {summary}", flush=True)
+
+    with np.load(args.region_counts, allow_pickle=False) as data:
+        selected_edges, _, selected = nereids.select_energy_ordered_detector_bins(
+            data["edges"],
+            data["energies"],
+            (data["counts_ob"], data["counts_calib"], data["counts_sample"]),
+            RESPONSE_ENERGY_RANGE_EV,
+        )
+        open_counts, room_counts, hot_counts = selected
+        room_exposure = float(data["pc_calib"] / data["pc_ob"])
+        hot_exposure = float(data["pc_sample"] / data["pc_ob"])
+        room_temperature_k = float(data["T_calib_k"])
+
+    isotope = nereids.load_endf_file(str(args.jendl_ta181))
+    calibration = nereids.calibrate_aggregated_1d(
+        detector_time_edges_us=selected_edges,
+        open_counts=open_counts,
+        room_counts=room_counts,
+        sample_over_open_exposure=room_exposure,
+        isotopes=[isotope],
+        room_temperature_k=room_temperature_k,
+        reference_flight_path_m=REFERENCE_PATH_M,
+        reference_timing_offset_us=REFERENCE_T0_US,
+        initial_physical_parameters=ROOM_PHYSICAL_START,
+        fit_energy_range_ev=FIT_ENERGY_RANGE_EV,
+        ic_profile=nereids.VENUS_UDR_MATCHED_IC_PROFILE,
+        physical_lower_bounds=(-5.0, 24.5, 0.2, 0.0),
+        physical_upper_bounds=(5.0, 25.5, 5.0, 0.01),
+        initial_background_parameters=ROOM_BACKGROUND_START,
+        debye_temperature_k=217.0,
+        physical_scale=(1.0, 0.05, 0.5, 0.00070374),
+        open_variance_factor=args.open_variance_factor,
+        room_variance_factor=args.room_variance_factor,
+        progress=report,
+    )
+    hot = nereids.fit_frozen_aggregated_1d(
+        calibration,
+        hot_counts=hot_counts,
+        sample_over_open_exposure=hot_exposure,
+        initial_temperature_k=1000.0,
+        initial_density_atoms_per_barn=0.00070374,
+        hot_variance_factor=args.hot_variance_factor,
+        progress=report,
+    )
+
+    def metrics(fit: nereids.Aggregated1DFitResult) -> dict[str, object]:
+        active = fit.fit_mask
+        return {
+            "parameters": fit.parameters,
+            "converged": fit.converged,
+            "bound_hits": list(fit.bound_hits),
+            "fit_energy_range_ev": list(fit.fit_energy_range_ev),
+            "fit_bins": int(np.count_nonzero(active)),
+            "supplied_bins": int(active.size),
+            "fit_max_abs_residual": fit.max_abs_residual,
+            "fit_rms_residual": fit.rms_residual,
+            "fit_poisson_max_abs_residual": float(
+                np.max(np.abs(fit.poisson_residual[active]))
+            ),
+            "fit_poisson_rms_residual": float(
+                np.sqrt(np.mean(fit.poisson_residual[active] ** 2))
+            ),
+            "all_supplied_max_abs_residual": float(np.max(np.abs(fit.residual))),
+            "all_supplied_rms_residual": float(
+                np.sqrt(np.mean(fit.residual**2))
+            ),
+            "all_supplied_poisson_max_abs_residual": float(
+                np.max(np.abs(fit.poisson_residual))
+            ),
+            "all_supplied_poisson_rms_residual": float(
+                np.sqrt(np.mean(fit.poisson_residual**2))
+            ),
+            "fit_bins_above_five": fit.bins_above_five,
+        }
+
+    payload = {
+        "provenance": {
+            "response_energy_range_ev": list(RESPONSE_ENERGY_RANGE_EV),
+            "fit_energy_range_ev": list(FIT_ENERGY_RANGE_EV),
+            "fit_range_origin": (
+                "pre-existing VENUS tantalum calibration region fixed before the "
+                "IC comparison; all supplied response-support bins are also reported"
+            ),
+            "variance_factors": {
+                "open": calibration.fit.open_variance_factor,
+                "room": calibration.fit.sample_variance_factor,
+                "hot": hot.sample_variance_factor,
+                "origin": (
+                    "measured from raw TPX1 pixel correlations for these exact "
+                    "acquisitions before the spectrum fit"
+                ),
+            },
+        },
+        "room": metrics(calibration.fit),
+        "hot": metrics(hot),
+    }
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+    figure, axes = plt.subplots(
+        2,
+        2,
+        figsize=(16, 9),
+        sharex="col",
+        gridspec_kw={"height_ratios": [3.0, 1.0]},
+        constrained_layout=True,
+    )
+    fits = (("Room calibration", calibration.fit), ("Frozen hot fit", hot))
+    for column, (label, fit) in enumerate(fits):
+        active = fit.fit_mask
+        inactive = ~active
+        axes[0, column].scatter(
+            fit.energy_ev[inactive],
+            fit.measured_transmission[inactive],
+            s=5,
+            alpha=0.2,
+            color="gray",
+            label="supplied, diagnostic only",
+        )
+        axes[0, column].scatter(
+            fit.energy_ev[active],
+            fit.measured_transmission[active],
+            s=7,
+            alpha=0.65,
+            color="black",
+            label="measured in fit window",
+        )
+        axes[0, column].plot(
+            fit.energy_ev,
+            fit.model_prediction,
+            color="tab:red",
+            linewidth=1.4,
+            label="NEREIDS",
+        )
+        axes[0, column].set_title(
+            f"{label}, {fit.fit_energy_range_ev[0]:g}–{fit.fit_energy_range_ev[1]:g} eV fit: "
+            f"max |residual|={fit.max_abs_residual:.3f}, RMS={fit.rms_residual:.3f}"
+        )
+        axes[0, column].set_ylabel("Transmission")
+        axes[0, column].legend()
+        axes[1, column].scatter(
+            fit.energy_ev[inactive],
+            fit.poisson_residual[inactive],
+            s=5,
+            alpha=0.12,
+            color="gray",
+            label="outside fit window",
+        )
+        axes[1, column].scatter(
+            fit.energy_ev[active],
+            fit.poisson_residual[active],
+            s=7,
+            alpha=0.35,
+            color="tab:orange",
+            label="independent-Poisson",
+        )
+        axes[1, column].scatter(
+            fit.energy_ev[active],
+            fit.residual[active],
+            s=7,
+            alpha=0.7,
+            color="tab:blue",
+            label="measured TPX1 covariance",
+        )
+        axes[1, column].axhline(0.0, color="black", linewidth=1.0)
+        axes[1, column].axhline(5.0, color="gray", linestyle="--", linewidth=1.0)
+        axes[1, column].axhline(-5.0, color="gray", linestyle="--", linewidth=1.0)
+        axes[1, column].set_xlabel("Energy (eV)")
+        axes[1, column].set_ylabel("Residual")
+        axes[1, column].legend()
+    args.output_figure.parent.mkdir(parents=True, exist_ok=True)
+    figure.savefig(args.output_figure, dpi=180)
+    plt.close(figure)
+    print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ keywords = [
   "cross-section",
   "spectroscopy",
 ]
-dependencies = ["numpy>=1.26"]
+dependencies = ["numpy>=1.26", "scipy>=1.12"]
 
 [project.urls]
 Homepage = "https://github.com/ornlneutronimaging/NEREIDS"

--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -69,7 +69,9 @@ a maintainer task.
 
 Aggregated (full-frame-summed) VENUS Hf 120 min spectrum used by the
 real-data regression gates in `tests/test_nereids.py`
-(`TestVenusMlbwRegression` — one LM/MLBW gate and one counts-KL gate).
+(`TestVenusMlbwRegression` — one LM/MLBW numerical gate and one gate proving
+that resolved counts fail closed when the source weights and detector-time
+edges required by the exact two-arm optimizer are omitted).
 Contents: `energies_ev` (7–200 eV window, ascending), `sample_counts`
 and `open_beam_counts` (full-frame pixel sums over the cube), and
 `pc_ratio` (the proton-charge ratio `c = Q_s / Q_ob`, ≈ 5.98). Same

--- a/tests/test_aggregated_1d.py
+++ b/tests/test_aggregated_1d.py
@@ -1,0 +1,253 @@
+"""Public aggregate 1D calibration-to-hot-fit workflow regression."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+import nereids
+
+
+def _kronrod_cells(energy_edges: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    positive_nodes = np.array(
+        [
+            0.9914553711208126,
+            0.9491079123427585,
+            0.8648644233597691,
+            0.7415311855993945,
+            0.5860872354676911,
+            0.4058451513773972,
+            0.2077849550078985,
+        ]
+    )
+    positive_weights = np.array(
+        [
+            0.02293532201052922,
+            0.06309209262997855,
+            0.1047900103222502,
+            0.1406532597155259,
+            0.1690047266392679,
+            0.1903505780647854,
+            0.2044329400752989,
+        ]
+    )
+    nodes = np.concatenate((-positive_nodes, [0.0], positive_nodes[::-1]))
+    weights = np.concatenate(
+        (positive_weights, [0.2094821410847278], positive_weights[::-1])
+    )
+    order = np.argsort(nodes)
+    lower = energy_edges[:-1, None]
+    upper = energy_edges[1:, None]
+    points = 0.5 * (
+        (upper - lower) * nodes[order][None, :] + upper + lower
+    )
+    normalized = np.broadcast_to(0.5 * weights[order][None, :], points.shape)
+    return np.ascontiguousarray(points), np.ascontiguousarray(normalized)
+
+
+def test_room_calibration_then_frozen_hot_fit_uses_public_api_only():
+    flight_path_m = 25.0
+    timing_offset_us = 0.7
+    n_bins = 18
+    detector_edges = np.linspace(
+        nereids.energy_to_tof(9.0, flight_path_m) + timing_offset_us,
+        nereids.energy_to_tof(5.0, flight_path_m) + timing_offset_us,
+        n_bins + 1,
+    )
+    energy_edges = np.array(
+        [
+            nereids.tof_to_energy(time - timing_offset_us, flight_path_m)
+            for time in detector_edges[::-1]
+        ]
+    )
+    points, weights = _kronrod_cells(energy_edges)
+    profile = nereids.IcShapeProfile(
+        alpha_sqrt_coefficient=0.0,
+        alpha_offset=4.0,
+        beta_sqrt_coefficient=0.0,
+        beta_offset=0.5,
+        slow_fraction=0.0,
+        channel_fwhm_us=0.0,
+        synthesis_energies=16,
+        synthesis_times=200,
+    )
+    mean_delay_us = 3.0 / profile.alpha_offset
+    effective_path_m = flight_path_m + mean_delay_us / nereids.energy_to_tof(
+        profile.pivot_energy_ev, 1.0
+    )
+    physical_parameters = np.array(
+        [timing_offset_us, effective_path_m, 1.0, 7.0e-4]
+    )
+    response = nereids.IkedaCarpenter(
+        flight_path_m=flight_path_m,
+        e_min_ev=float(energy_edges[0] * (1.0 - 1.0e-12)),
+        e_max_ev=float(energy_edges[-1] * (1.0 + 1.0e-12)),
+        alpha=nereids.EnergyLaw.const(4.0),
+        beta=0.5,
+        r=nereids.EnergyLaw.const(0.0),
+        n_energies=profile.synthesis_energies,
+        n_tau=profile.synthesis_times,
+        channel_fwhm_us=0.0,
+    )
+    isotope = nereids.create_resonance_data(
+        73,
+        181,
+        179.0,
+        7.0,
+        [(6.2, 0.08, 0.02, 0.04), (7.7, 0.12, 0.03, 0.05)],
+    )
+    room_sigma = np.asarray(
+        nereids.precompute_cross_sections(
+            points.ravel(), [isotope], temperature_k=300.0
+        )[0]
+    ).reshape(points.shape)
+    matrix = nereids.DetectorResponseMatrix(
+        points.ravel(), detector_edges, response, timing_offset_us
+    )
+    source = 1.0e6 * (1.0 + 0.1 * np.linspace(-1.0, 1.0, n_bins))
+    integrated_source = np.repeat(source, points.shape[1]) * weights.ravel()
+    open_counts = np.asarray(matrix.project(integrated_source))[::-1]
+    room_counts = np.asarray(
+        matrix.project(
+            integrated_source
+            * np.exp(-physical_parameters[3] * room_sigma.ravel())
+        )
+    )[::-1]
+    original_room = room_counts.copy()
+    original_open = open_counts.copy()
+
+    calibration = nereids.calibrate_aggregated_1d(
+        detector_time_edges_us=detector_edges,
+        open_counts=open_counts,
+        room_counts=room_counts,
+        sample_over_open_exposure=1.0,
+        isotopes=[isotope],
+        room_temperature_k=300.0,
+        reference_flight_path_m=flight_path_m,
+        reference_timing_offset_us=timing_offset_us,
+        initial_physical_parameters=physical_parameters,
+        fit_energy_range_ev=(5.1, 8.9),
+        ic_profile=profile,
+        physical_lower_bounds=(0.4, effective_path_m - 0.06, 0.8, 5.0e-4),
+        physical_upper_bounds=(1.0, effective_path_m + 0.06, 1.2, 9.0e-4),
+        background_lower_bounds=(0.9, -1.0e-6, -1.0e-6, -1.0e-6),
+        background_upper_bounds=(1.1, 1.0e-6, 1.0e-6, 1.0e-6),
+        outer_max_evaluations=8,
+        inner_max_evaluations=30,
+        source_max_iterations=500,
+    )
+
+    assert calibration.source.converged
+    assert calibration.fit.converged
+    np.testing.assert_array_equal(room_counts, original_room)
+    assert not np.shares_memory(calibration.source.observed_open_counts, open_counts)
+    open_counts[:] = 1.0
+    np.testing.assert_array_equal(
+        calibration.source.observed_open_counts, original_open
+    )
+    np.testing.assert_allclose(
+        calibration.fit.signal_prediction
+        + calibration.fit.background_prediction,
+        calibration.fit.model_prediction,
+        rtol=0.0,
+        atol=0.0,
+    )
+    np.testing.assert_allclose(calibration.fit.poisson_uncertainty, calibration.fit.uncertainty)
+    np.testing.assert_allclose(calibration.fit.poisson_residual, calibration.fit.residual)
+    assert calibration.fit.fit_energy_range_ev == (5.1, 8.9)
+    assert calibration.fit.open_variance_factor == 1.0
+    assert calibration.fit.sample_variance_factor == 1.0
+    assert calibration.fit.rms_residual < 2.0e-4
+    assert calibration.fit.parameters["density_atoms_per_barn"] == pytest.approx(
+        physical_parameters[3], abs=2.0e-7
+    )
+
+    hot_temperature_k = 700.0
+    hot_density = 7.5e-4
+    hot_sigma = np.asarray(
+        nereids.precompute_cross_sections(
+            points.ravel(), [isotope], temperature_k=hot_temperature_k
+        )[0]
+    ).reshape(points.shape)
+    hot_counts = np.asarray(
+        matrix.project(integrated_source * np.exp(-hot_density * hot_sigma.ravel()))
+    )[::-1]
+    original_hot = hot_counts.copy()
+    hot = nereids.fit_frozen_aggregated_1d(
+        calibration,
+        hot_counts=hot_counts,
+        sample_over_open_exposure=1.0,
+        initial_temperature_k=650.0,
+        initial_density_atoms_per_barn=7.0e-4,
+        temperature_bounds_k=(100.0, 1200.0),
+        density_bounds_atoms_per_barn=(1.0e-4, 2.0e-3),
+        background_lower_bounds=(0.9, -1.0e-6, -1.0e-6, -1.0e-6),
+        background_upper_bounds=(1.1, 1.0e-6, 1.0e-6, 1.0e-6),
+        max_evaluations=12,
+    )
+
+    np.testing.assert_array_equal(hot_counts, original_hot)
+    np.testing.assert_allclose(
+        hot.signal_prediction + hot.background_prediction,
+        hot.model_prediction,
+        rtol=0.0,
+        atol=0.0,
+    )
+    np.testing.assert_allclose(hot.poisson_uncertainty, hot.uncertainty)
+    np.testing.assert_allclose(hot.poisson_residual, hot.residual)
+    assert hot.fit_energy_range_ev == calibration.fit.fit_energy_range_ev
+    assert hot.parameters["temperature_k"] == pytest.approx(hot_temperature_k, abs=0.2)
+    assert hot.parameters["density_atoms_per_barn"] == pytest.approx(
+        hot_density, abs=2.0e-7
+    )
+    assert hot.rms_residual < 2.0e-3
+
+    failed_source = replace(calibration.source, converged=False)
+    failed_calibration = replace(calibration, source=failed_source)
+    with pytest.raises(RuntimeError, match="non-converged open-beam source"):
+        nereids.fit_frozen_aggregated_1d(
+            failed_calibration,
+            hot_counts=hot_counts,
+            sample_over_open_exposure=1.0,
+            initial_temperature_k=650.0,
+            initial_density_atoms_per_barn=7.0e-4,
+        )
+
+
+def test_source_iteration_limit_must_be_positive():
+    with pytest.raises(ValueError, match="source_max_iterations must be a positive integer"):
+        nereids.calibrate_aggregated_1d(
+            detector_time_edges_us=np.array([1.0, 2.0]),
+            open_counts=np.array([10.0]),
+            room_counts=np.array([9.0]),
+            sample_over_open_exposure=1.0,
+            isotopes=[object()],
+            room_temperature_k=300.0,
+            reference_flight_path_m=25.0,
+            reference_timing_offset_us=0.0,
+            initial_physical_parameters=(0.0, 25.0, 1.0, 1.0e-3),
+            fit_energy_range_ev=(1.0, 2.0),
+            ic_profile=nereids.VENUS_UDR_MATCHED_IC_PROFILE,
+            physical_lower_bounds=(-1.0, 24.0, 0.5, 0.0),
+            physical_upper_bounds=(1.0, 26.0, 2.0, 0.01),
+            source_max_iterations=0,
+        )
+
+
+def test_debye_effective_temperature_matches_solid_tantalum_reference():
+    observed = nereids.solid_debye_effective_temperature(300.82681290235263, 217.0)
+    assert observed == pytest.approx(308.60538943915935, rel=2.0e-14)
+
+
+def test_profiled_two_arm_residual_is_zero_at_observed_ratio():
+    open_counts = np.array([100.0, 150.0, 200.0])
+    sample_counts = np.array([40.0, 90.0, 160.0])
+    exposure = 0.8
+    ratio = sample_counts / open_counts / exposure
+    residual = nereids.profiled_two_arm_residual(
+        open_counts, sample_counts, exposure, ratio
+    )
+    np.testing.assert_allclose(residual, 0.0, atol=2.0e-7)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -452,6 +452,38 @@ class TestManifestWorkflowTools:
         assert result["success"] is False
         assert "raw count input cannot be fit in the transmission domain" in result["error"]
 
+    def test_count_spectrum_rejects_lm_in_count_domain(self, tmp_path, monkeypatch):
+        np.savez(
+            tmp_path / "counts.npz",
+            energies_ev=np.linspace(1.0, 30.0, 20),
+            sample_counts=np.full(20, 900.0),
+            open_beam_counts=np.full(20, 1000.0),
+        )
+        fitter_called = False
+
+        def forbidden_count_fit(**_kwargs):
+            nonlocal fitter_called
+            fitter_called = True
+            raise AssertionError("invalid counts + LM route reached the fitter")
+
+        monkeypatch.setattr(nereids, "fit_counts_spectrum_typed", forbidden_count_fit)
+        _write_json_frontmatter_manifest(
+            tmp_path,
+            {
+                "mode": "single_spectrum",
+                "data": {"kind": "counts_npz", "path": "counts.npz"},
+                "isotopes": [_synthetic_u238_entry()],
+                "fit": {"solver": "lm", "max_iter": 5},
+                "resolution": {"kind": "none"},
+            },
+        )
+
+        result = process_resonance_dataset(str(tmp_path))
+
+        assert result["success"] is False
+        assert "raw count input cannot use solver='lm'" in result["error"]
+        assert fitter_called is False
+
     def test_process_density_map_manifest(self, tmp_path):
         energies = np.linspace(1.0, 30.0, 120)
         true_density = 0.002

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -693,6 +693,67 @@ class TestManifestWorkflowTools:
         assert result["success"] is False
         assert "single_spectrum workflow requires data.path" in result["validation"]["errors"]
 
+    def test_validate_and_dry_run_reject_counts_with_active_resolution(self, tmp_path):
+        np.savez(
+            tmp_path / "counts.npz",
+            energies_ev=np.linspace(1.0, 30.0, 20),
+            sample_counts=np.full(20, 900.0),
+            open_beam_counts=np.full(20, 1000.0),
+        )
+        _write_json_frontmatter_manifest(
+            tmp_path,
+            {
+                "mode": "single_spectrum",
+                "data": {"kind": "counts_npz", "path": "counts.npz"},
+                "isotopes": [_synthetic_u238_entry()],
+                "fit": {"solver": "poisson_kl", "max_iter": 5},
+                "resolution": {
+                    "kind": "gaussian",
+                    "flight_path_m": 25.0,
+                    "delta_t_us": 1.0,
+                    "delta_l_m": 0.01,
+                },
+            },
+        )
+
+        validation = validate_resonance_dataset(str(tmp_path))
+        dry_run = process_resonance_dataset(str(tmp_path), dry_run=True)
+
+        assert validation["valid"] is False
+        assert dry_run["success"] is False
+        assert dry_run["validation"]["errors"] == validation["errors"]
+        message = "\n".join(validation["errors"])
+        assert "counts input with instrument resolution is unsupported" in message
+        assert "separate open/sample response arms R[Phi] and R[Phi*T]" in message
+
+    def test_validation_allows_transmission_with_active_resolution(self, tmp_path):
+        np.savez(
+            tmp_path / "spectrum.npz",
+            energies_ev=np.linspace(1.0, 30.0, 20),
+            transmission=np.ones(20),
+            uncertainty=np.full(20, 0.01),
+        )
+        _write_json_frontmatter_manifest(
+            tmp_path,
+            {
+                "mode": "single_spectrum",
+                "data": {"kind": "transmission_npz", "path": "spectrum.npz"},
+                "isotopes": [_synthetic_u238_entry()],
+                "fit": {"solver": "lm", "max_iter": 5},
+                "resolution": {
+                    "kind": "gaussian",
+                    "flight_path_m": 25.0,
+                    "delta_t_us": 1.0,
+                    "delta_l_m": 0.01,
+                },
+            },
+        )
+
+        validation = validate_resonance_dataset(str(tmp_path))
+
+        assert validation["valid"] is True
+        assert not any("counts input" in error for error in validation["errors"])
+
     def test_fit_summary_is_strict_json_safe(self):
         result = SimpleNamespace(
             densities=np.asarray([np.nan]),

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -484,6 +484,43 @@ class TestManifestWorkflowTools:
         assert "raw count input cannot use solver='lm'" in result["error"]
         assert fitter_called is False
 
+    def test_transmission_spectrum_rejects_joint_poisson_before_fit(
+        self, tmp_path, monkeypatch
+    ):
+        np.savez(
+            tmp_path / "spectrum.npz",
+            energies_ev=np.linspace(1.0, 30.0, 20),
+            transmission=np.ones(20),
+            uncertainty=np.full(20, 0.01),
+        )
+        fitter_called = False
+
+        def forbidden_transmission_fit(**_kwargs):
+            nonlocal fitter_called
+            fitter_called = True
+            raise AssertionError("invalid transmission + joint Poisson route reached the fitter")
+
+        monkeypatch.setattr(nereids, "fit_spectrum_typed", forbidden_transmission_fit)
+        _write_json_frontmatter_manifest(
+            tmp_path,
+            {
+                "mode": "single_spectrum",
+                "data": {"kind": "transmission_npz", "path": "spectrum.npz"},
+                "isotopes": [_synthetic_u238_entry()],
+                "fit": {"solver": "joint_poisson", "max_iter": 5},
+                "resolution": {"kind": "none"},
+            },
+        )
+
+        result = process_resonance_dataset(str(tmp_path))
+
+        assert result["success"] is False
+        assert (
+            "normalized transmission input cannot use a Poisson/KL count likelihood"
+            in result["error"]
+        )
+        assert fitter_called is False
+
     def test_process_density_map_manifest(self, tmp_path):
         energies = np.linspace(1.0, 30.0, 120)
         true_density = 0.002

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -370,6 +370,88 @@ class TestManifestWorkflowTools:
         assert (tmp_path / "output" / "nereids_spectrum_fit.npz").exists()
         assert (tmp_path / "output" / "nereids_mcp_result.json").exists()
 
+    def test_count_spectrum_stays_in_count_domain_by_default(
+        self, tmp_path, monkeypatch
+    ):
+        energies = np.linspace(1.0, 30.0, 20)
+        sample = np.full(20, 900.0)
+        open_beam = np.full(20, 1000.0)
+        np.savez(
+            tmp_path / "counts.npz",
+            energies_ev=energies,
+            sample_counts=sample,
+            open_beam_counts=open_beam,
+        )
+        captured = {}
+
+        def fake_fit_counts_spectrum_typed(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                densities=np.asarray([0.001]),
+                uncertainties=np.asarray([0.0001]),
+                reduced_chi_squared=1.0,
+                deviance_per_dof=1.0,
+                converged=True,
+                iterations=1,
+                temperature_k=None,
+                anorm=1.0,
+                background=[0.0, 0.0, 0.0],
+            )
+
+        def forbidden_transmission_fit(**kwargs):
+            raise AssertionError("raw counts were silently converted to transmission")
+
+        monkeypatch.setattr(
+            nereids, "fit_counts_spectrum_typed", fake_fit_counts_spectrum_typed
+        )
+        monkeypatch.setattr(
+            nereids, "fit_spectrum_typed", forbidden_transmission_fit
+        )
+        _write_json_frontmatter_manifest(
+            tmp_path,
+            {
+                "mode": "single_spectrum",
+                "data": {"kind": "counts_npz", "path": "counts.npz"},
+                "isotopes": [_synthetic_u238_entry()],
+                "fit": {"max_iter": 5},
+                "resolution": {"kind": "none"},
+            },
+        )
+
+        result = process_resonance_dataset(str(tmp_path))
+
+        assert result["success"] is True
+        np.testing.assert_array_equal(captured["sample_counts"], sample)
+        np.testing.assert_array_equal(captured["open_beam_counts"], open_beam)
+        assert "solver" not in captured  # binding default resolves counts to KL
+
+    def test_count_spectrum_rejects_transmission_fit_domain(self, tmp_path):
+        np.savez(
+            tmp_path / "counts.npz",
+            energies_ev=np.linspace(1.0, 30.0, 20),
+            sample_counts=np.full(20, 900.0),
+            open_beam_counts=np.full(20, 1000.0),
+        )
+        _write_json_frontmatter_manifest(
+            tmp_path,
+            {
+                "mode": "single_spectrum",
+                "data": {"kind": "counts_npz", "path": "counts.npz"},
+                "isotopes": [_synthetic_u238_entry()],
+                "fit": {
+                    "solver": "lm",
+                    "fit_domain": "transmission",
+                    "max_iter": 5,
+                },
+                "resolution": {"kind": "none"},
+            },
+        )
+
+        result = process_resonance_dataset(str(tmp_path))
+
+        assert result["success"] is False
+        assert "raw count input cannot be fit in the transmission domain" in result["error"]
+
     def test_process_density_map_manifest(self, tmp_path):
         energies = np.linspace(1.0, 30.0, 120)
         true_density = 0.002
@@ -463,7 +545,7 @@ class TestManifestWorkflowTools:
                     "open_beam_path": open_beam_path.name,
                 },
                 "isotopes": [_synthetic_u238_entry(initial_density=0.001)],
-                "fit": {"solver": "lm", "max_iter": 5},
+                "fit": {"solver": "auto", "max_iter": 5},
                 "resolution": {"kind": "none"},
                 "output": {"directory": "output"},
             },
@@ -723,8 +805,8 @@ class TestManifestWorkflowTools:
         assert dry_run["success"] is False
         assert dry_run["validation"]["errors"] == validation["errors"]
         message = "\n".join(validation["errors"])
-        assert "counts input with instrument resolution is unsupported" in message
-        assert "separate open/sample response arms R[Phi] and R[Phi*T]" in message
+        assert "not available through the MCP manifest" in message
+        assert "incident fluence weights and measured detector-time bin edges" in message
 
     def test_validation_allows_transmission_with_active_resolution(self, tmp_path):
         np.savez(

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -1439,7 +1439,9 @@ class TestSpatialMapBadValues:
         sample = np.full((n_e, 2, 2), 100.0)
         flux = np.full((n_e, 2, 2), 200.0)
         background = np.zeros((n_e, 2, 2))
-        background[6, 1, 0] = 1.0
+        # This is deliberately below the old 1e-12 tolerance. Unsupported
+        # background is a model choice, so every exact nonzero must fail.
+        background[6, 1, 0] = 5.0e-13
         data = nereids.from_counts_with_nuisance(sample, flux, background)
 
         with pytest.raises(ValueError, match="non-zero detector_background"):

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -1433,6 +1433,18 @@ class TestSpatialMapBadValues:
         with pytest.raises(ValueError, match="flux"):
             nereids.spatial_map_typed(data, energies, [u238_data], max_iter=10)
 
+    def test_rejects_nonzero_detector_background_before_spatial_fit(self, u238_data):
+        energies = self._energies()
+        n_e = len(energies)
+        sample = np.full((n_e, 2, 2), 100.0)
+        flux = np.full((n_e, 2, 2), 200.0)
+        background = np.zeros((n_e, 2, 2))
+        background[6, 1, 0] = 1.0
+        data = nereids.from_counts_with_nuisance(sample, flux, background)
+
+        with pytest.raises(ValueError, match="non-zero detector_background"):
+            nereids.spatial_map_typed(data, energies, [u238_data], max_iter=10)
+
     def test_accepts_negative_transmission(self, u238_data):
         # SAMMY does not reject negative transmission (noise / over-
         # subtraction); only finiteness is required, so this must NOT raise.

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -554,6 +554,54 @@ class TestTabulatedKernelOrientation:
         )
 
 
+class TestTabulatedDetectorBins:
+    """The public tabulated-response API integrates the loaded UDR directly
+    into measured detector-time bins."""
+
+    TOF_FACTOR = 72.298254398292800
+    L = 25.0
+
+    @staticmethod
+    def _write_kernel(path):
+        path.write_text(
+            "\n".join(
+                [
+                    "synthetic asymmetric triangular response",
+                    "-----",
+                    "   2.50000e+001   0.00000e+000",
+                    "-1.0 0.0",
+                    "0.0 1.0",
+                    "2.0 0.0",
+                    "",
+                ]
+            )
+        )
+
+    def test_exact_bin_probabilities_without_window_renormalization(self, tmp_path):
+        kernel_path = tmp_path / "synthetic_exact_bins.txt"
+        self._write_kernel(kernel_path)
+        response = nereids.load_resolution(str(kernel_path), self.L)
+        arrival = self.TOF_FACTOR * self.L / np.sqrt(25.0)
+
+        probabilities = np.asarray(
+            response.detector_bin_probabilities(
+                25.0,
+                [arrival - 2.0, arrival - 1.0, arrival, arrival + 1.0],
+                0.0,
+            )
+        )
+
+        np.testing.assert_allclose(probabilities, [0.0, 1.0 / 3.0, 1.0 / 2.0])
+        assert probabilities.sum() == pytest.approx(5.0 / 6.0)
+
+    def test_invalid_flight_path_is_rejected_when_loading(self, tmp_path):
+        kernel_path = tmp_path / "synthetic_invalid_path.txt"
+        self._write_kernel(kernel_path)
+
+        with pytest.raises(ValueError, match="flight_path"):
+            nereids.load_resolution(str(kernel_path), float("nan"))
+
+
 class TestTabulatedKernelWidthInterpolation:
     """Regression for issue #632: kernel width between reference energies
     must follow the physical power law, not the arithmetic blend chord.

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -602,6 +602,73 @@ class TestTabulatedDetectorBins:
             nereids.load_resolution(str(kernel_path), float("nan"))
 
 
+class TestTwoArmCountResponse:
+    """The public operator keeps the open and sample detector arms separate."""
+
+    TOF_FACTOR = 72.298254398292800
+    L = 25.0
+
+    @staticmethod
+    def _write_triangle(path):
+        path.write_text(
+            "\n".join(
+                [
+                    "synthetic one-microsecond triangle",
+                    "-----",
+                    "   2.50000e+001   0.00000e+000",
+                    "-1.0 0.0",
+                    "0.0 1.0",
+                    "1.0 0.0",
+                    "",
+                ]
+            )
+        )
+
+    def test_public_tabulated_operator_integrates_two_true_energies(self, tmp_path):
+        kernel_path = tmp_path / "two_arm_triangle.txt"
+        self._write_triangle(kernel_path)
+        response = nereids.load_resolution(str(kernel_path), self.L)
+        arrival_0 = self.TOF_FACTOR * self.L / np.sqrt(25.0)
+        energy_1 = (self.TOF_FACTOR * self.L / (arrival_0 + 1.0)) ** 2
+
+        open_beam, sample = nereids.two_arm_count_response(
+            np.array([25.0, energy_1]),
+            np.array([100.0, 200.0]),
+            np.array([0.2, 0.8]),
+            np.array(
+                [arrival_0 - 1.0, arrival_0, arrival_0 + 1.0, arrival_0 + 2.0]
+            ),
+            response,
+        )
+
+        np.testing.assert_allclose(open_beam, [50.0, 150.0, 100.0], atol=2e-11)
+        np.testing.assert_allclose(sample, [10.0, 90.0, 80.0], atol=2e-11)
+
+    def test_public_operator_accepts_analytical_ic_without_conversion(self):
+        ic = nereids.IkedaCarpenter(
+            flight_path_m=self.L,
+            e_min_ev=20.0,
+            e_max_ev=30.0,
+            alpha=nereids.EnergyLaw.const(1.2),
+            beta=0.2,
+            r=nereids.EnergyLaw.const(0.25),
+        )
+        arrival = self.TOF_FACTOR * self.L / np.sqrt(25.0)
+        edges = np.array([arrival, arrival + 1.0, arrival + 5.0, arrival + 20.0])
+        probabilities = np.asarray(ic.detector_bin_probabilities(25.0, edges, 0.0))
+
+        open_beam, sample = nereids.two_arm_count_response(
+            np.array([25.0]),
+            np.array([80.0]),
+            np.array([0.5]),
+            edges,
+            ic,
+        )
+
+        np.testing.assert_allclose(open_beam, 80.0 * probabilities, atol=2e-12)
+        np.testing.assert_allclose(sample, 40.0 * probabilities, atol=2e-12)
+
+
 class TestTabulatedKernelWidthInterpolation:
     """Regression for issue #632: kernel width between reference energies
     must follow the physical power law, not the arithmetic blend chord.

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -669,6 +669,144 @@ class TestTwoArmCountResponse:
         np.testing.assert_allclose(sample, 40.0 * probabilities, atol=2e-12)
 
 
+class TestTwoArmCountBackground:
+    """Count backgrounds stay separate and their full prediction is returned."""
+
+    @staticmethod
+    def _signals():
+        return (
+            np.array([1000.0, 900.0, 800.0, 700.0, 600.0]),
+            np.array([600.0, 540.0, 480.0, 420.0, 360.0]),
+        )
+
+    def test_recovers_independent_template_and_returns_components(self):
+        open_signal, sample_signal = self._signals()
+        open_template = np.array([[0.2, 0.5, 1.0, 2.0, 4.0]])
+        sample_template = np.array([[4.0, 2.0, 1.0, 0.5, 0.2]])
+        true_amplitude = 25.0
+        observed_open = open_signal + true_amplitude * open_template[0]
+        observed_sample = sample_signal + true_amplitude * sample_template[0]
+
+        result = nereids.fit_two_arm_background_templates(
+            observed_open,
+            observed_sample,
+            open_signal,
+            sample_signal,
+            1.0,
+            1.0,
+            ["blocked_beam_reference"],
+            open_template,
+            sample_template,
+            np.array([1.0]),
+        )
+
+        assert result.converged
+        assert result.amplitudes_identifiable
+        np.testing.assert_allclose(result.amplitudes, [true_amplitude], atol=1e-6)
+        np.testing.assert_allclose(result.open_neutron_signal, open_signal)
+        np.testing.assert_allclose(result.sample_neutron_signal, sample_signal)
+        np.testing.assert_allclose(
+            result.open_background, true_amplitude * open_template[0], atol=1e-6
+        )
+        np.testing.assert_allclose(result.open_total, observed_open, atol=1e-6)
+        np.testing.assert_allclose(result.sample_total, observed_sample, atol=1e-6)
+        assert result.poisson_deviance < 1e-10
+
+    def test_wrong_flat_template_leaves_bad_count_fit(self):
+        open_signal, sample_signal = self._signals()
+        true_open = np.array([0.2, 0.5, 1.0, 2.0, 4.0])
+        true_sample = np.array([4.0, 2.0, 1.0, 0.5, 0.2])
+        observed_open = open_signal + 100.0 * true_open
+        observed_sample = sample_signal + 100.0 * true_sample
+
+        result = nereids.fit_two_arm_background_templates(
+            observed_open,
+            observed_sample,
+            open_signal,
+            sample_signal,
+            1.0,
+            1.0,
+            ["wrong_flat_reference"],
+            np.ones((1, 5)),
+            np.ones((1, 5)),
+            np.array([1.0]),
+        )
+
+        assert result.converged
+        assert result.deviance_per_dof > 5.0
+
+    def test_template_units_do_not_change_physical_fit(self):
+        open_signal = np.array([100.0, 200.0, 300.0])
+        sample_signal = np.array([80.0, 160.0, 240.0])
+        template = np.full((1, 3), 1e-8)
+        true_amplitude = 1e9
+        observed_open = open_signal + true_amplitude * template[0]
+        observed_sample = sample_signal + true_amplitude * template[0]
+
+        result = nereids.fit_two_arm_background_templates(
+            observed_open,
+            observed_sample,
+            open_signal,
+            sample_signal,
+            1.0,
+            1.0,
+            ["same_reference_in_tiny_units"],
+            template,
+            template,
+            np.array([0.0]),
+        )
+
+        assert result.converged
+        np.testing.assert_allclose(result.amplitudes, [true_amplitude], rtol=1e-6)
+        np.testing.assert_allclose(result.open_total, observed_open, atol=1e-8)
+        np.testing.assert_allclose(result.sample_total, observed_sample, atol=1e-8)
+        assert 0.0 <= result.deviance_per_dof < 1e-10
+
+    def test_exposure_scale_is_not_fitted_as_false_background(self):
+        open_signal = np.array([100.0, 100.0])
+        sample_signal = np.array([50.0, 50.0])
+
+        result = nereids.fit_two_arm_background_templates(
+            np.array([100.0, 100.0]),
+            np.array([100.0, 100.0]),
+            open_signal,
+            sample_signal,
+            1.0,
+            2.0,
+            ["sample_only"],
+            np.zeros((1, 2)),
+            np.ones((1, 2)),
+            np.array([10.0]),
+        )
+
+        assert result.converged
+        np.testing.assert_allclose(result.amplitudes, [0.0], atol=1e-10)
+        np.testing.assert_allclose(result.sample_neutron_signal, [100.0, 100.0])
+        assert result.poisson_deviance == 0.0
+
+    def test_dependent_component_amounts_are_marked_unidentifiable(self):
+        signal = np.full(3, 100.0)
+
+        result = nereids.fit_two_arm_background_templates(
+            np.full(3, 120.0),
+            np.full(3, 120.0),
+            signal,
+            signal,
+            1.0,
+            1.0,
+            ["dark", "gamma"],
+            np.array([[1.0] * 3, [2.0] * 3]),
+            np.array([[1.0] * 3, [2.0] * 3]),
+            np.array([0.0, 5.0]),
+        )
+
+        assert result.converged
+        assert not result.amplitudes_identifiable
+        assert np.isnan(result.amplitude_uncertainties).all()
+        np.testing.assert_allclose(result.open_background, [20.0] * 3)
+        assert result.poisson_deviance == 0.0
+
+
 class TestTabulatedKernelWidthInterpolation:
     """Regression for issue #632: kernel width between reference energies
     must follow the physical power law, not the arithmetic blend chord.

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -4347,6 +4347,8 @@ class TestCalibrateResolution:
         # signature froze, so they must sit at the END — inserting them
         # mid-signature would silently shift every pre-existing call passing
         # >= 14 positional arguments.
+        import inspect
+
         sig = nereids.calibrate_resolution.__text_signature__
         assert sig is not None
         assert (
@@ -4354,6 +4356,14 @@ class TestCalibrateResolution:
             < sig.index("psr_fwhm_ns")
             < sig.index("fit_psr")
         ), f"psr_fwhm_ns/fit_psr must trail the signature: {sig}"
+        # Named Rust constants are rendered as ``...`` by PyO3 even though the
+        # call path uses the right value.  Keep the introspected public default
+        # equal to the stub and to the fitting-core default instead of exposing
+        # an unusable Ellipsis value to help(), IDEs, and manifest checks.
+        default = inspect.signature(nereids.calibrate_resolution).parameters[
+            "psr_fwhm_ns"
+        ].default
+        assert default == 350.0
 
 
 

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -2828,12 +2828,23 @@ class TestVenusMlbwRegression:
         # shifts -0.07 % and the iteration count halves (14 -> 7) because
         # analytic steps satisfy the relative-chi2 tolerance sooner.
         #
+        # Baseline regenerated after the source-aware free-gas integration
+        # replaced interpolation of a sampled zero-temperature table for
+        # resolved SLBW/MLBW data.  The evaluated Hf-177 resonance parameters
+        # are unchanged; the thermal integral now evaluates that resonance
+        # equation at its own quadrature points, so its result no longer
+        # depends on whether the caller's output grid happened to resolve the
+        # narrow source line.  The independent full-kernel and derivative
+        # tests in ``continuous_doppler.rs`` carry the correctness check.  On
+        # this frozen workload, density moves +0.134 %, reduced chi-squared
+        # improves by 3.58e-6 relative, and the iteration count stays at 7.
+        #
         # These pinned values are machine-generated regression anchors
         # (produced by the code under test); the correctness burden is
         # carried by the SAMMY-oracle suites (samtry, ex001) and the
-        # analytic kernel pins in doppler.rs.
-        EXPECTED_DENSITY = 8.10458528518008e-05
-        EXPECTED_CHI2_R = 219657.2439575215
+        # analytic kernel pins in doppler.rs and continuous_doppler.rs.
+        EXPECTED_DENSITY = 8.115412297872233e-05
+        EXPECTED_CHI2_R = 219656.45748585448
         EXPECTED_ITERATIONS = 7
 
         FLOAT_TOL = pytest.approx

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -4073,6 +4073,34 @@ class TestCalibrateEnergySmoke:
         np.testing.assert_array_equal(uncertainty, s_before)
 
 
+class TestIkedaCarpenterCausalResponse:
+    def test_detector_bin_probabilities_preserve_probability_and_clock(self):
+        flight_path_m = 25.0
+        energy_ev = 4.0
+        arrival_us = nereids.energy_to_tof(energy_ev, flight_path_m)
+        ic = nereids.IkedaCarpenter(
+            flight_path_m=flight_path_m,
+            e_min_ev=1.0,
+            e_max_ev=10.0,
+            alpha=nereids.EnergyLaw.const(2.0),
+            beta=0.5,
+            r=nereids.EnergyLaw.const(0.3),
+        )
+
+        probabilities = np.asarray(
+            ic.detector_bin_probabilities(
+                energy_ev,
+                [arrival_us - 1.0, arrival_us, arrival_us + 1.0, arrival_us + 80.0],
+                0.0,
+            )
+        )
+
+        assert probabilities.shape == (3,)
+        assert probabilities[0] == 0.0
+        assert np.all(probabilities[1:] > 0.0)
+        assert 0.999 < probabilities.sum() <= 1.0
+
+
 class TestCalibrateResolution:
     """Resolution calibration binding: position is PINNED by default; the shared
     SAMMY energy-scale ``(t0, L_scale)`` is an explicit, prior-constrained opt-in

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -4074,6 +4074,22 @@ class TestCalibrateEnergySmoke:
 
 
 class TestIkedaCarpenterCausalResponse:
+    def test_source_pulse_keeps_physical_delay_origin(self):
+        ic = nereids.IkedaCarpenter(
+            flight_path_m=25.0,
+            e_min_ev=1.0,
+            e_max_ev=10.0,
+            alpha=nereids.EnergyLaw.const(2.0),
+            beta=0.5,
+            r=nereids.EnergyLaw.const(0.3),
+        )
+
+        delay_us, density = map(np.asarray, ic.source_pulse_at(4.0))
+
+        assert delay_us[0] == 0.0
+        assert delay_us[np.argmax(density)] > 0.0
+        assert np.all(np.diff(delay_us) > 0.0)
+
     def test_detector_bin_probabilities_preserve_probability_and_clock(self):
         flight_path_m = 25.0
         energy_ev = 4.0

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -712,6 +712,58 @@ class TestTwoArmCountResponse:
         assert result.converged
         assert float(result.densities[0]) == pytest.approx(true_density, abs=2.0e-6)
         assert float(result.deviance_per_dof) < 1.0e-8
+        assert result.prediction_energies_ev.shape == sample.shape
+        assert result.signal_prediction.shape == sample.shape
+        assert result.background_prediction.shape == sample.shape
+        assert result.model_prediction.shape == sample.shape
+        np.testing.assert_allclose(result.background_prediction, 0.0, atol=0.0)
+        np.testing.assert_allclose(
+            result.signal_prediction + result.background_prediction,
+            result.model_prediction,
+            rtol=0.0,
+            atol=2.0e-15,
+        )
+
+    def test_reusable_matrix_matches_function_and_has_correct_transpose(self):
+        energies = np.array([5.0, 6.0, 7.0])
+        source = np.array([100.0, 200.0, 300.0])
+        transmission = np.array([0.9, 0.7, 0.5])
+        detector_edges = np.linspace(650.0, 850.0, 17)
+        ic = nereids.IkedaCarpenter(
+            flight_path_m=self.L,
+            e_min_ev=4.0,
+            e_max_ev=8.0,
+            alpha=nereids.EnergyLaw.const(1.2),
+            beta=0.2,
+            r=nereids.EnergyLaw.const(0.25),
+        )
+        expected_open, expected_sample = nereids.two_arm_count_response(
+            energies, source, transmission, detector_edges, ic
+        )
+        matrix = nereids.DetectorResponseMatrix(energies, detector_edges, ic)
+        observed_open, observed_sample = matrix.apply(source, transmission)
+
+        np.testing.assert_array_equal(observed_open, expected_open)
+        np.testing.assert_array_equal(observed_sample, expected_sample)
+        np.testing.assert_array_equal(matrix.project(source), expected_open)
+        detector_values = np.linspace(-2.0, 3.0, detector_edges.size - 1)
+        left = float(np.dot(matrix.project(source), detector_values))
+        right = float(np.dot(source, matrix.transpose_project(detector_values)))
+        assert left == pytest.approx(right, abs=2.0e-12)
+        assert matrix.n_true_energies == energies.size
+        assert matrix.n_detector_bins == detector_edges.size - 1
+        assert matrix.nonzero_probabilities > 0
+        assert matrix.storage_bytes > 0
+
+        doubled = nereids.DetectorResponseMatrix(
+            np.repeat(energies, 2), detector_edges, ic
+        )
+        collapsed = doubled.collapse_true_energy_groups(
+            np.tile([0.25, 0.75], energies.size), 2
+        )
+        np.testing.assert_allclose(
+            collapsed.project(source), matrix.project(source), rtol=0.0, atol=2.0e-13
+        )
 
 
 class TestTwoArmCountBackground:
@@ -4051,6 +4103,14 @@ class TestStubConformance:
             if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
                 if not node.name.startswith("_"):
                     stub_names.add(node.name)
+            elif isinstance(node, (ast.Import, ast.ImportFrom)):
+                for alias in node.names:
+                    exported_name = alias.asname or alias.name.split(".")[0]
+                    if not exported_name.startswith("_"):
+                        stub_names.add(exported_name)
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                if not node.target.id.startswith("_"):
+                    stub_names.add(node.target.id)
 
         # Dunders + the ``__version__`` style attributes don't belong
         # in the stub; pyo3's auto-injected ``annotations`` import isn't
@@ -4771,6 +4831,14 @@ class TestMultiplicativeBaseline:
         assert r.baseline is None
         assert r.baseline_e_ref_ev is None
         assert r.warnings == []
+        np.testing.assert_array_equal(r.prediction_energies_ev, energies)
+        np.testing.assert_allclose(r.background_prediction, 0.0, atol=0.0)
+        np.testing.assert_allclose(
+            r.signal_prediction + r.background_prediction,
+            r.model_prediction,
+            rtol=0.0,
+            atol=2.0e-15,
+        )
 
     def test_baseline_with_default_background_rejected_on_all_fitters(
         self, u238_data
@@ -4837,6 +4905,26 @@ class TestMultiplicativeBaseline:
         assert r.anorm == 1.0, "Anorm was frozen at its init"
         assert r.baseline is not None
         assert abs(r.baseline[0] - _BL_TRUE[0]) < 2e-2
+        e_ref = float(r.baseline_e_ref_ev)
+        log_energy = np.log(energies / e_ref)
+        fitted_baseline = (
+            r.baseline[0]
+            + r.baseline[1] * log_energy
+            + r.baseline[2] * log_energy * log_energy
+        )
+        back_a, back_b, back_c = r.background
+        expected_background = fitted_baseline * (
+            back_a + back_b / np.sqrt(energies) + back_c * np.sqrt(energies)
+        )
+        np.testing.assert_allclose(
+            r.background_prediction, expected_background, rtol=2.0e-13, atol=2.0e-14
+        )
+        np.testing.assert_allclose(
+            r.signal_prediction + r.background_prediction,
+            r.model_prediction,
+            rtol=0.0,
+            atol=2.0e-15,
+        )
 
     def test_baseline_suboptions_require_baseline_true(self, u238_data):
         energies = np.linspace(1.0, 30.0, 100)

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -668,6 +668,51 @@ class TestTwoArmCountResponse:
         np.testing.assert_allclose(open_beam, 80.0 * probabilities, atol=2e-12)
         np.testing.assert_allclose(sample, 40.0 * probabilities, atol=2e-12)
 
+    def test_public_ic_count_fit_uses_exact_separate_arms(self, u238_data):
+        true_density = 5.0e-4
+        energies = np.linspace(5.0, 8.0, 80)
+        transmission = np.asarray(
+            nereids.forward_model(
+                energies,
+                [(u238_data, true_density)],
+                temperature_k=293.6,
+            )
+        )
+        source = 4.0e4 * np.linspace(1.0, 1.4, energies.size)
+        detector_edges = np.linspace(630.0, 882.5, 102)
+        ic = nereids.IkedaCarpenter(
+            flight_path_m=self.L,
+            e_min_ev=5.0,
+            e_max_ev=8.0,
+            alpha=nereids.EnergyLaw.const(1.2),
+            beta=0.2,
+            r=nereids.EnergyLaw.const(0.25),
+        )
+        open_beam, sample = nereids.two_arm_count_response(
+            energies,
+            source,
+            transmission,
+            detector_edges,
+            ic,
+        )
+
+        result = nereids.fit_counts_spectrum_typed(
+            sample,
+            open_beam,
+            energies,
+            isotopes=[(u238_data, 2.0e-4)],
+            temperature_k=293.6,
+            solver="kl",
+            max_iter=400,
+            resolution=ic,
+            incident_fluence_weights=source,
+            detector_time_edges_us=detector_edges,
+        )
+
+        assert result.converged
+        assert float(result.densities[0]) == pytest.approx(true_density, abs=2.0e-6)
+        assert float(result.deviance_per_dof) < 1.0e-8
+
 
 class TestTwoArmCountBackground:
     """Count backgrounds stay separate and their full prediction is returned."""
@@ -2815,108 +2860,33 @@ class TestVenusMlbwRegression:
             f"A dispatch regression can prevent convergence entirely — investigate."
         )
 
-    def test_counts_kl_fit_matches_baseline(self, venus_data):
-        """Counts-KL (joint-Poisson) fit on the same real VENUS spectrum.
+    def test_counts_with_resolution_fails_before_fitting(self, venus_data):
+        """Resolved counts without source weights and time edges fail closed.
 
-        This is the real-data regression gate for the counts-path solver:
-        it substantiates, in-tree, the docs' claim that the joint-Poisson
-        deviance path is exercised against real VENUS counts — the
-        synthetic counts-KL tests elsewhere use NEREIDS-generated
-        observations and cannot do that.
-
-        Two properties are pinned:
-
-        * The fit converges with the anchored density.  As with the LM
-          gate above, the pinned values are machine-generated regression
-          anchors (produced by the code under test); correctness of the
-          deviance math is carried by the analytic joint-Poisson unit
-          tests in nereids-fitting.
-        * ``deviance_per_dof`` lands in the >> 1 regime (measured ~3.1e4).
-          Real VENUS counts carry un-modelled upstream physics, so D/dof
-          saturates at 10^4-10^5 — exactly the regime documented on
-          ``JointPoissonFitConfig::enable_polish`` (and the reason polish
-          is off by default).  A sudden drop to O(1) would mean the gate
-          silently switched to a synthetic-like input, not that the model
-          got better.
-
-        The KL density (~2.9e-5) deliberately differs from the LM gate's
-        (~8.1e-5): with a mis-specified no-background single-isotope model
-        on real data, the transmission-domain least-squares and the
-        counts-domain deviance weight bins differently and converge to
-        different biased optima.  Both anchors move only when their
-        respective solver paths change.
-
-        Tolerances follow the LM gate's cross-backend rationale: anchors
-        were captured on macOS (Accelerate); ``rel=1e-6`` absorbs
-        BLAS/libm sum-ordering differences on Linux CI while staying
-        orders of magnitude tighter than any real dispatch regression.
-        If this gate ever flaps across backends, relax the deviance
-        anchor first — the sum over ~4e3 bins amplifies bin-level libm
-        differences far more than the converged density does.
+        Instrument response acts separately on the open and sample count
+        arms. The public API must not fall back to a broadened transmission
+        ratio when the exact detector inputs are missing.
         """
         E, S_agg, O_agg, c, hf177 = venus_data
 
-        result = nereids.fit_counts_spectrum_typed(
-            S_agg,
-            O_agg,
-            E,
-            isotopes=[(hf177, 1.0e-5)],
-            solver="kl",
-            temperature_k=293.6,
-            max_iter=200,
-            background=False,
-            c=c,
-            flight_path_m=25.0,
-            delta_t_us=0.5,
-            delta_l_m=0.005,
-        )
-
-        # Anchors regenerated after #635's analytic-Jacobian availability
-        # fix. The old anchor was captured at an identity-Fisher
-        # gradient-descent STALL: without an analytic transmission Jacobian
-        # the joint-Poisson stage 1 silently degraded to projected gradient
-        # descent, which stopped 1.7 % away (in density) from the true
-        # optimum of the SAME objective. With the analytic Fisher the fit
-        # reaches a strictly BETTER minimum (deviance/dof 31445.853 <
-        # 31445.957) in 3 iterations. The model is unchanged (bit-exact
-        # parity verified); only the optimum actually attained improved.
-        EXPECTED_DENSITY = 2.9596692297867937e-05
-        EXPECTED_DEVIANCE_PER_DOF = 31445.852761391532
-
-        assert bool(result.converged) is True, (
-            f"counts-KL fit did not converge on the real VENUS fixture "
-            f"(converged={bool(result.converged)})"
-        )
-        assert float(result.densities[0]) == pytest.approx(
-            EXPECTED_DENSITY, rel=1e-6
-        ), (
-            f"counts-KL density drifted: got {float(result.densities[0])!r}, "
-            f"expected {EXPECTED_DENSITY!r} (±1e-6 rel)"
-        )
-        # Coarse physical bracket, independent of the machine-generated
-        # anchor above: both solver families land in (2.9-8.1)e-5
-        # atoms/barn on this measured Hf spectrum, so any value outside
-        # [1e-5, 1e-4] means solver breakage, not sample physics.  This
-        # prevents a future wholesale re-anchoring commit from silently
-        # absorbing an order-of-magnitude regression.
-        assert 1e-5 < float(result.densities[0]) < 1e-4, (
-            f"counts-KL density {float(result.densities[0])!r} fell outside "
-            f"the physical bracket [1e-5, 1e-4] for this measured sample"
-        )
-        assert result.deviance_per_dof is not None, (
-            "counts-KL dispatch must populate deviance_per_dof (primary GOF)"
-        )
-        assert float(result.deviance_per_dof) == pytest.approx(
-            EXPECTED_DEVIANCE_PER_DOF, rel=1e-6
-        ), (
-            f"deviance/dof drifted: got {float(result.deviance_per_dof)!r}, "
-            f"expected {EXPECTED_DEVIANCE_PER_DOF!r} (±1e-6 rel)"
-        )
-        assert float(result.deviance_per_dof) > 1e3, (
-            "real-data regime check: D/dof should be >> 1 on raw VENUS "
-            "counts (un-modelled upstream physics); an O(1) value means "
-            "the gate is no longer fitting real data"
-        )
+        with pytest.raises(
+            ValueError,
+            match="requires the exact separate-arm model",
+        ):
+            nereids.fit_counts_spectrum_typed(
+                S_agg,
+                O_agg,
+                E,
+                isotopes=[(hf177, 1.0e-5)],
+                solver="kl",
+                temperature_k=293.6,
+                max_iter=200,
+                background=False,
+                c=c,
+                flight_path_m=25.0,
+                delta_t_us=0.5,
+                delta_l_m=0.005,
+            )
 
 
 # ===========================================================================
@@ -3137,40 +3107,23 @@ class TestFixDensities:
             f"frozen density must report NaN σ, got {r.uncertainties[0]}"
         )
 
-    def test_fix_densities_kl_reports_temperature_uncertainty(self, u238_data):
-        """The KL transmission solver (``solver="kl"``) must also report a
-        finite temperature 1-σ with a density frozen — the parallel path the
-        LM tests don't exercise. Pre-fix a leftover full-index overwrite
-        clobbered ``temperature_k_unc`` to None on this path (review R2 P0)."""
-        energies = np.linspace(1.0, 30.0, 400)
-        true_density = 8.0e-4
-        true_temp = 350.0
-        t = np.asarray(
-            nereids.forward_model(
-                energies, [(u238_data, true_density)], temperature_k=true_temp
+    def test_transmission_rejects_count_likelihood(self, u238_data):
+        """Normalized transmission is not Poisson count data."""
+        energies = np.linspace(1.0, 30.0, 40)
+        transmission = np.ones_like(energies)
+        uncertainty = np.full_like(energies, 0.01)
+
+        with pytest.raises(
+            ValueError,
+            match="normalized transmission cannot use a Poisson/KL count likelihood",
+        ):
+            nereids.fit_spectrum_typed(
+                transmission=transmission,
+                uncertainty=uncertainty,
+                energies=energies,
+                isotopes=[(u238_data, 8.0e-4)],
+                solver="kl",
             )
-        )
-        sigma = np.full_like(t, 0.005)
-        r = nereids.fit_spectrum_typed(
-            transmission=t,
-            uncertainty=sigma,
-            energies=energies,
-            isotopes=[(u238_data, true_density)],
-            solver="kl",
-            temperature_k=300.0,
-            fit_temperature=True,
-            fix_densities=True,
-            max_iter=200,
-        )
-        assert bool(r.converged) is True
-        assert r.densities[0] == true_density
-        assert r.temperature_k is not None
-        # The regression: temperature_k_unc was None pre-fix on the KL path.
-        assert r.temperature_k_unc is not None
-        assert np.isfinite(r.temperature_k_unc) and r.temperature_k_unc > 0.0, (
-            "KL frozen-density temperature σ must be finite positive, "
-            f"got {r.temperature_k_unc}"
-        )
 
     def test_fix_densities_counts_path_holds_density_and_reports_uncertainty(
         self, u238_data
@@ -3297,66 +3250,20 @@ class TestFixDensities:
             "default (flag absent) must equal scale_by_chi2=False"
         )
 
-    def test_scale_by_chi2_transmission_kl_scales_by_reduced_chi2(self, u238_data):
-        """Issue #638 (review R1): on the transmission Poisson-KL path
-        (``fit_spectrum_typed(solver="kl")``), ``scale_by_chi2=True`` scales σ by
-        ``sqrt(reduced_chi_squared)`` — the SAME Gaussian goodness-of-fit the
-        result reports, the identical prescription the LM path applies — NOT a
-        Poisson deviance on transmission fractions. The direction guard is the
-        regression check: a deliberately poor fit (reduced-χ² > 1) must GROW σ;
-        the original bug scaled by the transmission Poisson deviance, which gave
-        ``D ≪ dof`` on a poor pseudo-Poisson fit and SHRANK σ (~30×)."""
-        energies = np.linspace(1.0, 30.0, 300)
-        true_density = 8.0e-4
-        t_clean = np.asarray(
-            nereids.forward_model(energies, [(u238_data, true_density)])
-        )
-        sigma = 0.01 * np.maximum(t_clean, 0.01)
+    def test_counts_reject_least_squares_ratio_fallback(self, u238_data):
+        """Separate count arms must not be silently divided for LM."""
+        energies = np.linspace(1.0, 30.0, 40)
+        sample = np.full_like(energies, 900.0)
+        open_beam = np.full_like(energies, 1000.0)
 
-        # ±k (relative) high-frequency zig-zag the smooth density model cannot
-        # absorb. Multiplicative so transmission stays strictly positive; since
-        # σ = 0.01·max(t, 0.01), the reported Gaussian reduced-χ² ≈ (100·k)².
-        def zigzag(k):
-            sign = np.where(np.arange(t_clean.size) % 2 == 0, 1.0, -1.0)
-            return t_clean * (1.0 + k * sign)
-
-        def check(t):
-            def run(scale):
-                return nereids.fit_spectrum_typed(
-                    transmission=t,
-                    uncertainty=sigma,
-                    energies=energies,
-                    isotopes=[(u238_data, 5.0e-4)],
-                    solver="kl",
-                    max_iter=200,
-                    scale_by_chi2=scale,
-                )
-
-            unscaled = run(False)
-            scaled = run(True)
-            assert bool(unscaled.converged) and bool(scaled.converged)
-            rcs = float(scaled.reduced_chi_squared)
-            # The flag only rescales the post-convergence covariance, so the fit
-            # (and its reported GOF) is identical between the two runs.
-            assert float(unscaled.reduced_chi_squared) == pytest.approx(rcs, rel=1e-9)
-            assert np.isfinite(rcs) and rcs > 0.0
-            factor = float(np.sqrt(rcs))
-            s_un = float(unscaled.uncertainties[0])
-            s_sc = float(scaled.uncertainties[0])
-            assert s_sc == pytest.approx(s_un * factor, rel=1e-6), (
-                f"σ_scaled {s_sc} must equal σ_unscaled {s_un} × sqrt(rcs {rcs})"
+        with pytest.raises(ValueError, match="raw sample/open-beam counts cannot use solver='lm'"):
+            nereids.fit_counts_spectrum_typed(
+                sample_counts=sample,
+                open_beam_counts=open_beam,
+                energies=energies,
+                isotopes=[(u238_data, 8.0e-4)],
+                solver="lm",
             )
-            return rcs, s_sc / s_un
-
-        # Poor fit (±3% → reduced-χ² ≈ 9 > 1): σ GROWS (bug inverted this).
-        rcs_poor, ratio_poor = check(zigzag(0.03))
-        assert rcs_poor > 1.0, f"zig-zag fit should give reduced-χ² > 1, got {rcs_poor}"
-        assert ratio_poor > 1.0, f"poor fit must grow σ, ratio = {ratio_poor}"
-
-        # Good fit (±0.3% → reduced-χ² ≈ 0.09 < 1): σ shrinks.
-        rcs_good, ratio_good = check(zigzag(0.003))
-        assert rcs_good < 1.0, f"clean-ish fit should give reduced-χ² < 1, got {rcs_good}"
-        assert ratio_good < 1.0, f"good fit must shrink σ, ratio = {ratio_good}"
 
     def test_fix_densities_spatial_map_holds_density(self, u238_data):
         """``spatial_map_typed`` must freeze densities per pixel: the frozen


### PR DESCRIPTION
## Summary

- Adds a supported aggregate 1D workflow: calibrate the instrument response from room-temperature data, then fit the hot spectrum with that calibration frozen.
- Returns the fitted energy axis, signal, additive background, and complete model so users do not have to reconstruct the fit in notebooks.
- Caches detector-bin probabilities generated by the IC model in a reusable Rust matrix, allowing the frozen room response to be reused during source inference and hot-spectrum fitting. With the VENUS proton-pulse correction, these probabilities are still integrated numerically.
- Requires callers to state the IC profile, fit range, physical bounds, and detector-variance factors, and records them in the result.
- Documents and tests this supported route. Spatial fitting is intentionally left for the next phase.

## Scientific boundaries

- Measured counts and evaluated nuclear cross sections are never modified.
- Hot-spectrum data cannot influence the room-temperature calibration.
- The hot fit reuses the frozen room response, source estimate, material, nuclear evaluation, and fit window.
- The VENUS example uses the previously selected 8–45 eV calibration and fitting region while also reporting the wider 4–120 eV diagnostic range.
- Both ordinary Poisson residuals and TPX1-correlation-adjusted residuals are reported.

## Validation

- Python API documentation check: passed (67 public symbols, 46 documented, 23 explicitly allowlisted).
- Instrument-response physics tests: 8 passed.
- Pipeline tests: 180 passed.
- Focused public aggregate-workflow and API tests: 11 passed.
- Complete Python test suite with the optional MCP dependency enabled: 283 passed.
- Copilot review: added the missing early rejection for `joint_poisson` on normalized-transmission input and a regression test proving the invalid route never reaches the fitter.
- Independent review identified six problems. All five code problems were fixed and re-reviewed; final exact-revision delivery verification remains open while this PR is a draft.

For the accepted 8–45 eV region, the room-temperature maximum/RMS residual is 6.077/1.111 and the frozen hot-fit maximum/RMS residual is 8.867/1.265. The example also reports the full supplied 4–120 eV diagnostics (room maximum 9.775; hot maximum 50.713) instead of hiding bins outside the fitting region.

## Tracking

Related: #688, #691, #694, #701.
