### PR TITLE
physics(ic): Wave-1 causal detector-bin response (R5·7)

### DIFF
--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -401,6 +401,7 @@ class IkedaCarpenter:
         n_tau: int = 600,
         burst_sigma_us: float | None = None,
         channel_fwhm_us: float | None = None,
+        beta_law: EnergyLaw | None = None,
     ) -> None: ...
     def as_tabulated(self) -> TabulatedResolution:
         """The synthesized tabulated kernel (usable as a resolution file)."""
@@ -411,6 +412,26 @@ class IkedaCarpenter:
 
         Raises ``ValueError`` when the tau-grid cannot resolve the prompt
         core and requested folds within the sample cap at this energy.
+        """
+        ...
+
+    def source_pulse_at(self, true_energy_ev: float) -> tuple[list[float], list[float]]:
+        """Physical ``(moderator_delay_us, density)`` at one true energy.
+
+        Unlike :meth:`kernel_at`, this keeps the pulse's time origin.
+        """
+        ...
+
+    def detector_bin_probabilities(
+        self,
+        true_energy_ev: float,
+        detector_time_edges_us: list[float],
+        timing_offset_us: float,
+    ) -> list[float]:
+        """Probability in each detector-time bin for one true energy.
+
+        The probabilities are not renormalized when the supplied time window
+        omits part of the pulse.
         """
         ...
 

--- a/bindings/python/python/nereids/__init__.pyi
+++ b/bindings/python/python/nereids/__init__.pyi
@@ -402,7 +402,10 @@ class IkedaCarpenter:
         burst_sigma_us: float | None = None,
         channel_fwhm_us: float | None = None,
         beta_law: EnergyLaw | None = None,
-    ) -> None: ...
+    ) -> None:
+        """When ``beta_law`` is supplied it overrides the scalar ``beta``
+        (which is still required positionally but otherwise ignored)."""
+        ...
     def as_tabulated(self) -> TabulatedResolution:
         """The synthesized tabulated kernel (usable as a resolution file)."""
         ...
@@ -411,14 +414,20 @@ class IkedaCarpenter:
         """``(tof_offsets_us, weights)`` at one energy; mode at offset 0.
 
         Raises ``ValueError`` when the tau-grid cannot resolve the prompt
-        core and requested folds within the sample cap at this energy.
+        core and requested folds within the sample cap at this energy, or
+        when a parameter law is invalid at this probe energy (non-positive
+        or singular rate, storage fraction outside [0, 1]).
         """
         ...
 
     def source_pulse_at(self, true_energy_ev: float) -> tuple[list[float], list[float]]:
         """Physical ``(moderator_delay_us, density)`` at one true energy.
 
-        Unlike :meth:`kernel_at`, this keeps the pulse's time origin.
+        Unlike :meth:`kernel_at`, this keeps the pulse's time origin. The
+        density is a peak-normalized shape (maximum 1), not a probability
+        density; with a symmetric burst/channel fold the leading delays can
+        be negative. Raises ``ValueError`` for a nonphysical probe energy or
+        a parameter law that is invalid there.
         """
         ...
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -957,6 +957,9 @@ impl PyIkedaCarpenter {
 
     /// `(moderator_delay_us, density)` for the physical source pulse at one
     /// true energy. Unlike `kernel_at`, this keeps the pulse's time origin.
+    /// The density is a peak-normalized shape (maximum 1), not a probability
+    /// density; with a symmetric burst/channel fold the leading delays can be
+    /// negative (the fold reaches before the moderator origin).
     fn source_pulse_at(&self, true_energy_ev: f64) -> PyResult<(Vec<f64>, Vec<f64>)> {
         self.inner
             .source_pulse_at(true_energy_ev)

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -861,9 +861,11 @@ impl PyEnergyLaw {
 /// the *same* broadening path as a Monte-Carlo file, so the IC-vs-tabulated
 /// comparison differs only in kernel source.
 ///
-/// Parameters: `alpha`/`r` are [`EnergyLaw`]s (fixed-or-fit general case),
-/// `beta` (1/µs) is the storage rate; optional `burst_sigma_us` (Gaussian) and
-/// `channel_fwhm_us` (triangle) fold in the proton-burst and chopper terms.
+/// Parameters: `alpha`/`r` are [`EnergyLaw`]s (fixed-or-fit general case).
+/// `beta` keeps the original constant-rate API; the optional trailing
+/// `beta_law` overrides it with an energy-dependent rate. Optional
+/// `burst_sigma_us` (Gaussian) and `channel_fwhm_us` (triangle) fold in the
+/// proton-burst and chopper terms.
 #[pyclass(name = "IkedaCarpenter", skip_from_py_object)]
 #[derive(Clone)]
 struct PyIkedaCarpenter {
@@ -884,6 +886,7 @@ impl PyIkedaCarpenter {
         n_tau = 600,
         burst_sigma_us = None,
         channel_fwhm_us = None,
+        beta_law = None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -897,6 +900,7 @@ impl PyIkedaCarpenter {
         n_tau: usize,
         burst_sigma_us: Option<f64>,
         channel_fwhm_us: Option<f64>,
+        beta_law: Option<PyEnergyLaw>,
     ) -> PyResult<Self> {
         for (name, v) in [
             ("burst_sigma_us", burst_sigma_us),
@@ -912,7 +916,7 @@ impl PyIkedaCarpenter {
         }
         let params = IkedaCarpenterParams {
             alpha: alpha.inner,
-            beta,
+            beta: beta_law.map_or(EnergyLaw::Const(beta), |law| law.inner),
             r: r.inner,
             burst_sigma_us,
             channel_fwhm_us,
@@ -948,6 +952,28 @@ impl PyIkedaCarpenter {
     fn kernel_at(&self, energy_ev: f64) -> PyResult<(Vec<f64>, Vec<f64>)> {
         self.inner
             .kernel_at(energy_ev)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+    }
+
+    /// `(moderator_delay_us, density)` for the physical source pulse at one
+    /// true energy. Unlike `kernel_at`, this keeps the pulse's time origin.
+    fn source_pulse_at(&self, true_energy_ev: f64) -> PyResult<(Vec<f64>, Vec<f64>)> {
+        self.inner
+            .source_pulse_at(true_energy_ev)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+    }
+
+    /// Probability that a neutron at one true energy is recorded in each
+    /// adjacent detector-time bin. The result is not renormalized when the
+    /// supplied time window omits part of the pulse.
+    fn detector_bin_probabilities(
+        &self,
+        true_energy_ev: f64,
+        detector_time_edges_us: Vec<f64>,
+        timing_offset_us: f64,
+    ) -> PyResult<Vec<f64>> {
+        self.inner
+            .detector_bin_probabilities(true_energy_ev, &detector_time_edges_us, timing_offset_us)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
@@ -1467,7 +1493,9 @@ impl PyResolutionCalibration {
                         d.set_item("a0", *a0)?;
                         d.set_item("a1", *a1)?;
                     }
-                    d.set_item("beta", p.beta)?;
+                    if let EnergyLaw::Const(beta) = p.beta {
+                        d.set_item("beta", beta)?;
+                    }
                     if let EnergyLaw::Const(r) = &p.r {
                         d.set_item("r", *r)?;
                     }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -948,7 +948,9 @@ impl PyIkedaCarpenter {
     /// Raises ``ValueError`` when the τ-grid cannot resolve the prompt core
     /// and requested folds within the sample cap at this energy (construction
     /// validates the reference energies; a probe energy outside their range
-    /// can still be unresolvable).
+    /// can still be unresolvable), or when a parameter law is invalid at this
+    /// probe energy (non-positive or singular rate, storage fraction outside
+    /// [0, 1]).
     fn kernel_at(&self, energy_ev: f64) -> PyResult<(Vec<f64>, Vec<f64>)> {
         self.inner
             .kernel_at(energy_ev)

--- a/crates/nereids-fitting/src/resolution_calib.rs
+++ b/crates/nereids-fitting/src/resolution_calib.rs
@@ -611,7 +611,7 @@ fn build_resolution(
                     a0: theta[0].exp(),
                     a1: theta[1].exp(),
                 },
-                beta: theta[2].exp(),
+                beta: EnergyLaw::Const(theta[2].exp()),
                 // Scalar R: a free κ in ExpMilliEv is unidentifiable in the eV
                 // regime (R ≡ 0 across 1–200 eV for ANY plausible κ); a scalar
                 // lets the calibrant decide whether a storage tail is present.
@@ -1252,7 +1252,10 @@ mod tests {
         let EnergyLaw::Const(rr) = p.r else {
             panic!("expected a Const R law");
         };
-        (a0, a1, p.beta, rr, p.channel_fwhm_us.unwrap_or(0.0))
+        let EnergyLaw::Const(beta) = p.beta else {
+            panic!("expected a Const beta law");
+        };
+        (a0, a1, beta, rr, p.channel_fwhm_us.unwrap_or(0.0))
     }
 
     fn synthetic_base_udr() -> TabulatedResolution {
@@ -1606,7 +1609,7 @@ mod tests {
         let ic = IkedaCarpenter::new(
             IkedaCarpenterParams {
                 alpha: EnergyLaw::SqrtE { a0: 0.30, a1: 0.0 },
-                beta: 0.1,
+                beta: EnergyLaw::Const(0.1),
                 r: EnergyLaw::ExpMilliEv { kappa: 25.0 },
                 burst_sigma_us: None,
                 channel_fwhm_us: None,
@@ -1810,7 +1813,7 @@ mod tests {
         let ic = IkedaCarpenter::new(
             IkedaCarpenterParams {
                 alpha: EnergyLaw::SqrtE { a0: 0.30, a1: 0.0 },
-                beta: 0.1,
+                beta: EnergyLaw::Const(0.1),
                 r: EnergyLaw::ExpMilliEv { kappa: 25.0 },
                 burst_sigma_us: None,
                 channel_fwhm_us: None,
@@ -2119,7 +2122,7 @@ mod tests {
         let ic_truth = IkedaCarpenter::new(
             IkedaCarpenterParams {
                 alpha: EnergyLaw::SqrtE { a0: 0.35, a1: 0.05 },
-                beta: 0.1,
+                beta: EnergyLaw::Const(0.1),
                 r: EnergyLaw::Const(0.1),
                 burst_sigma_us: None,
                 channel_fwhm_us: Some(0.35),
@@ -2201,7 +2204,7 @@ mod tests {
         let ic_truth = IkedaCarpenter::new(
             IkedaCarpenterParams {
                 alpha: EnergyLaw::SqrtE { a0: 0.35, a1: 0.05 },
-                beta: 0.1,
+                beta: EnergyLaw::Const(0.1),
                 r: EnergyLaw::Const(0.1),
                 burst_sigma_us: None,
                 channel_fwhm_us: Some(psr_true),
@@ -2258,7 +2261,7 @@ mod tests {
         let ic_truth = IkedaCarpenter::new(
             IkedaCarpenterParams {
                 alpha: EnergyLaw::SqrtE { a0: 0.35, a1: 0.05 },
-                beta: 0.1,
+                beta: EnergyLaw::Const(0.1),
                 r: EnergyLaw::Const(0.1),
                 burst_sigma_us: None,
                 channel_fwhm_us: None, // unfolded truth
@@ -2321,7 +2324,7 @@ mod tests {
         let ic_truth = IkedaCarpenter::new(
             IkedaCarpenterParams {
                 alpha: EnergyLaw::SqrtE { a0: 0.35, a1: 0.05 },
-                beta: 0.1, // irrelevant at R = 0 (no storage term)
+                beta: EnergyLaw::Const(0.1), // irrelevant at R = 0 (no storage term)
                 r: EnergyLaw::Const(0.0),
                 burst_sigma_us: None,
                 channel_fwhm_us: Some(0.35),
@@ -2627,7 +2630,7 @@ mod tests {
                     a0: 0.5,
                     a1: IC_A1_MAX,
                 },
-                beta: IC_BETA_MIN,
+                beta: EnergyLaw::Const(IC_BETA_MIN),
                 r: EnergyLaw::Const(IC_R_MAX),
                 burst_sigma_us: None,
                 channel_fwhm_us: Some(fwhm_us),

--- a/crates/nereids-fitting/src/resolution_calib.rs
+++ b/crates/nereids-fitting/src/resolution_calib.rs
@@ -2362,10 +2362,13 @@ mod tests {
         // that no MATERIAL storage fraction is claimed either way; the
         // deterministic positive pin for the bounds_hit labeling mechanism
         // is bounds_hit_labels_saturated_upper_bound below.
-        let (_, _, _, r_cal, _) = decoded_ic(&r);
+        let (_, _, beta_cal, r_cal, _) = decoded_ic(&r);
         assert!(
-            r.bounds_hit.iter().any(|s| s == "r:lower") || r_cal < 0.1,
-            "R = 0 truth must not claim a material storage fraction: \
+            r.bounds_hit.iter().any(|s| s == "r:lower") || (r_cal < 0.08 && beta_cal > 1.0),
+            "R = 0 truth must not claim a material storage fraction: an \
+             interior ridge endpoint is admissible only when the claimed \
+             storage is small AND fast (β above the ~1.6 µs⁻¹ prompt rate, \
+             i.e. absorbable) — a slow visible tail must fail. \
              bounds_hit = {:?}, decoded = {:?}",
             r.bounds_hit,
             decoded_ic(&r)

--- a/crates/nereids-fitting/src/resolution_calib.rs
+++ b/crates/nereids-fitting/src/resolution_calib.rs
@@ -2355,9 +2355,78 @@ mod tests {
             &cfg,
         )
         .unwrap();
+        // At R_truth = 0 the β↔R ridge is FLAT: a fast-β storage term is
+        // absorbable by the freed α(E) coefficients, so the optimizer's
+        // endpoint — pinned on the r lower bound, or slightly interior —
+        // depends on the kernel discretization. The physical contract is
+        // that no MATERIAL storage fraction is claimed either way; the
+        // deterministic positive pin for the bounds_hit labeling mechanism
+        // is bounds_hit_labels_saturated_upper_bound below.
+        let (_, _, _, r_cal, _) = decoded_ic(&r);
         assert!(
-            r.bounds_hit.iter().any(|s| s == "r:lower"),
-            "R = 0 truth must pin the storage fraction: bounds_hit = {:?}, decoded = {:?}",
+            r.bounds_hit.iter().any(|s| s == "r:lower") || r_cal < 0.1,
+            "R = 0 truth must not claim a material storage fraction: \
+             bounds_hit = {:?}, decoded = {:?}",
+            r.bounds_hit,
+            decoded_ic(&r)
+        );
+    }
+
+    #[test]
+    fn bounds_hit_labels_saturated_upper_bound() {
+        // A truth channel fold WIDER than the fitted PSR box (2.5 µs vs
+        // PSR_FWHM_US_MAX = 1.0 µs) pulls the fitted width monotonically
+        // into the upper bound: fold width is identifiable through the
+        // kernel's second moment (unlike the β↔R ridge coordinates), so the
+        // pin is deterministic — the positive test for the bounds_hit
+        // labeling mechanism.
+        let iso = synthetic_isotope(72, 178, 20.0, 0.05, 0.06);
+        let sample = SampleParams::new(300.0, vec![(iso, 2.0e-3)]).unwrap();
+        let energies: Vec<f64> = (0..120).map(|i| 14.0 + i as f64 * 0.05).collect();
+        let cfg = CalibrationConfig {
+            ic_n_energies: 32,
+            ic_n_tau: 300,
+            restarts: 1,
+            ..Default::default()
+        };
+        let ic_truth = IkedaCarpenter::new(
+            IkedaCarpenterParams {
+                alpha: EnergyLaw::SqrtE { a0: 0.35, a1: 0.05 },
+                beta: EnergyLaw::Const(0.1),
+                r: EnergyLaw::Const(0.0),
+                burst_sigma_us: None,
+                channel_fwhm_us: Some(2.5),
+            },
+            cfg.flight_path_m,
+            &SynthesisGrid {
+                e_min_ev: (energies[0] * 0.5).max(1e-3),
+                e_max_ev: energies.last().unwrap() * 2.0,
+                n_energies: cfg.ic_n_energies,
+                n_tau: cfg.ic_n_tau,
+            },
+        )
+        .unwrap();
+        let truth = ResolutionFunction::IkedaCarpenter(Arc::new(ic_truth));
+        let data = forward_model(
+            &energies,
+            &sample,
+            Some(&InstrumentParams { resolution: truth }),
+        )
+        .unwrap();
+        let unc = vec![0.004; energies.len()];
+        let r = calibrate_resolution(
+            ResolutionFamily::IkedaCarpenter { fit_psr: true },
+            &energies,
+            &data,
+            &unc,
+            &sample,
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            r.bounds_hit.iter().any(|s| s == "psr_fwhm_us:upper"),
+            "a truth fold wider than the PSR box must pin the upper bound: \
+             bounds_hit = {:?}, decoded = {:?}",
             r.bounds_hit,
             decoded_ic(&r)
         );

--- a/crates/nereids-fitting/tests/ic_closed_loop.rs
+++ b/crates/nereids-fitting/tests/ic_closed_loop.rs
@@ -102,7 +102,7 @@ fn closed_loop(t_true_k: f64) {
                 a0: A0_TRUE,
                 a1: A1_TRUE,
             },
-            beta: BETA_TRUE,
+            beta: EnergyLaw::Const(BETA_TRUE),
             r: EnergyLaw::Const(R_TRUE),
             burst_sigma_us: None,
             channel_fwhm_us: Some(PSR_TRUE_US),
@@ -180,15 +180,18 @@ fn closed_loop(t_true_k: f64) {
     let EnergyLaw::Const(r_cal) = p.r else {
         panic!("expected a Const R law");
     };
+    let EnergyLaw::Const(beta_cal) = p.beta else {
+        panic!("expected a Const beta law");
+    };
     assert!(a1 > 0.0, "α(E) positive by construction (a1 = {a1})");
     assert!(
         (a0 - A0_TRUE).abs() < 0.10,
         "a0 = {a0}, truth {A0_TRUE} (T = {t_true_k} K)"
     );
     assert!(
-        (p.beta - BETA_TRUE).abs() < 0.20,
+        (beta_cal - BETA_TRUE).abs() < 0.20,
         "β = {}, truth {BETA_TRUE} (T = {t_true_k} K)",
-        p.beta
+        beta_cal
     );
     assert!(
         (r_cal - R_TRUE).abs() < 0.12,
@@ -266,7 +269,7 @@ fn closed_loop(t_true_k: f64) {
     eprintln!(
         "closed_loop(T={t_true_k} K): χ²/dof={:.3}, a0={a0:.3}, a1={a1:.4}, β={:.3}, R={:.3}, \
          T_fit={t_fit:.1} ± {sigma_t:.1} K",
-        cal.chi2_dof, p.beta, r_cal
+        cal.chi2_dof, beta_cal, r_cal
     );
 }
 

--- a/crates/nereids-physics/src/ikeda_carpenter.rs
+++ b/crates/nereids-physics/src/ikeda_carpenter.rs
@@ -129,7 +129,9 @@
 //! applies its `psr_fwhm_ns` fold to the IC family only, never to
 //! tabulated/UDR kernels).
 
-use crate::resolution::{ResolutionParseError, TabulatedResolution};
+use crate::resolution::{
+    ResolutionParseError, TOF_FACTOR, TabulatedResolution, piecewise_linear_bin_masses,
+};
 
 /// de Broglie wavelength factor: λ (Å) = `LAMBDA_ANGSTROM_FACTOR` / √(E in eV).
 ///
@@ -265,6 +267,73 @@ pub fn ic_pulse(alpha: f64, beta: f64, r: f64, tau: f64) -> f64 {
     (1.0 - r) * fast + r * slow
 }
 
+/// Cumulative probability of the Ikeda–Carpenter moderator pulse.
+///
+/// Returns `P(U <= tau)` for moderator delay `U`. `tau` is in µs and rates
+/// are in 1/µs. The prompt term is the Gamma(3, α) cumulative distribution;
+/// the storage term is the cumulative distribution of Gamma(3, α) plus an
+/// independent exponential delay with rate β.
+///
+/// The expression is evaluated without subtracting nearly equal exponentials
+/// when `α ≈ β`. This is the bin-integral companion to [`ic_pulse`].
+#[must_use]
+pub fn ic_cdf(alpha: f64, beta: f64, r: f64, tau: f64) -> f64 {
+    if tau.is_nan() || tau <= 0.0 {
+        return 0.0;
+    }
+    if tau == f64::INFINITY {
+        return 1.0;
+    }
+    if !tau.is_finite() {
+        return 0.0;
+    }
+
+    let alpha = alpha.max(MIN_RATE);
+    let beta = beta.max(MIN_RATE);
+    let at = alpha * tau;
+    let fast = gamma3_cdf(at);
+    if r <= 0.0 {
+        return fast;
+    }
+
+    // The storage CDF is the prompt CDF minus the positive survival
+    // correction below. Written this way, the α=β limit is Gamma(4, α).
+    let u = (alpha - beta) * tau;
+    let correction = if u.abs() < 0.05 {
+        at.powi(3) * (-beta * tau).exp() * h_over_cube_taylor(u)
+    } else {
+        // Bounded form: neither exponential can overflow even when β >> α.
+        let bracket = (-beta * tau).exp() - (-alpha * tau).exp() * (1.0 + u + 0.5 * u * u);
+        at.powi(3) * bracket / u.powi(3)
+    };
+    (fast - r * correction).clamp(0.0, 1.0)
+}
+
+/// Gamma(3, rate=1) cumulative distribution at dimensionless time `x`.
+fn gamma3_cdf(x: f64) -> f64 {
+    if x <= 0.0 {
+        return 0.0;
+    }
+    if x < 0.5 {
+        // Integral of x² exp(-x) / 2 as an alternating series. The direct
+        // `1 - exp(-x)(1+x+x²/2)` loses most digits for small x.
+        let mut n = 0_u32;
+        let mut term = x.powi(3) / 6.0;
+        let mut sum = term;
+        loop {
+            let n_f = f64::from(n);
+            term *= -x * (n_f + 3.0) / ((n_f + 1.0) * (n_f + 4.0));
+            let next = sum + term;
+            n += 1;
+            if next == sum || n >= 128 {
+                return next.clamp(0.0, 1.0);
+            }
+            sum = next;
+        }
+    }
+    (1.0 - (-x).exp() * (1.0 + x + 0.5 * x * x)).clamp(0.0, 1.0)
+}
+
 /// Energy-dependence law for an Ikeda–Carpenter parameter.
 ///
 /// A small closed set so the *fixed-or-fit* cases share one representation:
@@ -321,8 +390,8 @@ impl EnergyLaw {
 pub struct IkedaCarpenterParams {
     /// Fast (slowing-down) rate `α(E)`, 1/µs. Must evaluate to > 0.
     pub alpha: EnergyLaw,
-    /// Slow (storage) rate `β`, 1/µs. Energy-independent, must be > 0.
-    pub beta: f64,
+    /// Slow (storage) rate `β(E)`, 1/µs. Must evaluate to > 0.
+    pub beta: EnergyLaw,
     /// Storage mixing fraction `R(E)`, 0 ≤ R ≤ 1.
     pub r: EnergyLaw,
     /// Optional proton-burst Gaussian standard deviation (µs).
@@ -338,7 +407,7 @@ impl IkedaCarpenterParams {
     pub fn constant(alpha: f64, beta: f64, r: f64) -> Self {
         Self {
             alpha: EnergyLaw::Const(alpha),
-            beta,
+            beta: EnergyLaw::Const(beta),
             r: EnergyLaw::Const(r),
             burst_sigma_us: None,
             channel_fwhm_us: None,
@@ -404,7 +473,7 @@ impl IkedaCarpenter {
     /// # Errors
     /// Returns [`ResolutionParseError::InvalidFormat`] for a non-positive
     /// flight path, a degenerate grid (`n_energies < 2`, `n_tau < 8`,
-    /// `e_min ≤ 0`, `e_max ≤ e_min`), a non-positive `β`, a parameter/grid
+    /// `e_min ≤ 0`, `e_max ≤ e_min`), a non-positive `β(E)`, a parameter/grid
     /// combination whose τ-grid cannot resolve the prompt core and requested
     /// folds within the `MAX_TAU_SAMPLES` cap at some reference energy (see
     /// `tau_geometry` — remedy: larger `β`, `R = 0`, or a wider/disabled
@@ -442,13 +511,6 @@ impl IkedaCarpenter {
                 grid.e_min_ev, grid.e_max_ev
             )));
         }
-        if !params.beta.is_finite() || params.beta <= 0.0 {
-            return Err(ResolutionParseError::InvalidFormat(format!(
-                "beta must be a positive finite number, got {}",
-                params.beta
-            )));
-        }
-
         let ln_lo = grid.e_min_ev.ln();
         let ln_hi = grid.e_max_ev.ln();
         let denom = (grid.n_energies - 1) as f64;
@@ -466,6 +528,18 @@ impl IkedaCarpenter {
             return Err(ResolutionParseError::InvalidFormat(format!(
                 "Ikeda–Carpenter α(E) must be > 0, but α({bad}) = {} is not",
                 params.alpha.eval(bad)
+            )));
+        }
+        // β is a rate, so every synthesized reference energy must give a
+        // positive finite value. Reject invalid laws instead of clamping them
+        // into a different pulse.
+        if let Some(&bad) = ref_energies.iter().find(|&&e| {
+            let beta = params.beta.eval(e);
+            !beta.is_finite() || beta <= 0.0
+        }) {
+            return Err(ResolutionParseError::InvalidFormat(format!(
+                "Ikeda–Carpenter β(E) must be > 0, but β({bad}) = {} is not",
+                params.beta.eval(bad)
             )));
         }
         // Reject storage-fraction laws that fall outside [0, 1] (synthesis clamps
@@ -546,14 +620,138 @@ impl IkedaCarpenter {
     /// convention.
     ///
     /// # Errors
-    /// Returns [`ResolutionParseError::InvalidFormat`] when the τ-grid cannot
-    /// resolve the prompt core and requested folds within `MAX_TAU_SAMPLES`
-    /// at this energy. Construction validates every *reference* energy, but a
-    /// probe energy outside `[e_min, e_max]` — for the √E law, above `e_max`,
-    /// where the larger α(E) imposes a finer prompt resolution floor against
-    /// the same storage-tail span — can still leave the resolvable region.
+    /// Returns [`ResolutionParseError::InvalidFormat`] when the requested
+    /// energy or an energy-dependent rate/fraction is non-physical, or when
+    /// the τ-grid cannot resolve the prompt core and requested folds within
+    /// `MAX_TAU_SAMPLES` at this energy. Construction validates every
+    /// *reference* energy, but a probe outside `[e_min, e_max]` can still leave
+    /// the physical or resolvable region.
     pub fn kernel_at(&self, energy_ev: f64) -> Result<(Vec<f64>, Vec<f64>), ResolutionParseError> {
+        self.validate_probe_energy(energy_ev)?;
         synth_kernel(&self.params, self.n_tau, energy_ev)
+    }
+
+    /// Evaluate the physical source pulse at one true neutron energy.
+    ///
+    /// Returns sampled moderator-delay coordinates in µs and peak-normalized
+    /// densities. Unlike [`Self::kernel_at`], this method does not move the
+    /// pulse mode to zero. With no symmetric proton/channel fold, the delay is
+    /// causal and starts at zero. A symmetric fold may extend the sampled
+    /// support below zero relative to its stated time origin.
+    ///
+    /// # Errors
+    /// Returns [`ResolutionParseError::InvalidFormat`] if `energy_ev` is not a
+    /// positive finite true energy, if an energy law is unphysical at that
+    /// energy, or if the requested pulse cannot be resolved by the configured
+    /// sampling limits.
+    pub fn source_pulse_at(
+        &self,
+        energy_ev: f64,
+    ) -> Result<(Vec<f64>, Vec<f64>), ResolutionParseError> {
+        self.validate_probe_energy(energy_ev)?;
+        synth_source_pulse(&self.params, self.n_tau, energy_ev)
+    }
+
+    /// Probability that a neutron of known true energy is recorded in each
+    /// supplied detector-time bin.
+    ///
+    /// `detector_time_edges_us` are the actual measured bin edges. The nominal
+    /// arrival time is
+    /// `timing_offset_us + TOF_FACTOR * flight_path_m / sqrt(true_energy_ev)`.
+    /// `timing_offset_us` represents the shared clock/detector offset; it does
+    /// not absorb or remove the moderator pulse's physical mode.
+    ///
+    /// The returned vector has one entry per adjacent edge pair and is not
+    /// renormalized to the supplied window: bins that do not cover the full
+    /// pulse correctly sum to less than one.
+    ///
+    /// With no burst or channel fold, probabilities come directly from the
+    /// analytical IC CDF. With either optional fold, the continuous pulse is
+    /// represented on the configured synthesis grid and integrated as a
+    /// piecewise-linear density. The finite numerical support is not silently
+    /// renormalized; omitted physical tail probability remains omitted.
+    ///
+    /// # Errors
+    /// Returns [`ResolutionParseError::InvalidFormat`] unless the true energy
+    /// is physical, the timing offset is finite, and at least two finite bin
+    /// edges are supplied in strictly increasing order.
+    pub fn detector_bin_probabilities(
+        &self,
+        true_energy_ev: f64,
+        detector_time_edges_us: &[f64],
+        timing_offset_us: f64,
+    ) -> Result<Vec<f64>, ResolutionParseError> {
+        self.validate_probe_energy(true_energy_ev)?;
+        if !timing_offset_us.is_finite() {
+            return Err(ResolutionParseError::InvalidFormat(format!(
+                "timing_offset_us must be finite, got {timing_offset_us}"
+            )));
+        }
+        if detector_time_edges_us.len() < 2
+            || detector_time_edges_us.iter().any(|x| !x.is_finite())
+            || detector_time_edges_us.windows(2).any(|w| w[0] >= w[1])
+        {
+            return Err(ResolutionParseError::InvalidFormat(
+                "detector time edges must contain at least two finite, strictly increasing values"
+                    .to_string(),
+            ));
+        }
+
+        let nominal_arrival =
+            timing_offset_us + TOF_FACTOR * self.flight_path_m / true_energy_ev.sqrt();
+        let relative_edges: Vec<f64> = detector_time_edges_us
+            .iter()
+            .map(|edge| edge - nominal_arrival)
+            .collect();
+
+        if self.params.burst_sigma_us.unwrap_or(0.0) == 0.0
+            && self.params.channel_fwhm_us.unwrap_or(0.0) == 0.0
+        {
+            let alpha = self.params.alpha.eval(true_energy_ev);
+            let beta = self.params.beta.eval(true_energy_ev);
+            let r = self.params.r.eval(true_energy_ev);
+            return Ok(relative_edges
+                .windows(2)
+                .map(|edge| {
+                    (ic_cdf(alpha, beta, r, edge[1]) - ic_cdf(alpha, beta, r, edge[0])).max(0.0)
+                })
+                .collect());
+        }
+
+        let (times, densities) =
+            synth_source_pulse_density(&self.params, self.n_tau, true_energy_ev)?;
+        piecewise_linear_bin_masses(&times, &densities, &relative_edges).ok_or_else(|| {
+            ResolutionParseError::InvalidFormat(format!(
+                "Ikeda–Carpenter pulse at E = {true_energy_ev} eV has zero sampled area"
+            ))
+        })
+    }
+
+    fn validate_probe_energy(&self, energy_ev: f64) -> Result<(), ResolutionParseError> {
+        if !energy_ev.is_finite() || energy_ev <= 0.0 {
+            return Err(ResolutionParseError::InvalidFormat(format!(
+                "true energy must be positive and finite, got {energy_ev}"
+            )));
+        }
+        let alpha = self.params.alpha.eval(energy_ev);
+        let beta = self.params.beta.eval(energy_ev);
+        let r = self.params.r.eval(energy_ev);
+        if !alpha.is_finite() || alpha <= 0.0 {
+            return Err(ResolutionParseError::InvalidFormat(format!(
+                "Ikeda–Carpenter alpha({energy_ev}) must be positive and finite, got {alpha}"
+            )));
+        }
+        if !beta.is_finite() || beta <= 0.0 {
+            return Err(ResolutionParseError::InvalidFormat(format!(
+                "Ikeda–Carpenter beta({energy_ev}) must be positive and finite, got {beta}"
+            )));
+        }
+        if !r.is_finite() || !(0.0..=1.0).contains(&r) {
+            return Err(ResolutionParseError::InvalidFormat(format!(
+                "Ikeda–Carpenter R({energy_ev}) must be in [0, 1], got {r}"
+            )));
+        }
+        Ok(())
     }
 }
 
@@ -653,8 +851,22 @@ fn synth_kernel(
     n_tau: usize,
     energy_ev: f64,
 ) -> Result<(Vec<f64>, Vec<f64>), ResolutionParseError> {
+    let (mut offsets, weights) = synth_source_pulse(params, n_tau, energy_ev)?;
+    let peak_time = offsets[argmax(&weights)];
+    for offset in &mut offsets {
+        *offset -= peak_time;
+    }
+    Ok((offsets, weights))
+}
+
+/// Synthesize one physical-time source pulse without moving its mode.
+fn synth_source_pulse_density(
+    params: &IkedaCarpenterParams,
+    n_tau: usize,
+    energy_ev: f64,
+) -> Result<(Vec<f64>, Vec<f64>), ResolutionParseError> {
     let alpha = params.alpha.eval(energy_ev).max(MIN_RATE);
-    let beta = params.beta.max(MIN_RATE);
+    let beta = params.beta.eval(energy_ev).max(MIN_RATE);
     let r = params.r.eval(energy_ev).clamp(0.0, 1.0);
 
     let (dtau, tau_max, margin) = tau_geometry(params, n_tau, alpha, beta, r).map_err(|msg| {
@@ -673,10 +885,34 @@ fn synth_kernel(
     let taus: Vec<f64> = (j_lo..=j_hi).map(|j| j as f64 * dtau).collect();
     let mut weights: Vec<f64> = taus.iter().map(|&t| ic_pulse(alpha, beta, r, t)).collect();
 
+    // Correct only the sampled quadrature error of the analytical moderator
+    // density. The target is its exact CDF at the finite grid endpoint, not
+    // one, so physical moderator probability beyond the grid is not moved
+    // back into the sampled support. This matters for the coarsest admitted
+    // n_tau values, where peak-normalization used to hide a large area error.
+    let sampled_area = dtau
+        * (0.5 * weights[0]
+            + weights[1..weights.len() - 1].iter().sum::<f64>()
+            + 0.5 * weights[weights.len() - 1]);
+    let moderator_mass = ic_cdf(alpha, beta, r, *taus.last().expect("non-empty tau grid"));
+    if !sampled_area.is_finite() || sampled_area <= 0.0 {
+        return Err(ResolutionParseError::InvalidFormat(format!(
+            "Ikeda–Carpenter pulse at E = {energy_ev} eV has zero sampled area"
+        )));
+    }
+    let area_correction = moderator_mass / sampled_area;
+    for weight in &mut weights {
+        *weight *= area_correction;
+    }
+
     if let Some(sigma) = params.burst_sigma_us
         && sigma > 0.0
     {
-        weights = convolve_same(&weights, &gaussian_kernel(dtau, sigma));
+        let (kernel, retained_mass) = gaussian_kernel(dtau, sigma);
+        weights = convolve_same(&weights, &kernel);
+        for weight in &mut weights {
+            *weight *= retained_mass;
+        }
     }
     if let Some(fwhm) = params.channel_fwhm_us
         && fwhm > 0.0
@@ -684,10 +920,8 @@ fn synth_kernel(
         weights = convolve_same(&weights, &triangle_kernel(dtau, fwhm));
     }
 
-    // Anchor the mode at offset 0.
     let peak_idx = argmax(&weights);
     let peak_val = weights[peak_idx].max(f64::MIN_POSITIVE);
-    let tau_peak = taus[peak_idx];
 
     // Trim tails below TRIM_REL of peak, keeping one guard sample each side so
     // the convolution's neighbor-difference trapezoid widths stay defined.
@@ -701,9 +935,25 @@ fn synth_kernel(
         .rposition(|&w| w > thresh)
         .map_or(weights.len() - 1, |i| (i + 1).min(weights.len() - 1));
 
-    let offsets: Vec<f64> = (lo..=hi).map(|j| taus[j] - tau_peak).collect();
-    let w: Vec<f64> = (lo..=hi).map(|j| weights[j] / peak_val).collect();
-    Ok((offsets, w))
+    let offsets: Vec<f64> = (lo..=hi).map(|j| taus[j]).collect();
+    let densities: Vec<f64> = (lo..=hi).map(|j| weights[j]).collect();
+    Ok((offsets, densities))
+}
+
+/// Synthesize the public peak-normalized source-pulse representation.
+fn synth_source_pulse(
+    params: &IkedaCarpenterParams,
+    n_tau: usize,
+    energy_ev: f64,
+) -> Result<(Vec<f64>, Vec<f64>), ResolutionParseError> {
+    let (offsets, densities) = synth_source_pulse_density(params, n_tau, energy_ev)?;
+    let peak = densities
+        .iter()
+        .copied()
+        .fold(0.0_f64, f64::max)
+        .max(f64::MIN_POSITIVE);
+    let weights = densities.into_iter().map(|value| value / peak).collect();
+    Ok((offsets, weights))
 }
 
 /// Index of the maximum element (first on ties). Slice is non-empty by
@@ -722,7 +972,7 @@ fn argmax(xs: &[f64]) -> usize {
 
 /// Symmetric, unit-sum Gaussian kernel sampled on a `dtau`-spaced grid out to
 /// ±[`GAUSS_REACH_SIGMAS`]·σ.
-fn gaussian_kernel(dtau: f64, sigma: f64) -> Vec<f64> {
+fn gaussian_kernel(dtau: f64, sigma: f64) -> (Vec<f64>, f64) {
     let half = ((GAUSS_REACH_SIGMAS * sigma / dtau).ceil() as isize).max(1);
     let mut k: Vec<f64> = (-half..=half)
         .map(|j| {
@@ -730,8 +980,10 @@ fn gaussian_kernel(dtau: f64, sigma: f64) -> Vec<f64> {
             (-0.5 * t * t).exp()
         })
         .collect();
+    let raw_sum: f64 = k.iter().sum();
+    let retained_mass = (raw_sum * dtau / (sigma * std::f64::consts::TAU.sqrt())).clamp(0.0, 1.0);
     normalize_sum(&mut k);
-    k
+    (k, retained_mass)
 }
 
 /// Symmetric, unit-sum triangle kernel of FWHM `fwhm` (half-base = FWHM;
@@ -879,7 +1131,7 @@ mod tests {
         // The synthesized kernel must contain no non-finite entries.
         let p = IkedaCarpenterParams {
             alpha: EnergyLaw::Const(0.05),
-            beta: 4.0,
+            beta: EnergyLaw::Const(4.0),
             r: EnergyLaw::Const(0.5),
             burst_sigma_us: None,
             channel_fwhm_us: None,
@@ -956,7 +1208,7 @@ mod tests {
         // α(E) ∝ √E ⇒ prompt width 1/α shrinks with E ⇒ smaller TOF support.
         let p = IkedaCarpenterParams {
             alpha: EnergyLaw::SqrtE { a0: 0.3, a1: 0.0 },
-            beta: 0.1,
+            beta: EnergyLaw::Const(0.1),
             r: EnergyLaw::Const(0.0),
             burst_sigma_us: None,
             channel_fwhm_us: None,

--- a/crates/nereids-physics/src/ikeda_carpenter.rs
+++ b/crates/nereids-physics/src/ikeda_carpenter.rs
@@ -186,14 +186,35 @@ const TRI_MIN_SAMPLES_PER_SIDE: f64 = 3.0;
 /// probability as O(dtau²) even while the total mass is conserved (the
 /// triangle kernel's kink drives the error; measured at α = 1 µs⁻¹,
 /// FWHM = 10 µs: 7.5e-3 max per-bin error at 3 samples per side, ~1.2e-4 at
-/// 24, ~3e-7 at the 600-sample default). Twenty-four per side bounds the
-/// per-bin error of every accepted call at ~1e-4; a coarser sampled grid is
-/// rejected loudly at the detector-bin gate rather than silently
-/// redistributing leading-edge mass. SAMMY's UDR convolution integrates
-/// piecewise-linear segment products analytically (`udr/mudr4.f90`
-/// `Ud_Convolute`/`Udr_Add`) and needs no such floor; the sampled route
-/// keeps one and enforces it at the consumer whose contract is per-bin.
+/// 24, ~3e-7 at the 600-sample default). The per-bin gate takes the
+/// STRICTEST of the applicable floors — this one, the burst
+/// [`GAUSS_BIN_SAMPLES_PER_SIGMA`], and the prompt-core
+/// [`PROMPT_BIN_SAMPLES`] — so every accepted per-bin call is bounded at
+/// ~1e-4 whichever feature binds; a coarser sampled grid is rejected loudly
+/// rather than silently redistributing leading-edge mass. SAMMY's UDR
+/// convolution integrates piecewise-linear segment products analytically
+/// (`udr/mudr4.f90` `Ud_Convolute`/`Udr_Add`) and needs no such floor; the
+/// sampled route keeps one and enforces it at the consumer whose contract
+/// is per-bin.
 const TRI_BIN_SAMPLES_PER_SIDE: f64 = 24.0;
+
+/// Per-bin accuracy floor for a sampled Gaussian burst
+/// (`dtau ≤ σ / GAUSS_BIN_SAMPLES_PER_SIGMA` at the detector-bin gate).
+/// Measured at α = 1 µs⁻¹, σ = 2 µs, admitted `dtau = σ`: 1.46e-2 max
+/// per-bin error while the total conserved to 5e-10; the O(dtau²) scaling
+/// puts twelve samples per σ at ~1e-4. SAMMY integrates the Gaussian burst
+/// analytically over piecewise-linear segments (`Ud_Burst`) and needs no
+/// floor; the sampled sibling of the triangle gate keeps one.
+const GAUSS_BIN_SAMPLES_PER_SIGMA: f64 = 12.0;
+
+/// Per-bin accuracy floor for the PROMPT core on the sampled fold path
+/// (`dtau ≤ fast_reach / PROMPT_BIN_SAMPLES`). A wide fold can set a bin
+/// floor far coarser than the Γ₃ pulse's own structure (scale `1/α`), so
+/// the fold floors alone would admit prompt-undersampled grids; the α = 1,
+/// FWHM = 10 µs measurement (1.2e-4 at dtau = fast_reach/43) anchors
+/// forty-eight samples across the prompt reach at ~1e-4. Only the sampled
+/// fold path needs this — the fold-free branch is analytic.
+const PROMPT_BIN_SAMPLES: f64 = 48.0;
 
 /// Reach of the sampled/folded Gaussian burst in standard deviations. At
 /// ±`GAUSS_REACH_SIGMAS`·σ = ±8σ the truncated two-sided Gaussian mass is
@@ -819,26 +840,39 @@ impl IkedaCarpenter {
 
         let (times, densities) =
             synth_source_pulse_density(&self.params, self.n_tau, true_energy_ev)?;
-        // Per-bin accuracy gate: the point-sampled channel-triangle
-        // convolution mis-assigns individual bins as O(dtau²) even while
-        // conserving the total (leading-edge mass below the sampled support
-        // silently redistributes into the window). Synthesis accepts the
-        // moment-level FWHM/3 step for the calibration consumer; this
-        // per-bin consumer requires the stricter TRI_BIN_SAMPLES_PER_SIDE
-        // step and rejects a coarser grid loudly.
-        if let Some(fwhm) = self.params.channel_fwhm_us.filter(|&f| f > 0.0)
-            && times.len() >= 2
-        {
+        // Per-bin accuracy gate: the point-sampled fold convolution
+        // mis-assigns individual bins as O(dtau²) even while conserving the
+        // total (leading-edge mass below the sampled support silently
+        // redistributes into the window). Synthesis accepts the moment-level
+        // steps for the calibration consumer; this per-bin consumer requires
+        // the STRICTEST applicable bin floor — prompt core, channel
+        // triangle, Gaussian burst — and rejects a coarser grid loudly.
+        if times.len() >= 2 {
             let dtau = times[1] - times[0];
-            let bin_floor = fwhm / TRI_BIN_SAMPLES_PER_SIDE;
+            let alpha_probe = self.params.alpha.eval(true_energy_ev);
+            let mut bin_floor = FAST_REACH_E_FOLDS / alpha_probe.max(MIN_RATE) / PROMPT_BIN_SAMPLES;
+            let mut binding = "prompt core".to_string();
+            if let Some(fwhm) = self.params.channel_fwhm_us.filter(|&f| f > 0.0) {
+                let tri = fwhm / TRI_BIN_SAMPLES_PER_SIDE;
+                if tri < bin_floor {
+                    bin_floor = tri;
+                    binding = format!("{fwhm} µs channel triangle");
+                }
+            }
+            if let Some(sigma) = self.params.burst_sigma_us.filter(|&s| s > 0.0) {
+                let gauss = sigma / GAUSS_BIN_SAMPLES_PER_SIGMA;
+                if gauss < bin_floor {
+                    bin_floor = gauss;
+                    binding = format!("{sigma} µs Gaussian burst");
+                }
+            }
             if dtau > bin_floor * (1.0 + 1e-12) {
                 return Err(ResolutionParseError::InvalidFormat(format!(
                     "Ikeda–Carpenter detector-bin probabilities at E = \
                      {true_energy_ev} eV: the sampled τ-step {dtau:.4} µs \
-                     exceeds the per-bin accuracy floor FWHM/{TRI_BIN_SAMPLES_PER_SIDE} \
-                     = {bin_floor:.4} µs for the {fwhm} µs channel triangle; \
-                     increase n_tau (or shorten the storage tail) so the \
-                     sampled fold meets the per-bin bound"
+                     exceeds the per-bin accuracy floor {bin_floor:.4} µs \
+                     set by the {binding}; increase n_tau (or shorten the \
+                     storage tail) so the sampled fold meets the per-bin bound"
                 )));
             }
         }
@@ -935,26 +969,30 @@ fn tau_geometry(
     let mut dtau_req = fast_reach / (n_tau as f64 - 1.0);
     let mut floor = fast_reach / (MIN_N_TAU as f64 - 1.0);
     let mut fold_desc = String::new();
+    // With any fold active, the REQUESTED step targets the per-bin accuracy
+    // floors (prompt core, triangle, burst — see the *_BIN_* constants) so
+    // the detector-bin path is accurate whenever the sample cap affords it;
+    // the HARD floors stay at the moment level (MIN_N_TAU prompt density,
+    // FWHM/TRI_MIN_SAMPLES_PER_SIDE, σ) so cap-limited long-tail
+    // configurations still synthesize for the moment-level consumers
+    // (calibration), and only the per-bin gate in
+    // `detector_bin_probabilities` rejects them.
+    let any_fold = params.channel_fwhm_us.filter(|&f| f > 0.0).is_some()
+        || params.burst_sigma_us.filter(|&s| s > 0.0).is_some();
+    if any_fold {
+        dtau_req = dtau_req.min(fast_reach / PROMPT_BIN_SAMPLES);
+    }
     if let Some(fwhm) = params.channel_fwhm_us
         && fwhm > 0.0
     {
-        // The REQUESTED step targets the per-bin accuracy floor
-        // (FWHM/TRI_BIN_SAMPLES_PER_SIDE) so the detector-bin path is
-        // accurate whenever the sample cap affords it; the HARD floor stays
-        // at the moment-level FWHM/TRI_MIN_SAMPLES_PER_SIDE so cap-limited
-        // long-tail configurations still synthesize for the moment-level
-        // consumers (calibration), and only the per-bin gate in
-        // `detector_bin_probabilities` rejects them.
-        let tri_bin_target = fwhm / TRI_BIN_SAMPLES_PER_SIDE;
-        let tri_floor = fwhm / TRI_MIN_SAMPLES_PER_SIDE;
-        dtau_req = dtau_req.min(tri_bin_target);
-        floor = floor.min(tri_floor);
+        dtau_req = dtau_req.min(fwhm / TRI_BIN_SAMPLES_PER_SIDE);
+        floor = floor.min(fwhm / TRI_MIN_SAMPLES_PER_SIDE);
         fold_desc.push_str(&format!(", channel triangle FWHM = {fwhm} µs"));
     }
     if let Some(sigma) = params.burst_sigma_us
         && sigma > 0.0
     {
-        dtau_req = dtau_req.min(sigma);
+        dtau_req = dtau_req.min(sigma / GAUSS_BIN_SAMPLES_PER_SIGMA);
         floor = floor.min(sigma);
         fold_desc.push_str(&format!(", burst σ = {sigma} µs"));
     }

--- a/crates/nereids-physics/src/ikeda_carpenter.rs
+++ b/crates/nereids-physics/src/ikeda_carpenter.rs
@@ -171,7 +171,29 @@ const MIN_N_TAU: usize = 8;
 /// the discrete triangle toward the exact delta `[0, 1, 0]`, silently
 /// erasing a requested fold — [`tau_geometry`] rejects that instead
 /// (strictly: `capped_step > FWHM/3`).
+///
+/// This floor guarantees MOMENT-level accuracy (the calibration consumer's
+/// contract); per-bin detector probabilities need the far stricter
+/// [`TRI_BIN_SAMPLES_PER_SIDE`], enforced at the detector-bin gate rather
+/// than here so realistic long-storage-tail calibrations stay buildable
+/// under the [`MAX_TAU_SAMPLES`] cap.
 const TRI_MIN_SAMPLES_PER_SIDE: f64 = 3.0;
+
+/// Per-bin accuracy floor for the SAMPLED detector-bin path
+/// (`dtau ≤ FWHM / TRI_BIN_SAMPLES_PER_SIDE` required by
+/// `detector_bin_probabilities` when a channel fold is active). The
+/// point-sampled discrete convolution mis-assigns individual detector-bin
+/// probability as O(dtau²) even while the total mass is conserved (the
+/// triangle kernel's kink drives the error; measured at α = 1 µs⁻¹,
+/// FWHM = 10 µs: 7.5e-3 max per-bin error at 3 samples per side, ~1.2e-4 at
+/// 24, ~3e-7 at the 600-sample default). Twenty-four per side bounds the
+/// per-bin error of every accepted call at ~1e-4; a coarser sampled grid is
+/// rejected loudly at the detector-bin gate rather than silently
+/// redistributing leading-edge mass. SAMMY's UDR convolution integrates
+/// piecewise-linear segment products analytically (`udr/mudr4.f90`
+/// `Ud_Convolute`/`Udr_Add`) and needs no such floor; the sampled route
+/// keeps one and enforces it at the consumer whose contract is per-bin.
+const TRI_BIN_SAMPLES_PER_SIDE: f64 = 24.0;
 
 /// Reach of the sampled/folded Gaussian burst in standard deviations. At
 /// ±`GAUSS_REACH_SIGMAS`·σ = ±8σ the truncated two-sided Gaussian mass is
@@ -287,7 +309,9 @@ pub fn ic_pulse(alpha: f64, beta: f64, r: f64, tau: f64) -> f64 {
 ///
 /// Domain contract: non-finite `alpha`, `beta`, or `r` returns NaN so garbage
 /// in stays visible; finite non-positive rates are floored to [`MIN_RATE`]
-/// and `r <= 0` disables the storage term, matching [`ic_pulse`].
+/// and `r <= 0` disables the storage term, matching [`ic_pulse`]. A NaN `tau`
+/// returns 0 — `tau` is the integration coordinate, not a parameter, and a
+/// non-arriving coordinate contributes no mass.
 #[must_use]
 pub fn ic_cdf(alpha: f64, beta: f64, r: f64, tau: f64) -> f64 {
     if !alpha.is_finite() || !beta.is_finite() || !r.is_finite() {
@@ -588,8 +612,8 @@ impl IkedaCarpenter {
             if let Some(&bad) = ref_energies.iter().find(|&&e| law.is_singular_at(e)) {
                 return Err(ResolutionParseError::InvalidFormat(format!(
                     "Ikeda–Carpenter {name}(E) law is singular at E = {bad} eV \
-                     (an InverseLambda denominator or ExpMilliEv κ within \
-                     ±{MIN_RATE} of zero)"
+                     (an InverseLambda denominator within \
+                     ±{MIN_RATE} of zero, or an ExpMilliEv κ in [−{MIN_RATE}, 0])"
                 )));
             }
         }
@@ -795,6 +819,29 @@ impl IkedaCarpenter {
 
         let (times, densities) =
             synth_source_pulse_density(&self.params, self.n_tau, true_energy_ev)?;
+        // Per-bin accuracy gate: the point-sampled channel-triangle
+        // convolution mis-assigns individual bins as O(dtau²) even while
+        // conserving the total (leading-edge mass below the sampled support
+        // silently redistributes into the window). Synthesis accepts the
+        // moment-level FWHM/3 step for the calibration consumer; this
+        // per-bin consumer requires the stricter TRI_BIN_SAMPLES_PER_SIDE
+        // step and rejects a coarser grid loudly.
+        if let Some(fwhm) = self.params.channel_fwhm_us.filter(|&f| f > 0.0)
+            && times.len() >= 2
+        {
+            let dtau = times[1] - times[0];
+            let bin_floor = fwhm / TRI_BIN_SAMPLES_PER_SIDE;
+            if dtau > bin_floor * (1.0 + 1e-12) {
+                return Err(ResolutionParseError::InvalidFormat(format!(
+                    "Ikeda–Carpenter detector-bin probabilities at E = \
+                     {true_energy_ev} eV: the sampled τ-step {dtau:.4} µs \
+                     exceeds the per-bin accuracy floor FWHM/{TRI_BIN_SAMPLES_PER_SIDE} \
+                     = {bin_floor:.4} µs for the {fwhm} µs channel triangle; \
+                     increase n_tau (or shorten the storage tail) so the \
+                     sampled fold meets the per-bin bound"
+                )));
+            }
+        }
         piecewise_linear_bin_masses(&times, &densities, &relative_edges).ok_or_else(|| {
             ResolutionParseError::InvalidFormat(format!(
                 "Ikeda–Carpenter pulse at E = {true_energy_ev} eV has zero sampled area"
@@ -816,8 +863,8 @@ impl IkedaCarpenter {
             if law.is_singular_at(energy_ev) {
                 return Err(ResolutionParseError::InvalidFormat(format!(
                     "Ikeda–Carpenter {name}({energy_ev}) law is singular (an \
-                     InverseLambda denominator or ExpMilliEv κ within \
-                     ±{MIN_RATE} of zero)"
+                     InverseLambda denominator within ±{MIN_RATE} of zero, \
+                     or an ExpMilliEv κ in [−{MIN_RATE}, 0])"
                 )));
             }
         }
@@ -849,7 +896,7 @@ impl IkedaCarpenter {
 /// The step is anchored to the PROMPT core — `n_tau` samples across the fast
 /// Gamma(3) pulse (`fast_reach / (n_tau − 1)`) — and REFINED to resolve any
 /// requested instrument fold (triangle: ≥ [`TRI_MIN_SAMPLES_PER_SIDE`]
-/// samples per side, i.e. `dtau ≤ FWHM/3`; Gaussian burst: `dtau ≤ σ`, i.e.
+/// samples per side, i.e. `dtau ≤ FWHM/TRI_MIN_SAMPLES_PER_SIDE`; Gaussian burst: `dtau ≤ σ`, i.e.
 /// ≥ [`GAUSS_REACH_SIGMAS`] samples per ±`GAUSS_REACH_SIGMAS`·σ side). A longer storage tail
 /// (β ≪ α, R > 0) extends the SAMPLE COUNT (`j_hi ∝ tau_max/dtau`) instead
 /// of the step; [`MAX_TAU_SAMPLES`] bounds that count by widening the step —
@@ -891,8 +938,16 @@ fn tau_geometry(
     if let Some(fwhm) = params.channel_fwhm_us
         && fwhm > 0.0
     {
+        // The REQUESTED step targets the per-bin accuracy floor
+        // (FWHM/TRI_BIN_SAMPLES_PER_SIDE) so the detector-bin path is
+        // accurate whenever the sample cap affords it; the HARD floor stays
+        // at the moment-level FWHM/TRI_MIN_SAMPLES_PER_SIDE so cap-limited
+        // long-tail configurations still synthesize for the moment-level
+        // consumers (calibration), and only the per-bin gate in
+        // `detector_bin_probabilities` rejects them.
+        let tri_bin_target = fwhm / TRI_BIN_SAMPLES_PER_SIDE;
         let tri_floor = fwhm / TRI_MIN_SAMPLES_PER_SIDE;
-        dtau_req = dtau_req.min(tri_floor);
+        dtau_req = dtau_req.min(tri_bin_target);
         floor = floor.min(tri_floor);
         fold_desc.push_str(&format!(", channel triangle FWHM = {fwhm} µs"));
     }
@@ -1469,10 +1524,12 @@ mod tests {
         let prompt_step = (18.0 / alpha) / (n_tau as f64 - 1.0);
 
         // (a) Moderate tail (β = 0.25 ⇒ slow_reach = 64 µs): the cap does not
-        // bite, so the step equals the prompt-core step exactly and the grid
-        // still spans the full tail.
+        // bite and the 0.5 µs triangle's per-bin refinement target
+        // (FWHM/24 ≈ 0.021 µs) sits above the prompt-core step, so the step
+        // equals the prompt-core step exactly and the grid still spans the
+        // full tail.
         let p = IkedaCarpenterParams {
-            channel_fwhm_us: Some(0.35),
+            channel_fwhm_us: Some(0.5),
             ..IkedaCarpenterParams::constant(alpha, 0.25, 0.5)
         };
         let (offs, wts) = synth_kernel(&p, n_tau, 10.0).unwrap();
@@ -1486,7 +1543,7 @@ mod tests {
             "prompt-core spacing {dtau} > fast_reach/(n_tau−1) = {prompt_step}"
         );
         // ≥ 3 nonzero triangle samples per side at this step.
-        let tri = triangle_kernel(dtau, 0.35);
+        let tri = triangle_kernel(dtau, 0.5);
         let nonzero_per_side = tri.iter().take(tri.len() / 2).filter(|&&v| v > 0.0).count();
         assert!(
             nonzero_per_side >= 3,
@@ -1626,46 +1683,48 @@ mod tests {
     }
 
     #[test]
-    fn boundary_step_fwhm_over_3_is_admitted_and_fold_survives() {
-        // Review #645 round 2, F3: pin the exactly-admitted boundary
-        // `dtau = FWHM/3` (rejection is STRICT: `capped_step > floor`). Per
-        // the TRI_MIN_SAMPLES_PER_SIDE doc, each triangle side then samples
-        // at {FWHM/3, 2FWHM/3, FWHM} — weights {2/3, 1/3, 0}: exactly 2
-        // strictly interior nonzero samples, endpoint ON the triangle zero —
-        // and the fold stays effective (non-delta, second moment ≈ 4FWHM²/27).
+    fn boundary_step_at_triangle_floor_is_admitted_and_fold_survives() {
+        // Pin the exactly-admitted uncapped step `dtau = FWHM /
+        // TRI_BIN_SAMPLES_PER_SIDE` (the bin-eager refinement target),
+        // written in terms of the constant so the pin survives value
+        // changes. For N samples per side the discrete triangle's variance
+        // is (1 − 1/N²)·FWHM²/6 exactly (N = 3 gives the historical
+        // 4·FWHM²/27 of the moment-level floor), and each side keeps N − 1
+        // strictly interior nonzero samples with the endpoint ON the
+        // triangle zero.
         //
         // Route to the boundary: n_tau = MIN_N_TAU = 8 with α = 1 gives a
-        // prompt design step 18/7 ≈ 2.57 µs, far coarser than FWHM/3 for a
-        // 1 µs triangle, so the fold refinement pins dtau to exactly
-        // `fwhm / TRI_MIN_SAMPLES_PER_SIDE`. R = 0 keeps the cap inert
-        // (capped step 18/8191 ≪ floor).
+        // prompt design step 18/7 ≈ 2.57 µs, far coarser than the target for
+        // a 1 µs triangle, so the fold refinement pins dtau to exactly the
+        // target. R = 0 keeps the cap inert (capped step 18/8191 ≪ target).
+        let n = TRI_BIN_SAMPLES_PER_SIDE;
         let fwhm = 1.0;
         let p = IkedaCarpenterParams {
             channel_fwhm_us: Some(fwhm),
             ..IkedaCarpenterParams::constant(1.0, 0.1, 0.0)
         };
         let (offs, _) = synth_kernel(&p, MIN_N_TAU, 10.0)
-            .expect("the dtau = FWHM/3 boundary must be admitted, not rejected");
+            .expect("the dtau = floor boundary must be admitted, not rejected");
         let dtau = offs[1] - offs[0];
-        let boundary = fwhm / TRI_MIN_SAMPLES_PER_SIDE;
+        let boundary = fwhm / n;
         assert!(
             (dtau - boundary).abs() < 1e-12,
-            "step {dtau} µs is not the FWHM/3 boundary {boundary} µs"
+            "step {dtau} µs is not the FWHM/{n} boundary {boundary} µs"
         );
 
-        // The sampled triangle at the boundary: ≥ 7 samples, exactly 2
-        // strictly interior nonzero per side, center far below the delta's 1.
+        // The sampled triangle at the boundary: N − 1 strictly interior
+        // nonzero samples per side, center far below the delta's 1.
         let tri = triangle_kernel(dtau, fwhm);
-        assert!(tri.len() >= 7, "boundary triangle too short: {}", tri.len());
         let per_side = tri
             .iter()
             .take(tri.len() / 2)
             .filter(|&&v| v > 1e-9)
             .count();
         assert_eq!(
-            per_side, 2,
-            "boundary triangle must keep 2 strictly interior nonzero samples \
-             per side: {tri:?}"
+            per_side,
+            n as usize - 1,
+            "boundary triangle must keep N − 1 strictly interior nonzero \
+             samples per side: {tri:?}"
         );
         let center = tri[tri.len() / 2];
         assert!(
@@ -1673,15 +1732,12 @@ mod tests {
             "center weight {center} — boundary triangle degenerated toward a delta"
         );
 
-        // Fold effectiveness: the discrete triangle's variance is 4·FWHM²/27
-        // (samples {0, ±FWHM/3, ±2FWHM/3} with weights ∝ {1, 2/3, 1/3}),
-        // ≈ 89 % of the analytic FWHM²/6 — the fold physics survives the
-        // 2-interior-sample discretization.
+        // Fold effectiveness: discrete variance (1 − 1/N²)·FWHM²/6.
         let tri_offs: Vec<f64> = (0..tri.len())
             .map(|i| (i as f64 - (tri.len() / 2) as f64) * dtau)
             .collect();
         let v = kernel_variance(&tri_offs, &tri);
-        let want = 4.0 * fwhm * fwhm / 27.0;
+        let want = (1.0 - 1.0 / (n * n)) * fwhm * fwhm / 6.0;
         assert!(
             ((v - want) / want).abs() < 0.02,
             "boundary triangle variance {v} µs² vs discrete analytic {want} µs²"

--- a/crates/nereids-physics/src/ikeda_carpenter.rs
+++ b/crates/nereids-physics/src/ikeda_carpenter.rs
@@ -329,8 +329,9 @@ pub fn ic_pulse(alpha: f64, beta: f64, r: f64, tau: f64) -> f64 {
 /// when `α ≈ β`. This is the bin-integral companion to [`ic_pulse`].
 ///
 /// Domain contract: non-finite `alpha`, `beta`, or `r` returns NaN so garbage
-/// in stays visible; finite non-positive rates are floored to [`MIN_RATE`]
-/// and `r <= 0` disables the storage term, matching [`ic_pulse`]. A NaN `tau`
+/// in stays visible; finite non-positive rates are floored to `MIN_RATE`
+/// (1e-9 µs⁻¹) and `r <= 0` disables the storage term, matching
+/// [`ic_pulse`]. A NaN `tau`
 /// returns 0 — `tau` is the integration coordinate, not a parameter, and a
 /// non-arriving coordinate contributes no mass.
 #[must_use]

--- a/crates/nereids-physics/src/ikeda_carpenter.rs
+++ b/crates/nereids-physics/src/ikeda_carpenter.rs
@@ -44,7 +44,8 @@
 //!
 //! - `α(E)` [1/µs]: fast moderation/leakage rate; sets the prompt width.
 //!   Leading epithermal scaling `α ∝ √E` (Mantid `α = 1/(α₀+α₁λ)`, λ ∝ 1/√E).
-//! - `β` [1/µs]: slow storage rate; sets the delayed tail. Energy-independent.
+//! - `β(E)` [1/µs]: slow storage rate; sets the delayed tail. Constant by
+//!   default; optionally energy-dependent through an [`EnergyLaw`].
 //! - `R(E)`, 0 ≤ R ≤ 1: storage mixing fraction; `R ≈ exp(−E_meV/κ)` → **R→0 in
 //!   the 1–200 eV resonance regime**, so IC there is dominated by the
 //!   one-parameter prompt Gamma(3, α(E)) term.
@@ -175,8 +176,11 @@ const TRI_MIN_SAMPLES_PER_SIDE: f64 = 3.0;
 /// Reach of the sampled/folded Gaussian burst in standard deviations (±4σ:
 /// e^{−8} ≈ 3.4e-4 of peak at the edge, well below any consuming tolerance
 /// once convolved). Also fixes the burst resolution floor `dtau ≤ σ`
-/// (≥ `GAUSS_REACH_SIGMAS` samples per side).
-const GAUSS_REACH_SIGMAS: f64 = 4.0;
+/// (≥ `GAUSS_REACH_SIGMAS` samples per side). At ±8σ the truncated two-sided
+/// Gaussian mass is erfc(8/√2) ≈ 1.2e-15, so the retained-mass bookkeeping in
+/// [`gaussian_kernel`] stays exact at f64 scale and no physically meaningful
+/// mass is discarded for any detector window.
+const GAUSS_REACH_SIGMAS: f64 = 8.0;
 
 /// Prompt-tail reach in e-folds: the τ-grid spans `FAST_REACH_E_FOLDS / α`
 /// so the prompt Gamma(3) tail `τ²e^{−ατ}` is < ~1e-8 of peak at the edge.
@@ -284,15 +288,26 @@ pub fn ic_cdf(alpha: f64, beta: f64, r: f64, tau: f64) -> f64 {
     if tau == f64::INFINITY {
         return 1.0;
     }
-    if !tau.is_finite() {
-        return 0.0;
-    }
 
     let alpha = alpha.max(MIN_RATE);
     let beta = beta.max(MIN_RATE);
     let at = alpha * tau;
     let fast = gamma3_cdf(at);
     if r <= 0.0 {
+        return fast;
+    }
+
+    // Far in the tails the general expressions overflow — `at³` or `u³`
+    // reach f64::INFINITY and produce inf·0 / inf/inf = NaN — while the
+    // limits are exact to full f64 precision, so return them directly.
+    // For at ≥ 1e100 the prompt CDF is 1 and the storage correction is
+    // exp(−βτ) with relative error ≤ 3βτ/at; for βτ ≥ 1e100 the storage
+    // delay is instantaneous and the correction is 0.
+    const CDF_TAIL_LIMIT: f64 = 1.0e100;
+    if at >= CDF_TAIL_LIMIT {
+        return (1.0 - r * (-beta * tau).exp()).clamp(0.0, 1.0);
+    }
+    if beta * tau >= CDF_TAIL_LIMIT {
         return fast;
     }
 
@@ -313,6 +328,12 @@ pub fn ic_cdf(alpha: f64, beta: f64, r: f64, tau: f64) -> f64 {
 fn gamma3_cdf(x: f64) -> f64 {
     if x <= 0.0 {
         return 0.0;
+    }
+    // Beyond x ≈ 750 the survival term exp(−x)·(1+x+x²/2) underflows to an
+    // exact zero long before the polynomial can overflow (x² reaches
+    // f64::INFINITY only at x ~ 1.3e154, where 0·inf would be NaN).
+    if x >= 750.0 {
+        return 1.0;
     }
     if x < 0.5 {
         // Integral of x² exp(-x) / 2 as an alternating series. The direct
@@ -362,12 +383,7 @@ impl EnergyLaw {
             EnergyLaw::Const(c) => c,
             EnergyLaw::SqrtE { a0, a1 } => a0 * e.sqrt() + a1,
             EnergyLaw::InverseLambda { a0, a1 } => {
-                let lambda = if e > 0.0 {
-                    LAMBDA_ANGSTROM_FACTOR / e.sqrt()
-                } else {
-                    f64::INFINITY
-                };
-                let denom = a0 + a1 * lambda;
+                let denom = inverse_lambda_denom(a0, a1, e);
                 if denom.abs() < MIN_RATE {
                     1.0 / MIN_RATE
                 } else {
@@ -383,6 +399,35 @@ impl EnergyLaw {
             }
         }
     }
+
+    /// True when the law is numerically singular at `energy_ev`: the raw
+    /// `InverseLambda` denominator lies inside the ±[`MIN_RATE`] window that
+    /// [`EnergyLaw::eval`] floors away. The floor keeps a fit trial step from
+    /// dividing by zero mid-optimization, but a *configured* law inside that
+    /// window is a mathematically undefined rate, not a large one — without
+    /// this check the floor converts an undefined (or tiny-negative)
+    /// denominator into a plausible huge positive rate before the range
+    /// validation below can see it.
+    #[must_use]
+    pub(crate) fn is_singular_at(&self, energy_ev: f64) -> bool {
+        match *self {
+            EnergyLaw::InverseLambda { a0, a1 } => {
+                inverse_lambda_denom(a0, a1, energy_ev.max(0.0)).abs() < MIN_RATE
+            }
+            _ => false,
+        }
+    }
+}
+
+/// Raw `InverseLambda` denominator `a0 + a1·λ(E)` — shared by [`EnergyLaw::eval`]
+/// and the singularity check so the two can never disagree on the window.
+fn inverse_lambda_denom(a0: f64, a1: f64, e: f64) -> f64 {
+    let lambda = if e > 0.0 {
+        LAMBDA_ANGSTROM_FACTOR / e.sqrt()
+    } else {
+        f64::INFINITY
+    };
+    a0 + a1 * lambda
 }
 
 /// Parameters of the Ikeda–Carpenter resolution model.
@@ -518,6 +563,19 @@ impl IkedaCarpenter {
             .map(|i| (ln_lo + (i as f64 / denom) * (ln_hi - ln_lo)).exp())
             .collect();
 
+        // Reject singular rate laws before the range checks: a near-zero
+        // InverseLambda denominator is an undefined configuration, and eval's
+        // numerical floor would otherwise convert it into a plausible huge
+        // positive rate that the α > 0 / β > 0 checks below cannot distinguish
+        // from genuine physics.
+        for (name, law) in [("α", &params.alpha), ("β", &params.beta)] {
+            if let Some(&bad) = ref_energies.iter().find(|&&e| law.is_singular_at(e)) {
+                return Err(ResolutionParseError::InvalidFormat(format!(
+                    "Ikeda–Carpenter {name}(E) law is singular at E = {bad} eV: \
+                     its InverseLambda denominator is within ±{MIN_RATE} of zero"
+                )));
+            }
+        }
         // Reject parameter laws that yield a non-positive fast rate α(E): the
         // pulse would otherwise degenerate (synthesis clamps α to a tiny floor,
         // producing a meaningless near-flat kernel rather than failing loudly).
@@ -732,6 +790,14 @@ impl IkedaCarpenter {
             return Err(ResolutionParseError::InvalidFormat(format!(
                 "true energy must be positive and finite, got {energy_ev}"
             )));
+        }
+        for (name, law) in [("alpha", &self.params.alpha), ("beta", &self.params.beta)] {
+            if law.is_singular_at(energy_ev) {
+                return Err(ResolutionParseError::InvalidFormat(format!(
+                    "Ikeda–Carpenter {name}({energy_ev}) law is singular: its \
+                     InverseLambda denominator is within ±{MIN_RATE} of zero"
+                )));
+            }
         }
         let alpha = self.params.alpha.eval(energy_ev);
         let beta = self.params.beta.eval(energy_ev);

--- a/crates/nereids-physics/src/ikeda_carpenter.rs
+++ b/crates/nereids-physics/src/ikeda_carpenter.rs
@@ -173,13 +173,12 @@ const MIN_N_TAU: usize = 8;
 /// (strictly: `capped_step > FWHM/3`).
 const TRI_MIN_SAMPLES_PER_SIDE: f64 = 3.0;
 
-/// Reach of the sampled/folded Gaussian burst in standard deviations (±4σ:
-/// e^{−8} ≈ 3.4e-4 of peak at the edge, well below any consuming tolerance
-/// once convolved). Also fixes the burst resolution floor `dtau ≤ σ`
-/// (≥ `GAUSS_REACH_SIGMAS` samples per side). At ±8σ the truncated two-sided
-/// Gaussian mass is erfc(8/√2) ≈ 1.2e-15, so the retained-mass bookkeeping in
+/// Reach of the sampled/folded Gaussian burst in standard deviations. At
+/// ±`GAUSS_REACH_SIGMAS`·σ = ±8σ the truncated two-sided Gaussian mass is
+/// erfc(8/√2) ≈ 1.2e-15, so the retained-mass bookkeeping in
 /// [`gaussian_kernel`] stays exact at f64 scale and no physically meaningful
-/// mass is discarded for any detector window.
+/// mass is discarded for any detector window. Also fixes the burst
+/// resolution floor `dtau ≤ σ` (≥ `GAUSS_REACH_SIGMAS` samples per side).
 const GAUSS_REACH_SIGMAS: f64 = 8.0;
 
 /// Prompt-tail reach in e-folds: the τ-grid spans `FAST_REACH_E_FOLDS / α`
@@ -218,9 +217,9 @@ const R_NEGLIGIBLE: f64 = 1e-9;
 /// whose floor cannot be met within the cap is REJECTED loudly by
 /// [`IkedaCarpenter::new`] instead of silently under-sampled. The actual
 /// guarantee is on the pulse body only: the symmetric burst/channel fold
-/// margin (± `4σ + FWHM` at the resolved step) adds its samples ON TOP of
-/// the cap, so the final grid can exceed `MAX_TAU_SAMPLES` by the margin
-/// sample count.
+/// margin (± `GAUSS_REACH_SIGMAS·σ + FWHM` at the resolved step) adds its
+/// samples ON TOP of the cap, so the final grid can exceed
+/// `MAX_TAU_SAMPLES` by the margin sample count.
 const MAX_TAU_SAMPLES: usize = 8192;
 
 /// Taylor expansion of `h(u)/u³` where `h(u) = 1 − e^{−u}(1 + u + ½u²)`, for
@@ -245,6 +244,11 @@ fn h_over_cube_taylor(u: f64) -> f64 {
 /// near `u = α−β·τ → 0` where that bracket cancels.
 #[must_use]
 pub fn ic_pulse(alpha: f64, beta: f64, r: f64, tau: f64) -> f64 {
+    // Same domain contract as ic_cdf: non-finite parameters return NaN so
+    // garbage in stays visible instead of flooring into a plausible pulse.
+    if !alpha.is_finite() || !beta.is_finite() || !r.is_finite() {
+        return f64::NAN;
+    }
     if !tau.is_finite() || tau < 0.0 {
         return 0.0;
     }
@@ -280,8 +284,15 @@ pub fn ic_pulse(alpha: f64, beta: f64, r: f64, tau: f64) -> f64 {
 ///
 /// The expression is evaluated without subtracting nearly equal exponentials
 /// when `α ≈ β`. This is the bin-integral companion to [`ic_pulse`].
+///
+/// Domain contract: non-finite `alpha`, `beta`, or `r` returns NaN so garbage
+/// in stays visible; finite non-positive rates are floored to [`MIN_RATE`]
+/// and `r <= 0` disables the storage term, matching [`ic_pulse`].
 #[must_use]
 pub fn ic_cdf(alpha: f64, beta: f64, r: f64, tau: f64) -> f64 {
+    if !alpha.is_finite() || !beta.is_finite() || !r.is_finite() {
+        return f64::NAN;
+    }
     if tau.is_nan() || tau <= 0.0 {
         return 0.0;
     }
@@ -414,6 +425,10 @@ impl EnergyLaw {
             EnergyLaw::InverseLambda { a0, a1 } => {
                 inverse_lambda_denom(a0, a1, energy_ev.max(0.0)).abs() < MIN_RATE
             }
+            // κ = 0 is undefined and a tiny NEGATIVE κ is a divergent law
+            // (exp(+E/|κ|)); eval's floor maps both to 0.0, which is the
+            // legitimate κ → 0⁺ limit only for positive κ.
+            EnergyLaw::ExpMilliEv { kappa } => (-MIN_RATE..=0.0).contains(&kappa),
             _ => false,
         }
     }
@@ -479,7 +494,8 @@ pub struct SynthesisGrid {
     /// `n_tau = 8` density, folds at ≥ 3 triangle samples per side / ≥ 1
     /// sample per burst σ): a combination that cannot be resolved within the
     /// cap is rejected by [`IkedaCarpenter::new`]. Active burst/channel folds
-    /// add their ±(4σ + FWHM) margin samples on top of the cap.
+    /// add their ±(`GAUSS_REACH_SIGMAS`·σ + FWHM) margin samples on top of
+    /// the cap.
     pub n_tau: usize,
 }
 
@@ -568,11 +584,12 @@ impl IkedaCarpenter {
         // numerical floor would otherwise convert it into a plausible huge
         // positive rate that the α > 0 / β > 0 checks below cannot distinguish
         // from genuine physics.
-        for (name, law) in [("α", &params.alpha), ("β", &params.beta)] {
+        for (name, law) in [("α", &params.alpha), ("β", &params.beta), ("R", &params.r)] {
             if let Some(&bad) = ref_energies.iter().find(|&&e| law.is_singular_at(e)) {
                 return Err(ResolutionParseError::InvalidFormat(format!(
-                    "Ikeda–Carpenter {name}(E) law is singular at E = {bad} eV: \
-                     its InverseLambda denominator is within ±{MIN_RATE} of zero"
+                    "Ikeda–Carpenter {name}(E) law is singular at E = {bad} eV \
+                     (an InverseLambda denominator or ExpMilliEv κ within \
+                     ±{MIN_RATE} of zero)"
                 )));
             }
         }
@@ -791,11 +808,16 @@ impl IkedaCarpenter {
                 "true energy must be positive and finite, got {energy_ev}"
             )));
         }
-        for (name, law) in [("alpha", &self.params.alpha), ("beta", &self.params.beta)] {
+        for (name, law) in [
+            ("alpha", &self.params.alpha),
+            ("beta", &self.params.beta),
+            ("R", &self.params.r),
+        ] {
             if law.is_singular_at(energy_ev) {
                 return Err(ResolutionParseError::InvalidFormat(format!(
-                    "Ikeda–Carpenter {name}({energy_ev}) law is singular: its \
-                     InverseLambda denominator is within ±{MIN_RATE} of zero"
+                    "Ikeda–Carpenter {name}({energy_ev}) law is singular (an \
+                     InverseLambda denominator or ExpMilliEv κ within \
+                     ±{MIN_RATE} of zero)"
                 )));
             }
         }
@@ -828,7 +850,7 @@ impl IkedaCarpenter {
 /// Gamma(3) pulse (`fast_reach / (n_tau − 1)`) — and REFINED to resolve any
 /// requested instrument fold (triangle: ≥ [`TRI_MIN_SAMPLES_PER_SIDE`]
 /// samples per side, i.e. `dtau ≤ FWHM/3`; Gaussian burst: `dtau ≤ σ`, i.e.
-/// ≥ [`GAUSS_REACH_SIGMAS`] samples per ±4σ side). A longer storage tail
+/// ≥ [`GAUSS_REACH_SIGMAS`] samples per ±`GAUSS_REACH_SIGMAS`·σ side). A longer storage tail
 /// (β ≪ α, R > 0) extends the SAMPLE COUNT (`j_hi ∝ tau_max/dtau`) instead
 /// of the step; [`MAX_TAU_SAMPLES`] bounds that count by widening the step —
 /// but never past the resolution FLOOR (`fast_reach / (MIN_N_TAU − 1)` for
@@ -895,9 +917,9 @@ fn tau_geometry(
     Ok((dtau_req.max(capped_step), tau_max, margin_of(params)))
 }
 
-/// Symmetric τ-grid margin for the burst/channel folds: ±(4σ + FWHM), the
-/// folds' full reach. These samples come ON TOP of [`MAX_TAU_SAMPLES`] (the
-/// cap governs the pulse body only).
+/// Symmetric τ-grid margin for the burst/channel folds:
+/// ±([`GAUSS_REACH_SIGMAS`]·σ + FWHM), the folds' full reach. These samples
+/// come ON TOP of [`MAX_TAU_SAMPLES`] (the cap governs the pulse body only).
 fn margin_of(params: &IkedaCarpenterParams) -> f64 {
     params
         .burst_sigma_us

--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -910,6 +910,12 @@ fn piecewise_linear_bin_integrals(
     if times.is_empty() || times.len() != weights.len() {
         return None;
     }
+    // A duplicated (or decreasing) time gives a zero-width segment whose
+    // slope is ±inf/NaN inside the CDF interpolation when an edge lands
+    // there; mirror the strictly-increasing edge validation instead.
+    if times.windows(2).any(|w| w[1] <= w[0]) {
+        return None;
+    }
 
     if times.len() == 1 {
         if !normalize_support {
@@ -5334,6 +5340,19 @@ Resolution file
         // A one-point kernel without a defined width is rejected in the
         // density (masses) mode.
         assert!(piecewise_linear_bin_integrals(&[2.0], &[3.5], &[0.0, 5.0], false).is_none());
+        // Non-strictly-increasing times are rejected in both modes: a
+        // zero-width segment would otherwise put ±inf/NaN into the CDF slope.
+        for mode in [true, false] {
+            assert!(
+                piecewise_linear_bin_integrals(
+                    &[0.0, 1.0, 1.0, 2.0],
+                    &[0.0, 1.0, 1.0, 0.0],
+                    &[0.5, 1.5],
+                    mode
+                )
+                .is_none()
+            );
+        }
 
         // Support normalization: a triangle on [0, 2] integrates to one over
         // its full support, and a partial window reports the true fraction.

--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -895,6 +895,92 @@ fn trapezoidal_moments(offsets: &[f64], weights: &[f64]) -> (f64, f64) {
     (centroid, sigma)
 }
 
+/// Integrate a sampled distribution into adjacent requested edges.
+///
+/// With `normalize_support`, a one-point kernel is treated as a unit delta and
+/// a longer kernel is normalized over its supplied support. Without it, the
+/// supplied values retain their physical density scale and a one-point density
+/// is rejected because it has no defined integration width.
+fn piecewise_linear_bin_integrals(
+    times: &[f64],
+    weights: &[f64],
+    edges: &[f64],
+    normalize_support: bool,
+) -> Option<Vec<f64>> {
+    if times.is_empty() || times.len() != weights.len() {
+        return None;
+    }
+
+    if times.len() == 1 {
+        if !normalize_support {
+            return None;
+        }
+        if !times[0].is_finite() || !weights[0].is_finite() || weights[0] <= 0.0 {
+            return None;
+        }
+        let mut probabilities = vec![0.0; edges.len().saturating_sub(1)];
+        for (index, edge) in edges.windows(2).enumerate() {
+            let in_bin = edge[0] <= times[0]
+                && (times[0] < edge[1]
+                    || (index + 1 == probabilities.len() && times[0] == edge[1]));
+            if in_bin {
+                probabilities[index] = 1.0;
+                break;
+            }
+        }
+        return Some(probabilities);
+    }
+
+    let mut cumulative = Vec::with_capacity(times.len());
+    cumulative.push(0.0);
+    for i in 0..times.len() - 1 {
+        let width = times[i + 1] - times[i];
+        let area = 0.5 * (weights[i] + weights[i + 1]) * width;
+        cumulative.push(cumulative[i] + area.max(0.0));
+    }
+    let total = *cumulative.last()?;
+    if !total.is_finite() || total <= 0.0 {
+        return None;
+    }
+    let scale = if normalize_support { total } else { 1.0 };
+
+    let cdf = |x: f64| -> f64 {
+        if x <= times[0] {
+            return 0.0;
+        }
+        if x >= times[times.len() - 1] {
+            return total / scale;
+        }
+        let hi = times.partition_point(|&time| time <= x);
+        let lo = hi - 1;
+        let width = times[hi] - times[lo];
+        let dx = x - times[lo];
+        let slope = (weights[hi] - weights[lo]) / width;
+        let partial = weights[lo] * dx + 0.5 * slope * dx * dx;
+        ((cumulative[lo] + partial) / scale).clamp(0.0, total / scale)
+    };
+
+    Some(
+        edges
+            .windows(2)
+            .map(|edge| (cdf(edge[1]) - cdf(edge[0])).max(0.0))
+            .collect(),
+    )
+}
+
+/// Integrate a sampled density without changing its physical mass scale.
+///
+/// This is used by analytical responses whose source density is already in
+/// probability per unit time. Probability omitted by finite numerical support
+/// therefore remains omitted instead of being redistributed into that support.
+pub(crate) fn piecewise_linear_bin_masses(
+    times: &[f64],
+    densities: &[f64],
+    edges: &[f64],
+) -> Option<Vec<f64>> {
+    piecewise_linear_bin_integrals(times, densities, edges, false)
+}
+
 impl TabulatedResolution {
     /// Reference energies (eV), sorted ascending.
     pub fn ref_energies(&self) -> &[f64] {

--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -912,8 +912,15 @@ fn piecewise_linear_bin_integrals(
     }
     // A duplicated (or decreasing) time gives a zero-width segment whose
     // slope is ±inf/NaN inside the CDF interpolation when an edge lands
-    // there; mirror the strictly-increasing edge validation instead.
-    if times.windows(2).any(|w| w[1] <= w[0]) {
+    // there — and a NaN time passes a pure monotonicity check (every NaN
+    // comparison is false) only to underflow `hi - 1` in the CDF closure
+    // (`partition_point` returns 0 when the first predicate is false).
+    // Validate finiteness and strict ordering of BOTH coordinate arrays up
+    // front; NaN weights are caught downstream by the total-mass check.
+    if times.iter().any(|t| !t.is_finite()) || times.windows(2).any(|w| w[1] <= w[0]) {
+        return None;
+    }
+    if edges.iter().any(|e| !e.is_finite()) || edges.windows(2).any(|w| w[1] <= w[0]) {
         return None;
     }
 
@@ -5340,8 +5347,11 @@ Resolution file
         // A one-point kernel without a defined width is rejected in the
         // density (masses) mode.
         assert!(piecewise_linear_bin_integrals(&[2.0], &[3.5], &[0.0, 5.0], false).is_none());
-        // Non-strictly-increasing times are rejected in both modes: a
-        // zero-width segment would otherwise put ±inf/NaN into the CDF slope.
+        // Non-strictly-increasing or non-finite coordinates are rejected in
+        // both modes: a zero-width segment would put ±inf/NaN into the CDF
+        // slope, and a NaN time passes monotonicity (every NaN comparison is
+        // false) only to underflow the CDF's partition_point index.
+        let w3 = [0.0, 1.0, 0.0];
         for mode in [true, false] {
             assert!(
                 piecewise_linear_bin_integrals(
@@ -5352,6 +5362,17 @@ Resolution file
                 )
                 .is_none()
             );
+            for bad_times in [[0.0, f64::NAN, 2.0], [0.0, 1.0, f64::INFINITY]] {
+                assert!(
+                    piecewise_linear_bin_integrals(&bad_times, &w3, &[0.5, 1.5], mode).is_none()
+                );
+            }
+            for bad_edges in [[0.5, f64::NAN], [1.5, 0.5]] {
+                assert!(
+                    piecewise_linear_bin_integrals(&[0.0, 1.0, 2.0], &w3, &bad_edges, mode)
+                        .is_none()
+                );
+            }
         }
 
         // Support normalization: a triangle on [0, 2] integrates to one over

--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -5313,4 +5313,36 @@ Resolution file
             "the dip must measurably alter at least one in-window target"
         );
     }
+
+    #[test]
+    fn piecewise_linear_normalized_branch_pins_delta_and_partial_window() {
+        // The normalize_support = true branch gains its consumer in the
+        // tabulated detector-bin work; these pins fix its semantics now so
+        // that consumer inherits a tested contract.
+        let delta = |t: f64, edges: &[f64]| {
+            piecewise_linear_bin_integrals(&[t], &[3.5], edges, true)
+                .expect("one-point kernel is a unit delta under normalization")
+        };
+        assert_eq!(delta(2.0, &[0.0, 1.0, 3.0, 5.0]), vec![0.0, 1.0, 0.0]);
+        // The last bin is right-closed: a delta exactly on the final edge
+        // belongs to it.
+        assert_eq!(delta(5.0, &[0.0, 1.0, 3.0, 5.0]), vec![0.0, 0.0, 1.0]);
+        // A delta outside every bin contributes nothing.
+        assert_eq!(delta(9.0, &[0.0, 1.0, 3.0, 5.0]), vec![0.0, 0.0, 0.0]);
+        // A one-point kernel without a defined width is rejected in the
+        // density (masses) mode.
+        assert!(piecewise_linear_bin_integrals(&[2.0], &[3.5], &[0.0, 5.0], false).is_none());
+
+        // Support normalization: a triangle on [0, 2] integrates to one over
+        // its full support, and a partial window reports the true fraction.
+        let times = [0.0, 1.0, 2.0];
+        let weights = [0.0, 4.0, 0.0]; // arbitrary scale — normalization removes it
+        let full = piecewise_linear_bin_integrals(&times, &weights, &[0.0, 2.0], true)
+            .expect("triangle integrates");
+        assert!((full[0] - 1.0).abs() < 1e-15);
+        let halves = piecewise_linear_bin_integrals(&times, &weights, &[0.0, 0.5, 1.0], true)
+            .expect("triangle integrates");
+        assert!((halves[0] - 0.125).abs() < 1e-15);
+        assert!((halves[1] - 0.375).abs() < 1e-15);
+    }
 }

--- a/crates/nereids-physics/src/resolution.rs
+++ b/crates/nereids-physics/src/resolution.rs
@@ -5316,9 +5316,11 @@ Resolution file
 
     #[test]
     fn piecewise_linear_normalized_branch_pins_delta_and_partial_window() {
-        // The normalize_support = true branch gains its consumer in the
-        // tabulated detector-bin work; these pins fix its semantics now so
-        // that consumer inherits a tested contract.
+        // Production currently consumes only the non-normalizing
+        // piecewise_linear_bin_masses path; the normalize_support = true
+        // branch has no production caller yet (the tabulated detector-bin
+        // operator adopts it next). These pins fix its semantics ahead of
+        // that consumer.
         let delta = |t: f64, edges: &[f64]| {
             piecewise_linear_bin_integrals(&[t], &[3.5], edges, true)
                 .expect("one-point kernel is a unit delta under normalization")

--- a/crates/nereids-physics/tests/ic_causal_response.rs
+++ b/crates/nereids-physics/tests/ic_causal_response.rs
@@ -595,6 +595,84 @@ fn singular_inverse_lambda_laws_are_rejected() {
 }
 
 #[test]
+fn storage_cdf_matches_arbitrary_precision_convolution_reference() {
+    // Reference values computed OUTSIDE this codebase from the DEFINING
+    // convolution: CDF = (1−r)·Γ₃(ατ) + r·∫₀^τ (α³s²e^{−αs}/2)·(1−e^{−β(τ−s)}) ds
+    // via 40-digit decimal Simpson (40 000 intervals; quadrature error ≲ 1e-14).
+    // They share no code with ic_cdf or ic_pulse, so a storage-term error
+    // common to both implementations cannot hide here. Tolerance covers the
+    // f64 implementations' Taylor truncation near the |u| = 0.05 boundary
+    // (measured 4.7e-12 at case 3 against a 60-digit closed-form check).
+    let pins: [(f64, f64, f64, f64, f64); 4] = [
+        (1.7, 0.45, 0.35, 2.7, 0.665_083_699_251_977_2),
+        (0.6, 2.4, 0.8, 3.0, 0.219_541_992_689_109_74),
+        (1.0, 0.995, 0.5, 8.0, 0.971_788_676_687_669_9),
+        (2.0, 0.25, 0.3, 6.0, 0.899_740_379_887_985_2),
+    ];
+    for (alpha, beta, r, tau, reference) in pins {
+        let cdf = ic_cdf(alpha, beta, r, tau);
+        assert!(
+            (cdf - reference).abs() < 1.0e-11,
+            "ic_cdf({alpha}, {beta}, {r}, {tau}) = {cdf:.16e} vs external reference {reference:.16e}"
+        );
+    }
+}
+
+#[test]
+fn non_finite_rate_parameters_return_visible_nan() {
+    // Domain contract: garbage in stays visible. A NaN rate must not be
+    // floored into a plausible CDF or pulse value.
+    for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        assert!(ic_cdf(bad, 0.5, 0.3, 2.0).is_nan());
+        assert!(ic_cdf(2.0, bad, 0.3, 2.0).is_nan());
+        assert!(ic_cdf(2.0, 0.5, bad, 2.0).is_nan());
+        assert!(ic_pulse(bad, 0.5, 0.3, 2.0).is_nan());
+        assert!(ic_pulse(2.0, bad, 0.3, 2.0).is_nan());
+        assert!(ic_pulse(2.0, 0.5, bad, 2.0).is_nan());
+    }
+    // Finite non-positive rates keep the documented floor semantics.
+    assert!(ic_cdf(-1.0, 0.5, 0.0, 2.0).is_finite());
+}
+
+#[test]
+fn singular_exp_milli_ev_r_law_is_rejected() {
+    // κ = 0 (undefined) and tiny-negative κ (divergent law) must not be
+    // silently mapped to R = 0 by eval's floor.
+    for kappa in [0.0, -5.0e-10] {
+        let err = IkedaCarpenter::new(
+            IkedaCarpenterParams {
+                alpha: EnergyLaw::Const(2.0),
+                beta: EnergyLaw::Const(0.5),
+                r: EnergyLaw::ExpMilliEv { kappa },
+                burst_sigma_us: None,
+                channel_fwhm_us: None,
+            },
+            25.0,
+            &SynthesisGrid::new(1.0, 100.0),
+        )
+        .expect_err("singular R law must not construct")
+        .to_string();
+        assert!(
+            err.contains("singular"),
+            "κ = {kappa}: error must name the singularity, got: {err}"
+        );
+    }
+    // A small POSITIVE κ is the legitimate κ → 0⁺ limit (R → 0) and stays valid.
+    IkedaCarpenter::new(
+        IkedaCarpenterParams {
+            alpha: EnergyLaw::Const(2.0),
+            beta: EnergyLaw::Const(0.5),
+            r: EnergyLaw::ExpMilliEv { kappa: 5.0e-10 },
+            burst_sigma_us: None,
+            channel_fwhm_us: None,
+        },
+        25.0,
+        &SynthesisGrid::new(1.0, 100.0),
+    )
+    .expect("positive tiny κ is the valid R → 0 limit");
+}
+
+#[test]
 fn cdf_far_tail_values_are_exact_not_nan() {
     // Far-tail regression: at³ / u³ overflow used to produce inf·0 = NaN,
     // which detector-bin differencing then silently converted to zero mass.

--- a/crates/nereids-physics/tests/ic_causal_response.rs
+++ b/crates/nereids-physics/tests/ic_causal_response.rs
@@ -425,10 +425,13 @@ fn gaussian_fold_preserves_finite_window_tail_mass() {
 
 #[test]
 fn unequal_rate_storage_cdf_matches_pulse_quadrature() {
-    // General α ≠ β storage CDF against Simpson integration of the density —
-    // the two functions share no code path for the storage term, so this pins
-    // both the bounded-bracket branch (|u| ≥ 0.05) and the Taylor branch
-    // (0 < |u| < 0.05) against an independent quadrature oracle.
+    // General α ≠ β storage CDF against Simpson integration of the density.
+    // ic_pulse and ic_cdf DO share h_over_cube_taylor and the bracket
+    // algebra, so this is not a fully independent oracle: its power is the
+    // derivative-vs-integral functional identity (a shared coefficient error
+    // would still break CDF = ∫ pulse above the tolerance), and full
+    // independence comes from the external 40-digit convolution pins in
+    // storage_cdf_matches_arbitrary_precision_convolution_reference.
     let cases: [(f64, f64, f64, f64); 6] = [
         (1.7, 0.45, 0.35, 0.4),  // bounded branch, early time
         (1.7, 0.45, 0.35, 2.7),  // bounded branch, mid pulse
@@ -591,6 +594,100 @@ fn singular_inverse_lambda_laws_are_rejected() {
     assert!(
         err.contains("singular"),
         "probe error must name the singularity, got: {err}"
+    );
+}
+
+#[test]
+fn coarse_folded_grid_meets_per_bin_accuracy_bound() {
+    // The review reproduction: α = 1 µs⁻¹, R = 0, triangle FWHM = 10 µs,
+    // E = 25 eV. At n_tau = 8 the sampled step (2.57 µs) mis-assigned up to
+    // 8.5e-3 of probability per bin (a leading-edge bin returned exactly 0
+    // against a true 1.8e-3) while conserving the total. The detector-bin
+    // gate now REJECTS that grid loudly; an n_tau meeting the FWHM/24
+    // per-bin floor is accepted and EVERY bin — including the leading edge
+    // below the coarse grid's sampled support — must match the analytic
+    // Γ₃⊗triangle oracle within the documented ~1e-4 bound.
+    let (alpha, fwhm) = (1.0_f64, 10.0_f64);
+    let flight_path_m = 25.0_f64;
+    let true_energy_ev = 25.0_f64;
+    let nominal = TOF_FACTOR * flight_path_m / true_energy_ev.sqrt();
+    let delay_edges: Vec<f64> = (0..=13).map(|k| -10.0 + 3.0 * k as f64).collect();
+    let detector_edges: Vec<f64> = delay_edges.iter().map(|d| nominal + d).collect();
+    let grid_with = |n_tau: usize| SynthesisGrid {
+        e_min_ev: 24.0,
+        e_max_ev: 26.0,
+        n_energies: 2,
+        n_tau,
+    };
+    let params = IkedaCarpenterParams {
+        channel_fwhm_us: Some(fwhm),
+        ..IkedaCarpenterParams::constant(alpha, 0.1, 0.0)
+    };
+
+    // (i) The reproduction grid AUTO-REFINES: n_tau = 8 only anchors the
+    // prompt step; the fold refinement targets FWHM/24, the cap affords it,
+    // and the detector-bin gate passes — the coarse-grid mis-assignment is
+    // gone by construction, verified per bin below.
+    let model = IkedaCarpenter::new(params.clone(), flight_path_m, &grid_with(8))
+        .expect("bin-eager refinement admits the coarse anchor");
+    let got = model
+        .detector_bin_probabilities(true_energy_ev, &detector_edges, 0.0)
+        .expect("valid folded detector bins");
+
+    // (ii) A cap-limited configuration (long storage tail forces the step
+    // above the per-bin target, though synthesis stays valid for the
+    // moment-level consumers) fails closed at the detector-bin gate.
+    let cap_limited = IkedaCarpenter::new(
+        IkedaCarpenterParams {
+            channel_fwhm_us: Some(0.35),
+            ..IkedaCarpenterParams::constant(2.0, 0.02, 0.5)
+        },
+        flight_path_m,
+        &SynthesisGrid::new(24.0, 26.0),
+    )
+    .expect("moment-level synthesis admits the cap-limited tail");
+    let err = cap_limited
+        .detector_bin_probabilities(true_energy_ev, &[nominal, nominal + 1.0], 0.0)
+        .expect_err("a cap-limited sampled step must be rejected for per-bin use")
+        .to_string();
+    assert!(
+        err.contains("per-bin accuracy floor"),
+        "rejection must name the per-bin floor, got: {err}"
+    );
+
+    let triangle = |c: f64| {
+        if c.abs() >= fwhm {
+            0.0
+        } else {
+            (1.0 - c.abs() / fwhm) / fwhm
+        }
+    };
+    let bin_oracle = |lo: f64, hi: f64| {
+        simpson(
+            |c| triangle(c) * (gamma3_cdf(alpha * (hi - c)) - gamma3_cdf(alpha * (lo - c))),
+            -fwhm,
+            fwhm,
+            20_000,
+        )
+    };
+    let mut leading_edge_mass = 0.0;
+    for (bin, edge) in delay_edges.windows(2).enumerate() {
+        let want = bin_oracle(edge[0], edge[1]);
+        assert!(
+            (got[bin] - want).abs() < 5.0e-4,
+            "bin {bin} [{}, {}] µs: sampled fold {:.6e} vs analytic oracle {want:.6e}",
+            edge[0],
+            edge[1],
+            got[bin]
+        );
+        if edge[1] <= -6.0 {
+            leading_edge_mass += got[bin];
+        }
+    }
+    assert!(
+        leading_edge_mass > 5.0e-4,
+        "leading-edge bins below the old sampled support must carry their \
+         real mass, got {leading_edge_mass:.3e}"
     );
 }
 

--- a/crates/nereids-physics/tests/ic_causal_response.rs
+++ b/crates/nereids-physics/tests/ic_causal_response.rs
@@ -692,6 +692,82 @@ fn coarse_folded_grid_meets_per_bin_accuracy_bound() {
 }
 
 #[test]
+fn coarse_gaussian_burst_meets_per_bin_accuracy_bound() {
+    // The round-4 sibling of the triangle case: a burst-only fold at a
+    // coarse anchor (σ = 2 µs, n_tau = 8) used to be admitted with
+    // dtau = σ and mis-assigned up to 1.46e-2 per bin while conserving the
+    // total. The bin-eager refinement now targets σ/12, and every bin must
+    // match the analytic Gaussian⊗Γ₃-CDF oracle within the documented
+    // ~1e-4 bound; a cap-limited burst grid fails closed at the gate.
+    let (alpha, sigma) = (1.0_f64, 2.0_f64);
+    let flight_path_m = 25.0_f64;
+    let true_energy_ev = 25.0_f64;
+    let nominal = TOF_FACTOR * flight_path_m / true_energy_ev.sqrt();
+    let model = IkedaCarpenter::new(
+        IkedaCarpenterParams {
+            burst_sigma_us: Some(sigma),
+            ..IkedaCarpenterParams::constant(alpha, 0.1, 0.0)
+        },
+        flight_path_m,
+        &SynthesisGrid {
+            e_min_ev: 24.0,
+            e_max_ev: 26.0,
+            n_energies: 2,
+            n_tau: 8,
+        },
+    )
+    .expect("bin-eager refinement admits the coarse burst anchor");
+
+    let delay_edges: Vec<f64> = (0..=10).map(|k| -6.0 + 2.5 * k as f64).collect();
+    let detector_edges: Vec<f64> = delay_edges.iter().map(|d| nominal + d).collect();
+    let got = model
+        .detector_bin_probabilities(true_energy_ev, &detector_edges, 0.0)
+        .expect("valid burst detector bins");
+
+    let normal_density =
+        |c: f64| (-0.5 * (c / sigma).powi(2)).exp() / (sigma * std::f64::consts::TAU.sqrt());
+    let bin_oracle = |lo: f64, hi: f64| {
+        simpson(
+            |c| normal_density(c) * (gamma3_cdf(alpha * (hi - c)) - gamma3_cdf(alpha * (lo - c))),
+            -10.0 * sigma,
+            10.0 * sigma,
+            50_000,
+        )
+    };
+    for (bin, edge) in delay_edges.windows(2).enumerate() {
+        let want = bin_oracle(edge[0], edge[1]);
+        assert!(
+            (got[bin] - want).abs() < 5.0e-4,
+            "bin {bin} [{}, {}] µs: sampled burst {:.6e} vs analytic oracle {want:.6e}",
+            edge[0],
+            edge[1],
+            got[bin]
+        );
+    }
+
+    // Cap-limited burst (long storage tail forces the step above σ/12
+    // though synthesis stays valid at the moment level): fail closed,
+    // naming the Gaussian floor.
+    let cap_limited = IkedaCarpenter::new(
+        IkedaCarpenterParams {
+            burst_sigma_us: Some(0.5),
+            ..IkedaCarpenterParams::constant(2.0, 0.02, 0.5)
+        },
+        flight_path_m,
+        &SynthesisGrid::new(24.0, 26.0),
+    )
+    .expect("moment-level synthesis admits the cap-limited burst tail");
+    let err = cap_limited
+        .detector_bin_probabilities(true_energy_ev, &[nominal, nominal + 1.0], 0.0)
+        .expect_err("a cap-limited burst step must be rejected for per-bin use")
+        .to_string();
+    assert!(
+        err.contains("per-bin accuracy floor") && err.contains("Gaussian burst"),
+        "rejection must name the Gaussian per-bin floor, got: {err}"
+    );
+}
+
+#[test]
 fn storage_cdf_matches_arbitrary_precision_convolution_reference() {
     // Reference values computed OUTSIDE this codebase from the DEFINING
     // convolution: CDF = (1−r)·Γ₃(ατ) + r·∫₀^τ (α³s²e^{−αs}/2)·(1−e^{−β(τ−s)}) ds

--- a/crates/nereids-physics/tests/ic_causal_response.rs
+++ b/crates/nereids-physics/tests/ic_causal_response.rs
@@ -1,7 +1,28 @@
 use nereids_physics::ikeda_carpenter::{
-    EnergyLaw, IkedaCarpenter, IkedaCarpenterParams, SynthesisGrid,
+    EnergyLaw, IkedaCarpenter, IkedaCarpenterParams, SynthesisGrid, ic_cdf, ic_pulse,
 };
 use nereids_physics::resolution::TOF_FACTOR;
+
+/// Simpson integral of `f` over `[a, b]` with `2n` intervals, accumulated
+/// with Neumaier compensation so the oracle's summation noise stays below the
+/// tolerances that use it (naive summation of 2e5 terms costs ~1e-11).
+fn simpson(f: impl Fn(f64) -> f64, a: f64, b: f64, n: usize) -> f64 {
+    let h = (b - a) / (2 * n) as f64;
+    let mut sum = f(a) + f(b);
+    let mut compensation = 0.0_f64;
+    for k in 1..2 * n {
+        let w = if k % 2 == 1 { 4.0 } else { 2.0 };
+        let value = w * f(a + k as f64 * h);
+        let t = sum + value;
+        compensation += if sum.abs() >= value.abs() {
+            (sum - t) + value
+        } else {
+            (value - t) + sum
+        };
+        sum = t;
+    }
+    (sum + compensation) * h / 3.0
+}
 
 fn gamma3_cdf(x: f64) -> f64 {
     if x <= 0.0 {
@@ -326,15 +347,6 @@ fn gaussian_fold_preserves_finite_window_tail_mass() {
     let lower = delays[0];
     let upper = delays[delays.len() - 1];
     let nominal_arrival = TOF_FACTOR * flight_path_m / true_energy_ev.sqrt();
-    let got: f64 = model
-        .detector_bin_probabilities(
-            true_energy_ev,
-            &[nominal_arrival + lower, nominal_arrival + upper],
-            0.0,
-        )
-        .expect("valid folded detector window")
-        .iter()
-        .sum();
 
     // Independent oracle: integrate the exact Gamma(3) moderator CDF over a
     // standard normal variable. This does not use the sampled convolution or
@@ -343,27 +355,262 @@ fn gaussian_fold_preserves_finite_window_tail_mass() {
         (-0.5 * (delay / sigma).powi(2)).exp() / (sigma * std::f64::consts::TAU.sqrt())
     };
     let moderator_cdf = |delay: f64| gamma3_cdf(alpha * delay);
-    let integrand = |gaussian_delay: f64| {
-        normal_density(gaussian_delay)
-            * (moderator_cdf(upper - gaussian_delay) - moderator_cdf(lower - gaussian_delay))
+    let window_oracle = |lo: f64, hi: f64| {
+        simpson(
+            |gaussian_delay: f64| {
+                normal_density(gaussian_delay)
+                    * (moderator_cdf(hi - gaussian_delay) - moderator_cdf(lo - gaussian_delay))
+            },
+            -10.0 * sigma,
+            10.0 * sigma,
+            100_000,
+        )
     };
-    let integration_limit = 10.0 * sigma;
-    let intervals = 200_000_usize;
-    let step = 2.0 * integration_limit / intervals as f64;
-    let mut oracle = integrand(-integration_limit) + integrand(integration_limit);
-    for index in 1..intervals {
-        let delay = -integration_limit + index as f64 * step;
-        oracle += if index % 2 == 0 { 2.0 } else { 4.0 } * integrand(delay);
-    }
-    oracle *= step / 3.0;
+    let window_sum = |lo: f64, hi: f64| -> f64 {
+        model
+            .detector_bin_probabilities(
+                true_energy_ev,
+                &[nominal_arrival + lo, nominal_arrival + hi],
+                0.0,
+            )
+            .expect("valid folded detector window")
+            .iter()
+            .sum()
+    };
 
+    // Broad window covering the whole sampled support: with the ±8σ reach the
+    // truncated Gaussian mass is ~1e-15, so a broad window must no longer be
+    // undercounted by the truncation bookkeeping.
+    let got_broad = window_sum(lower, upper);
+    let oracle_broad = window_oracle(lower, upper);
     assert!(
-        1.0 - oracle > 4.0e-5,
-        "oracle window must expose enough missing tail to reject silent renormalization"
+        (got_broad - oracle_broad).abs() < 2.0e-5,
+        "sampled Gaussian-folded probability {got_broad} disagrees with independent integral {oracle_broad}"
     );
     assert!(
-        (got - oracle).abs() < 2.0e-5,
-        "sampled Gaussian-folded probability {got} disagrees with independent integral {oracle}"
+        1.0 - got_broad < 1.0e-6,
+        "broad window undercounted: kernel-truncation bookkeeping discarded {:.3e}",
+        1.0 - got_broad
+    );
+    assert!(
+        got_broad < 1.0,
+        "finite window was silently renormalized to one"
+    );
+
+    // Deliberately cut window: the upper edge sits on a sampled grid point
+    // near +2σ, so real fold mass lies beyond it. Both the oracle and the
+    // sampled path must SEE that loss — a renormalizing implementation would
+    // report ~1 (comparison is loose because the n_tau = 8 grid is
+    // deliberately coarse; the broad-window comparison above is the tight one).
+    let cut = delays
+        .iter()
+        .copied()
+        .min_by(|a, b| (a - 2.0 * sigma).abs().total_cmp(&(b - 2.0 * sigma).abs()))
+        .expect("non-empty sampled support");
+    let got_cut = window_sum(lower, cut);
+    let oracle_cut = window_oracle(lower, cut);
+    assert!(
+        1.0 - oracle_cut > 1.0e-2,
+        "cut-window oracle must expose real missing mass (got {oracle_cut})"
+    );
+    assert!(
+        1.0 - got_cut > 1.0e-2,
+        "cut window silently renormalized: reported {got_cut}"
+    );
+    assert!(
+        got_cut < got_broad,
+        "cutting the window must reduce the reported mass"
+    );
+}
+
+#[test]
+fn unequal_rate_storage_cdf_matches_pulse_quadrature() {
+    // General α ≠ β storage CDF against Simpson integration of the density —
+    // the two functions share no code path for the storage term, so this pins
+    // both the bounded-bracket branch (|u| ≥ 0.05) and the Taylor branch
+    // (0 < |u| < 0.05) against an independent quadrature oracle.
+    let cases: [(f64, f64, f64, f64); 6] = [
+        (1.7, 0.45, 0.35, 0.4),  // bounded branch, early time
+        (1.7, 0.45, 0.35, 2.7),  // bounded branch, mid pulse
+        (1.7, 0.45, 0.35, 12.0), // bounded branch, deep tail
+        (0.6, 2.4, 0.8, 3.0),    // β > α (negative u)
+        (1.0, 0.995, 0.5, 8.0),  // Taylor branch: u = 0.04
+        (1.0, 0.995, 0.5, 1.0),  // Taylor branch: u = 0.005
+    ];
+    // Tolerance: near the |u| = 0.05 Taylor-branch boundary the two
+    // implementations carry independent series truncation — measured against
+    // a 60-digit reference at (1, 0.995, 0.5, 8): ic_cdf 4.7e-12, the
+    // integrated pulse 1.4e-11 — so the comparison budget is their sum.
+    for (alpha, beta, r, tau) in cases {
+        let quad = simpson(|t| ic_pulse(alpha, beta, r, t), 0.0, tau, 100_000);
+        let cdf = ic_cdf(alpha, beta, r, tau);
+        assert!(
+            (cdf - quad).abs() < 5.0e-11,
+            "ic_cdf({alpha}, {beta}, {r}, {tau}) = {cdf:.16e} vs quadrature {quad:.16e}"
+        );
+    }
+}
+
+#[test]
+fn storage_with_channel_fold_preserves_missing_tail_mass() {
+    // The sampled fold path with storage active (r > 0 AND a channel fold):
+    // the oracle is a double quadrature — the triangle channel density folded
+    // with the pulse-density integral — sharing only `ic_pulse` with the code
+    // under test (whose CDF equivalence the quadrature test above pins).
+    let (alpha, beta, r) = (2.0, 0.25, 0.3);
+    let fwhm = 0.7_f64; // triangle half-base = FWHM
+    let flight_path_m = 25.0_f64;
+    let true_energy_ev = 25.0_f64;
+    let model = IkedaCarpenter::new(
+        IkedaCarpenterParams {
+            alpha: EnergyLaw::Const(alpha),
+            beta: EnergyLaw::Const(beta),
+            r: EnergyLaw::Const(r),
+            burst_sigma_us: None,
+            channel_fwhm_us: Some(fwhm),
+        },
+        flight_path_m,
+        &SynthesisGrid::new(1.0, 100.0),
+    )
+    .expect("valid folded storage IC model");
+
+    let nominal = TOF_FACTOR * flight_path_m / true_energy_ev.sqrt();
+    // The window deliberately cuts the slow storage tail (β = 0.25 ⇒ mean
+    // storage delay 4 µs) so real mass lies beyond the last edge.
+    let edges = [nominal - 1.0, nominal + 1.0, nominal + 3.0, nominal + 6.0];
+    let got: f64 = model
+        .detector_bin_probabilities(true_energy_ev, &edges, 0.0)
+        .expect("valid detector bins")
+        .iter()
+        .sum();
+
+    let half_base = fwhm;
+    let triangle = |c: f64| (1.0 - c.abs() / half_base) / half_base;
+    let window_mass = |lo: f64, hi: f64| {
+        simpson(
+            |c| {
+                let a = (lo - c).max(0.0);
+                let b = (hi - c).max(0.0);
+                if b <= a {
+                    0.0
+                } else {
+                    triangle(c) * simpson(|t| ic_pulse(alpha, beta, r, t), a, b, 4_000)
+                }
+            },
+            -half_base,
+            half_base,
+            600,
+        )
+    };
+    let oracle = window_mass(-1.0, 6.0);
+    assert!(
+        1.0 - oracle > 0.05,
+        "window must lose real storage-tail mass (oracle = {oracle:.6})"
+    );
+    assert!(
+        (got - oracle).abs() < 5.0e-5,
+        "folded storage window mass {got:.8} vs double-quadrature oracle {oracle:.8}"
     );
     assert!(got < 1.0, "finite window was silently renormalized to one");
+}
+
+#[test]
+fn singular_inverse_lambda_laws_are_rejected() {
+    let grid = SynthesisGrid::new(5.0, 50.0);
+    // Construction: an all-zero (undefined at every energy) rate law must be
+    // rejected loudly, not floored into a plausible ~1e9 µs⁻¹ rate.
+    for (name, params) in [
+        (
+            "alpha",
+            IkedaCarpenterParams {
+                alpha: EnergyLaw::InverseLambda { a0: 0.0, a1: 0.0 },
+                beta: EnergyLaw::Const(0.1),
+                r: EnergyLaw::Const(0.0),
+                burst_sigma_us: None,
+                channel_fwhm_us: None,
+            },
+        ),
+        (
+            "beta",
+            IkedaCarpenterParams {
+                alpha: EnergyLaw::Const(2.0),
+                beta: EnergyLaw::InverseLambda { a0: 0.0, a1: 0.0 },
+                r: EnergyLaw::Const(0.5),
+                burst_sigma_us: None,
+                channel_fwhm_us: None,
+            },
+        ),
+        (
+            "tiny-negative beta",
+            IkedaCarpenterParams {
+                alpha: EnergyLaw::Const(2.0),
+                beta: EnergyLaw::InverseLambda {
+                    a0: -5.0e-10,
+                    a1: 0.0,
+                },
+                r: EnergyLaw::Const(0.5),
+                burst_sigma_us: None,
+                channel_fwhm_us: None,
+            },
+        ),
+    ] {
+        let err = IkedaCarpenter::new(params, 25.0, &grid)
+            .expect_err("singular law must not construct")
+            .to_string();
+        assert!(
+            err.contains("singular"),
+            "{name}: error must name the singularity, got: {err}"
+        );
+    }
+
+    // Probe-time: a law that is regular over the whole synthesis range but
+    // whose denominator crosses zero at a probe energy outside it must fail
+    // at that probe, not evaluate through the floor. λ(4 eV) is recovered
+    // through the public eval so the crossing is placed exactly.
+    let lambda_at_4 = 1.0 / EnergyLaw::InverseLambda { a0: 0.0, a1: 1.0 }.eval(4.0);
+    let crossing = EnergyLaw::InverseLambda {
+        a0: 1.0,
+        a1: -1.0 / lambda_at_4,
+    };
+    let model = IkedaCarpenter::new(
+        IkedaCarpenterParams {
+            alpha: EnergyLaw::Const(2.0),
+            beta: crossing,
+            r: EnergyLaw::Const(0.2),
+            burst_sigma_us: None,
+            channel_fwhm_us: None,
+        },
+        25.0,
+        &grid,
+    )
+    .expect("regular over the synthesis range");
+    let err = model
+        .kernel_at(4.0)
+        .expect_err("singular probe energy must be rejected")
+        .to_string();
+    assert!(
+        err.contains("singular"),
+        "probe error must name the singularity, got: {err}"
+    );
+}
+
+#[test]
+fn cdf_far_tail_values_are_exact_not_nan() {
+    // Far-tail regression: at³ / u³ overflow used to produce inf·0 = NaN,
+    // which detector-bin differencing then silently converted to zero mass.
+    let deep_prompt = ic_cdf(1.0, 1.0e-6, 0.5, 1.0e103);
+    assert_eq!(deep_prompt, 1.0, "deep prompt tail must saturate at 1");
+
+    let instant_storage = ic_cdf(1.0, 1.0e101, 0.5, 1.0);
+    assert!(
+        instant_storage.is_finite() && (0.0..=1.0).contains(&instant_storage),
+        "instant-storage limit must stay finite, got {instant_storage}"
+    );
+    assert!(
+        (instant_storage - gamma3_cdf(1.0)).abs() < 1.0e-15,
+        "instant storage decays to the prompt CDF"
+    );
+
+    let overflow_prompt = ic_cdf(1.0e155, 1.0, 0.0, 1.0);
+    assert_eq!(overflow_prompt, 1.0, "Γ₃ far tail must saturate at 1");
 }

--- a/crates/nereids-physics/tests/ic_causal_response.rs
+++ b/crates/nereids-physics/tests/ic_causal_response.rs
@@ -1,0 +1,369 @@
+use nereids_physics::ikeda_carpenter::{
+    EnergyLaw, IkedaCarpenter, IkedaCarpenterParams, SynthesisGrid,
+};
+use nereids_physics::resolution::TOF_FACTOR;
+
+fn gamma3_cdf(x: f64) -> f64 {
+    if x <= 0.0 {
+        0.0
+    } else {
+        1.0 - (-x).exp() * (1.0 + x + 0.5 * x * x)
+    }
+}
+
+#[test]
+fn prompt_only_bins_match_closed_form_and_keep_physical_time() {
+    let alpha = 2.0;
+    let flight_path_m = 25.0_f64;
+    let true_energy_ev = 25.0_f64;
+    let timing_offset_us = 3.25_f64;
+    let model = IkedaCarpenter::new(
+        IkedaCarpenterParams::constant(alpha, 0.1, 0.0),
+        flight_path_m,
+        &SynthesisGrid::new(1.0, 100.0),
+    )
+    .expect("valid prompt-only IC model");
+
+    let nominal_arrival = timing_offset_us + TOF_FACTOR * flight_path_m / true_energy_ev.sqrt();
+    let delay_edges = [0.0, 0.5, 1.0, 2.0, 10.0];
+    let detector_edges: Vec<f64> = delay_edges
+        .iter()
+        .map(|delay| nominal_arrival + delay)
+        .collect();
+
+    let actual = model
+        .detector_bin_probabilities(true_energy_ev, &detector_edges, timing_offset_us)
+        .expect("valid detector bins");
+    let expected: Vec<f64> = delay_edges
+        .windows(2)
+        .map(|edge| gamma3_cdf(alpha * edge[1]) - gamma3_cdf(alpha * edge[0]))
+        .collect();
+
+    assert_eq!(actual.len(), expected.len());
+    for (bin, (&got, &want)) in actual.iter().zip(&expected).enumerate() {
+        assert!(
+            (got - want).abs() < 2e-12,
+            "bin {bin}: causal IC probability {got:.16e} != closed form {want:.16e}"
+        );
+    }
+
+    let (delays, weights) = model
+        .source_pulse_at(true_energy_ev)
+        .expect("valid physical source pulse");
+    let peak = weights
+        .iter()
+        .enumerate()
+        .max_by(|(_, a), (_, b)| a.total_cmp(b))
+        .map(|(index, _)| index)
+        .expect("non-empty pulse");
+    let step = delays[1] - delays[0];
+    assert!(
+        (delays[peak] - 2.0 / alpha).abs() <= step,
+        "source pulse peak was moved from physical delay 2/alpha={} us to {} us",
+        2.0 / alpha,
+        delays[peak]
+    );
+}
+
+#[test]
+fn energy_law_is_evaluated_at_true_energy() {
+    let flight_path_m = 25.0;
+    let params = IkedaCarpenterParams {
+        alpha: EnergyLaw::SqrtE { a0: 1.0, a1: 0.0 },
+        beta: EnergyLaw::Const(0.1),
+        r: EnergyLaw::Const(0.0),
+        burst_sigma_us: None,
+        channel_fwhm_us: None,
+    };
+    let model = IkedaCarpenter::new(params, flight_path_m, &SynthesisGrid::new(1.0, 100.0))
+        .expect("valid energy-dependent IC model");
+
+    for true_energy_ev in [1.0_f64, 4.0] {
+        let nominal_arrival = TOF_FACTOR * flight_path_m / true_energy_ev.sqrt();
+        let edges = [nominal_arrival, nominal_arrival + 1.0];
+        let got = model
+            .detector_bin_probabilities(true_energy_ev, &edges, 0.0)
+            .expect("valid detector bin")[0];
+        let alpha = true_energy_ev.sqrt();
+        let want = gamma3_cdf(alpha);
+        assert!(
+            (got - want).abs() < 2e-12,
+            "E={true_energy_ev} eV used the wrong pulse: {got:.16e} != {want:.16e}"
+        );
+    }
+}
+
+#[test]
+fn moderator_rates_that_follow_neutron_speed_preserve_scaled_pulse_time() {
+    let flight_path_m = 25.0;
+    let params = IkedaCarpenterParams {
+        alpha: EnergyLaw::SqrtE { a0: 2.0, a1: 0.0 },
+        beta: EnergyLaw::SqrtE { a0: 0.5, a1: 0.0 },
+        r: EnergyLaw::Const(0.3),
+        burst_sigma_us: None,
+        channel_fwhm_us: None,
+    };
+    let model = IkedaCarpenter::new(params, flight_path_m, &SynthesisGrid::new(1.0, 4.0))
+        .expect("valid speed-scaled IC model");
+
+    let probability_to_scaled_delay = |energy_ev: f64, delay_us: f64| {
+        let arrival = TOF_FACTOR * flight_path_m / energy_ev.sqrt();
+        model
+            .detector_bin_probabilities(energy_ev, &[arrival, arrival + delay_us], 0.0)
+            .expect("valid detector bin")[0]
+    };
+
+    let at_one_ev = probability_to_scaled_delay(1.0, 2.0);
+    let at_four_ev = probability_to_scaled_delay(4.0, 1.0);
+    assert!(
+        (at_one_ev - at_four_ev).abs() < 2e-12,
+        "speed-scaled moderator pulse changed shape: {at_one_ev:.16e} != {at_four_ev:.16e}"
+    );
+}
+
+#[test]
+fn probe_outside_synthesis_range_rejects_nonphysical_beta_law() {
+    let model = IkedaCarpenter::new(
+        IkedaCarpenterParams {
+            alpha: EnergyLaw::Const(1.0),
+            beta: EnergyLaw::SqrtE { a0: -1.0, a1: 2.0 },
+            r: EnergyLaw::Const(0.3),
+            burst_sigma_us: None,
+            channel_fwhm_us: None,
+        },
+        25.0,
+        &SynthesisGrid::new(1.0, 2.0),
+    )
+    .expect("beta law is physical inside the synthesis range");
+
+    let legacy_error = model
+        .kernel_at(9.0)
+        .expect_err("legacy kernel probe must reject a negative beta law")
+        .to_string();
+    assert!(
+        legacy_error.contains("beta(9)"),
+        "legacy kernel probe hid the invalid beta law behind: {legacy_error}"
+    );
+    assert!(
+        model.source_pulse_at(9.0).is_err(),
+        "physical source probe must reject a negative beta law"
+    );
+}
+
+#[test]
+fn invalid_detector_edges_fail_instead_of_being_reordered() {
+    let model = IkedaCarpenter::new(
+        IkedaCarpenterParams::constant(1.0, 0.1, 0.0),
+        25.0,
+        &SynthesisGrid::new(1.0, 100.0),
+    )
+    .expect("valid IC model");
+
+    assert!(
+        model
+            .detector_bin_probabilities(10.0, &[100.0, 99.0], 0.0)
+            .is_err()
+    );
+    assert!(
+        model
+            .detector_bin_probabilities(10.0, &[100.0, f64::NAN], 0.0)
+            .is_err()
+    );
+    assert!(
+        model
+            .detector_bin_probabilities(0.0, &[100.0, 101.0], 0.0)
+            .is_err()
+    );
+}
+
+#[test]
+fn equal_rate_storage_limit_matches_gamma4_closed_form() {
+    let rate = 1.25_f64;
+    let flight_path_m = 25.0_f64;
+    let true_energy_ev = 16.0_f64;
+    let model = IkedaCarpenter::new(
+        IkedaCarpenterParams::constant(rate, rate, 1.0),
+        flight_path_m,
+        &SynthesisGrid::new(1.0, 100.0),
+    )
+    .expect("valid equal-rate storage model");
+    let nominal_arrival = TOF_FACTOR * flight_path_m / true_energy_ev.sqrt();
+    let delay_edges = [0.0, 0.2, 0.8, 2.0, 20.0];
+    let detector_edges: Vec<f64> = delay_edges
+        .iter()
+        .map(|delay| nominal_arrival + delay)
+        .collect();
+
+    let got = model
+        .detector_bin_probabilities(true_energy_ev, &detector_edges, 0.0)
+        .expect("valid detector bins");
+    let gamma4_cdf = |delay: f64| {
+        let x = rate * delay;
+        if x <= 0.0 {
+            0.0
+        } else {
+            1.0 - (-x).exp() * (1.0 + x + x * x / 2.0 + x.powi(3) / 6.0)
+        }
+    };
+    for (index, edge) in delay_edges.windows(2).enumerate() {
+        let want = gamma4_cdf(edge[1]) - gamma4_cdf(edge[0]);
+        assert!(
+            (got[index] - want).abs() < 3e-12,
+            "equal-rate storage bin {index}: {} != {want}",
+            got[index]
+        );
+    }
+}
+
+#[test]
+fn symmetric_sns_pulse_fold_keeps_source_clock_and_preserves_missing_tail_mass() {
+    let alpha = 2.0_f64;
+    let flight_path_m = 25.0_f64;
+    let true_energy_ev = 25.0_f64;
+    let params = IkedaCarpenterParams {
+        channel_fwhm_us: Some(0.35),
+        ..IkedaCarpenterParams::constant(alpha, 0.1, 0.0)
+    };
+    let model = IkedaCarpenter::new(params, flight_path_m, &SynthesisGrid::new(1.0, 100.0))
+        .expect("valid folded IC model");
+    let (delays, weights) = model
+        .source_pulse_at(true_energy_ev)
+        .expect("valid folded source pulse");
+
+    let mut area = 0.0;
+    let mut first_moment = 0.0;
+    for i in 0..delays.len() - 1 {
+        let width = delays[i + 1] - delays[i];
+        area += 0.5 * (weights[i] + weights[i + 1]) * width;
+        first_moment += width
+            * (delays[i] * (2.0 * weights[i] + weights[i + 1])
+                + delays[i + 1] * (weights[i] + 2.0 * weights[i + 1]))
+            / 6.0;
+    }
+    let mean = first_moment / area;
+    assert!(
+        (mean - 3.0 / alpha).abs() < 3e-3,
+        "symmetric fold moved the physical source mean from {} us to {mean} us",
+        3.0 / alpha
+    );
+
+    let nominal_arrival = TOF_FACTOR * flight_path_m / true_energy_ev.sqrt();
+    let detector_edges: Vec<f64> = (0..=20)
+        .map(|index| {
+            nominal_arrival
+                + delays[0]
+                + (delays[delays.len() - 1] - delays[0]) * index as f64 / 20.0
+        })
+        .collect();
+    let probabilities = model
+        .detector_bin_probabilities(true_energy_ev, &detector_edges, 0.0)
+        .expect("valid folded detector bins");
+    let total: f64 = probabilities.iter().sum();
+
+    // Independent oracle for X + C, where X is the prompt-only Gamma(3,
+    // alpha) moderator delay and C is the symmetric triangular channel-time
+    // density. Integrating the analytical moderator CDF over C predicts the
+    // probability inside these finite detector edges without using the
+    // implementation's sampled convolution or bin integration.
+    let gamma3_cdf = |delay: f64| {
+        let x = alpha * delay;
+        if x <= 0.0 {
+            0.0
+        } else {
+            1.0 - (-x).exp() * (1.0 + x + x * x / 2.0)
+        }
+    };
+    let half_base = 0.35_f64;
+    let lower = delays[0];
+    let upper = delays[delays.len() - 1];
+    let integrand = |channel_delay: f64| {
+        let channel_density = (1.0 - channel_delay.abs() / half_base) / half_base;
+        channel_density * (gamma3_cdf(upper - channel_delay) - gamma3_cdf(lower - channel_delay))
+    };
+    let intervals = 20_000_usize;
+    let step = 2.0 * half_base / intervals as f64;
+    let mut oracle = integrand(-half_base) + integrand(half_base);
+    for index in 1..intervals {
+        let delay = -half_base + index as f64 * step;
+        oracle += if index % 2 == 0 { 2.0 } else { 4.0 } * integrand(delay);
+    }
+    oracle *= step / 3.0;
+    assert!(
+        (total - oracle).abs() < 2.0e-7,
+        "sampled folded pulse has probability {total}, independent analytical integral gives {oracle}"
+    );
+    assert!(
+        oracle < 1.0,
+        "finite detector edges must omit a physical tail"
+    );
+    assert!(probabilities.iter().all(|p| p.is_finite() && *p >= 0.0));
+}
+
+#[test]
+fn gaussian_fold_preserves_finite_window_tail_mass() {
+    let alpha = 100.0_f64;
+    let sigma = 1.0_f64;
+    let flight_path_m = 25.0_f64;
+    let true_energy_ev = 25.0_f64;
+    let params = IkedaCarpenterParams {
+        burst_sigma_us: Some(sigma),
+        ..IkedaCarpenterParams::constant(alpha, 1.0, 0.0)
+    };
+    let model = IkedaCarpenter::new(
+        params,
+        flight_path_m,
+        &SynthesisGrid {
+            e_min_ev: 24.0,
+            e_max_ev: 26.0,
+            n_energies: 2,
+            n_tau: 8,
+        },
+    )
+    .expect("valid Gaussian-folded IC model");
+    let (delays, _) = model
+        .source_pulse_at(true_energy_ev)
+        .expect("valid folded source pulse");
+    let lower = delays[0];
+    let upper = delays[delays.len() - 1];
+    let nominal_arrival = TOF_FACTOR * flight_path_m / true_energy_ev.sqrt();
+    let got: f64 = model
+        .detector_bin_probabilities(
+            true_energy_ev,
+            &[nominal_arrival + lower, nominal_arrival + upper],
+            0.0,
+        )
+        .expect("valid folded detector window")
+        .iter()
+        .sum();
+
+    // Independent oracle: integrate the exact Gamma(3) moderator CDF over a
+    // standard normal variable. This does not use the sampled convolution or
+    // detector-bin integrator under test.
+    let normal_density = |delay: f64| {
+        (-0.5 * (delay / sigma).powi(2)).exp() / (sigma * std::f64::consts::TAU.sqrt())
+    };
+    let moderator_cdf = |delay: f64| gamma3_cdf(alpha * delay);
+    let integrand = |gaussian_delay: f64| {
+        normal_density(gaussian_delay)
+            * (moderator_cdf(upper - gaussian_delay) - moderator_cdf(lower - gaussian_delay))
+    };
+    let integration_limit = 10.0 * sigma;
+    let intervals = 200_000_usize;
+    let step = 2.0 * integration_limit / intervals as f64;
+    let mut oracle = integrand(-integration_limit) + integrand(integration_limit);
+    for index in 1..intervals {
+        let delay = -integration_limit + index as f64 * step;
+        oracle += if index % 2 == 0 { 2.0 } else { 4.0 } * integrand(delay);
+    }
+    oracle *= step / 3.0;
+
+    assert!(
+        1.0 - oracle > 4.0e-5,
+        "oracle window must expose enough missing tail to reject silent renormalization"
+    );
+    assert!(
+        (got - oracle).abs() < 2.0e-5,
+        "sampled Gaussian-folded probability {got} disagrees with independent integral {oracle}"
+    );
+    assert!(got < 1.0, "finite window was silently renormalized to one");
+}

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -4,6 +4,7 @@ All tests use synthetic data built with ``nereids.create_resonance_data()``
 so no network access or ENDF downloads are required.
 """
 
+import math
 import os
 import tempfile
 import warnings
@@ -4191,6 +4192,63 @@ class TestIkedaCarpenterCausalResponse:
         assert probabilities[0] == 0.0
         assert np.all(probabilities[1:] > 0.0)
         assert 0.999 < probabilities.sum() <= 1.0
+
+    def test_partial_window_reports_known_missing_mass(self):
+        # A deliberately partial window whose true mass is the analytic
+        # Gamma(3, alpha) CDF at the cut: a binding that silently renormalized
+        # the window would report 1.0 instead.
+        flight_path_m = 25.0
+        energy_ev = 4.0
+        alpha = 2.0
+        arrival_us = nereids.energy_to_tof(energy_ev, flight_path_m)
+        ic = nereids.IkedaCarpenter(
+            flight_path_m=flight_path_m,
+            e_min_ev=1.0,
+            e_max_ev=10.0,
+            alpha=nereids.EnergyLaw.const(alpha),
+            beta=0.5,
+            r=nereids.EnergyLaw.const(0.0),
+        )
+
+        probabilities = np.asarray(
+            ic.detector_bin_probabilities(
+                energy_ev, [arrival_us, arrival_us + 1.0], 0.0
+            )
+        )
+
+        x = alpha * 1.0
+        gamma3_at_cut = 1.0 - math.exp(-x) * (1.0 + x + 0.5 * x * x)
+        assert probabilities.shape == (1,)
+        assert probabilities[0] == pytest.approx(gamma3_at_cut, abs=1e-9)
+        assert probabilities[0] < 1.0
+
+    def test_energy_dependent_beta_law_scales_storage_tail(self):
+        # With alpha and beta both proportional to sqrt(E), the pulse is a
+        # pure time rescaling: P(delay <= 2 us at 1 eV) equals
+        # P(delay <= 1 us at 4 eV). A binding that ignored beta_law (or
+        # evaluated it at a fixed reference energy) breaks the equality.
+        flight_path_m = 25.0
+        ic = nereids.IkedaCarpenter(
+            flight_path_m=flight_path_m,
+            e_min_ev=0.5,
+            e_max_ev=10.0,
+            alpha=nereids.EnergyLaw.sqrt_e(2.0, 0.0),
+            beta=999.0,  # overridden by beta_law
+            r=nereids.EnergyLaw.const(0.4),
+            beta_law=nereids.EnergyLaw.sqrt_e(0.5, 0.0),
+        )
+
+        def mass_within(energy_ev, delay_us):
+            arrival = nereids.energy_to_tof(energy_ev, flight_path_m)
+            (p,) = ic.detector_bin_probabilities(
+                energy_ev, [arrival, arrival + delay_us], 0.0
+            )
+            return p
+
+        slow = mass_within(1.0, 2.0)
+        fast = mass_within(4.0, 1.0)
+        assert 0.0 < slow < 1.0
+        assert slow == pytest.approx(fast, abs=1e-9)
 
 
 class TestCalibrateResolution:

--- a/tests/test_nereids.py
+++ b/tests/test_nereids.py
@@ -4149,6 +4149,50 @@ class TestCalibrateEnergySmoke:
         np.testing.assert_array_equal(uncertainty, s_before)
 
 
+class TestIkedaCarpenterCausalResponse:
+    def test_source_pulse_keeps_physical_delay_origin(self):
+        ic = nereids.IkedaCarpenter(
+            flight_path_m=25.0,
+            e_min_ev=1.0,
+            e_max_ev=10.0,
+            alpha=nereids.EnergyLaw.const(2.0),
+            beta=0.5,
+            r=nereids.EnergyLaw.const(0.3),
+        )
+
+        delay_us, density = map(np.asarray, ic.source_pulse_at(4.0))
+
+        assert delay_us[0] == 0.0
+        assert delay_us[np.argmax(density)] > 0.0
+        assert np.all(np.diff(delay_us) > 0.0)
+
+    def test_detector_bin_probabilities_preserve_probability_and_clock(self):
+        flight_path_m = 25.0
+        energy_ev = 4.0
+        arrival_us = nereids.energy_to_tof(energy_ev, flight_path_m)
+        ic = nereids.IkedaCarpenter(
+            flight_path_m=flight_path_m,
+            e_min_ev=1.0,
+            e_max_ev=10.0,
+            alpha=nereids.EnergyLaw.const(2.0),
+            beta=0.5,
+            r=nereids.EnergyLaw.const(0.3),
+        )
+
+        probabilities = np.asarray(
+            ic.detector_bin_probabilities(
+                energy_ev,
+                [arrival_us - 1.0, arrival_us, arrival_us + 1.0, arrival_us + 80.0],
+                0.0,
+            )
+        )
+
+        assert probabilities.shape == (3,)
+        assert probabilities[0] == 0.0
+        assert np.all(probabilities[1:] > 0.0)
+        assert 0.999 < probabilities.sum() <= 1.0
+
+
 class TestCalibrateResolution:
     """Resolution calibration binding: position is PINNED by default; the shared
     SAMMY energy-scale ``(t0, L_scale)`` is an explicit, prior-constrained opt-in


### PR DESCRIPTION
Wave-1 PR-1: causal Ikeda-Carpenter detector-bin response, per contract record R5·7.
Adds ic_cdf, source_pulse_at, detector_bin_probabilities; breaking beta: f64 -> EnergyLaw; window loss preserved, never renormalized.
Oracles validate against independent closed forms (new capability, no fail-on-main claim).
Validation: clippy clean; 26 Rust suites green; 277 Python tests green.
